### PR TITLE
check return value of krb5_get_tgs_ktypes()

### DIFF
--- a/src/lib/krb5/krb/send_tgs.c
+++ b/src/lib/krb5/krb/send_tgs.c
@@ -198,7 +198,9 @@ k5_make_tgs_req(krb5_context context,
         req.nktypes = 1;
     } else {
         /* Get the default TGS enctypes. */
-        krb5_get_tgs_ktypes(context, desired->server, &defenctypes);
+        ret = krb5_get_tgs_ktypes(context, desired->server, &defenctypes);
+        if (ret)
+            goto cleanup;
         for (count = 0; defenctypes[count]; count++);
         req.ktype = defenctypes;
         req.nktypes = count;


### PR DESCRIPTION
The return value of krb5_get_tgs_ktypes() is never checked. If it fails it could cause memory corruption or a core dump. Return value needs to be checked before dereferencing argument.
