### PR TITLE
Remove indent workaround in man page RST sources

### DIFF
--- a/doc/admin/admin_commands/kadmin_local.rst
+++ b/doc/admin/admin_commands/kadmin_local.rst
@@ -341,9 +341,7 @@ Options:
         - *dn* and *containerdn* should be within the subtrees or
           principal container configured in the realm.
 
-Example:
-
- ::
+Example::
 
     kadmin: addprinc jennifer
     WARNING: no policy specified for "jennifer@ATHENA.MIT.EDU";
@@ -448,9 +446,7 @@ The following options are available:
     Keeps the existing keys in the database.  This flag is usually not
     necessary except perhaps for ``krbtgt`` principals.
 
-Example:
-
- ::
+Example::
 
     kadmin: cpw systest
     Enter password for principal systest@BLEEP.COM:
@@ -492,9 +488,7 @@ running the the program to be the same as the one being listed.
 
 Alias: **getprinc**
 
-Examples:
-
- ::
+Examples::
 
     kadmin: getprinc tlyu/admin
     Principal: tlyu/admin@BLEEP.COM
@@ -540,9 +534,7 @@ This command requires the **list** privilege.
 
 Alias: **listprincs**, **get_principals**, **get_princs**
 
-Example:
-
- ::
+Example::
 
     kadmin:  listprincs test*
     test3@SECURE-TEST.OV.COM
@@ -595,9 +587,7 @@ This command requires the **modify** privilege.
 
 Alias: **setstr**
 
-Example:
-
- ::
+Example::
 
     set_string host/foo.mit.edu session_enctypes aes128-cts
     set_string user@FOO.COM otp [{"type":"hotp","username":"custom"}]
@@ -688,9 +678,7 @@ The following options are available:
     with commas (',') only.  To clear the allowed key/salt policy use
     a value of '-'.
 
-Example:
-
- ::
+Example::
 
     kadmin: add_policy -maxlife "2 days" -minlength 5 guests
     kadmin:
@@ -728,9 +716,7 @@ This command requires the **delete** privilege.
 
 Alias: **delpol**
 
-Example:
-
- ::
+Example::
 
     kadmin: del_policy guests
     Are you sure you want to delete the policy "guests"?
@@ -754,9 +740,7 @@ This command requires the **inquire** privilege.
 
 Alias: getpol
 
-Examples:
-
- ::
+Examples::
 
     kadmin: get_policy admin
     Policy: admin
@@ -794,9 +778,7 @@ This command requires the **list** privilege.
 
 Aliases: **listpols**, **get_policies**, **getpols**.
 
-Examples:
-
- ::
+Examples::
 
     kadmin:  listpols
     test-pol
@@ -850,9 +832,7 @@ An entry for each of the principal's unique encryption types is added,
 ignoring multiple keys with the same encryption type but different
 salt types.
 
-Example:
-
- ::
+Example::
 
     kadmin: ktadd -k /tmp/foo-new-keytab host/foo.mit.edu
     Entry for principal host/foo.mit.edu@ATHENA.MIT.EDU with kvno 3,
@@ -887,9 +867,7 @@ The options are:
 **-q**
     Display less verbose information.
 
-Example:
-
- ::
+Example::
 
     kadmin: ktremove kadmin/admin all
     Entry for principal kadmin/admin with kvno 3 removed from keytab

--- a/doc/admin/admin_commands/kdb5_ldap_util.rst
+++ b/doc/admin/admin_commands/kdb5_ldap_util.rst
@@ -122,9 +122,7 @@ Creates realm in directory. Options:
     documented in the description of the **add_principal** command in
     :ref:`kadmin(1)`.
 
-Example:
-
- ::
+Example::
 
     kdb5_ldap_util -D cn=admin,o=org -H ldaps://ldap-server1.mit.edu
         create -subtrees o=org -sscope SUB -r ATHENA.MIT.EDU
@@ -183,9 +181,7 @@ Modifies the attributes of a realm.  Options:
     documented in the description of the **add_principal** command in
     :ref:`kadmin(1)`.
 
-Example:
-
- ::
+Example::
 
     shell% kdb5_ldap_util -D cn=admin,o=org -H
         ldaps://ldap-server1.mit.edu modify +requires_preauth -r
