### PR TITLE
Check for not having found an entry properly

### DIFF
--- a/src/kdc/do_tgs_req.c
+++ b/src/kdc/do_tgs_req.c
@@ -1117,7 +1117,7 @@ find_alternate_tgs(kdc_realm_t *kdc_active_realm, krb5_principal princ,
         goto cleanup;
     }
 cleanup:
-    if (retval == 0 && server_ptr == NULL)
+    if (retval == 0 && *server_ptr == NULL)
         retval = KRB5_KDB_NOENTRY;
     if (retval != 0)
         *status = "UNKNOWN_SERVER";


### PR DESCRIPTION
Return KRB5_KDB_NOENTRY if we failed to set a return entry, rather than if the destination pointer for it is NULL.
