### PR TITLE
Catch more strtol() failures when using KEYRINGs

### DIFF
--- a/src/lib/krb5/ccache/cc_keyring.c
+++ b/src/lib/krb5/ccache/cc_keyring.c
@@ -593,7 +593,7 @@ get_collection(const char *anchor_name, const char *collection_name,
 {
     krb5_error_code ret;
     key_serial_t persistent_id, anchor_id, possess_id = 0;
-    char *ckname;
+    char *ckname, *cnend;
     long uidnum;
 
     *collection_id_out = 0;
@@ -607,8 +607,8 @@ get_collection(const char *anchor_name, const char *collection_name,
          */
         if (*collection_name != '\0') {
             errno = 0;
-            uidnum = strtol(collection_name, NULL, 10);
-            if (errno)
+            uidnum = strtol(collection_name, &cnend, 10);
+            if (errno || *cnend != '\0')
                 return KRB5_KCC_INVALID_UID;
         } else {
             uidnum = geteuid();


### PR DESCRIPTION
When parsing what should be a UID while resolving a KEYRING ccache name, don't just depend on strtol() to set errno when the residual that we pass to it can't be parsed as a number.  In addition to checking errno, pass in and check the value of an "endptr".

On our testing systems, we've been seeing "KEYRING:persistent:root" being accepted as a name (attempted because the reporter had set default_ccache_name to "KEYRING:persistent:%{username}") when it shouldn't be, as reported in https://bugzilla.redhat.com/show_bug.cgi?id=1029110
