### PR TITLE
Map .hin files to the C language for doxygen

### DIFF
--- a/src/doc/Doxyfile.in
+++ b/src/doc/Doxyfile.in
@@ -4,6 +4,7 @@ JAVADOC_AUTOBRIEF      = YES
 OPTIMIZE_OUTPUT_FOR_C  = YES
 WARN_IF_UNDOCUMENTED   = NO
 SHOW_FILES             = NO
+EXTENSION_MAPPING      = hin=C
 INPUT                  = @SRC@/include/krb5/krb5.hin @DOC@/doxy_examples
 EXAMPLE_PATH           = @DOC@/doxy_examples
 GENERATE_HTML          = NO


### PR DESCRIPTION
I think this is not urgent.
I ran into trouble packaging 1.13-alpha1 for Debian, but have applied the patch locally.
