### PR TITLE
add kiprop service principal during kdb creation.

### DIFF
--- a/doc/admin/admin_commands/kadmind.rst
+++ b/doc/admin/admin_commands/kadmind.rst
@@ -53,8 +53,9 @@ and policy updates incrementally instead of receiving full dumps of
 the database.  This facility can be enabled in the :ref:`kdc.conf(5)`
 file with the **iprop_enable** option.  Incremental propagation
 requires the principal ``kiprop/MASTER\@REALM`` (where MASTER is the
-master KDC's canonical host name, and REALM the realm name) to be
-registered in the database.
+master KDC's canonical host name, and REALM the realm name). In release
+1.13, this principal is automatically created and registered into the 
+datebase.
 
 
 OPTIONS

--- a/doc/admin/database.rst
+++ b/doc/admin/database.rst
@@ -805,7 +805,8 @@ Both master and slave sides must have a principal named
 ``kiprop/hostname`` (where *hostname* is the lowercase,
 fully-qualified, canonical name for the host) registered in the
 Kerberos database, and have keys for that principal stored in the
-default keytab file (|keytab|).
+default keytab file (|keytab|). In release 1.13, on the master KDC 
+side, the ``kiprop/hostname`` principal is created automatically.
 
 On the master KDC side, the ``kiprop/hostname`` principal must be
 listed in the kadmind ACL file :ref:`kadm5.acl(5)`, and given the

--- a/src/plugins/kdb/ldap/ldap_util/kdb5_ldap_realm.c
+++ b/src/plugins/kdb/ldap/ldap_util/kdb5_ldap_realm.c
@@ -361,13 +361,16 @@ create_special_princs(krb5_context context, krb5_principal master_princ,
     if (ret)
         return ret;
 
-    /* Create kadmin/admin and kadmin/<hostname>. */
+    /* Create kadmin/admin, kadmin/<hostname> and kiprop/<hostname>. */
     rblock.max_life = ADMIN_LIFETIME;
     rblock.flags = KRB5_KDB_DISALLOW_TGT_BASED;
     ret = create_fixed_special(context, &rblock, mkey, "kadmin", "admin");
     if (ret)
         return ret;
     ret = create_hostbased_special(context, &rblock, mkey, "kadmin");
+    if (ret)
+        return ret;
+    ret = create_hostbased_special(context, &rblock, mkey, "kiprop");
     if (ret)
         return ret;
 

--- a/src/tests/dejagnu/config/default.exp
+++ b/src/tests/dejagnu/config/default.exp
@@ -1254,7 +1254,7 @@ proc setup_kerberos_db { standalone } {
     }
 
     # Add an incremental-propagation service.
-    set test "kadmin.local ank kiprop/$hostname"
+    set test "kadmin.local ank krbtest/fast"
     set body {
 	if $failall {
 	    break
@@ -1263,18 +1263,6 @@ proc setup_kerberos_db { standalone } {
 	verbose "starting $test"
 	expect_after $def_exp_after
 
-	expect "kadmin.local: "
-	send "ank kiprop/$hostname@$REALMNAME\r"
-	# It echos...
-	expect "ank kiprop/$hostname@$REALMNAME\r"
-	expect "Enter password for principal \"kiprop/$hostname@$REALMNAME\":"
-	send "kiproppass$KEY\r"
-	expect "Re-enter password for principal \"kiprop/$hostname@$REALMNAME\":"
-	send "kiproppass$KEY\r"
-	expect {
-	    "Principal \"kiprop/$hostname@$REALMNAME\" created" { }
-	    "Principal or policy already exists while creating*" { }
-	}
 	expect "kadmin.local: "
 	send "ank +requires_preauth krbtest/fast@$REALMNAME\r"
 	expect "Enter password for principal \"krbtest/fast@$REALMNAME\":"

--- a/src/tests/t_iprop.py
+++ b/src/tests/t_iprop.py
@@ -153,7 +153,6 @@ if not os.path.exists(ulog):
 
 # Create the principal used to authenticate kpropd to kadmind.
 kiprop_princ = 'kiprop/' + hostname
-realm.addprinc(kiprop_princ)
 realm.extract_keytab(kiprop_princ, realm.keytab)
 
 # Create the initial slave1 and slave2 databases.


### PR DESCRIPTION
As discussed with Will Fiveash, this changeset adds kiprop/FQDN into kdb during creation. I followed the kadmin/FQDN principal creation style. And I noticed that after my change, the kiprop test failed. So I changed the test suite accordingly to work with my changeset.

I followed the surrounding coding style. But there may be places needed to be modified and improved. Please feel free to give comments on the change. Thanks!
