### PR TITLE
Fix minor memory leak in klist (again)

### DIFF
--- a/src/clients/klist/klist.c
+++ b/src/clients/klist/klist.c
@@ -533,6 +533,7 @@ do_ccache(krb5_ccache cache)
         }
         krb5_free_cred_contents(kcontext, &creds);
     }
+    krb5_free_principal(kcontext, princ);
     if (code == KRB5_CC_END) {
         if ((code = krb5_cc_end_seq_get(kcontext, cache, &cur))) {
             if (!status_only)
@@ -555,7 +556,6 @@ do_ccache(krb5_ccache cache)
             com_err(progname, code, _("while retrieving a ticket"));
         return 1;
     }
-    krb5_free_principal(kcontext, princ);
 }
 
 char *


### PR DESCRIPTION
[No urgency on this one; it's not for pullup to 1.13.  Found with Coverity Scan.]

Commit 6e51f9cc3152c8e419fe7f459bcf521d60358434 attempted to fix two
minor memory leaks in klist, but one of the fixes was dead code.  In
do_ccache, free princ before we look at the code which terminated the
loop, not after we have returned on either branch.
