### PR TITLE
Fix invalid JSON handling in KDC OTP module

### DIFF
--- a/src/plugins/preauth/otp/otp_state.c
+++ b/src/plugins/preauth/otp/otp_state.c
@@ -401,6 +401,8 @@ decode_config_json(const char *config, k5_json_array *out)
 
     /* Decode the config string and make sure it's an array. */
     retval = k5_json_decode((config != NULL) ? config : "[{}]", &val);
+    if (retval != 0)
+        goto error;
     if (k5_json_get_tid(val) != K5_JSON_TID_ARRAY) {
         retval = EINVAL;
         goto error;


### PR DESCRIPTION
If the OTP configuration for a principal contains invalid JSON, the
KDC OTP module calls k5_json_get_tid on a null pointer, causing the
KDC process to crash.  Fix this bug by checking the return value of
k5_json_decode in decode_config_json.

ticket: 7912 (new)
target_version: 1.12.2
tags: pullup
