### PR TITLE
krb5-config.in: Make --libs spit out LIB_PATH only

### DIFF
--- a/src/build-tools/krb5-config.in
+++ b/src/build-tools/krb5-config.in
@@ -31,12 +31,7 @@ prefix=@prefix@
 exec_prefix=@exec_prefix@
 includedir=@includedir@
 libdir=@libdir@
-CC_LINK='@CC_LINK@'
 KDB5_DB_LIB=@KDB5_DB_LIB@
-LDFLAGS='@LDFLAGS@'
-RPATH_FLAG='@RPATH_FLAG@'
-PROG_RPATH_FLAGS='@PROG_RPATH_FLAGS@'
-PTHREAD_CFLAGS='@PTHREAD_CFLAGS@'
 DL_LIB='@DL_LIB@'
 DEFCCNAME='@DEFCCNAME@'
 DEFKTNAME='@DEFKTNAME@'
@@ -210,20 +205,10 @@ fi
 if test -n "$do_libs"; then
     # Assumes /usr/lib is the standard library directory everywhere...
     if test "$libdir" = /usr/lib; then
-	libdirarg=
+	lib_flags=
     else
-	libdirarg="-L$libdir"
+	lib_flags="-L$libdir"
     fi
-    # Ugly gross hack for our build tree
-    lib_flags=`echo $CC_LINK | sed -e 's/\$(CC)//' \
-	    -e 's/\$(PURE)//' \
-	    -e 's#\$(PROG_RPATH_FLAGS)#'"$PROG_RPATH_FLAGS"'#' \
-	    -e 's#\$(PROG_RPATH)#'$libdir'#' \
-	    -e 's#\$(PROG_LIBPATH)#'$libdirarg'#' \
-	    -e 's#\$(RPATH_FLAG)#'"$RPATH_FLAG"'#' \
-	    -e 's#\$(LDFLAGS)#'"$LDFLAGS"'#' \
-	    -e 's#\$(PTHREAD_CFLAGS)#'"$PTHREAD_CFLAGS"'#' \
-	    -e 's#\$(CFLAGS)##'`
 
     if test $library = 'kdb'; then
 	lib_flags="$lib_flags -lkdb5 $KDB5_DB_LIB"


### PR DESCRIPTION
krb5-config --libs spits out how MIT Kerberos was linked
explicitly with -rpath, etc. This is not interesting for
the lib user, moreover, it breaks dependends compilations
because it forces every caller to transform his -L to -rpath.
pkg-config files do not do this. They are correct and spit out
-L only. Both should resemble and do resemble now.

Configured and compiled on RHEL6, FreeBSD 9.3, HP-UX 11.31.
Stuff is already in production on top of 1.12.1 on HP-UX.

It'd be great to see those changes in 1.12.3
