### PR TITLE
PKINIT memory handling fix and improvements

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit.h
+++ b/src/plugins/preauth/pkinit/pkinit.h
@@ -340,8 +340,6 @@ void init_krb5_pa_pk_as_req_draft9(krb5_pa_pk_as_req_draft9 **in);
 void init_krb5_reply_key_pack(krb5_reply_key_pack **in);
 void init_krb5_reply_key_pack_draft9(krb5_reply_key_pack_draft9 **in);
 
-void init_krb5_auth_pack(krb5_auth_pack **in);
-void init_krb5_auth_pack_draft9(krb5_auth_pack_draft9 **in);
 void init_krb5_pa_pk_as_rep(krb5_pa_pk_as_rep **in);
 void init_krb5_pa_pk_as_rep_draft9(krb5_pa_pk_as_rep_draft9 **in);
 void init_krb5_subject_pk_info(krb5_subject_pk_info **in);

--- a/src/plugins/preauth/pkinit/pkinit_lib.c
+++ b/src/plugins/preauth/pkinit/pkinit_lib.c
@@ -302,27 +302,6 @@ init_krb5_reply_key_pack_draft9(krb5_reply_key_pack_draft9 **in)
 }
 
 void
-init_krb5_auth_pack(krb5_auth_pack **in)
-{
-    (*in) = malloc(sizeof(krb5_auth_pack));
-    if ((*in) == NULL) return;
-    (*in)->clientPublicValue = NULL;
-    (*in)->supportedCMSTypes = NULL;
-    (*in)->clientDHNonce.length = 0;
-    (*in)->clientDHNonce.data = NULL;
-    (*in)->pkAuthenticator.paChecksum.contents = NULL;
-    (*in)->supportedKDFs = NULL;
-}
-
-void
-init_krb5_auth_pack_draft9(krb5_auth_pack_draft9 **in)
-{
-    (*in) = malloc(sizeof(krb5_auth_pack_draft9));
-    if ((*in) == NULL) return;
-    (*in)->clientPublicValue = NULL;
-}
-
-void
 init_krb5_pa_pk_as_rep(krb5_pa_pk_as_rep **in)
 {
     (*in) = malloc(sizeof(krb5_pa_pk_as_rep));


### PR DESCRIPTION
This branch includes one commit to fix an unlikely double-free in the PKINIT client code, and another commit to improve the memory-handling practices of pkinit_as_req_create and pa_pkinit_gen_req.
