### PR TITLE
Export gssrpc_bindresvport_sa

### DIFF
--- a/src/lib/rpc/libgssrpc.exports
+++ b/src/lib/rpc/libgssrpc.exports
@@ -15,6 +15,7 @@ gssrpc_authnone_create
 gssrpc_authunix_create
 gssrpc_authunix_create_default
 gssrpc_bindresvport
+gssrpc_bindresvport_sa
 gssrpc_callrpc
 gssrpc_clnt_broadcast
 gssrpc_clnt_create


### PR DESCRIPTION
It was added in commit 0d04b60d159ab83b943e43802b1449a3b074bc83, but
was not added to the library export symbol list, and thus was unusable
on systems that enforced library export lists.

ticket: 8003 (new)
tags: pullup
target_version: 1.13
