### PR TITLE
Use gssalloc_malloc for GSS error tokens

### DIFF
--- a/src/lib/gssapi/krb5/accept_sec_context.c
+++ b/src/lib/gssapi/krb5/accept_sec_context.c
@@ -1243,7 +1243,7 @@ fail:
         toktype = KG_TOK_CTX_ERROR;
 
         token.length = g_token_size(mech_used, tmsglen);
-        token.value = (unsigned char *) xmalloc(token.length);
+        token.value = gssalloc_malloc(token.length);
         if (!token.value)
             goto done;
 


### PR DESCRIPTION
In kg_accept_krb5, use gssalloc_malloc when allocating space for the
error token, since it will be freed with gssalloc_free.  Using malloc
can cause heap corruption on Windows.  This bug was masked by #1445
before 1.12.
