### PR TITLE
Make krb5_cc_new_unique() create DIR: directories

### DIFF
--- a/src/lib/krb5/ccache/cc_dir.c
+++ b/src/lib/krb5/ccache/cc_dir.c
@@ -404,6 +404,9 @@ dcc_gen_new(krb5_context context, krb5_ccache *cache_out)
     ret = k5_path_join(dirname, "tktXXXXXX", &template);
     if (ret)
         goto cleanup;
+    ret = verify_dir(context, dirname);
+    if (ret)
+        goto cleanup;
     ret = krb5int_fcc_new_unique(context, template, &fcc);
     if (ret)
         goto cleanup;


### PR DESCRIPTION
When we use krb5_cc_new_unique() to create a new cache in a directory (DIR:) cache collection, we'll fail if the directory doesn't exist yet.

Go ahead and preemptively check for and create the target directory, as we do during krb5_cc_resolve(), before attempting to create a new file under it.