@@ -207,9 +203,7 @@ Displays the attributes of a realm.  Options:
 **-r** *realm*
     Specifies the Kerberos realm of the database.
 
-Example:
-
- ::
+Example::
 
     kdb5_ldap_util -D cn=admin,o=org -H ldaps://ldap-server1.mit.edu
         view -r ATHENA.MIT.EDU
@@ -239,9 +233,7 @@ Destroys an existing realm. Options:
 **-r** *realm*
     Specifies the Kerberos realm of the database.
 
-Example:
-
- ::
+Example::
 
     shell% kdb5_ldap_util -D cn=admin,o=org -H
         ldaps://ldap-server1.mit.edu destroy -r ATHENA.MIT.EDU
@@ -262,9 +254,7 @@ list
 
 Lists the name of realms.
 
-Example:
-
- ::
+Example::
 
     shell% kdb5_ldap_util -D cn=admin,o=org -H
         ldaps://ldap-server1.mit.edu list
@@ -297,9 +287,7 @@ to the LDAP server.  Options:
     Specifies Distinguished Name (DN) of the service object whose
     password is to be stored in file.
 
-Example:
-
- ::
+Example::
 
     kdb5_ldap_util stashsrvpw -f /home/andrew/conf_keyfile
         cn=service-kdc,o=org
@@ -342,9 +330,7 @@ Creates a ticket policy in the directory.  Options:
 *policy_name*
     Specifies the name of the ticket policy.
 
-Example:
-
- ::
+Example::
 
     kdb5_ldap_util -D cn=admin,o=org -H ldaps://ldap-server1.mit.edu
         create_policy -r ATHENA.MIT.EDU -maxtktlife "1 day"
@@ -369,9 +355,7 @@ modify_policy
 Modifies the attributes of a ticket policy.  Options are same as for
 **create_policy**.
 
-Example:
-
- ::
+Example::
 
     kdb5_ldap_util -D cn=admin,o=org -H
         ldaps://ldap-server1.mit.edu modify_policy -r ATHENA.MIT.EDU
@@ -395,9 +379,7 @@ Displays the attributes of a ticket policy.  Options:
 *policy_name*
     Specifies the name of the ticket policy.
 
-Example:
-
- ::
+Example::
 
     kdb5_ldap_util -D cn=admin,o=org -H ldaps://ldap-server1.mit.edu
         view_policy -r ATHENA.MIT.EDU tktpolicy
@@ -431,9 +413,7 @@ Destroys an existing ticket policy.  Options:
 *policy_name*
     Specifies the name of the ticket policy.
 
-Example:
-
- ::
+Example::
 
     kdb5_ldap_util -D cn=admin,o=org -H ldaps://ldap-server1.mit.edu
         destroy_policy -r ATHENA.MIT.EDU tktpolicy
@@ -458,9 +438,7 @@ realm.  Options:
 **-r** *realm*
     Specifies the Kerberos realm of the database.
 
-Example:
-
- ::
+Example::
 
     kdb5_ldap_util -D cn=admin,o=org -H ldaps://ldap-server1.mit.edu
         list_policy -r ATHENA.MIT.EDU

--- a/doc/admin/admin_commands/kpropd.rst
+++ b/doc/admin/admin_commands/kpropd.rst
@@ -34,9 +34,7 @@ file, the slave Kerberos server will have an up-to-date KDC database.
 
 Where incremental propagation is not used, kpropd is commonly invoked
 out of inetd(8) as a nowait service.  This is done by adding a line to
-the ``/etc/inetd.conf`` file which looks like this:
-
- ::
+the ``/etc/inetd.conf`` file which looks like this::
 
     kprop  stream  tcp  nowait  root  /usr/local/sbin/kpropd  kpropd
 

--- a/doc/admin/admin_commands/kproplog.rst
+++ b/doc/admin/admin_commands/kproplog.rst
@@ -53,9 +53,7 @@ OPTIONS
 
 **-v**
     Display individual attributes per update.  An example of the
-    output generated for one entry:
-
-     ::
+    output generated for one entry::
 
         Update Entry
            Update serial # : 4

