### PR TITLE
g_order_check() fails iff first token arrives out-of-order

### DIFF
--- a/src/lib/gssapi/generic/util_ordering.c
+++ b/src/lib/gssapi/generic/util_ordering.c
@@ -195,6 +195,21 @@ g_order_check(void **vqueue, uint64_t seqnum)
                     return(GSS_S_UNSEQ_TOKEN);
             }
         }
+        /*
+         * Exception: if first token arrived out-of-order.
+         * In that case first two elements in queue are 0xFFFFFFFF and some k,
+         * where k > seqnum. We need to insert seqnum before k.
+         * We check this after the for-loop, because this should be rare.
+         */
+        if ((QELEM(q, q->start) == (((uint64_t)0 - 1) & q->mask)) &&
+            ((QELEM(q, q->start + 1) > seqnum))) {
+                queue_insert(q, q->start, seqnum);
+                if (q->do_replay && !q->do_sequence)
+                    return(GSS_S_COMPLETE);
+                else
+                    return(GSS_S_UNSEQ_TOKEN);
+
+        }
     }
 
     /* this should never happen */


### PR DESCRIPTION
After the queue was re-written to store deltas from firstnum, the first
(dummy) element was changed from firstnum-1 to (-1 & mask). Now, when the
firstnum arrives out of order, it should be inserted between the
dummy element and the element that arrived first. But its delta from
firstnum is zero, which is not greater that the value of dummy element
(all ones binary). It doesn't fit in any other place in the queue
either, and g_order_check returns GSS_S_FAILURE, which (according to the
comment) should never happen.

To reproduce:     2 - 1 - 3
Expected outcome: GSS_S_GAP_TOKEN, GSS_S_UNSEQ_TOKEN, GSS_S_COMPLETE
Actual outcome:   GSS_S_GAP_TOKEN, GSS_S_FAILURE, GSS_S_COMPLETE
