### PR TITLE
Extracting PAC fails on multiple PACs

### DIFF
--- a/src/lib/gssapi/krb5/krb5_gss_glue.c
+++ b/src/lib/gssapi/krb5/krb5_gss_glue.c
@@ -367,8 +367,7 @@ gsskrb5_extract_authz_data_from_sec_context(OM_uint32 *minor_status,
         return major_status;
     }
 
-    if (data_set == GSS_C_NO_BUFFER_SET ||
-        data_set->count != 1) {
+    if (data_set == GSS_C_NO_BUFFER_SET || data_set->count == 0) {
         return GSS_S_FAILURE;
     }
 


### PR DESCRIPTION
gsskrb5_extract_authz_data_from_sec_context() fails, if there is
more than one authorization element in the ticket. But there have
been tickets containing 2-3 authorization elements...

This fix extracts first element in the data set instead of failing.