--- a/doc/admin/admin_commands/krb5kdc.rst
+++ b/doc/admin/admin_commands/krb5kdc.rst
@@ -119,9 +119,7 @@ The realms are listed on the command line.  Per-realm options that can
 be specified on the command line pertain for each realm that follows
 it and are superseded by subsequent definitions of the same option.
 
-For example:
-
- ::
+For example::
 
     krb5kdc -p 2001 -r REALM1 -p 2002 -r REALM2 -r REALM3
 

--- a/doc/admin/admin_commands/sserver.rst
+++ b/doc/admin/admin_commands/sserver.rst
@@ -30,17 +30,13 @@ installed as |keytab|.
 The **-S** option allows for a different keytab than the default.
 
 sserver is normally invoked out of inetd(8), using a line in
-``/etc/inetd.conf`` that looks like this:
-
- ::
+``/etc/inetd.conf`` that looks like this::
 
     sample stream tcp nowait root /usr/local/sbin/sserver sserver
 
 Since ``sample`` is normally not a port defined in ``/etc/services``,
 you will usually have to add a line to ``/etc/services`` which looks
-like this:
-
- ::
+like this::
 
     sample          13135/tcp
 
@@ -52,9 +48,7 @@ connecting to, be sure that both hosts have an entry in /etc/services
 for the sample tcp port, and that the same port number is in both
 files.
 
-When you run sclient you should see something like this:
-
- ::
+When you run sclient you should see something like this::
 
     sendauth succeeded, reply is:
     reply len 32, contents:
@@ -64,49 +58,39 @@ When you run sclient you should see something like this:
 COMMON ERROR MESSAGES
 ---------------------
 
-1) kinit returns the error:
-
-    ::
+1) kinit returns the error::
 
        kinit: Client not found in Kerberos database while getting
-           initial credentials
+              initial credentials
 
    This means that you didn't create an entry for your username in the
    Kerberos database.
 
-2) sclient returns the error:
-
-    ::
+2) sclient returns the error::
 
        unknown service sample/tcp; check /etc/services
 
    This means that you don't have an entry in /etc/services for the
    sample tcp port.
 
-3) sclient returns the error:
-
-    ::
+3) sclient returns the error::
 
        connect: Connection refused
 
    This probably means you didn't edit /etc/inetd.conf correctly, or
    you didn't restart inetd after editing inetd.conf.
 
-4) sclient returns the error:
-
-    ::
+4) sclient returns the error::
 
        sclient: Server not found in Kerberos database while using
-           sendauth
+                sendauth
 
    This means that the ``sample/hostname@LOCAL.REALM`` service was not
    defined in the Kerberos database; it should be created using
    :ref:`kadmin(1)`, and a keytab file needs to be generated to make
    the key for that service principal available for sclient.
 
-5) sclient returns the error:
-
-    ::
+5) sclient returns the error::
 
        sendauth rejected, error reply is:
            "No such file or directory"

