### PR TITLE
Fix calloc check in krb5_authdata_context_init

### DIFF
--- a/src/lib/krb5/krb/authdata.c
+++ b/src/lib/krb5/krb/authdata.c
@@ -407,7 +407,7 @@ krb5_authdata_context_init(krb5_context kcontext,
     }
 
     context = calloc(1, sizeof(*context));
-    if (kcontext == NULL) {
+    if (context == NULL) {
         code = ENOMEM;
         goto cleanup;
     }


### PR DESCRIPTION
Noticed by Will in RT #7973
