### PR TITLE
Fix KDC worker process argument parsing

### DIFF
--- a/src/kdc/main.c
+++ b/src/kdc/main.c
@@ -665,9 +665,11 @@ initialize_realms(krb5_context kcontext, int argc, char **argv)
     }
 
     /*
-     * Loop through the option list.  Each time we encounter a realm name,
-     * use the previously scanned options to fill in for defaults.
+     * Loop through the option list.  Each time we encounter a realm name, use
+     * the previously scanned options to fill in for defaults.  We do this
+     * twice if worker processes are used, so we must initialize optind.
      */
+    optind = 1;
     while ((c = getopt(argc, argv, "x:r:d:mM:k:R:e:P:p:s:nw:4:T:X3")) != -1) {
         switch(c) {
         case 'x':


### PR DESCRIPTION
To create worker processes, the KDC shuts down realms, forks off the
worker processes, then reinitializes realms in each child.
Reinitializing realms requires making a second pass over the
command-line arguments.  To do this with getopt, optind must be
reinitialized to 1 for each pass; otherwise, no options will be seen
the second time around.
