### PR TITLE
Improve pointer hygiene around gss_display_name

### DIFF
--- a/src/lib/gssapi/krb5/disp_name.c
+++ b/src/lib/gssapi/krb5/disp_name.c
@@ -37,14 +37,16 @@ krb5_gss_display_name(minor_status, input_name, output_name_buffer,
     krb5_gss_name_t k5name = (krb5_gss_name_t) input_name;
     gss_OID nametype = (gss_OID) gss_nt_krb5_name;
 
+    output_name_buffer->length = 0;
+    output_name_buffer->value = NULL;
+    if (output_name_type)
+        *output_name_type = GSS_C_NO_OID;
+
     code = krb5_gss_init_context(&context);
     if (code) {
         *minor_status = code;
         return GSS_S_FAILURE;
     }
-
-    output_name_buffer->length = 0;
-    output_name_buffer->value = NULL;
 
     if (krb5_princ_type(context, k5name->princ) == KRB5_NT_WELLKNOWN) {
         if (krb5_principal_compare(context, k5name->princ,

--- a/src/lib/gssapi/mechglue/g_glue.c
+++ b/src/lib/gssapi/mechglue/g_glue.c
@@ -647,6 +647,8 @@ OM_uint32 gssint_convert_name_to_union_name(minor_status, mech,
 	    major_status = GSS_S_FAILURE;
 	    goto allocation_failure;
     }
+    union_name->external_name->length = 0;
+    union_name->external_name->value = NULL;
 
     major_status = mech->gss_display_name(minor_status,
 					  internal_name,


### PR DESCRIPTION
GSSAPI functions are responsible for setting their output parameters
on failure.  Take greater care to do so in krb5_gss_display_name.

The mechglue is generally defensive about initializing variables used
as outputs, and not assuming that mechs will set them on failure.
Make gssint_convert_name_to_union_name initialize
union_name->external_name before calling mech->gss_display_name, so
that if the mech's gss_display_name doesn't touch it, we don't free an
uninitialized pointer.

Either one of these changes prevents an unlikely memory bug which
could occur if krb5_gss_init_context fails within
krb5_gss_display_name when called from
gssint_convert_name_to_union_name.

ticket: 7915 (new)
target_version: 1.12.2
