### PR TITLE
Adjust asn1c test vector code for new asn1c

### DIFF
--- a/src/tests/asn.1/make-vectors.c
+++ b/src/tests/asn.1/make-vectors.c
@@ -101,7 +101,7 @@ static PA_OTP_CHALLENGE_t challenge_2 = { { "maxnonce", 8 }, &service,
                                           &s2kparams };
 
 /* Minimal PA-OTP-REQUEST */
-static UInt32_t kvno;           /* Initialized to 5 in main(). */
+static UInt32_t kvno = 5;
 static PA_OTP_REQUEST_t request_1 = { { "\0\0\0\0", 4, 0 }, NULL,
                                       { 0, &kvno,
                                         { "krbASN.1 test message", 21 } } };
@@ -153,7 +153,6 @@ main()
 {
     /* Initialize values which can't use static initializers. */
     asn_long2INTEGER(&otp_format, 2);  /* Alphanumeric */
-    asn_long2INTEGER(&kvno, 5);
     OBJECT_IDENTIFIER_set_arcs(&alg_sha256.algorithm, sha256_arcs,
                                sizeof(*sha256_arcs),
                                sizeof(sha256_arcs) / sizeof(*sha256_arcs));


### PR DESCRIPTION
asn1c 0.9.22 added support for representing integers using unsigned
types if they have appropriate constraints.  This changes the
representation of RFC4120's UInt32 type from Integer_t to unsigned
long.  In make-vectors.c, this means we can use a static initializer
for kvno, and that the old method of calling asn_long2INTEGER doesn't
work.  Adjust make-vectors.c to assume the newer version of asn1c.
