### PR TITLE
Remove PKINIT longhorn compatibility option

### DIFF
--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -1054,9 +1054,6 @@ PKINIT krb5.conf options
     times.  Its value should contain the acceptable hostname for the
     KDC (as contained in its certificate).
 
-**pkinit_longhorn**
-    If this flag is set to true, we are talking to the Longhorn KDC.
-
 **pkinit_pool**
     Specifies the location of intermediate certificates which may be
     used by the client to complete the trust chain between a KDC

--- a/src/plugins/preauth/pkinit/pkinit.h
+++ b/src/plugins/preauth/pkinit/pkinit.h
@@ -40,20 +40,6 @@
 #include "pkinit_accessor.h"
 #include "pkinit_trace.h"
 
-/*
- * It is anticipated that all the special checks currently
- * required when talking to a Longhorn server will go away
- * by the time it is officially released and all references
- * to the longhorn global can be removed and any code
- * #ifdef'd with LONGHORN_BETA_COMPAT can be removed.
- * And this #define!
- */
-#define LONGHORN_BETA_COMPAT 1
-#ifdef LONGHORN_BETA_COMPAT
-extern int longhorn;	    /* XXX Talking to a Longhorn server? */
-#endif
-
-
 #ifndef WITHOUT_PKCS11
 #include "pkcs11.h"
 
@@ -88,7 +74,6 @@ extern int longhorn;	    /* XXX Talking to a Longhorn server? */
 #define KRB5_CONF_PKINIT_IDENTITY               "pkinit_identity"
 #define KRB5_CONF_PKINIT_KDC_HOSTNAME           "pkinit_kdc_hostname"
 #define KRB5_CONF_PKINIT_KDC_OCSP               "pkinit_kdc_ocsp"
-#define KRB5_CONF_PKINIT_LONGHORN               "pkinit_longhorn"
 #define KRB5_CONF_PKINIT_POOL                   "pkinit_pool"
 #define KRB5_CONF_PKINIT_REQUIRE_CRL_CHECKING   "pkinit_require_crl_checking"
 #define KRB5_CONF_PKINIT_REVOKE                 "pkinit_revoke"

--- a/src/plugins/preauth/pkinit/pkinit_clnt.c
+++ b/src/plugins/preauth/pkinit/pkinit_clnt.c
@@ -43,19 +43,6 @@
 #include "pkinit.h"
 #include "k5-json.h"
 
-/*
- * It is anticipated that all the special checks currently
- * required when talking to a Longhorn server will go away
- * by the time it is officially released and all references
- * to the longhorn global can be removed and any code
- * #ifdef'd with LONGHORN_BETA_COMPAT can be removed.
- *
- * Current testing (20070620) is against a patched Beta 3
- * version of Longhorn.  Most, if not all, problems should
- * be fixed in SP1 of Longhorn.
- */
-int longhorn = 0;       /* Talking to a Longhorn server? */
-
 /**
  * Return true if we should use ContentInfo rather than SignedData. This
  * happens if we are talking to what might be an old (pre-6112) MIT KDC and
@@ -192,8 +179,8 @@ pa_pkinit_gen_req(krb5_context context,
      * in order to get the Checksum rather than a Nonce in the reply.
      * This can be removed when LH SP1 is released.
      */
-    if ((return_pa_data[0]->pa_type == KRB5_PADATA_PK_AS_REP_OLD
-         && reqctx->opts->win2k_require_cksum) || (longhorn == 1)) {
+    if (return_pa_data[0]->pa_type == KRB5_PADATA_PK_AS_REP_OLD &&
+        reqctx->opts->win2k_require_cksum) {
         return_pa_data[1] = k5alloc(sizeof(*return_pa_data[1]), &retval);
         if (return_pa_data[1] == NULL)
             goto cleanup;
@@ -829,34 +816,24 @@ pkinit_as_rep_parse(krb5_context context,
         if ((retval = k5int_decode_krb5_reply_key_pack(&k5data,
                                                        &key_pack)) != 0) {
             pkiDebug("failed to decode reply_key_pack\n");
-#ifdef LONGHORN_BETA_COMPAT
-            /*
-             * LH Beta 3 requires the extra pa-data, even for RFC requests,
-             * in order to get the Checksum rather than a Nonce in the reply.
-             * This can be removed when LH SP1 is released.
-             */
-            if (pa_type == KRB5_PADATA_PK_AS_REP && longhorn == 0)
-#else
-                if (pa_type == KRB5_PADATA_PK_AS_REP)
-#endif
-                    goto cleanup;
-                else {
-                    if ((retval =
-                         k5int_decode_krb5_reply_key_pack_draft9(&k5data,
-                                                                 &key_pack9)) != 0) {
-                        pkiDebug("failed to decode reply_key_pack_draft9\n");
-                        goto cleanup;
-                    }
-                    pkiDebug("decode reply_key_pack_draft9\n");
-                    if (key_pack9->nonce != request->nonce) {
-                        pkiDebug("nonce in AS_REP=%d doesn't match AS_REQ=%d\n",                                 key_pack9->nonce, request->nonce);
-                        retval = -1;
-                        goto cleanup;
-                    }
-                    krb5_copy_keyblock_contents(context, &key_pack9->replyKey,
-                                                key_block);
-                    break;
-                }
+            if (pa_type == KRB5_PADATA_PK_AS_REP)
+                goto cleanup;
+            retval = k5int_decode_krb5_reply_key_pack_draft9(&k5data,
+                                                             &key_pack9);
+            if (retval) {
+                pkiDebug("failed to decode reply_key_pack_draft9\n");
+                goto cleanup;
+            }
+            pkiDebug("decode reply_key_pack_draft9\n");
+            if (key_pack9->nonce != request->nonce) {
+                pkiDebug("nonce in AS_REP=%d doesn't match AS_REQ=%d\n",
+                         key_pack9->nonce, request->nonce);
+                retval = -1;
+                goto cleanup;
+            }
+            krb5_copy_keyblock_contents(context, &key_pack9->replyKey,
+                                        key_block);
+            break;
         }
         /*
          * This is hack but Windows sends back SHA1 checksum
@@ -990,13 +967,6 @@ pkinit_client_profile(krb5_context context,
         }
         free(eku_string);
     }
-#ifdef LONGHORN_BETA_COMPAT
-    /* Temporarily just set global flag from config file */
-    pkinit_libdefault_boolean(context, realm,
-                              KRB5_CONF_PKINIT_LONGHORN,
-                              0,
-                              &longhorn);
-#endif
 
     /* Only process anchors here if they were not specified on command line */
     if (reqctx->idopts->anchors == NULL)


### PR DESCRIPTION
Remove the PKINIT Windows Server 2008 beta compatibility code
conditionalized under the "longhorn" variable.  It is not required to
interoperate with any released version of Windows.

ticket: 7934 (new)
