### PR TITLE
Correct includes for unlockiter.c

### DIFF
--- a/src/tests/unlockiter.c
+++ b/src/tests/unlockiter.c
@@ -35,7 +35,8 @@
  */
 
 #include <sys/types.h>
-#include <sys/socket.h>
+#include <sys/select.h>
+#include <sys/time.h>
 #include <sys/wait.h>
 
 #include <errno.h>
@@ -43,6 +44,7 @@
 #include <kadm5/admin.h>
 #include <signal.h>
 #include <stdlib.h>
+#include <string.h>             /* Some platforms need memset() for FD_ZERO */
 #include <unistd.h>
 
 struct cb_arg {


### PR DESCRIPTION
Some platforms (e.g., Solaris) need a declaration of memset() for the
FD_ZERO() macro to work, contrary to POSIX standards.  Add an
inclusion of <string.h> to accommodate them.  Also add <sys/time.h>,
possibly needed by some older platforms, and remove a spurious
inclusion of <sys/socket.h>.

ticket: 7977
