### PR TITLE
Correct documentation of 'x' in kadm5.acl

### DIFF
--- a/doc/admin/conf_files/kadm5_acl.rst
+++ b/doc/admin/conf_files/kadm5_acl.rst
@@ -54,7 +54,7 @@ ignored.  Lines containing ACL entries have the format:
     m  [Dis]allows the modification of principals or policies
     p  [Dis]allows the propagation of the principal database (used in :ref:`incr_db_prop`)
     s  [Dis]allows the explicit setting of the key for a principal
-    x  Short for admcil. All privileges
+    x  Short for admcilsp. All privileges
     \* Same as x.
     == ======================================================
 


### PR DESCRIPTION
As specified in src/lib/kadm5/srv/server_acl.h.
'admcilsp' is the order in which the bits are defined (which does not match the order of the table).
