### PR TITLE
Fix LDAP tests when sasl.h not found

### DIFF
--- a/src/tests/t_kdb.py
+++ b/src/tests/t_kdb.py
@@ -324,9 +324,16 @@ out = kldaputil(['list'])
 if out:
     fail('Unexpected kdb5_ldap_util list output after destroy')
 
+if not core_schema:
+    success('Warning: skipping some LDAP tests because core schema not found')
+    sys.exit(0)
+
+if runenv.have_sasl != 'yes':
+    success('Warning: skipping some LDAP tests because SASL support not built')
+    sys.exit(0)
+
 # Test SASL EXTERNAL auth.  Remove the DNs and service password file
-# from the DB module config.  EXTERNAL auth can work even if we didn't
-# build with the SASL header file, because no interaction is required.
+# from the DB module config.
 os.remove(ldap_pwfile)
 dbmod = conf['dbmodules']['ldap']
 dbmod['ldap_kdc_sasl_mech'] = dbmod['ldap_kadmind_sasl_mech'] = 'EXTERNAL'
@@ -339,14 +346,6 @@ realm.addprinc(realm.user_princ, password('user'))
 realm.kinit(realm.user_princ, password('user'))
 realm.stop()
 realm.run([kdb5_ldap_util, 'destroy', '-f'])
-
-if not core_schema:
-    success('Warning: skipping some LDAP tests because core schema not found')
-    sys.exit(0)
-
-if runenv.have_sasl != 'yes':
-    success('Warning: skipping some LDAP tests because SASL support not built')
-    sys.exit(0)
 
 # Test SASL DIGEST-MD5 auth.  We need to set a clear-text password for
 # the admin DN, so create a person entry (requires the core schema).


### PR DESCRIPTION
Do not try to run the SASL EXTERNAL auth test if we could not define a
useful interact function.  With current libraries the interact
function is asked for an authorization name, and the bind fails if it
gets an unsuccessful result or if no interaction function is defined.
