### PR TITLE
Add missing profile functions to libkrb5 exports

### DIFF
--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -623,6 +623,9 @@ profile_abandon
 profile_add_relation
 profile_clear_relation
 profile_flush
+profile_flush_to_buffer
+profile_flush_to_file
+profile_free_buffer
 profile_free_list
 profile_get_boolean
 profile_get_integer
@@ -631,7 +634,9 @@ profile_get_string
 profile_get_subsection_names
 profile_get_values
 profile_init
+profile_init_flags
 profile_init_path
+profile_init_vtable
 profile_iterator
 profile_iterator_create
 profile_iterator_free


### PR DESCRIPTION
profile_flush_to_buffer, profile_flush_to_file, profile_free_buffer,
profile_init_flags, and profile_init_vtable are all public profile
functions, but are inaccessible to libkrb5 applications on some
platforms because they were never added to the export list.  Add them
now.

(libprofile functions have never been part of the Windows DLL export
list, so do not change krb5_32.def at this time.)

ticket: 7930 (new)
target_version: 1.12.2
tags: pullup
