### PR TITLE
Don't remove ccache creds before storing them

### DIFF
--- a/src/lib/krb5/ccache/ccfns.c
+++ b/src/lib/krb5/ccache/ccfns.c
@@ -84,9 +84,6 @@ krb5_cc_store_cred(krb5_context context, krb5_ccache cache,
     krb5_ticket *tkt;
     krb5_principal s1, s2;
 
-    /* remove any dups */
-    krb5_cc_remove_cred(context, cache, KRB5_TC_MATCH_AUTHDATA, creds);
-
     TRACE_CC_STORE(context, cache, creds);
     ret = cache->ops->store(context, cache, creds);
     if (ret) return ret;


### PR DESCRIPTION
If this commit seems like a bad idea, we can get rid of the extraneous trace log message by calling cache->ops->remove_cred directly from store_cred.
