### PR TITLE
Fix a harmless DNS glue macro bug

### DIFF
--- a/src/lib/krb5/os/dnsglue.h
+++ b/src/lib/krb5/os/dnsglue.h
@@ -141,9 +141,9 @@
 #define SAFE_GETUINT16(base, max, ptr, incr, s, label)  \
     do {                                                \
         if (!INCR_OK(base, max, ptr, incr)) goto label; \
-        (s) = (unsigned short)(p)[0] << 8               \
-            | (unsigned short)(p)[1];                   \
-        (p) += (incr);                                  \
+        (s) = (unsigned short)(ptr)[0] << 8             \
+            | (unsigned short)(ptr)[1];                 \
+        (ptr) += (incr);                                \
     } while (0)
 
 struct krb5int_dns_state;


### PR DESCRIPTION
The definition of SAFE_GETUINT16 mistakenly uses "p" instead its ptr
parameter in three places, which happens to work because all current
invocations of the macro use "p" as the ptr argument.  Fix it to
correctly use the ptr parameter.

[ghudson@mit.edu: commit message]

ticket: 6845
