### PR TITLE
Consolidate DB option documentation

### DIFF
--- a/doc/admin/admin_commands/kadmin_local.rst
+++ b/doc/admin/admin_commands/kadmin_local.rst
@@ -138,18 +138,29 @@ OPTIONS
     Prevent fallback to AUTH_GSSAPI authentication flavor.
 
 **-x** *db_args*
-    Specifies the database specific arguments.  Options supported for
-    the LDAP database module are:
+    Specifies the database specific arguments.  See the next section
+    for supported options.
 
-    **-x host=**\ *hostname*
+.. _kadmin_options_end:
+
+.. _dboptions:
+
+DATABASE OPTIONS
+----------------
+
+Database options can be used to override database-specific defaults.
+Supported options for the DB2 module are:
+
+    **-x dbname=**\ \*filename*
+        Specifies the base filename of the DB2 database.
+
+Supported options for the LDAP module are:
+
+    **-x host=**\ *ldapuri*
         Specifies the LDAP server to connect to by a LDAP URI.
 
     **-x binddn=**\ *bind_dn*
-        Specifies the DN of the object used by the administration
-        server to bind to the LDAP server.  This object should have
-        the read and write privileges on the realm container, the
-        principal container, and the subtree that is referenced by the
-        realm.
+        Specifies the DN used to bind to the LDAP server.
 
     **-x bindpwd=**\ *bind_password*
         Specifies the password for the above mentioned binddn.  Using
@@ -162,8 +173,6 @@ OPTIONS
         sets the OpenLDAP client library debug level.  *level* is an
         integer to be interpreted by the library.  Debugging messages
         are printed to standard error.  New in release 1.12.
-
-.. _kadmin_options_end:
 
 
 COMMANDS

--- a/doc/admin/admin_commands/kadmind.rst
+++ b/doc/admin/admin_commands/kadmind.rst
@@ -105,37 +105,9 @@ OPTIONS
     to full resync requests when iprop is enabled.
 
 **-x** *db_args*
-    specifies database-specific arguments.
+    specifies database-specific arguments.  See :ref:`Database Options
+    <dboptions>` in :ref:`kadmin(1)` for supported arguments.
 
-    Options supported for LDAP database are:
-
-        **-x nconns=**\ *number_of_connections*
-            specifies the number of connections to be maintained per
-            LDAP server.
-
-        **-x host=**\ *ldapuri*
-            specifies the LDAP server to connect to by URI.
-
-        **-x binddn=**\ *binddn*
-            specifies the DN of the object used by the administration
-            server to bind to the LDAP server.  This object should
-            have read and write privileges on the realm container, the
-            principal container, and the subtree that is referenced by
-            the realm.
-
-        **-x bindpwd=**\ *bind_password*
-            specifies the password for the above mentioned binddn.
-            Using this option may expose the password to other users
-            on the system via the process list; to avoid this, instead
-            stash the password using the **stashsrvpw** command of
-            :ref:`kdb5_ldap_util(8)`.
-
-        **-x debug=**\ *level*
-            sets the OpenLDAP client library debug level.  *level* is
-            an integer to be interpreted by the library.  Debugging
-            messages are printed to standard error, so this option
-            must be used with the **-nofork** option to be useful.
-            New in release 1.12.
 
 SEE ALSO
 --------

--- a/doc/admin/admin_commands/krb5kdc.rst
+++ b/doc/admin/admin_commands/krb5kdc.rst
@@ -80,33 +80,8 @@ any other worker process exits.
           starts.
 
 The **-x** *db_args* option specifies database-specific arguments.
-Options supported for the LDAP database module are:
-
-    **-x** nconns=<number_of_connections>
-        Specifies the number of connections to be maintained per
-        LDAP server.
-
-    **-x** host=<ldapuri>
-        Specifies the LDAP server to connect to by URI.
-
-    **-x** binddn=<binddn>
-        Specifies the DN of the object used by the KDC server to bind
-        to the LDAP server.  This object should have read and write
-        privileges to the realm container, the principal container,
-        and the subtree that is referenced by the realm.
-
-    **-x** bindpwd=<bind_password>
-        Specifies the password for the above mentioned binddn.  Using
-        this option may expose the password to other users on the
-        system via the process list; to avoid this, instead stash the
-        password using the **stashsrvpw** command of
-        :ref:`kdb5_ldap_util(8)`.
-
-    **-x debug=**\ *level*
-        sets the OpenLDAP client library debug level.  *level* is an
-        integer to be interpreted by the library.  Debugging messages
-        are printed to standard error, so this option must be used
-        with the **-n** option to be useful.  New in release 1.12.
+See :ref:`Database Options <dboptions>` in :ref:`kadmin(1)` for
+supported arguments.
 
 The **-T** *offset* option specifies a time offset, in seconds, which
 the KDC will operate under.  It is intended only for testing purposes.


### PR DESCRIPTION
Document DB options in the kadmin/kadmin.local man page, in their own
section.  Refer to that section from the documentation of the -x
parameter of each other command which supports DB options.  Add
documentation for the "dbname" DB2 option.
