### PR TITLE
Improve salt type display in kadmin getprinc

### DIFF
--- a/doc/admin/admin_commands/kadmin_local.rst
+++ b/doc/admin/admin_commands/kadmin_local.rst
@@ -508,8 +508,8 @@ Examples:
     Last failed authentication: [never]
     Failed password attempts: 0
     Number of keys: 2
-    Key: vno 1, des-cbc-crc, no salt
-    Key: vno 1, des-cbc-crc, Version 4
+    Key: vno 1, des-cbc-crc
+    Key: vno 1, des-cbc-crc:v4
     Attributes:
     Policy: [none]
 

--- a/doc/admin/advanced/retiring-des.rst
+++ b/doc/admin/advanced/retiring-des.rst
@@ -91,17 +91,17 @@ and the database entries for some "high-value" principals were:
     [root@casio krb5kdc]# kadmin.local -r ZONE.MIT.EDU -q 'getprinc krbtgt/ZONE.MIT.EDU'
     [...]
     Number of keys: 1
-    Key: vno 1, des-cbc-crc, Version 4
+    Key: vno 1, des-cbc-crc:v4
     [...]
     [root@casio krb5kdc]# kadmin.local -r ZONE.MIT.EDU -q 'getprinc kadmin/admin'
     [...]
     Number of keys: 1
-    Key: vno 15, des-cbc-crc, no salt
+    Key: vno 15, des-cbc-crc
     [...]
     [root@casio krb5kdc]# kadmin.local -r ZONE.MIT.EDU -q 'getprinc kadmin/changepw'
     [...]
     Number of keys: 1
-    Key: vno 14, des-cbc-crc, no salt
+    Key: vno 14, des-cbc-crc
     [...]
 
 The ``krbtgt/REALM`` key appears to have never been changed since creation
@@ -162,11 +162,11 @@ After the change, the database entry is now:
     [root@casio krb5kdc]# kadmin.local -r ZONE.MIT.EDU -q 'getprinc krbtgt/ZONE.MIT.EDU'
     [...]
     Number of keys: 5
-    Key: vno 2, aes256-cts-hmac-sha1-96, no salt
-    Key: vno 2, aes128-cts-hmac-sha1-96, no salt
-    Key: vno 2, des3-cbc-sha1, no salt
-    Key: vno 2, des-cbc-crc, no salt
-    Key: vno 1, des-cbc-crc, Version 4
+    Key: vno 2, aes256-cts-hmac-sha1-96
+    Key: vno 2, aes128-cts-hmac-sha1-96
+    Key: vno 2, des3-cbc-sha1
+    Key: vno 2, des-cbc-crc
+    Key: vno 1, des-cbc-crc:v4
     [...]
 
 Since the expected disruptions from rekeying the krbtgt principal are
@@ -357,9 +357,9 @@ generate DES keys by default.
     contents-vnder-pressvre:~> kadmin -r ZONE.MIT.EDU -q 'getprinc zonetest'
     [...]
     Number of keys: 3
-    Key: vno 9, aes256-cts-hmac-sha1-96, no salt
-    Key: vno 9, aes128-cts-hmac-sha1-96, no salt
-    Key: vno 9, des3-cbc-sha1, no salt
+    Key: vno 9, aes256-cts-hmac-sha1-96
+    Key: vno 9, aes128-cts-hmac-sha1-96
+    Key: vno 9, des3-cbc-sha1
     [...]
 
     [kaduk@glossolalia ~]$ kadmin -p kaduk@ZONE.MIT.EDU -r ZONE.MIT.EDU -k \

--- a/src/kadmin/cli/kadmin.c
+++ b/src/kadmin/cli/kadmin.c
@@ -1445,15 +1445,16 @@ kadmin_getprinc(int argc, char *argv[])
                                      enctype, sizeof(enctype)))
                 snprintf(enctype, sizeof(enctype), _("<Encryption type 0x%x>"),
                          key_data->key_data_type[0]);
-            printf("Key: vno %d, %s, ", key_data->key_data_kvno, enctype);
-            if (key_data->key_data_ver > 1) {
+            printf("Key: vno %d, %s", key_data->key_data_kvno, enctype);
+            if (key_data->key_data_ver > 1 &&
+                key_data->key_data_type[1] != KRB5_KDB_SALTTYPE_NORMAL) {
                 if (krb5_salttype_to_string(key_data->key_data_type[1],
                                             salttype, sizeof(salttype)))
                     snprintf(salttype, sizeof(salttype), _("<Salt type 0x%x>"),
                              key_data->key_data_type[1]);
-                printf("%s\n", salttype);
-            } else
-                printf(_("no salt\n"));
+                printf(":%s", salttype);
+            }
+            printf("\n");
         }
         printf(_("MKey: vno %d\n"), dprinc.mkvno);
 

