### PR TITLE
Inverted logic of krb5_db_inited

### DIFF
--- a/doc/kadm5/api-funcspec.tex
+++ b/doc/kadm5/api-funcspec.tex
@@ -1107,9 +1107,8 @@ the Admin API open.  This function behaves differently when called by
 local and remote clients.
 
 For local clients, the function closes and reopens the Kerberos
-database with krb5_db_fini() and krb5_db_init(), and closes and
-reopens the Admin policy database with adb_policy_close() and
-adb_policy_open().  Although it is unlikely, any other these functions
+database with krb5_db_fini() and krb5_db_init().
+Although it is unlikely, either of these functions
 could return errors; in that case, this function calls
 kadm5_destroy and returns the error code.  Therefore, if
 kadm5_flush does not return KADM5_OK, the connection to the

--- a/src/lib/kadm5/server_internal.h
+++ b/src/lib/kadm5/server_internal.h
@@ -70,8 +70,6 @@ typedef struct _osa_princ_ent_t {
 } osa_princ_ent_rec, *osa_princ_ent_t;
 
 
-kadm5_ret_t    adb_policy_init(kadm5_server_handle_t handle);
-kadm5_ret_t    adb_policy_close(kadm5_server_handle_t handle);
 kadm5_ret_t    passwd_check(kadm5_server_handle_t handle,
                             const char *pass, kadm5_policy_ent_t policy,
                             krb5_principal principal);

--- a/src/lib/kadm5/srv/libkadm5srv_mit.exports
+++ b/src/lib/kadm5/srv/libkadm5srv_mit.exports
@@ -5,8 +5,6 @@ kadm5int_acl_check_krb
 kadm5int_acl_finish
 kadm5int_acl_impose_restrictions
 kadm5int_acl_init
-adb_policy_close
-adb_policy_init
 hist_princ
 kadm5_set_use_password_server
 kadm5_chpass_principal

--- a/src/lib/kadm5/srv/server_init.c
+++ b/src/lib/kadm5/srv/server_init.c
@@ -346,7 +346,6 @@ kadm5_ret_t kadm5_destroy(void *server_handle)
     destroy_pwqual(handle);
 
     k5_kadm5_hook_free_handles(handle->context, handle->hook_handles);
-    adb_policy_close(handle);
     krb5_db_fini(handle->context);
     krb5_free_principal(handle->context, handle->current_caller);
     kadm5_free_config_params(handle->context, &handle->params);
@@ -393,9 +392,7 @@ kadm5_ret_t kadm5_flush(void *server_handle)
 
     if ((ret = krb5_db_fini(handle->context)) ||
         (ret = krb5_db_open(handle->context, handle->db_args,
-                            KRB5_KDB_OPEN_RW | KRB5_KDB_SRV_TYPE_ADMIN)) ||
-        (ret = adb_policy_close(handle)) ||
-        (ret = adb_policy_init(handle))) {
+                            KRB5_KDB_OPEN_RW | KRB5_KDB_SRV_TYPE_ADMIN))) {
         (void) kadm5_destroy(server_handle);
         return ret;
     }

--- a/src/lib/kadm5/srv/server_misc.c
+++ b/src/lib/kadm5/srv/server_misc.c
@@ -35,24 +35,6 @@
 #include    <adm_proto.h>
 
 kadm5_ret_t
-adb_policy_init(kadm5_server_handle_t handle)
-{
-    /* now policy is initialized as part of database. No seperate call needed */
-    if (krb5_db_inited(handle->context) == 0)
-        return KADM5_OK;
-
-    return krb5_db_open( handle->context, NULL,
-                         KRB5_KDB_OPEN_RW | KRB5_KDB_SRV_TYPE_ADMIN );
-}
-
-kadm5_ret_t
-adb_policy_close(kadm5_server_handle_t handle)
-{
-    /* will be taken care by database close */
-    return KADM5_OK;
-}
-
-kadm5_ret_t
 init_pwqual(kadm5_server_handle_t handle)
 {
     krb5_error_code ret;


### PR DESCRIPTION
krb5_db_inited (counter-intuitively) returns error code, not
a boolean: 0 standing for initialized. Condition in adb_policy_init
was inverted.
