### PR TITLE
Fix install rule for gssapi_krb5.h

### DIFF
--- a/src/lib/gssapi/krb5/Makefile.in
+++ b/src/lib/gssapi/krb5/Makefile.in
@@ -247,7 +247,7 @@ generate-files-mac: gssapi_krb5.h error_map.h
 
 install-headers-unix install::
 	@set -x; for f in $(EXPORTED_HEADERS) ; \
-	do $(INSTALL_DATA) $$f	\
+	do $(INSTALL_DATA) $(srcdir)/$$f	\
 		$(DESTDIR)$(KRB5_INCDIR)/gssapi/$$f ; \
 	done
 


### PR DESCRIPTION
Revert r16428 now that gssapi_krb5.h is in the source tree.
