### PR TITLE
Bump DAL major version for iterate change

### DIFF
--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -817,7 +817,7 @@ krb5_dbe_free_string(krb5_context, char *);
  * This number indicates the date of the last incompatible change to the DAL.
  * The maj_ver field of the module's vtable structure must match this version.
  */
-#define KRB5_KDB_DAL_MAJOR_VERSION 4
+#define KRB5_KDB_DAL_MAJOR_VERSION 5
 
 /*
  * A krb5_context can hold one database object.  Modules should use


### PR DESCRIPTION
Commit ab009b8568d9b64b7e992ecdb98114e895b4a7ff for issue #7977
changed the signature of krb5_db_iterate() and properly bumped
KRB5_KDB_API_VERSION from 7 to 8.  It also changed the signature of
the DAL iterate() function, but did not bump
KRB5_KDB_DAL_MAJOR_VERSION.  Bump that version from 4 to 5 now.
