### PR TITLE
add KDC default referral feature

### DIFF
--- a/src/config-files/kdc.conf.M
+++ b/src/config-files/kdc.conf.M
@@ -273,6 +273,18 @@ specifies whether or not the list of transited realms for cross-realm
 tickets should be checked against the transit path computed from the
 realm names and the [capaths] section of its krb5.conf file
 
+.IP default_referral_realm
+This
+.B string
+specifies a realm to which the KDC will issue referrals for TGS requests
+otherwise qualifying for a referral but lacking a static realm mapping, as
+long as the presented TGT is not cross-realm (setting
+cross_realm_default_referral omits that check).
+
+.IP cross_realm_default_referral
+.B boolean
+(see default_referral_realm)
+
 .SH FILES 
 /usr/local/var/krb5kdc/kdc.conf
 

--- a/src/include/adm.h
+++ b/src/include/adm.h
@@ -201,6 +201,7 @@ typedef struct __krb5_realm_params {
     char *              realm_acl_file;
     char *              realm_host_based_services;
     char *              realm_no_host_referral;
+    char *              realm_default_referral_realm;
     krb5_int32          realm_kadmind_port;
     krb5_enctype        realm_enctype;
     krb5_deltat         realm_max_life;
@@ -208,8 +209,11 @@ typedef struct __krb5_realm_params {
     krb5_timestamp      realm_expiration;
     krb5_flags          realm_flags;
     krb5_key_salt_tuple *realm_keysalts;
+    unsigned int        realm_cross_realm_default_referral:1;
     unsigned int        realm_reject_bad_transit:1;
     unsigned int        realm_restrict_anon:1;
+    unsigned int        realm_default_referral_realm_valid:1;
+    unsigned int        realm_cross_realm_default_referral_valid:1;
     unsigned int        realm_kadmind_port_valid:1;
     unsigned int        realm_enctype_valid:1;
     unsigned int        realm_max_life_valid:1;

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -182,7 +182,7 @@ typedef INT64_TYPE krb5_int64;
 /* Get string buffer support. */
 #include "k5-buf.h"
 
-/* cofiguration variables */
+/* configuration variables */
 #define KRB5_CONF_ACL_FILE                       "acl_file"
 #define KRB5_CONF_ADMIN_KEYTAB                   "admin_keytab"
 #define KRB5_CONF_ADMIN_SERVER                   "admin_server"
@@ -193,10 +193,12 @@ typedef INT64_TYPE krb5_int64;
 #define KRB5_CONF_CANONICALIZE                   "canonicalize"
 #define KRB5_CONF_CCACHE_TYPE                    "ccache_type"
 #define KRB5_CONF_CLOCKSKEW                      "clockskew"
+#define KRB5_CONF_CROSS_REALM_DEFAULT_REFERRAL   "cross_realm_default_referral"
 #define KRB5_CONF_DATABASE_NAME                  "database_name"
 #define KRB5_CONF_DB_MODULE_DIR                  "db_module_dir"
 #define KRB5_CONF_DEFAULT                        "default"
 #define KRB5_CONF_DEFAULT_REALM                  "default_realm"
+#define KRB5_CONF_DEFAULT_REFERRAL_REALM         "default_referral_realm"
 #define KRB5_CONF_DEFAULT_DOMAIN                 "default_domain"
 #define KRB5_CONF_DEFAULT_TKT_ENCTYPES           "default_tkt_enctypes"
 #define KRB5_CONF_DEFAULT_TGS_ENCTYPES           "default_tgs_enctypes"

--- a/src/kdc/do_tgs_req.c
+++ b/src/kdc/do_tgs_req.c
@@ -76,7 +76,7 @@ prepare_error_tgs(struct kdc_request_state *, krb5_kdc_req *,krb5_ticket *,int,
                   krb5_principal,krb5_data **,const char *, krb5_pa_data **);
 
 static krb5_int32
-prep_reprocess_req(krb5_kdc_req *,krb5_principal *);
+prep_reprocess_req(krb5_kdc_req *,krb5_principal *,krb5_ticket *,char *,char *);
 
 /*ARGSUSED*/
 krb5_error_code
@@ -247,7 +247,8 @@ tgt_again:
                 goto cleanup;
 
             } else if ( db_ref_done == FALSE) {
-                retval = prep_reprocess_req(request, &krbtgt_princ);
+                retval = prep_reprocess_req(request, &krbtgt_princ, header_ticket,
+                                            cname, sname);
                 if (!retval) {
                     krb5_free_principal(kdc_context, request->server);
                     retval = krb5_copy_principal(kdc_context, krbtgt_princ,
@@ -1109,12 +1110,14 @@ cleanup:
 }
 
 static krb5_int32
-prep_reprocess_req(krb5_kdc_req *request, krb5_principal *krbtgt_princ)
+prep_reprocess_req(krb5_kdc_req *request, krb5_principal *krbtgt_princ, krb5_ticket *tgt, 
+                   char *cname, char *sname)
 {
     krb5_error_code retval = KRB5KRB_AP_ERR_BADMATCH;
     char **realms, **cpp, *temp_buf=NULL;
     krb5_data *comp1 = NULL, *comp2 = NULL;
-    char *comp1_str = NULL;
+    char *comp1_str = NULL, *tgsname = NULL;
+    krb5_boolean free_realm = TRUE;
 
     /* By now we know that server principal name is unknown.
      * If CANONICALIZE flag is set in the request
@@ -1122,6 +1125,7 @@ prep_reprocess_req(krb5_kdc_req *request, krb5_principal *krbtgt_princ)
      * the requested server princ. has exactly two components
      * either
      *      the name type is NT-SRV-HST
+     *      or name type is NT-SRV-INST 
      *      or name type is NT-UNKNOWN and
      *         the 1st component is listed in conf file under host_based_services
      * the 1st component is not in a list in conf under "no_host_referral"
@@ -1167,11 +1171,38 @@ prep_reprocess_req(krb5_kdc_req *request, krb5_principal *krbtgt_princ)
             strlcpy(temp_buf, comp2->data,comp2->length+1);
             retval = krb5int_get_domain_realm_mapping(kdc_context, temp_buf, &realms);
             free(temp_buf);
-            if (retval) {
-                /* no match found */
-                kdc_err(kdc_context, retval, "unable to find realm of host");
-                goto cleanup;
+            if (retval == 0 && (!realms || !realms[0]))
+                retval = KRB5KRB_AP_ERR_BADMATCH;
+            /* get TGS principal name for log message */
+            krb5_unparse_name(kdc_context, tgt->server, &tgsname);
+            if (!tgsname) tgsname = "<bad TGS principal name!>";
+            /* if there's a static realm mapping, we'll refer to that */
+            if (!retval)
+                krb5_klog_syslog(LOG_INFO,
+                                 "REFERRAL YES via static (%.*s -> %s): %s for %s with TGT %s",
+                                  comp2->length, comp2->data,
+                                  realms && realms[0] ? realms[0] : "NULL",
+                                  cname, sname, tgsname);
+            /* otherwise, consider for default referral if configured */
+            else if (default_referral_realm) {
+                /* if cross-realm default referral is off, compare the TGS realm and the issuer */
+                if (!cross_realm_default_referral &&
+                    strcmp(tgt->server->realm.data,
+                           krb5_princ_component(kdc_context, tgt->server, 1)->data)) {
+                    /* they're different; no referral */
+                    krb5_klog_syslog(LOG_INFO,
+                                     "REFERRAL NO via default (cross-realm): %s for %s with TGT %s",
+                                     cname, sname, tgsname);
+                    goto cleanup;
+                }
+                /* OK; issue a default referral */
+                krb5_klog_syslog(LOG_INFO,
+                                 "REFERRAL YES via default to %s: %s for %s with TGT %s",
+                                 default_referral_realm, cname, sname, tgsname);
+                realms = &default_referral_realm;
+                free_realm = FALSE;
             }
+
             if (realms == 0) {
                 retval = KRB5KRB_AP_ERR_BADMATCH;
                 goto cleanup;
@@ -1189,11 +1220,13 @@ prep_reprocess_req(krb5_kdc_req *request, krb5_principal *krbtgt_princ)
                                           (*request->server).realm.length,
                                           (*request->server).realm.data,
                                           "krbtgt", realms[0], (char *)0);
-            for (cpp = realms; *cpp; cpp++)
-                free(*cpp);
+            if (free_realm)
+                for (cpp = realms; *cpp; cpp++)
+                    free(*cpp);
         }
     }
 cleanup:
+    if (tgsname) free(tgsname);
     free(comp1_str);
 
     return retval;

--- a/src/kdc/extern.h
+++ b/src/kdc/extern.h
@@ -43,6 +43,8 @@ typedef struct __kdc_realm_data {
     char *              realm_no_host_referral; /* no referral for these services.
                                                  * If '*' - disallow all referrals and
                                                  * ignore realm_host_based_services */
+    char *              realm_default_referral_realm; /* target realm for default referrals */
+    krb5_boolean        realm_cross_realm_default_referral; /* do x-realm default referrals? */
     /*
      * Database per-realm data.
      */
@@ -93,6 +95,8 @@ kdc_realm_t *find_realm_data (char *, krb5_ui_4);
 #define tgs_server                      kdc_active_realm->realm_tgsprinc
 #define reject_bad_transit              kdc_active_realm->realm_reject_bad_transit
 #define restrict_anon                   kdc_active_realm->realm_restrict_anon
+#define default_referral_realm          kdc_active_realm->realm_default_referral_realm
+#define cross_realm_default_referral    kdc_active_realm->realm_cross_realm_default_referral
 
 /* various externs for KDC */
 extern krb5_data        empty_string;   /* an empty string */

--- a/src/kdc/main.c
+++ b/src/kdc/main.c
@@ -229,6 +229,18 @@ handle_referral_params(krb5_realm_params *rparams,
         return 0;
     }
 
+    /* default_referral_realm (default none) */
+    if (rparams && rparams->realm_default_referral_realm_valid)
+        rdp->realm_default_referral_realm = strdup(rparams->realm_default_referral_realm);
+    else
+        rdp->realm_default_referral_realm = NULL;
+
+    /* cross_realm_default_referral (default no) */
+    if (rparams && rparams->realm_cross_realm_default_referral_valid)
+        rdp->realm_cross_realm_default_referral = rparams->realm_cross_realm_default_referral;
+    else
+        rdp->realm_cross_realm_default_referral = 0;
+
     if (host_based_srvcs &&
         (krb5_match_config_pattern(host_based_srvcs, KRB5_CONF_ASTERISK) == TRUE)) {
         rdp->realm_host_based_services = strdup(KRB5_CONF_ASTERISK);

--- a/src/lib/kadm5/admin.h
+++ b/src/lib/kadm5/admin.h
@@ -281,6 +281,7 @@ typedef struct __krb5_realm_params {
     char *              realm_acl_file;
     char *              realm_host_based_services;
     char *              realm_no_host_referral;
+    char *              realm_default_referral_realm;
     krb5_int32          realm_kadmind_port;
     krb5_enctype        realm_enctype;
     krb5_deltat         realm_max_life;
@@ -288,8 +289,11 @@ typedef struct __krb5_realm_params {
     krb5_timestamp      realm_expiration;
     krb5_flags          realm_flags;
     krb5_key_salt_tuple *realm_keysalts;
+    unsigned int        realm_cross_realm_default_referral:1;
     unsigned int        realm_reject_bad_transit:1;
     unsigned int        realm_restrict_anon:1;
+    unsigned int        realm_default_referral_realm_valid:1;
+    unsigned int        realm_cross_realm_default_referral_valid:1;
     unsigned int        realm_kadmind_port_valid:1;
     unsigned int        realm_enctype_valid:1;
     unsigned int        realm_max_life_valid:1;

--- a/src/lib/kadm5/alt_prof.c
+++ b/src/lib/kadm5/alt_prof.c
@@ -1074,6 +1074,21 @@ krb5_read_realm_params(kcontext, realm, rparamp)
             host_based_srvcs = 0;
     }
 
+    /* default referral realm */
+    hierarchy[2] = KRB5_CONF_DEFAULT_REFERRAL_REALM;
+    if (!krb5_aprof_get_string(aprofile, hierarchy, TRUE, &svalue)) {
+        rparams->realm_default_referral_realm = svalue;
+        rparams->realm_default_referral_realm_valid = 1;
+    } else
+        rparams->realm_default_referral_realm = NULL;
+
+    /* cross-realm default referral */
+    hierarchy[2] = KRB5_CONF_CROSS_REALM_DEFAULT_REFERRAL;
+    if (!krb5_aprof_get_boolean(aprofile, hierarchy, TRUE, &bvalue)) {
+        rparams->realm_cross_realm_default_referral = bvalue;
+        rparams->realm_cross_realm_default_referral_valid = 1;
+    }
+
     /* Get the value for the default principal flags */
     hierarchy[2] = KRB5_CONF_DEFAULT_PRINCIPAL_FLAGS;
     if (!krb5_aprof_get_string(aprofile, hierarchy, TRUE, &svalue)) {


### PR DESCRIPTION
FEATURE

Two new realm configuration parameters:
- default_referral_realm (string, default none)
- cross_realm_default_referral (boolean, default false)

If default_referral_realm is set, then the KDC will issue referrals to the
specified realm for TGS requests otherwise qualifying for a referral but
lacking a static realm mapping, as long as the presented TGT is not
cross-realm (setting cross_realm_default_referral omits that check).

RATIONALE

I’ll explain by way of the real motivating situation for us. We have two realms:

  AD: Windows AD
UNIX: MIT Kerberos on Unix

We have two-way trust between these realms, and AD provides referrals to Unix via top-level name translation rules. Our hosts have a mix of realms in the same DNS domains, so static realm-mapping rules don’t work for us; we use _kerberos DNS TXT records for Unix clients to get host realm memberships. Consider the scenario of a client with Unix TGT accessing a Windows-realm service, say an OpenSSH client logging into the Bitvise WinSSHD server.
1. client acquires TGT for user@UNIX -> krbtgt/UNIX@UNIX
2. client correctly identifies the server in the AD realm
3. client obtains a cross-realm ticket krbtgt/AD@UNIX from Unix
4. client uses that to obtain an SSH service ticket host/foo@AD
5. client successfully logs into the SSH server (we use AD altSecurityIdentity attributes to authorize Unix principals to their corresponding AD accounts)

So far, so good. However, the client also requests GSSAPI delegation via SSH. This succeeds, and klist on the Windows side shows a forwarded TGT for krbtgt/AD@UNIX. This TGT works for accessing further Unix-realm services -- but access to AD services fails, even though the analogous situation with a Unix client would succeed.

The reason this fails is that Windows always assumes the realm of the TGT issuer for all requests, and relies on referrals to locate the correct realm if necessary. Say the remote Windows session now wants to access LDAP on a domain controller dc; Windows then queries a Unix KDC for ldap/dc@UNIX (because the TGT was issued by the Unix realm). This fails, because our Unix KDCs do not issue referrals.

The MIT KDC can do referrals, but only for hosts with static realm mappings in krb5.conf. Since in our case the realm mappings are in the DNS, this doesn’t work for us.

My patch allows the KDC to issue referrals to a designated default realm, in our case the AD realm. The trick is to avoid referral loops, and I do that by refusing to issue a default referral if the presented TGT is cross-realm; this indicates that the client has already consulted the other realm, so sending them back again would be pointless.

Certainly, using this feature with more than two realms would be less straightforward, and there are various corner cases to consider. However, I imagine our case may be quite common, and it has proved to solve the problem perfectly for us, so I thought I’d send it along for consideration. Other use cases include Unix clients using delegation to Microsoft SQL Server for “bulk insert” (in which the dataserver accesses a CIFS filesystem using the client’s credentials), and “chained queries” (in which the dataserver issues further queries to other dataservers using the client’s credentials).

Thanks,

Richard E. Silverman
