### PR TITLE
memleak in make_external_lucid_ctx_v1()

### DIFF
--- a/src/lib/gssapi/krb5/lucid_context.c
+++ b/src/lib/gssapi/krb5/lucid_context.c
@@ -215,6 +215,7 @@ make_external_lucid_ctx_v1(
         }
     }
     else {
+        xfree(lctx);
         return EINVAL;  /* XXX better error code? */
     }
 


### PR DESCRIPTION
Parfait analysis flagged a memory leak in lucid_context.c:

Memory allocated here:
179 /\* Allocate the structure */
180 if ((lctx = xmalloc(bufsize)) == NULL) {
181 retval = ENOMEM;
182 goto error_out;
183 }

but never freed when function returns here:
217 else {
218 return EINVAL; /\* XXX better error code? */
219 }