--- a/doc/admin/conf_files/kadm5_acl.rst
+++ b/doc/admin/conf_files/kadm5_acl.rst
@@ -19,9 +19,7 @@ SYNTAX
 ------
 
 Empty lines and lines starting with the sharp sign (``#``) are
-ignored.  Lines containing ACL entries have the format:
-
- ::
+ignored.  Lines containing ACL entries have the format::
 
     principal  permissions  [target_principal  [restrictions] ]
 
@@ -98,9 +96,7 @@ ignored.  Lines containing ACL entries have the format:
 EXAMPLE
 -------
 
-Here is an example of a kadm5.acl file.
-
- ::
+Here is an example of a kadm5.acl file::
 
     */admin@ATHENA.MIT.EDU        *                           # line 1
     joeadmin@ATHENA.MIT.EDU   ADMCIL                          # line 2

--- a/doc/admin/conf_files/kdc_conf.rst
+++ b/doc/admin/conf_files/kdc_conf.rst
@@ -491,9 +491,7 @@ In the following example, the logging messages from the KDC will go to
 the console and to the system log under the facility LOG_DAEMON with
 default severity of LOG_INFO; and the logging messages from the
 administrative server will be appended to the file
-``/var/adm/kadmin.log`` and sent to the device ``/dev/tty04``.
-
- ::
+``/var/adm/kadmin.log`` and sent to the device ``/dev/tty04``. ::
 
     [logging]
         kdc = CONSOLE
@@ -543,9 +541,7 @@ For each token type, the following tags may be specified:
     passed to the RADIUS server.  Otherwise, the realm will be
     included.  The default value is ``true``.
 
-In the following example, requests are sent to a remote server via UDP.
-
- ::
+In the following example, requests are sent to a remote server via UDP::
 
     [otp]
         MyRemoteTokenType = {
@@ -559,9 +555,7 @@ In the following example, requests are sent to a remote server via UDP.
 An implicit default token type named ``DEFAULT`` is defined for when
 the per-principal configuration does not specify a token type.  Its
 configuration is shown below.  You may override this token type to
-something applicable for your situation.
-
- ::
+something applicable for your situation::
 
     [otp]
         DEFAULT = {
@@ -579,18 +573,14 @@ PKINIT options
           realm-specific value over-rides, does not add to, a generic
           [kdcdefaults] specification.  The search order is:
 
-1. realm-specific subsection of [realms],
-
-    ::
+1. realm-specific subsection of [realms]::
 
        [realms]
            EXAMPLE.COM = {
                pkinit_anchors = FILE:/usr/local/example.com.crt
            }
 
-2. generic value in the [kdcdefaults] section.
-
-    ::
+2. generic value in the [kdcdefaults] section::
 
        [kdcdefaults]
            pkinit_anchors = DIR:/usr/local/generic_trusted_cas/
@@ -733,9 +723,7 @@ commands and configuration parameters that affect generation of keys
 take lists of enctype-salttype ("keysalt") pairs, known as *keysalt
 lists*.  Each keysalt pair is an enctype name followed by a salttype
 name, in the format *enc*:*salt*.  Individual keysalt list members are
-separated by comma (",") characters or space characters.  For example:
-
- ::
+separated by comma (",") characters or space characters.  For example::
 
     kadmin -e aes256-cts:normal,aes128-cts:normal
 
@@ -761,9 +749,7 @@ special           generate a random salt
 Sample kdc.conf File
 --------------------
 
-Here's an example of a kdc.conf file:
-
- ::
+Here's an example of a kdc.conf file::
 
     [kdcdefaults]
         kdc_ports = 88

--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -17,14 +17,11 @@ Structure
 
 The krb5.conf file is set up in the style of a Windows INI file.
 Sections are headed by the section name, in square brackets.  Each
-section may contain zero or more relations, of the form:
-
- ::
+section may contain zero or more relations, of the form::
 
     foo = bar
 
-or
- ::
+or::
 
     fubar = {
         foo = bar
@@ -36,8 +33,7 @@ value for the tag.  This means that neither the remainder of this
 configuration file nor any other configuration file will be checked
 for any other values for this tag.
 
-For example, if you have the following lines:
- ::
+For example, if you have the following lines::
 
     foo = bar*
     foo = baz
@@ -45,9 +41,7 @@ For example, if you have the following lines:
 then the second value of ``foo`` (``baz``) would never be read.
 
 The krb5.conf file can include other files using either of the
-following directives at the beginning of a line:
-
- ::
+following directives at the beginning of a line::
 
     include FILENAME
     includedir DIRNAME
@@ -62,9 +56,7 @@ file must begin with a section header.
 The krb5.conf file can specify that configuration should be obtained
 from a loadable module, rather than the file itself, using the
 following directive at the beginning of a line before any section
-headers:
-
- ::
+headers::
 
     module MODULEPATH:RESIDUAL
 
@@ -398,8 +390,7 @@ following tags may be specified in the realm's subsection:
         default realm, this rule is not applicable and the conversion
         will fail.
 
-    For example:
-     ::
+    For example::
 
         [realms]
             ATHENA.MIT.EDU = {
@@ -505,9 +496,7 @@ for that particular host or domain.  A host name relation implicitly
 provides the corresponding domain name relation, unless an explicit domain
 name relation is provided.  The Kerberos realm may be
 identified either in the realms_ section or using DNS SRV records.
-Host names and domain names should be in lower case.  For example:
-
- ::
+Host names and domain names should be in lower case.  For example::
 
     [domain_realm]
         crash.mit.edu = TEST.ATHENA.MIT.EDU
@@ -563,9 +552,7 @@ For example, ``ANL.GOV``, ``PNL.GOV``, and ``NERSC.GOV`` all wish to
 use the ``ES.NET`` realm as an intermediate realm.  ANL has a sub
 realm of ``TEST.ANL.GOV`` which will authenticate with ``NERSC.GOV``
 but not ``PNL.GOV``.  The [capaths] section for ``ANL.GOV`` systems
-would look like this:
-
- ::
+would look like this::
 
     [capaths]
         ANL.GOV = {
@@ -588,9 +575,7 @@ would look like this:
         }
 
 The [capaths] section of the configuration file used on ``NERSC.GOV``
-systems would look like this:
-
- ::
+systems would look like this::
 
     [capaths]
         NERSC.GOV = {
@@ -628,8 +613,7 @@ Each tag in the [appdefaults] section names a Kerberos V5 application
 or an option that is used by some Kerberos V5 application[s].  The
 value of the tag defines the default behaviors for that application.
 
-For example:
- ::
+For example::
 
     [appdefaults]
         telnet = {
@@ -851,27 +835,21 @@ PKINIT options
           A realm-specific value overrides, not adds to, a generic
           [libdefaults] specification.  The search order is:
 
-1. realm-specific subsection of [libdefaults]:
-
-    ::
+1. realm-specific subsection of [libdefaults]::
 
        [libdefaults]
            EXAMPLE.COM = {
                pkinit_anchors = FILE:/usr/local/example.com.crt
            }
 
-2. realm-specific value in the [realms] section,
-
-    ::
+2. realm-specific value in the [realms] section::
 
        [realms]
            OTHERREALM.ORG = {
                pkinit_anchors = FILE:/usr/local/otherrealm.org.crt
            }
 
-3. generic value in the [libdefaults] section.
-
-    ::
+3. generic value in the [libdefaults] section::
 
        [libdefaults]
            pkinit_anchors = DIR:/usr/local/generic_trusted_cas/
@@ -1004,9 +982,7 @@ PKINIT krb5.conf options
         * digitalSignature
         * keyEncipherment
 
-    Examples:
-
-     ::
+    Examples::
 
         pkinit_cert_match = ||<SUBJECT>.*DoE.*<SAN>.*@EXAMPLE.COM
         pkinit_cert_match = &&<EKU>msScLogin,clientAuth<ISSUER>.*DoE.*
@@ -1120,9 +1096,7 @@ Valid parameters are:
 Sample krb5.conf file
 ---------------------
 
-Here is an example of a generic krb5.conf file:
-
- ::
+Here is an example of a generic krb5.conf file::
 
     [libdefaults]
         default_realm = ATHENA.MIT.EDU

--- a/doc/admin/database.rst
+++ b/doc/admin/database.rst
@@ -140,7 +140,7 @@ type the following::
     Principal "david@ATHENA.MIT.EDU" created.
     kadmin:
 
-If you want to delete a principal ::
+If you want to delete a principal::
 
     kadmin: delprinc jennifer
     Are you sure you want to delete the principal

--- a/doc/admin/princ_dns.rst
+++ b/doc/admin/princ_dns.rst
@@ -38,12 +38,10 @@ the hostname.  They obtain the "canonical" name of the host when doing
 so.  By default, MIT Kerberos clients will also then do reverse DNS
 resolution (looking up the hostname associated with the IPv4 or IPv6
 address using ``getnameinfo()``) of the hostname.  Using the
-:ref:`krb5.conf(5)` setting
+:ref:`krb5.conf(5)` setting::
 
-    ::
-
-        [libdefaults]
-            rdns = false
+    [libdefaults]
+        rdns = false
 
 will disable reverse DNS lookup on clients.  The default setting is
 "true".
@@ -74,12 +72,10 @@ Overriding application behavior
 Applications can choose to use a default hostname component in their
 service principal name when accepting authentication, which avoids
 some sorts of hostname mismatches.  Because not all relevant
-applications do this yet, using the :ref:`krb5.conf(5)` setting
+applications do this yet, using the :ref:`krb5.conf(5)` setting::
 
-    ::
-
-        [libdefaults]
-            ignore_acceptor_hostname = true
+    [libdefaults]
+        ignore_acceptor_hostname = true
 
 will allow the Kerberos library to override the application's choice
 of service principal hostname and will allow a server program to

--- a/doc/appdev/init_creds.rst
+++ b/doc/appdev/init_creds.rst
@@ -27,9 +27,7 @@ credentials for a client using a password.  An application that needs
 to verify the credentials can call :c:func:`krb5_verify_init_creds`.
 Here is an example of code to obtain and verify TGT credentials, given
 strings *princname* and *password* for the client principal name and
-password:
-
-  ::
+password::
 
     krb5_error_code ret;
     krb5_creds creds;
@@ -57,9 +55,7 @@ The function :c:func:`krb5_get_init_creds_password` takes an options
 parameter (which can be a null pointer).  Use the function
 :c:func:`krb5_get_init_creds_opt_alloc` to allocate an options
 structure, and :c:func:`krb5_get_init_creds_opt_free` to free it.  For
-example:
-
-  ::
+example::
 
     krb5_error_code ret;
     krb5_get_init_creds_opt *opt = NULL;
@@ -97,9 +93,7 @@ with the KDC's realm and a single empty data component (the principal
 obtained by parsing ``@``\ *realmname*).  Authentication will take
 place using anonymous PKINIT; if successful, the client principal of
 the resulting tickets will be
-``WELLKNOWN/ANONYMOUS@WELLKNOWN:ANONYMOUS``.  Here is an example:
-
-  ::
+``WELLKNOWN/ANONYMOUS@WELLKNOWN:ANONYMOUS``.  Here is an example::
 
     krb5_get_init_creds_opt_set_anonymous(opt, 1);
     ret = krb5_build_principal(context, &client_princ, strlen(myrealm),
@@ -155,9 +149,7 @@ type information is available.
 Text-based applications can use a built-in text prompter
 implementation by supplying :c:func:`krb5_prompter_posix` as the
 *prompter* parameter and a null pointer as the *data* parameter.  For
-example:
-
-  ::
+example::
 
     ret = krb5_get_init_creds_password(context, &creds, client_princ,
                                        NULL, krb5_prompter_posix, NULL, 0,
@@ -229,9 +221,7 @@ be called multiple times.
 Example
 #######
 
-Here is an example of using a responder callback:
-
-  ::
+Here is an example of using a responder callback::
 
     static krb5_error_code
     my_responder(krb5_context context, void *data,
@@ -291,9 +281,7 @@ credentials.  It takes an options structure (which can be a null
 pointer).  Use :c:func:`krb5_verify_init_creds_opt_init` to initialize
 the caller-allocated options structure, and
 :c:func:`krb5_verify_init_creds_opt_set_ap_req_nofail` to set the
-"nofail" option.  For example:
-
-  ::
+"nofail" option.  For example::
 
     krb5_verify_init_creds_opt vopt;
 

--- a/doc/basic/date_format.rst
+++ b/doc/basic/date_format.rst
@@ -108,7 +108,7 @@ following ways:
 
 (See :ref:`abbreviation`.)
 
-Example ::
+Example::
 
     Set the default expiration date to July 27, 2012 at 20:30
     default_principal_expiration = 20120727203000

--- a/doc/user/user_commands/klist.rst
+++ b/doc/user/user_commands/klist.rst
@@ -44,9 +44,7 @@ OPTIONS
 
 **-f**
     Shows the flags present in the credentials, using the following
-    abbreviations:
-
-     ::
+    abbreviations::
 
         F    Forwardable
         f    forwarded

--- a/doc/user/user_commands/krb5-config.rst
+++ b/doc/user/user_commands/krb5-config.rst
@@ -71,9 +71,7 @@ krb5-config is particularly useful for compiling against a Kerberos
 installation that was installed in a non-standard location.  For example,
 a Kerberos installation that is installed in ``/opt/krb5/`` but uses
 libraries in ``/usr/local/lib/`` for text localization would produce
-the following output:
-
- ::
+the following output::
 
     shell% krb5-config --libs krb5
     -L/opt/krb5/lib -Wl,-rpath -Wl,/opt/krb5/lib -L/usr/local/lib -lkrb5 -lk5crypto -lcom_err

--- a/doc/user/user_commands/ksu.rst
+++ b/doc/user/user_commands/ksu.rst
@@ -86,8 +86,7 @@ user's home directory, ksu attempts to access two authorization files:
 contains the name of a principal that is authorized to access the
 account.
 
-For example:
- ::
+For example::
 
     jqpublic@USC.EDU
     jqpublic/secure@USC.EDU
@@ -221,9 +220,7 @@ OPTIONS
     defined the source cache name is set to ``krb5cc_<source uid>``.
     The target cache name is automatically set to ``krb5cc_<target
     uid>.(gen_sym())``, where gen_sym generates a new number such that
-    the resulting cache does not already exist.  For example:
-
-     ::
+    the resulting cache does not already exist.  For example::
 
         krb5cc_1984.2
 
@@ -283,9 +280,7 @@ Ticket granting ticket options:
 **-e** *command* [*args* ...]
     ksu proceeds exactly the same as if it was invoked without the
     **-e** option, except instead of executing the target shell, ksu
-    executes the specified command. Example of usage:
-
-     ::
+    executes the specified command. Example of usage::
 
         ksu bob -e ls -lag
 
@@ -304,9 +299,7 @@ Ticket granting ticket options:
     list of commands that the principal is authorized to execute.  A
     principal name followed by a ``*`` means that the user is
     authorized to execute any command.  Thus, in the following
-    example:
-
-     ::
+    example::
 
         jqpublic@USC.EDU ls mail /local/kerberos/klist
         jqpublic/secure@USC.EDU *
@@ -338,9 +331,7 @@ Ticket granting ticket options:
     thus all options intended for ksu must precede **-a**.
 
     The **-a** option can be used to simulate the **-e** option if
-    used as follows:
-
-     ::
+    used as follows::
 
         -a -c [command [arguments]].
 
@@ -376,8 +367,7 @@ ksu can be compiled with the following four flags:
     called to obtain the names of "legal shells".  Note that the
     target user's shell is obtained from the passwd file.
 
-Sample configuration:
- ::
+Sample configuration::
 
     KSU_OPTS = -DGET_TGT_VIA_PASSWD -DPRINC_LOOK_AHEAD -DCMD_PATH='"/bin /usr/ucb /local/bin"
 

--- a/doc/user/user_config/k5identity.rst
+++ b/doc/user/user_config/k5identity.rst
@@ -51,9 +51,7 @@ The following example .k5identity file selects the client principal
 ``alice@KRBTEST.COM`` if the server principal is within that realm,
 the principal ``alice/root@EXAMPLE.COM`` if the server host is within
 a servers subdomain, and the principal ``alice/mail@EXAMPLE.COM`` when
-accessing the IMAP service on ``mail.example.com``:
-
- ::
+accessing the IMAP service on ``mail.example.com``::
 
     alice@KRBTEST.COM       realm=KRBTEST.COM
     alice/root@EXAMPLE.COM  host=*.servers.example.com

--- a/doc/user/user_config/k5login.rst
+++ b/doc/user/user_config/k5login.rst
@@ -18,9 +18,7 @@ EXAMPLES
 --------
 
 Suppose the user ``alice`` had a .k5login file in her home directory
-containing just the following line:
-
- ::
+containing just the following line::
 
     bob@FOOBAR.ORG
 
@@ -35,9 +33,7 @@ machine's default realm to access the ``alice`` account.
 
 Let us further suppose that ``alice`` is a system administrator.
 Alice and the other system administrators would have their principals
-in root's .k5login file on each host:
-
- ::
+in root's .k5login file on each host::
 
     alice@BLEEP.COM
 


### PR DESCRIPTION
docutils 0.10 properly adds indentation to example blocks in man
pages, so we do not need to force an extra indentation level.  Get rid
of the workaround wherever we use it.

(I haven't assigned this a ticket or marked it for pullup, but perhaps I should.  We should also make sure that Tom's release machinery can easily use docutils 0.10+ to generate the man pages.)
