### PR TITLE
Fix null pointer dereference in pkinit_check_kdc_pkid()

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -3253,7 +3253,7 @@ pkinit_check_kdc_pkid(krb5_context context,
     pkiDebug("found kdcPkId in AS REQ\n");
     is = d2i_PKCS7_ISSUER_AND_SERIAL(NULL, &p, (int)pkid_len);
     if (is == NULL)
-        goto cleanup;
+        return retval;
 
     status = X509_NAME_cmp(X509_get_issuer_name(kdc_cert), is->issuer);
     if (!status) {
@@ -3263,7 +3263,7 @@ pkinit_check_kdc_pkid(krb5_context context,
     }
 
     retval = 0;
-cleanup:
+
     X509_NAME_free(is->issuer);
     ASN1_INTEGER_free(is->serial);
     free(is);


### PR DESCRIPTION
The cleanup code dereferences `is` when `is` is null, such as in `X509_NAME_free(is->issuer)`.  Instead, simply return in that case.
