### PR TITLE
Update kadmin set_string document

### DIFF
--- a/doc/admin/admin_commands/kadmin_local.rst
+++ b/doc/admin/admin_commands/kadmin_local.rst
@@ -573,11 +573,12 @@ Alias: **getstr**
 set_string
 ~~~~~~~~~~
 
-    **set_string** *principal* *key* *value*
+    **set_string** *principal* *name* *value*
 
 Sets a string attribute on *principal*.  String attributes are used to
 supply per-principal configuration to the KDC and some KDC plugin
-modules.  The following string attributes are recognized by the KDC:
+modules.  The following string attribute names are recognized by the
+KDC:
 
 **session_enctypes**
     Specifies the encryption types supported for session keys when the
@@ -585,9 +586,21 @@ modules.  The following string attributes are recognized by the KDC:
     :ref:`Encryption_types` in :ref:`kdc.conf(5)` for a list of the
     accepted values.
 
+**otp**
+    Enables One Time Passwords (OTP) preauthentication for a client
+    *principal*.  The *value* is a JSON string representing an array
+    of objects, each having optional ``type`` and ``username`` fields.
+
 This command requires the **modify** privilege.
 
 Alias: **setstr**
+
+Example:
+
+ ::
+
+    set_string host/foo.mit.edu session_enctypes aes128-cts
+    set_string user@FOO.COM otp [{"type":"hotp","username":"custom"}]
 
 .. _set_string_end:
 

--- a/doc/admin/otp.rst
+++ b/doc/admin/otp.rst
@@ -20,8 +20,8 @@ details of authentication.
 Defining token types
 --------------------
 
-Token types are defined in either krb5.conf or kdc.conf according to
-the following format::
+Token types are defined in either :ref:`krb5.conf(5)` or
+:ref:`kdc.conf(5)` according to the following format::
 
     [otp]
         <name> = {
@@ -63,8 +63,11 @@ Token instance configuration
 ----------------------------
 
 To enable OTP for a client principal, the administrator must define
-the **otp** string attribute for that principal.  The **otp** user
-string is a JSON string of the format::
+the **otp** string attribute for that principal.  (See
+:ref:`set_string`.)  The **otp** user string is a JSON string of the
+format:
+
+.. code-block:: xml
 
     [{
         "type": <string>,


### PR DESCRIPTION
Added 'otp' as an acceptable attribute name. Added examples.
Also, x-ref kadmin document from otp.
