### PR TITLE
Conditionalize use of LDAP_OPT_DEBUG_LEVEL

### DIFF
--- a/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap_conn.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap_conn.c
@@ -154,7 +154,9 @@ krb5_ldap_db_init(krb5_context context, krb5_ldap_context *ldap_context)
     if ((st=krb5_validate_ldap_context(context, ldap_context)) != 0)
         return st;
 
+#ifdef LDAP_OPT_DEBUG_LEVEL
     ldap_set_option(NULL, LDAP_OPT_DEBUG_LEVEL, &ldap_context->ldap_debug);
+#endif
     ldap_set_option(NULL, LDAP_OPT_PROTOCOL_VERSION, &version);
 #ifdef LDAP_OPT_NETWORK_TIMEOUT
     ldap_set_option(NULL, LDAP_OPT_NETWORK_TIMEOUT, &local_timelimit);


### PR DESCRIPTION
Conversation with Will suggests that we should try to use the OpenLDAP library on Solaris by default.  But I still want this patch since someone might prefer to use the native LDAP library for whatever reason, and because the configure goo for finding OpenLDAP on Solaris might not get written for a while.
