### PR TITLE
Fix the build on windows

### DIFF
--- a/src/lib/gssapi/mechglue/g_initialize.c
+++ b/src/lib/gssapi/mechglue/g_initialize.c
@@ -41,7 +41,9 @@
 #include <string.h>
 #include <ctype.h>
 #include <errno.h>
+#ifndef _WIN32
 #include <glob.h>
+#endif
 
 #define	M_DEFAULT	"default"
 
@@ -418,6 +420,7 @@ load_if_changed(const char *pathname, time_t last, time_t *highest)
 		loadConfigFile(pathname);
 }
 
+#ifndef _WIN32
 /* Try to load any config files which have changed since the last call.  Config
  * files are MECH_CONF and any files matching MECH_CONF_PATTERN. */
 static void
@@ -442,6 +445,7 @@ loadConfigFiles()
 
 	g_confFileModTime = highest;
 }
+#endif
 
 /*
  * determines if the mechList needs to be updated from file

--- a/src/lib/krb5/ccache/Makefile.in
+++ b/src/lib/krb5/ccache/Makefile.in
@@ -15,10 +15,16 @@ LOCALINCLUDES = -I$(srcdir)$(S)ccapi -I$(srcdir) -I. $(WIN_INCLUDES)
 ##WIN32##MSLSA_OBJ = $(OUTPRE)cc_mslsa.$(OBJEXT)
 ##WIN32##MSLSA_SRC = $(srcdir)/cc_mslsa.c
 
+##WIN32##!if 0
 KCMRPC_DEPS-osx = kcmrpc.h kcmrpc_types.h
 KCMRPC_OBJ-osx = kcmrpc.o
 KCMRPC_DEPS-no = # empty
 KCMRPC_OBJ-no = # empty
+
+KCMRPC_DEPS = $(KCMRPC_DEPS-@OSX@)
+KCMRPC_OBJS = $(KCMRPC_OBJS-@OSX@)
+##WIN32##!endif
+
 
 STLIBOBJS= \
 	ccbase.o \
@@ -37,7 +43,7 @@ STLIBOBJS= \
 	cc_memory.o \
 	cc_keyring.o \
 	ccfns.o \
-	ser_cc.o $(KCMRPC_OBJ-@OSX@)
+	ser_cc.o $(KCMRPC_OBJ)
 
 OBJS=	$(OUTPRE)ccbase.$(OBJEXT) \
 	$(OUTPRE)cccopy.$(OBJEXT) \
@@ -144,11 +150,11 @@ clean-unix::
 	$(RM) t_cc t_cc.o t_cccursor t_cccursor.o t_cccol t_cccol.o
 	$(RM) t_marshal t_marshal.o testcache
 
-depend:: $(KCMRPC_DEPS-@OSX@)
+depend:: $(KCMRPC_DEPS)
 
-##WIN32## $(OUTPRE)cc_mslsa.$(OBJEXT): cc_mslsa.c $(top_srcdir)/include/k5-int.h $(BUILDTOP)/include/krb5/osconf.h $(BUILDTOP)/include/krb5/autoconf.h $(BUILDTOP)/include/krb5.h $(COM_ERR_DEPS)
+##WIN32##$(OUTPRE)cc_mslsa.$(OBJEXT): cc_mslsa.c $(top_srcdir)/include/k5-int.h $(BUILDTOP)/include/krb5.h $(COM_ERR_DEPS)
 
-cc_kcm.so cc_kcm.o: $(KCMRPC_DEPS-@OSX@)
+cc_kcm.so cc_kcm.o: $(KCMRPC_DEPS)
 kcmrpc.so kcmrpc.o: kcmrpc.h kcmrpc_types.h
 
 @libobj_frag@

--- a/src/lib/krb5/ccache/cc_kcm.c
+++ b/src/lib/krb5/ccache/cc_kcm.c
@@ -37,6 +37,7 @@
  * sockets are used instead.
  */
 
+#ifndef _WIN32
 #include "k5-int.h"
 #include "k5-input.h"
 #include "cc-int.h"
@@ -48,8 +49,6 @@
 #include <servers/bootstrap.h>
 #include "kcmrpc.h"
 #endif
-
-#ifndef _WIN32
 
 #define MAX_REPLY_SIZE (10 * 1024 * 1024)
 

--- a/src/lib/krb5/os/Makefile.in
+++ b/src/lib/krb5/os/Makefile.in
@@ -59,7 +59,6 @@ OBJS= \
 	$(OUTPRE)c_ustime.$(OBJEXT)	\
 	$(OUTPRE)ccdefname.$(OBJEXT)	\
 	$(OUTPRE)changepw.$(OBJEXT)	\
-	$(OUTPRE)checkhost.$(OBJEXT)	\
 	$(OUTPRE)dnsglue.$(OBJEXT)	\
 	$(OUTPRE)dnssrv.$(OBJEXT)	\
 	$(OUTPRE)expand_path.$(OBJEXT)	\
@@ -106,7 +105,6 @@ SRCS= \
 	$(srcdir)/c_ustime.c	\
 	$(srcdir)/ccdefname.c	\
 	$(srcdir)/changepw.c	\
-	$(srcdir)/checkhost.c	\
 	$(srcdir)/dnsglue.c	\
 	$(srcdir)/dnssrv.c	\
 	$(srcdir)/expand_path.c	\

--- a/src/util/support/json.c
+++ b/src/util/support/json.c
@@ -70,10 +70,7 @@
  * Heimdal.
  */
 
-#include <stdlib.h>
-#include <string.h>
-#include <assert.h>
-#include <errno.h>
+#include <k5-platform.h>
 #include <k5-base64.h>
 #include <k5-json.h>
 #include <k5-buf.h>


### PR DESCRIPTION
Windows does not provide the glob() functionality used to implement
the /etc/gss/mechs.d/ feature, so we must avoid compiling the
relevant code for windows.  (It would never have been called, anyway.)

Adjust the ccache/Makefile.in rules to not use '-' or '@' in
make variable names that are processed by nmake.

Also in ccache/Makefile.in, remove some latent leading whitespace that
had been previously hidden by the previous rule; this exposed some
flawed dependencies that are now removed.

Windows does not provide sys/socket.h or sys/un.h, so don't try
to include them.

The commit which moved the KKDCP TLS support to a plugin left some
dangling references to checkhost.c byproducts in os/Makefile.in,
which can be safely removed.

Use k5-platform.h in support/json.c instead of a set of system includes;
this lets windows build the static inline helper functions therein.
