### PR TITLE
Update doc build instructions

### DIFF
--- a/doc/README
+++ b/doc/README
@@ -1,25 +1,8 @@
-HTML
-====
+BUILDING
+========
 
-To build the documentation as HTML pages run:
-
-sphinx-build source_dir  destination_dir
-
-where
-source_dir is the source directory which includes configuration file conf.py and all source files;
-destination_dir is the directory for the built documentation.
-
-Once completed, the newly generated HTML documentation can be viewed from the browser by pointing to destination_dir/index.html
-
-
-MAN PAGES
-=========
-
-Similarly, to build the documentation as man pages run:
-
-sphinx-build -b man source_dir  destination_dir
-
-The list of manual pages to be built should be constructed under man_pages section on conf.py
+See doc/build_this.rst for details about how to build the
+documentation.
 
 
 CONVENTIONS

--- a/doc/build_this.rst
+++ b/doc/build_this.rst
@@ -23,7 +23,9 @@ directory::
     sphinx-build . test_html
 
 You will see a number of warnings about missing files.  This is
-expected.
+expected.  If there is not already a ``doc/version.py`` file, you will
+need to create one by first running ``make version.py`` in the
+``src/doc`` directory of a configured build tree.
 
 
 Updating man pages


### PR DESCRIPTION
Documentation build instructions in doc/README were out of date.
Update them.

ticket: 7864 (new)
tags: pullup
target_version: 1.12.1
