### PR TITLE
Check for null *iter_p in profile_iterator()

### DIFF
--- a/src/util/profile/prof_get.c
+++ b/src/util/profile/prof_get.c
@@ -579,7 +579,7 @@ profile_iterator(void **iter_p, char **ret_name, char **ret_value)
         *ret_name = NULL;
     if (ret_value)
         *ret_value = NULL;
-    if (iter->magic != PROF_MAGIC_ITERATOR)
+    if (iter == NULL || iter->magic != PROF_MAGIC_ITERATOR)
         return PROF_MAGIC_ITERATOR;
     profile = iter->profile;
 


### PR DESCRIPTION
In profile_iterator(), return PROF_MAGIC_ITERATOR if *iter_p is NULL,
instead of dereferencing a null pointer, as we did prior to 1.10.
Correct calling code will not trigger this case, but incorrect code
has been reported in the field.
