### PR TITLE
Fix bugs in bindresvport_sa() changes

### DIFF
--- a/src/lib/rpc/svc_tcp.c
+++ b/src/lib/rpc/svc_tcp.c
@@ -159,8 +159,11 @@ svctcp_create(
 		}
 		set_cloexec_fd(sock);
 		madesock = TRUE;
-		memset(sa, 0, sizeof(struct sockaddr_in));
+		memset(&ss, 0, sizeof(ss));
 		sa->sa_family = AF_INET;
+#ifdef HAVE_SA_LEN
+		sa->sa_len = sizeof(struct sockaddr_in);
+#endif
 	} else {
 		len = sizeof(struct sockaddr_storage);
 		if (getsockname(sock, sa, &len) != 0) {

--- a/src/lib/rpc/svc_udp.c
+++ b/src/lib/rpc/svc_udp.c
@@ -130,8 +130,11 @@ svcudp_bufcreate(
 		}
 		set_cloexec_fd(sock);
 		madesock = TRUE;
-		memset(sa, 0, sizeof(struct sockaddr_in));
+		memset(&ss, 0, sizeof(ss));
 		sa->sa_family = AF_INET;
+#ifdef HAVE_SA_LEN
+		sa->sa_len = sizeof(struct sockaddr_in);
+#endif
 	} else {
 		len = sizeof(struct sockaddr_storage);
 		if (getsockname(sock, sa, &len) < 0) {


### PR DESCRIPTION
In svctcp_create() and svcudp_bufcreate(), set sa->sa_len on platforms
where that field exists, so that a subsequent call to socklen() will
return the correct result.

To make the code more self-evidently correct, zero the entire struct
sockaddr_storage object, using the memset(&ss, 0, sizeof(ss)) idiom.

ticket: 7956 (new)
