### PR TITLE
Fix faulty hostname canonicalization #if defined(COPY_FIRST_CANONNAME)

### DIFF
--- a/src/util/support/fake-addrinfo.c
+++ b/src/util/support/fake-addrinfo.c
@@ -1242,19 +1242,19 @@ getaddrinfo (const char *name, const char *serv, const struct addrinfo *hint,
                 ai->ai_canonname = 0;
             name2 = ai->ai_canonname ? ai->ai_canonname : name;
         } else {
-            /* Sometimes gethostbyname will be directed to /etc/hosts
-               first, and sometimes that file will have entries with
-               the unqualified name first.  So take the first entry
-               that looks like it could be a FQDN.  */
-            for (i = 0; hp->h_aliases[i]; i++) {
-                if (strchr(hp->h_aliases[i], '.') != 0) {
-                    name2 = hp->h_aliases[i];
+            /*
+             * Sometimes gethostbyname will be directed to /etc/hosts
+             * first, and sometimes that file will have entries with
+             * the unqualified name first.  So take the first entry
+             * that looks like it could be a FQDN. Starting with h_name
+             * and then all the aliases.
+             */
+            for (i = 0, name2 = hp->h_name; name2; i++) {
+                if (strchr(name2, '.') != 0)
                     break;
-                }
+                name2 = hp->h_aliases[i];
             }
-            /* Give up, just use the first name (h_name ==
-               h_aliases[0] on all systems I've seen).  */
-            if (hp->h_aliases[i] == 0)
+            if (name2 == 0)
                 name2 = hp->h_name;
         }
 


### PR DESCRIPTION
On Linux systems with an old GLIBC and also on AIX, the macro
COPY_FIRST_CANONNAME is defined src/util/support/fake-addrinfo.c.
With this macro defined, the ai_canonname field in the result of
getaddrinfo() was originally replaced by the first plausible FQDN
in h_aliases[] from gethostbyname().  The author's comment was:

```
/* ... (h_name == h_aliases[0] on all systems I've seen) ... */
```

Unfortunately, this is not only not documented, but in fact not true on
NetBSD 5, MacOSX Mountain Lion, Ubuntu Karmic, Debian 7.0 (wheezy), ...
(It is hard to image this was ever true on any platform, but perhaps
the author was unlucky enough to have found some.) On all the above,
the primary host name in h_name is NOT also listed in h_aliases[], which
contains only additional names.

The solution is to start with h_name and only then look at aliases,
stopping at the first name that is a plausible FQDN (contains a
'.').
