### PR TITLE
Add missing salt from enctype in t_kdb.py test

### DIFF
--- a/src/tests/t_kdb.py
+++ b/src/tests/t_kdb.py
@@ -298,12 +298,12 @@ realm.kinit(realm.user_princ, flags=['-R', '-S', 'alias'])
 realm.klist(realm.user_princ, 'alias@KRBTEST.COM')
 
 # Regression test for #7980 (fencepost when dividing keys up by kvno).
-realm.run_kadminl('addprinc -randkey -e aes256-cts,aes128-cts kvnoprinc')
-realm.run_kadminl('cpw -randkey -keepold -e aes256-cts,aes128-cts kvnoprinc')
+realm.run_kadminl('addprinc -randkey -e aes256-cts:normal,aes128-cts:normal kvnoprinc')
+realm.run_kadminl('cpw -randkey -keepold -e aes256-cts:normal,aes128-cts:normal kvnoprinc')
 out = realm.run_kadminl('getprinc kvnoprinc')
 if 'Number of keys: 4' not in out:
     fail('After cpw -keepold, wrong number of keys')
-realm.run_kadminl('cpw -randkey -keepold -e aes256-cts,aes128-cts kvnoprinc')
+realm.run_kadminl('cpw -randkey -keepold -e aes256-cts:normal,aes128-cts:normal kvnoprinc')
 out = realm.run_kadminl('getprinc kvnoprinc')
 if 'Number of keys: 6' not in out:
     fail('After cpw -keepold, wrong number of keys')


### PR DESCRIPTION
kadmin requires enctypes in form "key:salt"
If it is not given in that form, it reports error and the test fails.

The issue might remain hidden because the test is executed only if ldap is installed. If missing, the test silently passes (only the verbose output shows more detail).