### PR TITLE
mit-krb5.pot: fixing a typo by adding a missing whitespace

### DIFF
--- a/src/po/mit-krb5.pot
+++ b/src/po/mit-krb5.pot
@@ -4480,7 +4480,7 @@ msgstr ""
 
 #: ../../src/lib/krb5/ccache/cc_dir.c:237
 #, c-format
-msgid "Credential cache directory %s exists but isnot a directory"
+msgid "Credential cache directory %s exists but is not a directory"
 msgstr ""
 
 #: ../../src/lib/krb5/ccache/cc_dir.c:402


### PR DESCRIPTION
Only a cosmetic issue. Fixing a typo in the PO file for mit-krb5.
