### PR TITLE
gssapi: Fix the return flags if we don't have delegation credentials.

### DIFF
--- a/src/lib/gssapi/krb5/accept_sec_context.c
+++ b/src/lib/gssapi/krb5/accept_sec_context.c
@@ -314,8 +314,10 @@ kg_accept_dce(minor_status, context_handle, verifier_cred_handle,
     if (mech_type)
         *mech_type = GSS_C_NULL_OID;
     /* return a bogus cred handle */
-    if (delegated_cred_handle)
+    if (delegated_cred_handle) {
+        ctx->gss_flags &= ~GSS_C_DELEG_FLAG;
         *delegated_cred_handle = GSS_C_NO_CREDENTIAL;
+    }
 
     ctx = (krb5_gss_ctx_id_rec *)*context_handle;
 
@@ -499,8 +501,10 @@ kg_accept_krb5(minor_status, context_handle,
     if (mech_type)
         *mech_type = GSS_C_NULL_OID;
     /* return a bogus cred handle */
-    if (delegated_cred_handle)
+    if (delegated_cred_handle) {
         *delegated_cred_handle = GSS_C_NO_CREDENTIAL;
+        ctx->gss_flags &= GSS_C_DELEG_FLAG;
+    }
 
     /* handle default cred handle */
     if (verifier_cred_handle == GSS_C_NO_CREDENTIAL) {


### PR DESCRIPTION
The section 5.1 in RFC2744 for the ret_flags states:

GSS_C_DELEG_FLAG
  True - Delegated credentials are available via the
  delegated_cred_handle parameter.

So it should not be set if the credentials are not available.

---

I've found this testing the Samba GSSAPI implementation using MIT Kerberos. In Samba I've added an additional NULL check for the deleg_cred value now.

https://git.samba.org/?p=asn/samba.git;a=commitdiff;h=f5f39355ca98d462053efdf8811dfc5ccfaa1532
