### PR TITLE
Commits 1e4bdcfe and 8df1965d introduced a regression

### DIFF
--- a/src/configure.in
+++ b/src/configure.in
@@ -1,14 +1,14 @@
 K5_AC_INIT([aclocal.m4])
 
 # If $runstatedir isn't set by autoconf (<2.70), set it manually.
-if test x"$runstatedir" == x; then
+if test x"$runstatedir" = x; then
   runstatedir=$localstatedir/run
 fi
 AC_SUBST(runstatedir)
 
 # Don't make duplicate profile path entries for /etc/krb5.conf if
 # $sysconfdir is /etc
-if test "$sysconfdir" == /etc; then
+if test "$sysconfdir" = /etc; then
   SYSCONFCONF=""
 else
   SYSCONFCONF=":${sysconfdir}/krb5.conf"


### PR DESCRIPTION
I see the following on HP-UX:

```
$ ./configure --prefix=$HOME/krb5-1.12.1 --with-readline
./configure[2587]: ==: A test command parameter is not valid.
./configure[2594]: ==: A test command parameter is not valid.
checking for gcc... no
checking for cc... cc
```

and

```
$ make install
mkdir /krb5kdc
mkdir: Kein Zugriff möglich auf /: Berechtigung verweigert
*** Fehlerrückkehrcode 2

Stopp.
```

This little patch makes it work as expected.
