### PR TITLE
Fix uninitialized variable bug in KEYRING ccache

### DIFF
--- a/src/lib/krb5/ccache/cc_keyring.c
+++ b/src/lib/krb5/ccache/cc_keyring.c
@@ -1439,7 +1439,7 @@ get_time_offsets(krb5_context context, krb5_ccache id, int32_t *time_offset,
                  int32_t *usec_offset)
 {
     krcc_data *data = id->data;
-    krb5_error_code ret;
+    krb5_error_code ret = 0;
     key_serial_t key;
     void *payload = NULL;
     int psize;


### PR DESCRIPTION
Commit 5f4a4d7d357fedac5feadc65c09ecf487ff98db8 removed the only
unconditional assignment of ret in get_time_offsets, causing the
function to return an uninitialized value if nothing goes wrong.
Initialize ret at declaration time to fix this.
