### PR TITLE
Improve PKINIT certificate documentation

### DIFF
--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -1026,7 +1026,8 @@ PKINIT krb5.conf options
 
     **kpServerAuth**
         If **kpServerAuth** is specified, a KDC certificate with the
-        id-kp-serverAuth EKU as used by Microsoft will be accepted.
+        id-kp-serverAuth EKU will be accepted.  This key usage value
+        is used in most commercially issued server certificates.
 
     **none**
         If **none** is specified, then the KDC certificate will not be


### PR DESCRIPTION
Describe how to use a commercially-issued server certificate for
anonymous PKINIT.  Separate the KDC and client configuration
instructions so that the steps necessary for anonymous PKINIT are not
combined with the additional steps necessary for regular PKINIT.
Describe kpServerAuth as the EKU used in commercially issued server
certificates, not as the value used by Microsoft (which does not
appear to be true according to [MS-PKCA]).
