### PR TITLE
ctx->plugin_base_dir is freed in krb5_free_context, but not strduped by ...

### DIFF
--- a/src/lib/krb5/krb/copy_ctx.c
+++ b/src/lib/krb5/krb/copy_ctx.c
@@ -92,6 +92,14 @@ krb5_copy_context(krb5_context ctx, krb5_context *nctx_out)
     if (ret)
         goto errout;
 
+    if (ctx->plugin_base_dir != NULL) {
+        nctx->plugin_base_dir = strdup(ctx->plugin_base_dir);
+        if (nctx->plugin_base_dir == NULL) {
+            ret = ENOMEM;
+            goto errout;
+        }
+    }
+
     if (ctx->os_context.default_ccname != NULL) {
         nctx->os_context.default_ccname =
             strdup(ctx->os_context.default_ccname);


### PR DESCRIPTION
...krb5_copy_context.

This results in double free when the original and cloned contexts are both freed.
