### PR TITLE
Autodetect openssl cms support for libressl compatibility.

### DIFF
--- a/src/configure.in
+++ b/src/configure.in
@@ -242,6 +242,7 @@ case "$withval" in
 builtin|openssl)
   AC_CHECK_LIB(crypto, PKCS7_get_signer_info, PKINIT_CRYPTO_IMPL_LIBS=-lcrypto)
   PKINIT_CRYPTO_IMPL=openssl
+  AC_CHECK_LIB(crypto, CMS_get0_content, AC_DEFINE([HAVE_OPENSSL_CMS], 1, [Define to 1 if the openssl implementation supports cms.]))
   ;;
 nss)
   if test "${PKINIT_CRYPTO_IMPL_CFLAGS+set}" != set; then

--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -156,8 +156,8 @@ static char *
 pkinit_pkcs11_code_to_text(int err);
 
 
-#if OPENSSL_VERSION_NUMBER >= 0x10000000L
-/* Use CMS support present in OpenSSL 1.0 and later. */
+#ifdef HAVE_OPENSSL_CMS
+/* Use CMS support present in OpenSSL */
 #include <openssl/cms.h>
 #define pkinit_CMS_get0_content_signed(_cms) CMS_get0_content(_cms)
 #define pkinit_CMS_get0_content_data(_cms) CMS_get0_content(_cms)


### PR DESCRIPTION
Since cms support is now determined by autoconf, it will work as expected if openssl ever drops cms support or libressl ever adds it.

I have removed a previously proposed autoconf.h include at the request of Ben Kaduk.
