### PR TITLE
Avoid uninitialized data in t_prf.c

### DIFF
--- a/src/tests/gssapi/t_prf.c
+++ b/src/tests/gssapi/t_prf.c
@@ -124,8 +124,10 @@ main(int argc, char *argv[])
      * implementation.
      */
     context = (gss_ctx_id_t)&uctx;
+    memset(&uctx, 0, sizeof(uctx));
     uctx.mech_type = &mech_krb5;
     uctx.internal_ctx_id = (gss_ctx_id_t)&kgctx;
+    memset(&kgctx, 0, sizeof(kgctx));
     kgctx.k5_context = NULL;
     kgctx.established = 1;
     kgctx.have_acceptor_subkey = 1;


### PR DESCRIPTION
In t_prf.c, make sure that the partially initialized, faked-up
structures gss_union_ctx_id_desc and krb5_gss_ctx_id_rec are zeroed.
This avoids uninitialized reads in gss_pseudo_random(), which can
cause intermittent test failures on some platforms.