### PR TITLE
In kdb5_util dump, only lock DB for iprop dumps

### DIFF
--- a/src/kadmin/dbutil/dump.c
+++ b/src/kadmin/dbutil/dump.c
@@ -1230,7 +1230,7 @@ dump_db(int argc, char **argv)
     kdb_log_context *log_ctx;
     unsigned int ipropx_version = IPROPX_VERSION_0;
     krb5_kvno kt_kvno;
-    krb5_boolean conditional = FALSE;
+    krb5_boolean conditional = FALSE, db_locked = FALSE;
     kdb_last_t last;
 
     /* Parse the arguments. */
@@ -1396,15 +1396,16 @@ dump_db(int argc, char **argv)
     args.dump = dump;
     fprintf(args.ofile, "%s", dump->header);
 
-    /* We grab the lock twice (once again in the iterator call), but that's ok
-     * since krb5_db_lock handles recursive locks. */
-    ret = krb5_db_lock(util_context, KRB5_LOCKMODE_SHARED);
-    if (ret != 0 && ret != KRB5_PLUGIN_OP_NOTSUPP) {
-        fprintf(stderr, _("%s: Couldn't grab lock\n"), progname);
-        goto error;
-    }
-
     if (dump_sno) {
+        /* Make sure the dump reflects the serial number we're recording. */
+        ret = krb5_db_lock(util_context, KRB5_DB_LOCKMODE_SHARED);
+        if (ret == 0) {
+            db_locked = TRUE;
+        } else if (ret != KRB5_PLUGIN_OP_NOTSUPP) {
+            fprintf(stderr, _("%s: Couldn't grab lock\n"), progname);
+            goto error;
+        }
+
         ret = ulog_get_last(util_context, &last);
         if (ret) {
             com_err(progname, ret, _("while reading update log header"));
@@ -1442,7 +1443,8 @@ dump_db(int argc, char **argv)
     return;
 
 error:
-    krb5_db_unlock(util_context);
+    if (db_locked)
+        krb5_db_unlock(util_context);
     if (tmpofile != NULL)
         unlink(tmpofile);
     free(tmpofile);


### PR DESCRIPTION
Revert #7384, as there are no longer policy refcounts.  For iprop
dumps we want to make sure that the reported serial number matches the
DB state (although we could perhaps relax that requirement with enough
analysis), but for non-iprop dumps we don't need any transactional
guarantees.

Also use the correct constant name for the locking mode (the numeric
value is the same, fortunately), and only unlock the database if we
successfully locked it.

ticket: 7869 (new)
