### PR TITLE
Make use of strtoul() unconditional in locate_kdc

### DIFF
--- a/src/lib/krb5/os/locate_kdc.c
+++ b/src/lib/krb5/os/locate_kdc.c
@@ -217,14 +217,10 @@ locate_srv_conf_1(krb5_context context, const krb5_data *realm,
 
         if (port) {
             unsigned long l;
-#ifdef HAVE_STROUL
             char *endptr;
             l = strtoul (port, &endptr, 10);
             if (endptr == NULL || *endptr != 0)
                 return EINVAL;
-#else
-            l = atoi (port);
-#endif
             /* L is unsigned, don't need to check <0.  */
             if (l > 65535)
                 return EINVAL;


### PR DESCRIPTION
When parsing port numbers, we previously attempted to conditionalize use
of strtoul() on whether or not it was available, falling back to atoi()
instead, but we did so in a way that would always fall back to using
atoi().  We also call strtoul() from elsewhere without that condition,
so we don't gain anything by trying to be careful about it here.
