### PR TITLE
Prevent a write-to-NULL in encrypt_credencpart()

### DIFF
--- a/src/lib/krb5/krb/mk_cred.c
+++ b/src/lib/krb5/krb/mk_cred.c
@@ -49,13 +49,6 @@ encrypt_credencpart(krb5_context context, krb5_cred_enc_part *pcredpart,
                                   KRB5_KEYUSAGE_KRB_CRED_ENCPART, scratch,
                                   pencdata);
 
-    if (retval) {
-        memset(pencdata->ciphertext.data, 0, pencdata->ciphertext.length);
-        free(pencdata->ciphertext.data);
-        pencdata->ciphertext.length = 0;
-        pencdata->ciphertext.data = 0;
-    }
-
     memset(scratch->data, 0, scratch->length);
     krb5_free_data(context, scratch);
 


### PR DESCRIPTION
If krb5_encrypt_helper() returns an error, the ciphertext structure
may contain a non-zero length, but it will already have freed the
pointer to its data, making encrypt_credencpart()'s subsequent attempt
to clear and free the memory fail.

If krb5_encrypt_helper() encounters an error, clear the memory
before freeing it, and make sure that we don't return a non-zero
ciphertext length.  Because we know that krb5_encrypt_helper()
will only return an empty ciphertext data structure on error, stop
trying to clean it up in encrypt_credencpart().

Based on a patch from Jatin Nansi.
