### PR TITLE
Use dns_* interfaces on Apple platforms

### DIFF
--- a/src/lib/krb5/os/dnsglue.h
+++ b/src/lib/krb5/os/dnsglue.h
@@ -60,6 +60,10 @@
 #include <netdb.h>
 #endif /* WSHELPER */
 
+#if defined(__APPLE__)
+#include <dns.h>
+#endif
+
 #if HAVE_SYS_PARAM_H
 #include <sys/param.h>          /* for MAXHOSTNAMELEN */
 #endif


### PR DESCRIPTION
On Apple platforms, DNS resolution through libresolv behaves
differently depending on whether one uses the standard interfaces
(res__) or Apple's "super resolver" interfaces (dns__) that can access
the entire DNS resolver stack known to the system. Frequently, VPN
software that registers with mDNSResponder will only resolve queries
made to the latter. Using the res_\* interfaces in such cases will lead
to service discovery failures.
