### PR TITLE
Fix GSSAPI initialization memory leak on error

### DIFF
--- a/src/lib/gssapi/mechglue/g_initialize.c
+++ b/src/lib/gssapi/mechglue/g_initialize.c
@@ -614,8 +614,10 @@ gssint_register_mechinfo(gss_mech_info template)
 		if (krb5int_get_plugin_func(_dl, \
 					    #_symbol, \
 					    (void (**)())&(_mech)->_symbol, \
-					    &errinfo) || errinfo.code) \
+					    &errinfo) || errinfo.code) {  \
 			(_mech)->_symbol = NULL; \
+			k5_clear_error(&errinfo); \
+			} \
 	} while (0)
 
 /*
@@ -727,8 +729,10 @@ build_dynamicMech(void *dl, const gss_OID mech_type)
 					    "gssi" #_nsym,		\
 					    (void (**)())&(_mech)->_psym \
 					    ## _nsym,			\
-					    &errinfo) || errinfo.code)	\
+					    &errinfo) || errinfo.code) { \
 			(_mech)->_psym ## _nsym = NULL;			\
+			k5_clear_error(&errinfo);			\
+		}							\
 	} while (0)
 
 /* Build an interposer mechanism function table from dl. */


### PR DESCRIPTION
Here is a patch from Simo which he mentioned on IRC a few days ago.  I think it is correct, but needs:
- to address the same problem in GSS_ADD_DYNAMIC_METHOD
- a better commit summary
