### PR TITLE
Work around replay cache creation race

### DIFF
--- a/src/lib/krb5/rcache/rc_io.c
+++ b/src/lib/krb5/rcache/rc_io.c
@@ -158,7 +158,7 @@ krb5_rc_io_creat(krb5_context context, krb5_rc_iostuff *d, char **fn)
 {
     krb5_int16 rc_vno = htons(KRB5_RC_VNO);
     krb5_error_code retval = 0;
-    int do_not_unlink = 0;
+    int flags, do_not_unlink = 0;
     char *dir;
     size_t dirlen;
 
@@ -166,9 +166,13 @@ krb5_rc_io_creat(krb5_context context, krb5_rc_iostuff *d, char **fn)
     if (fn && *fn) {
         if (asprintf(&d->fn, "%s%s%s", dir, PATH_SEPARATOR, *fn) < 0)
             return KRB5_RC_IO_MALLOC;
-        unlink(d->fn);
-        d->fd = THREEPARAMOPEN(d->fn, O_WRONLY | O_CREAT | O_TRUNC | O_EXCL |
-                               O_BINARY, 0600);
+        d->fd = -1;
+        do {
+            if (unlink(d->fn) != 0 && errno != ENOENT)
+                break;
+            flags = O_WRONLY | O_CREAT | O_TRUNC | O_EXCL | O_BINARY;
+            d->fd = THREEPARAMOPEN(d->fn, flags, 0600);
+        } while (d->fd == -1 && errno == EEXIST);
     } else {
         retval = krb5_rc_io_mkstemp(context, d, dir);
         if (retval)


### PR DESCRIPTION
Here is the absolute minimum we can do to ease the pain of the rcache creation race (RT #3498).  If we have an A-unlink B-unlink A-open B-open race, we make the losing process (B in this case) retry.  Of course this results in A's file descriptor pointing to an unlinked file, just as if A had lost an A-unlink A-open B-unlink B-open race.  But it avoids spurious failures.
