### PR TITLE
Make KDC "status" statements more homogeneous

### DIFF
--- a/src/kdc/do_tgs_req.c
+++ b/src/kdc/do_tgs_req.c
@@ -209,7 +209,7 @@ process_tgs_req(struct server_handle *handle, krb5_data *pkt,
     /* Reset sprinc because kdc_find_fast() can replace request. */
     sprinc = request->server;
     if (errcode !=0) {
-        status = "kdc_find_fast";
+        status = "FIND_FAST";
         goto cleanup;
     }
 
@@ -639,7 +639,7 @@ process_tgs_req(struct server_handle *handle, krb5_data *pkt,
         /* assemble new transited field into allocated storage */
         if (header_enc_tkt->transited.tr_type !=
             KRB5_DOMAIN_X500_COMPRESS) {
-            status = "BAD_TRTYPE";
+            status = "VALIDATE_TRANSIT_TYPE";
             errcode = KRB5KDC_ERR_TRTYPE_NOSUPP;
             goto cleanup;
         }
@@ -651,7 +651,7 @@ process_tgs_req(struct server_handle *handle, krb5_data *pkt,
                               header_ticket->server,
                               enc_tkt_reply.client,
                               request->server))) {
-            status = "ADD_TR_FAIL";
+            status = "ADD_TO_TRANSITED_LIST";
             goto cleanup;
         }
         newtransited = 1;
@@ -722,7 +722,7 @@ process_tgs_req(struct server_handle *handle, krb5_data *pkt,
     if (!isflagset(request->kdc_options, KDC_OPT_ENC_TKT_IN_SKEY))
         krb5_free_keyblock_contents(kdc_context, &encrypting_key);
     if (errcode) {
-        status = "TKT_ENCRYPT";
+        status = "ENCRYPT_TICKET";
         goto cleanup;
     }
     ticket_reply.enc_part.kvno = ticket_kvno;
@@ -739,7 +739,7 @@ process_tgs_req(struct server_handle *handle, krb5_data *pkt,
                                         &reply,
                                         &reply_encpart);
         if (errcode) {
-            status = "KDC_RETURN_S4U2SELF_PADATA";
+            status = "MAKE_S4U2SELF_PADATA";
             au_state->status = status;
         }
         kau_s4u2self(kdc_context, errcode ? FALSE : TRUE, au_state);
@@ -779,13 +779,13 @@ process_tgs_req(struct server_handle *handle, krb5_data *pkt,
     errcode  = kdc_fast_response_handle_padata(state, request, &reply,
                                                subkey ? subkey->enctype : header_ticket->enc_part2->session->enctype);
     if (errcode !=0 ) {
-        status = "Preparing FAST padata";
+        status = "MAKE_FAST_RESPONSE";
         goto cleanup;
     }
     errcode =kdc_fast_handle_reply_key(state,
                                        subkey?subkey:header_ticket->enc_part2->session, &reply_key);
     if (errcode) {
-        status  = "generating reply key";
+        status  = "MAKE_FAST_REPLY_KEY";
         goto cleanup;
     }
     errcode = return_enc_padata(kdc_context, pkt, request,
@@ -1066,7 +1066,7 @@ gen_session_key(kdc_realm_t *kdc_active_realm, krb5_kdc_req *req,
     retval = krb5_c_make_random_key(kdc_context, useenctype, skey);
     if (retval != 0) {
         /* random key failed */
-        *status = "RANDOM_KEY_FAILED";
+        *status = "MAKE_RANDOM_KEY";
         goto cleanup;
     }
 cleanup:

--- a/src/kdc/kdc_log.c
+++ b/src/kdc/kdc_log.c
@@ -29,6 +29,20 @@
 #include <syslog.h>
 #include "adm_proto.h"
 
+/*
+ * A note on KDC-status string format.
+ *
+ * - All letters in the status string should be capitalized;
+ * - the words in the status phrase are separated by underscores;
+ * - abbreviations should be avoided.  Some acceptable "standard" acronyms
+ *   are AS_REQ, TGS_REP etc.
+ * - since in almost all cases KDC status string is set on error, no need
+ *   to state this fact as part of the status string;
+ * - KDC status string should be an imperative phrase.
+ *
+ * Example: "MAKE_RANDOM_KEY"
+ */
+
 /* Main logging routines for ticket requests.
 
    There are a few simple cases -- unparseable requests mainly --


### PR DESCRIPTION
Generally we want KDC status strings to be concise, informative and follow
some common rules:
- All letters in the status string should be capitalized;
- the words in the status phrase are separated by underscore;
- abbreviations should be avoided.  Some acceptable "standard" acronyms
  are AS_REQ, TGS_REP etc.
- since in almost all cases KDC status is set on error, no need
  to state this fact as part of the status string;
- KDC status string should be an imperative phrase.

For example, "DECRYPT_SERVER_KEY".

This commit is to modify some KDC status messages to follow this format.

Even though KDC status messages are not standardized, it is possible that some
administrators use them in the Kerberos log file processing. Hence, the vast
majority of them are left unchanged pending further investigation (mostly,
feedback from the administrators).
