### PR TITLE
KRB-49 Password history in LDAP KDB plugin

### DIFF
--- a/src/lib/kadm5/admin.h
+++ b/src/lib/kadm5/admin.h
@@ -110,7 +110,7 @@ typedef long            kadm5_ret_t;
 #define KADM5_RANDKEY_USED      0x100000
 #endif
 #define KADM5_LOAD              0x200000
-#define KADM5_NOKEY             0x400000
+#define KADM5_KEY_HIST          0x400000
 
 /* all but KEY_DATA, TL_DATA, LOAD */
 #define KADM5_PRINCIPAL_NORMAL_MASK 0x41ffff

--- a/src/lib/kadm5/srv/svr_principal.c
+++ b/src/lib/kadm5/srv/svr_principal.c
@@ -1543,6 +1543,9 @@ kadm5_chpass_principal_3(void *server_handle,
         KADM5_FAIL_AUTH_COUNT;
     /* | KADM5_CPW_FUNCTION */
 
+    if (hist_added == 1)
+        kdb->mask |= KADM5_KEY_HIST;
+
     ret = k5_kadm5_hook_chpass(handle->context, handle->hook_handles,
                                KADM5_HOOK_STAGE_PRECOMMIT, principal, keepold,
                                new_n_ks_tuple, new_ks_tuple, password);

--- a/src/plugins/kdb/ldap/libkdb_ldap/kerberos.ldif
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kerberos.ldif
@@ -555,7 +555,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.43.1
 ##### KrbKeySet ::= SEQUENCE {
 ##### attribute-major-vno       [0] UInt16,
 ##### attribute-minor-vno       [1] UInt16,
-##### kvno                      [2] UInt32,
+##### kvno                      [2] UInt32, -- actual order of the set of keys by descending age (0 ... oldest password)
 ##### mkvno                     [3] UInt32 OPTIONAL -- actually kadmin/history key,
 ##### keys                      [4] SEQUENCE OF KrbKey,
 ##### ...

--- a/src/plugins/kdb/ldap/libkdb_ldap/kerberos.schema
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kerberos.schema
@@ -444,7 +444,7 @@ attributetype ( 2.16.840.1.113719.1.301.4.43.1
 ##### KrbKeySet ::= SEQUENCE {
 ##### attribute-major-vno       [0] UInt16,
 ##### attribute-minor-vno       [1] UInt16,
-##### kvno                      [2] UInt32,
+##### kvno                      [2] UInt32, -- actual order of the set of keys by descending age (0 ... oldest password)
 ##### mkvno                     [3] UInt32 OPTIONAL -- actually kadmin/history key,
 ##### keys                      [4] SEQUENCE OF KrbKey,
 ##### ...

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.c
@@ -59,6 +59,7 @@ char     *principal_attributes[] = { "krbprincipalname",
                                      "krbExtraData",
                                      "krbObjectReferences",
                                      "krbAllowedToDelegateTo",
+                                     "krbpwdhistory",
                                      NULL };
 
 /* Must match KDB_*_ATTR macros in ldap_principal.h.  */
@@ -77,6 +78,7 @@ static char *attributes_set[] = { "krbmaxticketlife",
                                   "krbLastFailedAuth",
                                   "krbLoginFailedCount",
                                   "krbLastAdminUnlock",
+                                  "krbpwdhistory",
                                   NULL };
 
 void

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.h
@@ -32,6 +32,7 @@
 #define _LDAP_PRINCIPAL_H 1
 
 #include "ldap_tkt_policy.h"
+#include "princ_xdr.h"
 
 #define  KEYHEADER  12
 
@@ -82,6 +83,7 @@
 #define KDB_LAST_FAILED_ATTR                 0x001000
 #define KDB_FAIL_AUTH_COUNT_ATTR             0x002000
 #define KDB_LAST_ADMIN_UNLOCK_ATTR           0x004000
+#define KDB_PWD_HISTORY_ATTR                 0x008000
 
 /*
  * This is a private contract between krb5_ldap_lockout_audit()
@@ -119,6 +121,10 @@ krb5_ldap_unparse_principal_name(char *);
 
 krb5_error_code
 krb5_ldap_parse_principal_name(char *, char **);
+
+krb5_error_code
+krb5_decode_histkey(krb5_context, krb5_db_entry *, struct berval **,
+                    osa_princ_ent_rec *);
 
 krb5_error_code
 krb5_decode_krbsecretkey(krb5_context, krb5_db_entry *, struct berval **,

--- a/src/plugins/kdb/ldap/libkdb_ldap/princ_xdr.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/princ_xdr.c
@@ -200,20 +200,14 @@ krb5_lookup_tl_kadm_data(krb5_tl_data *tl_data, osa_princ_ent_rec *princ_entry)
 
 krb5_error_code
 krb5_update_tl_kadm_data(krb5_context context, krb5_db_entry *entry,
-			 char *policy_dn)
+			 osa_princ_ent_rec *princ_entry)
 {
     XDR xdrs;
-    osa_princ_ent_rec princ_entry;
     krb5_tl_data tl_data;
     krb5_error_code retval;
 
-    memset(&princ_entry, 0, sizeof(osa_princ_ent_rec));
-    princ_entry.admin_history_kvno = 2;
-    princ_entry.aux_attributes = KADM5_POLICY;
-    princ_entry.policy = policy_dn;
-
     xdralloc_create(&xdrs, XDR_ENCODE);
-    if (! ldap_xdr_osa_princ_ent_rec(&xdrs, &princ_entry)) {
+    if (! ldap_xdr_osa_princ_ent_rec(&xdrs, princ_entry)) {
 	xdr_destroy(&xdrs);
 	return KADM5_XDR_FAILURE;
     }

--- a/src/plugins/kdb/ldap/libkdb_ldap/princ_xdr.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/princ_xdr.h
@@ -57,6 +57,6 @@ krb5_lookup_tl_kadm_data(krb5_tl_data *tl_data, osa_princ_ent_rec *princ_entry);
 
 krb5_error_code
 krb5_update_tl_kadm_data(krb5_context context, krb5_db_entry *entry,
-			 char *policy_dn);
+			 osa_princ_ent_rec *princ_entry);
 
 #endif


### PR DESCRIPTION
This is yet another older Solaris fix, we would like to contribute upstream. It enables using password history in policies with LDAP KDB plugin.

The fix is equivalent to patch submitted in Ticket #5889, modulo a modification for new krb5_update_tl_kadm_data() API and explicit parenthesis for mask operations.