### PR TITLE
Initialize 'iterflags'

### DIFF
--- a/src/kadmin/dbutil/kdb5_mkey.c
+++ b/src/kadmin/dbutil/kdb5_mkey.c
@@ -912,7 +912,7 @@ kdb5_update_princ_encryption(int argc, char *argv[])
     char *regexp = NULL;
     krb5_keyblock *act_mkey;
     krb5_keylist_node *master_keylist = krb5_db_mkey_list_alias(util_context);
-    krb5_flags iterflags;
+    krb5_flags iterflags = 0;
 
     while ((optchar = getopt(argc, argv, "fnv")) != -1) {
         switch (optchar) {


### PR DESCRIPTION
It is only assigned to in the non-dry-run case, which clang detects
and aborts the build (when maintainer mode is enabled).

ticket: 8005 (new)
tags: pullup
target_version: 1.13
