### PR TITLE
Don't use system dictionary files for DB2 tests

### DIFF
--- a/src/plugins/kdb/db2/libdb2/test/run.test
+++ b/src/plugins/kdb/db2/libdb2/test/run.test
@@ -15,14 +15,6 @@ main()
 
 	if [ \! -z "$WORDLIST" -a -f "$WORDLIST" ]; then
 		DICT=$WORDLIST
-	elif [ -f /usr/local/lib/dict/words ]; then
-		DICT=/usr/local/lib/dict/words
-	elif [ -f /usr/share/dict/words ]; then
-		DICT=/usr/share/dict/words
-	elif [ -f /usr/dict/words ]; then
-		DICT=/usr/dict/words
-	elif [ -f /usr/share/lib/dict/words ]; then
-		DICT=/usr/share/lib/dict/words
 	elif [ -f $srcdir/../test/dictionary ]; then
 		DICT=`cd $srcdir/../test && pwd`/dictionary
 	else


### PR DESCRIPTION
The system dictionary may contain entries with punctuation, which can
confuse the shell.  It's more predictable to always use the word list
from the source tree.

ticket: 7862
status: open
