### PR TITLE
Fix bugs in previous cc_file.c changes

### DIFF
--- a/src/lib/krb5/ccache/cc_file.c
+++ b/src/lib/krb5/ccache/cc_file.c
@@ -117,6 +117,8 @@ static krb5_error_code
 set_errmsg_filename(krb5_context context, krb5_error_code ret,
                     const char *fname)
 {
+    if (!ret)
+        return 0;
     k5_setmsg(context, ret, "%s (filename: %s)", error_message(ret), fname);
     return ret;
 }
@@ -644,12 +646,13 @@ fcc_destroy(krb5_context context, krb5_ccache id)
 #endif /* MSDOS_FILESYSTEM */
 
 cleanup:
+    (void)set_errmsg_filename(context, ret, data->filename);
     k5_cc_mutex_unlock(context, &data->lock);
     free_fccdata(context, data);
     free(id);
 
     krb5_change_cache();
-    return set_errmsg_filename(context, ret, data->filename);
+    return ret;
 }
 
 extern const krb5_cc_ops krb5_fcc_ops;
@@ -893,11 +896,12 @@ krb5int_fcc_new_unique(krb5_context context, char *template, krb5_ccache *id)
     return 0;
 
 err_out:
+    (void)set_errmsg_filename(context, ret, data->filename);
     k5_cc_mutex_unlock(context, &data->lock);
     k5_cc_mutex_destroy(&data->lock);
     free(data->filename);
     free(data);
-    return set_errmsg_filename(context, ret, data->filename);
+    return ret;
 }
 
 /*


### PR DESCRIPTION
In fcc_destroy and krb5int_fcc_new_unique, call set_errmsg_filename
before deleting the cache handle, or else the reference to
data->filename is a use after free.

In set_errmsg_filename, do nothing if the code is 0, as we don't have
an error to annotate.
