### PR TITLE
Fix OTP tests with pyrad 2.x

### DIFF
--- a/src/tests/t_otp.py
+++ b/src/tests/t_otp.py
@@ -46,7 +46,7 @@ except ImportError:
 # we'll just include them here.
 radius_attributes = '''
 ATTRIBUTE    User-Name    1    string
-ATTRIBUTE    User-Password   2    string
+ATTRIBUTE    User-Password   2    octets
 ATTRIBUTE    NAS-Identifier  32    string
 '''
 


### PR DESCRIPTION
Declare User-Password as having type "octets" instead of "string" or
pyrad 2.x will throw a decoding error when retrieving it.
