### PR TITLE
Update iprop_master_ulogsize documentation

### DIFF
--- a/doc/admin/conf_files/kdc_conf.rst
+++ b/doc/admin/conf_files/kdc_conf.rst
@@ -202,8 +202,8 @@ The following tags may be specified in a [realms] subsection:
 
 **iprop_master_ulogsize**
     (Integer.)  Specifies the maximum number of log entries to be
-    retained for incremental propagation.  The maximum value is 2500;
-    the default value is 1000.
+    retained for incremental propagation.  The default value is 1000.
+    Prior to release 1.11, the maximum value was 2500.
 
 **iprop_slave_poll**
     (Delta time string.)  Specifies how often the slave KDC polls for


### PR DESCRIPTION
When we removed the maximum number of ulog entries (#7368), we did not
update the documentation for that parameter in kdc.conf.  Reported by
Richard Basch.

ticket: 7849
target_version: 1.12.2
tags: pullup
