### PR TITLE
Fix segv in krb5_copy_context. 

### DIFF
--- a/src/lib/krb5/krb/copy_ctx.c
+++ b/src/lib/krb5/krb/copy_ctx.c
@@ -85,12 +85,16 @@ krb5_copy_context(krb5_context ctx, krb5_context *nctx_out)
 
     memset(&nctx->err, 0, sizeof(nctx->err));
 
-    ret = k5_copy_etypes(ctx->in_tkt_etypes, &nctx->in_tkt_etypes);
-    if (ret)
-        goto errout;
-    ret = k5_copy_etypes(ctx->tgs_etypes, &nctx->tgs_etypes);
-    if (ret)
-        goto errout;
+    if (ctx->in_tkt_etypes != NULL) {
+        ret = k5_copy_etypes(ctx->in_tkt_etypes, &nctx->in_tkt_etypes);
+        if (ret)
+            goto errout;
+    }
+    if (ctx->tgs_etypes != NULL) {
+        ret = k5_copy_etypes(ctx->tgs_etypes, &nctx->tgs_etypes);
+        if (ret)
+            goto errout;
+    }
 
     if (ctx->os_context.default_ccname != NULL) {
         nctx->os_context.default_ccname =


### PR DESCRIPTION
Should check that ctx->in_tkt_etypes and ctx->tgs_etypes are not NULL before calling k5_copy_types.

k5_copy_types doesn't check whether *old_list is NULL, calls k5_count_types which then attempts to dereference elements in the NULL pointer and unsurprisingly segfaults.
