### PR TITLE
creds pointer needs to be set to NULL after free

### DIFF
--- a/src/lib/krb5/krb/rd_cred.c
+++ b/src/lib/krb5/krb/rd_cred.c
@@ -170,8 +170,10 @@ krb5_rd_cred_basic(krb5_context context, krb5_data *pcreddata,
     (*pppcreds)[i] = NULL;
 
 cleanup:
-    if (retval)
+    if (retval) {
         krb5_free_tgt_creds(context, *pppcreds);
+        *pppcreds = NULL;
+    }
 
 cleanup_cred:
     krb5_free_cred(context, pcred);


### PR DESCRIPTION
There is an bug fix in our bug pool related to creds pointer not set to NULL after freed. The bug fix is still applicable to MIT kerberos.

172cleanup:
173    if (retval)
174        krb5_free_tgt_creds(context, *pppcreds);
175
176cleanup_cred:
177    krb5_free_cred(context, pcred);
178    krb5_free_cred_enc_part(context, &encpart);
179
180    return retval;
181}

*pppcreds should be set to NULL after krb5_free_tgt_creds()
