### PR TITLE
Mention k5login_authoritative in k5login docs

### DIFF
--- a/doc/user/user_config/k5login.rst
+++ b/doc/user/user_config/k5login.rst
@@ -18,7 +18,7 @@ EXAMPLES
 --------
 
 Suppose the user ``alice`` had a .k5login file in her home directory
-containing the following line:
+containing just the following line:
 
  ::
 
@@ -26,7 +26,12 @@ containing the following line:
 
 This would allow ``bob`` to use Kerberos network applications, such as
 ssh(1), to access ``alice``'s account, using ``bob``'s Kerberos
-tickets.
+tickets.  In a default configuration (with **k5login_authoritative** set
+to true in :ref:`krb5.conf(5)`), this .k5login file would not let
+``alice`` use those network applications to access her account, since
+she is not listed!  With no .k5login file, or with **k5login_authoritative**
+set to false, a default rule would permit the principal ``alice`` in the
+machine's default realm to access the ``alice`` account.
 
 Let us further suppose that ``alice`` is a system administrator.
 Alice and the other system administrators would have their principals


### PR DESCRIPTION
In particular, it is set by default.  This can lead to confusing
behavior wherein adding a k5login file removes a user's remote
access.

Make an example more concrete to account for this case.
