### PR TITLE
Don't fail init due to EACCES on krb5.conf

### DIFF
--- a/src/lib/krb5/os/init_os_ctx.c
+++ b/src/lib/krb5/os/init_os_ctx.c
@@ -393,7 +393,7 @@ os_init_paths(krb5_context ctx, krb5_boolean kdc)
 
 #ifdef KRB5_DNS_LOOKUP
         /* if none of the filenames can be opened use an empty profile */
-        if (retval == ENOENT) {
+        if (retval == ENOENT || retval == EACCES || retval == EPERM) {
             retval = profile_init(NULL, &ctx->profile);
             if (!retval)
                 ctx->profile_in_memory = 1;


### PR DESCRIPTION
When DNS service discovery is enabled, we tolerate missing krb5.conf
files gracefully, but only when they don't exist (i.e.,
profile_init_flags returns ENOENT). If one of the possible
configuration files or a parent directory is inaccessible due to
insufficient permissions, however, we fail library initialization.
This patch gracefully falls back on DNS discovery in the EACCES and
EPERM case.
