### PR TITLE
Fix t_seqstate build with Solaris compiler

### DIFF
--- a/src/lib/gssapi/generic/Makefile.in
+++ b/src/lib/gssapi/generic/Makefile.in
@@ -146,8 +146,9 @@ clean-windows::
 	$(RM) $(HDRS) maptest.h
 	-if exist $(EHDRDIR)\nul rmdir $(EHDRDIR)
 
-t_seqstate: t_seqstate.o util_seqstate.o
-	$(CC_LINK) $(ALL_CFLAGS) -o $@ t_seqstate.o util_seqstate.o
+t_seqstate: t_seqstate.o util_seqstate.o $(SUPPORT_DEPLIB)
+	$(CC_LINK) $(ALL_CFLAGS) -o $@ t_seqstate.o util_seqstate.o \
+		$(SUPPORT_LIB)
 
 check-unix:: t_seqstate
 	$(RUN_SETUP) $(VALGRIND) ./t_seqstate


### PR DESCRIPTION
The Solaris native compiler (as of version 5.9) outputs code for
static inline functions even if they are not used.  So the
k5buf_to_gss helper in gssapiP_generic.h causes t_seqstate to have a
dependency on libkrb5support.

ticket: 7872
