### PR TITLE
ksu fails when -D flag is used and no DEBUG support was compiled.

### DIFF
--- a/doc/user/user_commands/ksu.rst
+++ b/doc/user/user_commands/ksu.rst
@@ -11,7 +11,6 @@ SYNOPSIS
 [ **-n** *target_principal_name* ]
 [ **-c** *source_cache_name* ]
 [ **-k** ]
-[ **-D** ]
 [ **-r** time ]
 [ **-pf** ]
 [ **-l** *lifetime* ]
@@ -228,9 +227,6 @@ OPTIONS
     Do not delete the target cache upon termination of the target
     shell or a command (**-e** command).  Without **-k**, ksu deletes
     the target cache.
-
-**-D**
-    Turn on debug mode.
 
 **-z**
     Restrict the copy of tickets from the source cache to the target

--- a/src/clients/ksu/main.c
+++ b/src/clients/ksu/main.c
@@ -66,7 +66,7 @@ static krb5_error_code resolve_target_cache(krb5_context ksu_context,
 void usage (){
     fprintf(stderr,
             _("Usage: %s [target user] [-n principal] [-c source cachename] "
-              "[-k] [-D] [-r time] [-pf] [-l lifetime] [-zZ] [-q] "
+              "[-k] [-r time] [-pf] [-l lifetime] [-zZ] [-q] "
               "[-e command [args... ] ] [-a [args... ] ]\n"), prog_name);
 }
 

--- a/src/man/ksu.man
+++ b/src/man/ksu.man
@@ -37,7 +37,6 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 [ \fB\-n\fP \fItarget_principal_name\fP ]
 [ \fB\-c\fP \fIsource_cache_name\fP ]
 [ \fB\-k\fP ]
-[ \fB\-D\fP ]
 [ \fB\-r\fP time ]
 [ \fB\-pf\fP ]
 [ \fB\-l\fP \fIlifetime\fP ]
@@ -258,9 +257,6 @@ krb5cc_1984.2
 Do not delete the target cache upon termination of the target
 shell or a command (\fB\-e\fP command).  Without \fB\-k\fP, ksu deletes
 the target cache.
-.TP
-.B \fB\-D\fP
-Turn on debug mode.
 .TP
 .B \fB\-z\fP
 Restrict the copy of tickets from the source cache to the target


### PR DESCRIPTION
- On Centos 6.x, ksu is compiled without debug support but when we try
  to actually use the "-D" flag that is shown as a valid option, ksu
  fails:

```
ccin2p3-vm # ksu targetuser -n remiferrand@IN2P3.FR -D
Usage: ksu [target user] [-n principal] [-c source cachename] [-k] [-D]
[-r time] [-pf] [-l lifetime] [-zZ] [-q] [-e command [args... ] ] [-a
[args... ] ]
ccin2p3-vm # echo $?
2
```

This patch makes ksu to accept `-D` as a valid option in `ksu` even if `DEBUG` was not compiled
in, but the option actually does nothing debug will not be activated.
