### PR TITLE
Disallow unlocked iteration of hash databases

### DIFF
--- a/src/plugins/kdb/db2/kdb_db2.c
+++ b/src/plugins/kdb/db2/kdb_db2.c
@@ -386,6 +386,9 @@ open_db(krb5_db2_context *dbc, int flags, int mode)
         break;
     }
 
+    /* Don't try unlocked iteration with a hash database. */
+    if (db != NULL && dbc->hashfirst)
+        dbc->unlockiter = FALSE;
 done:
     free(fname);
     return db;


### PR DESCRIPTION
It's not clear whether unlocked iteration over a hash DB2 database
will omit unaffected entries if database additions or deletions occur
concurrently with the iteration.  Avoid this situation by disabling
unlocked iteration in the unlikely event that someone is still using a
hash database for their KDB.

ticket: 7977
