### PR TITLE
Fix double free on static linked GSSAPI library 

### DIFF
--- a/src/util/et/error_message.c
+++ b/src/util/et/error_message.c
@@ -81,6 +81,7 @@ void com_err_terminate(void)
         enext = e->next;
         free(e);
     }
+    et_list = NULL;
     k5_mutex_unlock(&et_list_lock);
     k5_mutex_destroy(&et_list_lock);
     terminated = 1;


### PR DESCRIPTION
Finalization code from the GSSAPI library statically linked frees
nodes from the error tables list after the list was freed
by com_err_terminate(void).

The backtrace is:
remove_error_table(&et_k5g_error_table)
gss_krb5int_lib_fini(void)
gssint_mechglue_fini(void)

This issue makes the src/tests/gssapi/t_saslname crash at exit.

Signed-off-by: Mihai Serban mihai.serban@gmail.com
