### PR TITLE
Improve error message for PRNG seeding failure

### DIFF
--- a/src/lib/crypto/krb/prng_fortuna.c
+++ b/src/lib/crypto/krb/prng_fortuna.c
@@ -423,6 +423,10 @@ krb5_c_random_make_octets(krb5_context context, krb5_data *outdata)
 
     if (!have_entropy) {
         k5_mutex_unlock(&fortuna_lock);
+        if (context != NULL) {
+            k5_set_error(&context->err, KRB5_CRYPTO_INTERNAL,
+                         _("Random number generator could not be seeded"));
+        }
         return KRB5_CRYPTO_INTERNAL;
     }
 


### PR DESCRIPTION
Karl had a machine where /dev/urandom had changed to a regular file, and noted that we gave a cryptic error message.  This patch gives a better one, although it's not super-specific as talking about /dev/urandom would be wrong on Windows.

I didn't mark this for pullup since it's a pretty unusual case, but I did give it a ticket since it's a user-visible behavior change.
