### PR TITLE
Continue on unknown address error in sendto_kdc

### DIFF
--- a/src/lib/krb5/os/sendto_kdc.c
+++ b/src/lib/krb5/os/sendto_kdc.c
@@ -727,8 +727,9 @@ translate_ai_error (int err)
         return errno;
 #endif
     default:
-        /* An error code we haven't handled?  */
-        return EINVAL;
+        /* Treat unknown error codes as non-fatal, because glibc can return
+         * EAI_NODATA but doesn't declare EAI_NODATA without _GNU_SOURCE. */
+        return 0;
     }
 }
 


### PR DESCRIPTION
glibc does not declare EAI_NODATA unless _GNU_SOURCE is defined, but
nevertheless returns EAI_NODATA in some circumstances (including some
where it shouldn't, such as when it gets an NXDOMAIN but AI_ADDRCONFIG
was requested).  If we see an unrecognized getaddrinfo result when
resolving a KDC hostname in sendto_kdc, treat it as non-fatal as we
would for EAI_NONAME, and continue on to other KDCs.
