### PR TITLE
Fix two omissions in stdint.h changes

### DIFF
--- a/src/lib/gssapi/generic/gssapi.hin
+++ b/src/lib/gssapi/generic/gssapi.hin
@@ -52,6 +52,8 @@ extern "C" {
 #define KRB5_CALLCONV_C
 #endif
 
+#include <stdint.h>
+
 /*
  * First, include stddef.h to get size_t defined.
  */

--- a/src/util/gss-kernel-lib/Makefile.in
+++ b/src/util/gss-kernel-lib/Makefile.in
@@ -146,8 +146,8 @@ gssapi.h: $(INCLUDE)/gssapi.h
 	$(CP) $(INCLUDE)/gssapi.h $@
 gssapi/gssapi.h: gssapi $(GSS_GENERIC_BUILD)/gssapi.h
 	$(CP) $(GSS_GENERIC_BUILD)/gssapi.h $@
-gssapi/gssapi_krb5.h: gssapi $(GSS_KRB5_BUILD)/gssapi_krb5.h
-	$(CP) $(GSS_KRB5_BUILD)/gssapi_krb5.h $@
+gssapi/gssapi_krb5.h: gssapi $(GSS_KRB5)/gssapi_krb5.h
+	$(CP) $(GSS_KRB5)/gssapi_krb5.h $@
 gssapi/gssapi_alloc.h: gssapi $(GSS_GENERIC)/gssapi_alloc.h
 	$(CP) $(GSS_GENERIC)/gssapi_alloc.h $@
 gssapi/gssapi_ext.h: gssapi $(GSS_GENERIC)/gssapi_ext.h
@@ -209,8 +209,6 @@ $(GSS_GENERIC_BUILD)/gssapi.h:
 	(cd $(GSS_GENERIC_BUILD) && $(MAKE) gssapi.h)
 $(GSS_GENERIC_BUILD)/gssapi_err_generic.h:
 	(cd $(GSS_GENERIC_BUILD) && $(MAKE) gssapi_err_generic.h)
-$(GSS_KRB5_BUILD)/gssapi_krb5.h:
-	(cd $(GSS_KRB5_BUILD) && $(MAKE) gssapi_krb5.h)
 $(GSS_KRB5_BUILD)/gssapi_err_krb5.h:
 	(cd $(GSS_KRB5_BUILD) && $(MAKE) gssapi_err_krb5.h)
 $(INCLUDE_BUILD)/osconf.h:


### PR DESCRIPTION
Since we no longer prefix an "#include <stdint.h>" in the gssapi.h
preamble at build time, include it in gssapi.hin.

Update util/gss/kernel-lib/Makefile.in to account for gssapi_krb5.h
being in the source tree.
