### PR TITLE
Allow logger.c to work with redirected stderr

### DIFF
--- a/src/lib/kadm5/logger.c
+++ b/src/lib/kadm5/logger.c
@@ -594,7 +594,7 @@ krb5_klog_init(krb5_context kcontext, char *ename, char *whoami, krb5_boolean do
                  */
                 else if (!strcasecmp(cp, "STDERR")) {
                     log_control.log_entries[i].lfu_filep =
-                        fdopen(fileno(stderr), "a+");
+                        fdopen(fileno(stderr), "w");
                     if (log_control.log_entries[i].lfu_filep) {
                         log_control.log_entries[i].log_type = K_LOG_STDERR;
                         log_control.log_entries[i].lfu_fname =


### PR DESCRIPTION
In lib/kadm5/logger.c:krb5_klog_init(), if the configuration requests
STDERR logging, call fdopen() using mode "w" instead of "a+", to avoid
errors when stderr happens to be opened for write only.

ticket: 8001 (new)
target_version: 1.13
tags: pullup
