### PR TITLE
Remove starttime hack in EncTicketPart decoder

### DIFF
--- a/src/kdc/do_tgs_req.c
+++ b/src/kdc/do_tgs_req.c
@@ -383,12 +383,7 @@ process_tgs_req(struct server_handle *handle, krb5_data *pkt,
     if (isflagset(server->attributes, KRB5_KDB_OK_AS_DELEGATE))
         setflag(enc_tkt_reply.flags, TKT_FLG_OK_AS_DELEGATE);
 
-    /*
-     * Fix header_ticket's starttime; if it's zero, fill in the
-     * authtime's value.
-     */
-    if (!(header_enc_tkt->times.starttime))
-        header_enc_tkt->times.starttime = authtime;
+    /* Indicate support for encrypted padata (RFC 6806). */
     setflag(enc_tkt_reply.flags, TKT_FLG_ENC_PA_REP);
 
     /* don't use new addresses unless forwarded, see below */

--- a/src/lib/krb5/asn.1/asn1_k_encode.c
+++ b/src/lib/krb5/asn.1/asn1_k_encode.c
@@ -713,27 +713,13 @@ static const struct atype_info *authenticator_fields[] = {
 DEFSEQTYPE(untagged_authenticator, krb5_authenticator, authenticator_fields);
 DEFAPPTAGGEDTYPE(authenticator, 2, untagged_authenticator);
 
-static int
-is_enc_tkt_start_set(const void *p)
-{
-    const krb5_enc_tkt_part *val = p;
-    return (val->times.starttime != 0);
-}
-static void
-init_enc_tkt_start(void *p)
-{
-    krb5_enc_tkt_part *val = p;
-    val->times.starttime = val->times.authtime;
-}
 DEFFIELD(enc_tkt_0, krb5_enc_tkt_part, flags, 0, krb5_flags);
 DEFFIELD(enc_tkt_1, krb5_enc_tkt_part, session, 1, ptr_encryption_key);
 DEFFIELD(enc_tkt_2, krb5_enc_tkt_part, client, 2, realm_of_principal);
 DEFFIELD(enc_tkt_3, krb5_enc_tkt_part, client, 3, principal);
 DEFFIELD(enc_tkt_4, krb5_enc_tkt_part, transited, 4, transited);
 DEFFIELD(enc_tkt_5, krb5_enc_tkt_part, times.authtime, 5, kerberos_time);
-DEFFIELD(enc_tkt_6_def, krb5_enc_tkt_part, times.starttime, 6, kerberos_time);
-DEFOPTIONALTYPE(enc_tkt_6, is_enc_tkt_start_set, init_enc_tkt_start,
-                enc_tkt_6_def);
+DEFFIELD(enc_tkt_6, krb5_enc_tkt_part, times.starttime, 6, opt_kerberos_time);
 DEFFIELD(enc_tkt_7, krb5_enc_tkt_part, times.endtime, 7, kerberos_time);
 DEFFIELD(enc_tkt_8, krb5_enc_tkt_part, times.renew_till, 8, opt_kerberos_time);
 DEFFIELD(enc_tkt_9, krb5_enc_tkt_part, caddrs, 9,

--- a/src/tests/asn.1/krb5_decode_test.c
+++ b/src/tests/asn.1/krb5_decode_test.c
@@ -366,8 +366,7 @@ int main(argc, argv)
         setup(krb5_enc_tkt_part,ktest_make_sample_enc_tkt_part);
         decode_run("enc_tkt_part","","63 82 01 14 30 82 01 10 A0 07 03 05 00 FE DC BA 98 A1 13 30 11 A0 03 02 01 01 A1 0A 04 08 31 32 33 34 35 36 37 38 A2 10 1B 0E 41 54 48 45 4E 41 2E 4D 49 54 2E 45 44 55 A3 1A 30 18 A0 03 02 01 01 A1 11 30 0F 1B 06 68 66 74 73 61 69 1B 05 65 78 74 72 61 A4 2E 30 2C A0 03 02 01 01 A1 25 04 23 45 44 55 2C 4D 49 54 2E 2C 41 54 48 45 4E 41 2E 2C 57 41 53 48 49 4E 47 54 4F 4E 2E 45 44 55 2C 43 53 2E A5 11 18 0F 31 39 39 34 30 36 31 30 30 36 30 33 31 37 5A A6 11 18 0F 31 39 39 34 30 36 31 30 30 36 30 33 31 37 5A A7 11 18 0F 31 39 39 34 30 36 31 30 30 36 30 33 31 37 5A A8 11 18 0F 31 39 39 34 30 36 31 30 30 36 30 33 31 37 5A A9 20 30 1E 30 0D A0 03 02 01 02 A1 06 04 04 12 D0 00 23 30 0D A0 03 02 01 02 A1 06 04 04 12 D0 00 23 AA 24 30 22 30 0F A0 03 02 01 01 A1 08 04 06 66 6F 6F 62 61 72 30 0F A0 03 02 01 01 A1 08 04 06 66 6F 6F 62 61 72",decode_krb5_enc_tkt_part,ktest_equal_enc_tkt_part,krb5_free_enc_tkt_part);
 
-        /* ref.times.starttime = 0; */
-        ref.times.starttime = ref.times.authtime;
+        ref.times.starttime = 0;
         ref.times.renew_till = 0;
         ktest_destroy_address(&(ref.caddrs[1]));
         ktest_destroy_address(&(ref.caddrs[0]));


### PR DESCRIPTION
The EncTicketPart decoder sets starttime to authtime if it wasn't
included in the ASN.1 value.  This is problematic for upcoming CAMMAC
work, as we will need to re-encode a received EncTicketPart to check
the KDC verifier.  Remove that behavior and just use opt_kerberos_time
for the starttime field.  Adjust krb5_decode_test.c to match the new
decoder behavior.

Similarly, remove the process_tgs_req() code which sets starttime in
the header ticket if it isn't set.  Add a comment explaining the
unrelated code adjacent to it.

check_tgs_times() used the ticket starttime without checking if it was
present.  Add a fallback to times->authtime, and narrow the function
contract to make the implementation more concise.

There is a similar hack in the EncKDCRepPart decoder; leave that alone
for now.