### PR TITLE
Fix clean-unix rule for gssapi_krb5.h

### DIFF
--- a/src/lib/gssapi/krb5/Makefile.in
+++ b/src/lib/gssapi/krb5/Makefile.in
@@ -232,7 +232,7 @@ error_map.h: $(top_srcdir)/util/gen-map.pl \
 
 clean-unix::
 	$(RM) $(BUILDTOP)/include/gssapi/gssapi_krb5.h
-	-$(RM) gssapi_krb5.h error_map.h
+	-$(RM) error_map.h
 
 clean-unix:: clean-libobjs
 	$(RM) $(ETHDRS) $(ETSRCS)


### PR DESCRIPTION
Don't delete gssapi_krb5.h now that it is not generated.
