### PR TITLE
Export function gss_add_cred_with_password

### DIFF
--- a/src/lib/gssapi/libgssapi_krb5.exports
+++ b/src/lib/gssapi/libgssapi_krb5.exports
@@ -43,6 +43,7 @@ gss_acquire_cred_impersonate_name
 gss_add_buffer_set_member
 gss_add_cred
 gss_add_cred_impersonate_name
+gss_add_cred_with_password
 gss_add_oid_set_member
 gss_authorize_localname
 gss_canonicalize_name


### PR DESCRIPTION
This function is already present in gssapi_ext.h, but without exporting it, a link error will be produced every time it is used.

An example can be seen [here](https://gist.github.com/frozencemetery/7c8a016db7081f806baa).

This problem is present in master and at least as far back as 1.12 and likely earlier as well.