### PR TITLE
Add -e enctype option to k5srvutil

### DIFF
--- a/doc/admin/admin_commands/k5srvutil.rst
+++ b/doc/admin/admin_commands/k5srvutil.rst
@@ -9,6 +9,7 @@ SYNOPSIS
 **k5srvutil** *operation*
 [**-i**]
 [**-f** *filename*]
+[**-e** *keysalts*]
 
 DESCRIPTION
 -----------
@@ -31,7 +32,9 @@ a keytab or to add new keys to the keytab.
     existing tickets continue to work.  If the **-i** flag is given,
     k5srvutil will prompt for confirmation before changing each key.
     If the **-k** option is given, the old and new keys will be
-    displayed.
+    displayed.  Ordinarily, keys will be generated with the default
+    encryption types and key salts.  This can be overridden with the
+    **-e** option.
 
 **delold**
     Deletes keys that are not the most recent version from the keytab.

--- a/src/kadmin/cli/k5srvutil.sh
+++ b/src/kadmin/cli/k5srvutil.sh
@@ -38,7 +38,7 @@ cmd_error() {
     }
 
 usage() {
-    echo "Usage: $0 [-i] [-f file] list|change|delete|delold"
+    echo "Usage: $0 [-i] [-f file] [-e keysalts] list|change|delete|delold"
 }
 
 
@@ -47,7 +47,7 @@ change_key() {
     princs=`list_princs `
     for princ in $princs; do
 	if interactive_prompt "Change key " $princ; then
-	    kadmin -k -t $keytab -p $princ -q "ktadd -k $keytab $princ"
+	    kadmin -k -t $keytab -p $princ -q "ktadd -k $keytab $keysalts $princ"
 	fi
     done
     }
@@ -74,6 +74,7 @@ delete_keys() {
 
 keytab=/etc/krb5.keytab
 interactive=0
+keysalts=""
 
 while [ $# -gt 0 ] ; do
     opt=$1
@@ -85,6 +86,10 @@ while [ $# -gt 0 ] ; do
 	;;
 	"-i")
 	interactive=1
+	;;
+	"-e")
+	keysalts="$keysalts -e $1"
+	shift
 	;;
 	change|delold|delete|list)
 	set_command $opt


### PR DESCRIPTION
k5srvutil is a little more convenient to use for rolling keys than kadmin is.
When migrating off 1DES, though, it may be desirable to explicitly specify the
desired enctypes. This adds an option, -e, to k5srvutil to specify desired
enctypes.
