### PR TITLE
Make kg_impersonate_name check for NULL ccache

### DIFF
--- a/src/lib/gssapi/krb5/s4u_gss_glue.c
+++ b/src/lib/gssapi/krb5/s4u_gss_glue.c
@@ -55,6 +55,11 @@ kg_impersonate_name(OM_uint32 *minor_status,
     in_creds.client = user->princ;
     in_creds.server = impersonator_cred->name->princ;
 
+    if (impersonator_cred->ccache == NULL) {
+        *minor_status = KG_CCACHE_NOMATCH;
+        return GSS_S_DEFECTIVE_CREDENTIAL;
+    }
+
     if (impersonator_cred->req_enctypes != NULL)
         in_creds.keyblock.enctype = impersonator_cred->req_enctypes[0];
 


### PR DESCRIPTION
When making a call to gss_acquire_cred_impersonate_name
or gss_add_cred_impersonate_name using the krb5 mech,
the call kg_impersonate_name attempts to use the credentials
cache associated with the impersonator credentials.  However,
if the impersonator credentials were acquired with a usage of
GSS_C_ACCEPT, then the ccache member of the cred struct will
be NULL.  This will cause the call to segfault.

Instead, we now check in kg_impersonate_name to make sure that the
ccache member is not NULL.  If it is, we return a major and minor
status of GSS_S_DEFECTIVE_CREDENTIAL and KG_CCACHE_NOMATCH
(respectively).