--- a/src/lib/krb5/krb/str_conv.c
+++ b/src/lib/krb5/krb/str_conv.c
@@ -50,9 +50,8 @@
  * Local data structures.
  */
 struct salttype_lookup_entry {
-    krb5_int32          stt_enctype;            /* Salt type            */
-    const char *        stt_specifier;          /* How to recognize it  */
-    const char *        stt_output;             /* How to spit it out   */
+    krb5_int32          stt_enctype;            /* Salt type number */
+    const char *        stt_name;               /* Salt type name */
 };
 
 /*
@@ -61,14 +60,12 @@ struct salttype_lookup_entry {
 
 #include "kdb.h"
 static const struct salttype_lookup_entry salttype_table[] = {
-/* salt type                    input specifier output string  */
-/*----------------------------- --------------- ---------------*/
-    { KRB5_KDB_SALTTYPE_NORMAL,     "normal",       "Version 5"       },
-    { KRB5_KDB_SALTTYPE_V4,         "v4",           "Version 4"       },
-    { KRB5_KDB_SALTTYPE_NOREALM,    "norealm",      "Version 5 - No Realm" },
-    { KRB5_KDB_SALTTYPE_ONLYREALM,  "onlyrealm",    "Version 5 - Realm Only" },
-    { KRB5_KDB_SALTTYPE_SPECIAL,    "special",      "Special" },
-    { KRB5_KDB_SALTTYPE_AFS3,       "afs3",         "AFS version 3"    },
+    { KRB5_KDB_SALTTYPE_NORMAL,     "normal"     },
+    { KRB5_KDB_SALTTYPE_V4,         "v4",        },
+    { KRB5_KDB_SALTTYPE_NOREALM,    "norealm",   },
+    { KRB5_KDB_SALTTYPE_ONLYREALM,  "onlyrealm", },
+    { KRB5_KDB_SALTTYPE_SPECIAL,    "special",   },
+    { KRB5_KDB_SALTTYPE_AFS3,       "afs3",      },
 };
 static const int salttype_table_nents = sizeof(salttype_table)/
     sizeof(salttype_table[0]);
@@ -81,7 +78,7 @@ krb5_string_to_salttype(char *string, krb5_int32 *salttypep)
 
     found = 0;
     for (i=0; i<salttype_table_nents; i++) {
-        if (!strcasecmp(string, salttype_table[i].stt_specifier)) {
+        if (!strcasecmp(string, salttype_table[i].stt_name)) {
             found = 1;
             *salttypep = salttype_table[i].stt_enctype;
             break;
@@ -105,7 +102,7 @@ krb5_salttype_to_string(krb5_int32 salttype, char *buffer, size_t buflen)
     out = (char *) NULL;
     for (i=0; i<salttype_table_nents; i++) {
         if (salttype ==  salttype_table[i].stt_enctype) {
-            out = salttype_table[i].stt_output;
+            out = salttype_table[i].stt_name;
             break;
         }
     }

--- a/src/tests/t_mkey.py
+++ b/src/tests/t_mkey.py
@@ -49,7 +49,7 @@ def check_mkey_list(*expected):
 # Get the K/M principal.  Verify that it has the expected mkvno.  Each
 # remaining argment must be a sequence of two elements: an expected
 # key version and an expected enctype.
-keyline_re = re.compile(r'^Key: vno (\d+), (\S+), ')
+keyline_re = re.compile(r'^Key: vno (\d+), (\S+)$')
 def check_master_dbent(expected_mkvno, *expected_keys):
     outlines = realm.run_kadminl('getprinc K/M').splitlines()
     mkeyline = [l for l in outlines if l.startswith('MKey: vno ')]


### PR DESCRIPTION
In krb5_salttype_to_string, output the salt type name we would
recognize as input.

In the output of getprinc, display the enctype and salt type in a form
we would accept--either enctype:salttype if the salt type is not the
default, or just the enctype if it is.

Update t_mkey.py and t_salt.py to expect the new output format.

ticket: 5958
