### PR TITLE
insert new node before existing same name nodes that have already been deleted

### DIFF
--- a/src/util/profile/prof_tree.c
+++ b/src/util/profile/prof_tree.c
@@ -166,7 +166,7 @@ errcode_t profile_add_node(struct profile_node *section, const char *name,
     for (p=section->first_child, last = 0; p; last = p, p = p->next) {
         int cmp;
         cmp = strcmp(p->name, name);
-        if (cmp > 0)
+        if (cmp > 0 || (cmp == 0 && p->deleted))
             break;
     }
     retval = profile_create_node(name, value, &new);


### PR DESCRIPTION
We should insert the new node before any existing nodes that have already been deleted matching
the same name.

The problem is that when searching through the profile nodes that any previously deleted node matching the node name will not be iterated past.  A solution for this is to add any new nodes matching existing nodes that have been deleted before the deleted nodes.  This has the added benefit of efficiency, given that deleted nodes will not traversed during the sequence.
