### PR TITLE
Handlers won't take care of initializing 'err' if they're not called

### DIFF
--- a/src/lib/krb5/os/sendto_kdc.c
+++ b/src/lib/krb5/os/sendto_kdc.c
@@ -166,7 +166,7 @@ krb5_sendto_kdc(krb5_context context, const krb5_data *message,
                 const krb5_data *realm, krb5_data *reply, int *use_master,
                 int tcp_only)
 {
-    krb5_error_code retval, err;
+    krb5_error_code retval, err = 0;
     struct serverlist servers;
     int socktype1 = 0, socktype2 = 0, server_used;
 


### PR DESCRIPTION
We can get an KRB5_KDC_UNREACH error back without processing a server reply first, so we should go ahead and initialize 'err' so that it can't be uninitialized if k5_sendto() returns KRB5_KDC_UNREACH.
