### PR TITLE
Don't fdopen() in append mode in cc_file.c

### DIFF
--- a/src/lib/krb5/ccache/cc_file.c
+++ b/src/lib/krb5/ccache/cc_file.c
@@ -348,7 +348,7 @@ open_cache_file(krb5_context context, const char *filename,
         return ret;
     }
 
-    fp = fdopen(fd, writable ? "a+b" : "rb");
+    fp = fdopen(fd, writable ? "r+b" : "rb");
     if (fp == NULL) {
         (void)krb5_unlock_file(context, fd);
         (void)close(fd);


### PR DESCRIPTION
Implementations of fdopen() are inconsistent about the state of
the file offset after fdopen(., "a+") -- some position the stream
at the end of the file immediately (e.g., Solaris), for both reading
and writing, but others let reads occur from the beginning of the
file (e.g., glibc).

As it turns out, we only ever write to the file descriptor, not
through stdio, so opening the file with O_APPEND and using fdopen()
with "r+b" should give us sufficient append semantics, while
more portably letting the stream read from the beginning of the file.

This fixes the test suite on Solaris, a regression introduced
by commit 6979ead5e5c24ca0ec3569eb4bef48c2e5d8a726.
