### PR TITLE
Admin doc corrections with `kdb5_util load`

### DIFF
--- a/doc/admin/admin_commands/kdb5_util.rst
+++ b/doc/admin/admin_commands/kdb5_util.rst
@@ -204,7 +204,8 @@ Options:
 
 **-b7**
     requires the database to be in the Kerberos 5 Beta 7 format
-    ("kdb5_util load_dump version 4").
+    ("kdb5_util load_dump version 4").  This was the dump format
+    produced on releases prior to 1.2.2.
 
 **-ov**
     requires the database to be in "ovsec_adm_import" format.  Must be
@@ -234,7 +235,7 @@ Options:
     records from the dump file are added to or updated in the existing
     database.  (This is useful in conjunction with an ovsec_adm_export
     format dump if you want to preserve per-principal policy
-    information, since the current default format does not contain
+    information with default formats prior to -r13 as they do not contain
     this data.)  Otherwise, a new database is created containing only
     what is in the dump file and the old one destroyed upon successful
     completion.


### PR DESCRIPTION
Revised the example usage purpose statement for invoking `kdb5_util load -update` to clarify that loading a second dump made via -ov switch was no longer necessary since the -r13 format became the default.  -b7 applied to versions prior to 1.2.2.
