### PR TITLE
Fix +1 error in storing krbPrincipalKey LDAP attr.

### DIFF
--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
@@ -456,7 +456,8 @@ krb5_encode_krbsecretkey(krb5_key_data *key_data_in, int n_key_data,
             j++;
             last = i + 1;
 
-            currkvno = key_data[i].key_data_kvno;
+            if (i < n_key_data - 1)
+                currkvno = key_data[i + 1].key_data_kvno;
         }
     }
     ret[num_versions] = NULL;


### PR DESCRIPTION
For principal entries having keys with multiple kvnos (due to use of
-keepold), LDAP backend plugin makes an attempt to store all the keys
having the same kvno into single krbPrincipalKey attribute value.
There is an +1 error in the loop, causing currkvno variable being set
to the just processed value, instead of the next kvno.
As a result, second and all following groups of keys by kvnos are each
stored in two krbPrincipalKey attribute values.

Fixed to use correct kvno value.
