### PR TITLE
Get getopt from unistd.h (not getopt.h) in tests

### DIFF
--- a/src/lib/krb5/krb/t_cc_config.c
+++ b/src/lib/krb5/krb/t_cc_config.c
@@ -37,7 +37,6 @@
 
 #include <k5-int.h>
 #include "int-proto.h"
-#include <getopt.h>
 
 static void
 bail_on_err(krb5_context context, const char *msg, krb5_error_code code)

--- a/src/lib/krb5/krb/t_in_ccache.c
+++ b/src/lib/krb5/krb/t_in_ccache.c
@@ -36,7 +36,6 @@
  */
 
 #include "k5-int.h"
-#include <getopt.h>
 
 static void
 bail_on_err(krb5_context context, const char *msg, krb5_error_code code)

--- a/src/tests/gssapi/t_enctypes.c
+++ b/src/tests/gssapi/t_enctypes.c
@@ -33,7 +33,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <getopt.h>
 #include "k5-int.h"
 #include "common.h"
 

--- a/src/tests/responder.c
+++ b/src/tests/responder.c
@@ -56,7 +56,7 @@
  */
 
 #include <sys/types.h>
-#include <getopt.h>
+#include <unistd.h>
 #include <stdio.h>
 #include <string.h>
 #include <krb5.h>


### PR DESCRIPTION
POSIX defines getopt to be declared in unistd.h, and HP-UX (as of
version 11.31) does not appear to have getopt.h.  In test programs
which currently include getopt.h and aren't currently built on
Windows, include unistd.h or just assume we will get it via k5-int.h.

ticket: 7894 (new)
target_version: 1.12.2
tags: pullup
