### PR TITLE
Fix SAM-2 preauth when password argument is used

### DIFF
--- a/src/lib/krb5/krb/preauth_sam2.c
+++ b/src/lib/krb5/krb/preauth_sam2.c
@@ -95,6 +95,7 @@ sam2_process(krb5_context context, krb5_clpreauth_moddata moddata,
     krb5_prompt kprompt;
     krb5_prompt_type prompt_type;
     krb5_data defsalt, *salt;
+    struct gak_password *gakpw;
     krb5_checksum **cksum;
     krb5_data *scratch = NULL;
     krb5_boolean valid_cksum = 0;
@@ -219,9 +220,9 @@ sam2_process(krb5_context context, krb5_clpreauth_moddata moddata,
         }
 
         /* generate a key using the supplied password */
+        gakpw = ctx->gak_data;
         retval = krb5_c_string_to_key(context, sc2b->sam_etype,
-                                      (krb5_data *)ctx->gak_data, salt,
-                                      &ctx->as_key);
+                                      gakpw->password, salt, &ctx->as_key);
 
         if (retval) {
             krb5_free_sam_challenge_2(context, sc2);


### PR DESCRIPTION
sam2_process accesses gak_data to get the password, so that it can do
string-to-key with the etype in the SAM-2 challenge.  When #7642
changed gic_pwd.c to use struct gak_password instead of krb5_data,
sam2_process wasn't altered to match.  We don't see a problem when the
password is read through the prompter (as with kinit), because the
password winds up in the storage field at the beginning of the
gak_password structure.  But when a password is supplied as a
parameter (as with ksu), the storage field is empty and we get the
wrong answer from sam2_process.

ticket: 7862
target_version: 1.12.2
tags: pullup
