### PR TITLE
Check name isn't NULL in krb5_parse_name_flags

### DIFF
--- a/src/lib/krb5/krb/parse.c
+++ b/src/lib/krb5/krb/parse.c
@@ -186,6 +186,11 @@ krb5_parse_name_flags(krb5_context context, const char *name,
 
     *principal_out = NULL;
 
+    if (name == NULL) {
+        ret = KRB5_PARSE_MALFORMED;
+        goto cleanup;
+    }
+
     ret = allocate_princ(context, name, enterprise, &princ, &has_realm);
     if (ret)
         goto cleanup;


### PR DESCRIPTION
There is a potential for NULL pointer dereference in
krb5_parse_name_flags in calls of static functions allocate_princ
and parse_name_into_princ. There is at least one code path, that
leads to krb5_parse_name_flag being called with name == NULL:
when out of memory, build_name_with_realm called from add_admin_princ
returns NULL for fullname, which is then passed as name through
krb5_parse_name to krb5_parse_name_flags.

Return error when krb5_parse_name_flag is called with name == NULL.
