### PR TITLE
Don't free cred handle used in kadm5 server handle

### DIFF
--- a/src/lib/kadm5/clnt/client_internal.h
+++ b/src/lib/kadm5/clnt/client_internal.h
@@ -74,6 +74,7 @@ typedef struct _kadm5_server_handle_t {
     CLIENT *        clnt;
     int             client_socket;
     krb5_context    context;
+    gss_cred_id_t   cred;
     kadm5_config_params params;
     struct _kadm5_server_handle_t *lhandle;
 } kadm5_server_handle_rec, *kadm5_server_handle_t;


### PR DESCRIPTION
At the end of setup_gss(), gss_client_creds is always released.
But this credential handle is saved in kadm5_server_handle_t in
handle->clnt->cl_auth->(struct rpc_gss_data *)ah_private->sec->cred
Accessing these credentials can result in use after free.

The handle should only be freed on error.
