### PR TITLE
In ksu, handle typeless default_ccache_name values

### DIFF
--- a/src/clients/ksu/main.c
+++ b/src/clients/ksu/main.c
@@ -819,7 +819,7 @@ get_configured_defccname(krb5_context context, char **target_out)
 {
     krb5_error_code retval;
     const char *defname;
-    char *target;
+    char *target = NULL;
 
     *target_out = NULL;
 
@@ -838,10 +838,19 @@ get_configured_defccname(krb5_context context, char **target_out)
     }
 
     defname = krb5_cc_default_name(context);
-    target = (defname == NULL) ? NULL : strdup(defname);
+    if (defname != NULL) {
+        if (strchr(defname, ':') != NULL) {
+            target = strdup(defname);
+        } else {
+            if (asprintf(&target, "FILE:%s", defname) < 0) {
+                target = NULL;
+            }
+        }
+    }
     if (target == NULL) {
-        com_err(prog_name, ENOMEM, _("while determining target ccache name"));
-        return ENOMEM;
+        retval = errno;
+        com_err(prog_name, retval, _("while determining target ccache name"));
+        return retval;
     }
     *target_out = target;
     return 0;


### PR DESCRIPTION
When a configured or compiled-in default ccache name doesn't contain a cache type and ':' as a prefix, add one to the writeable value that we construct when we go to look it up.  This lets the rest of the application always assume that it'll be there.
