### PR TITLE
Implement secure cookies

### DIFF
--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -1469,6 +1469,14 @@ encode_krb5_pa_otp_enc_req(const krb5_data *, krb5_data **);
 krb5_error_code
 encode_krb5_kkdcp_message(const krb5_kkdcp_message *, krb5_data **);
 
+typedef struct _krb5_secure_cookie {
+    krb5_timestamp time;
+    krb5_pa_data data;
+} krb5_secure_cookie;
+
+krb5_error_code
+encode_krb5_secure_cookie(const krb5_secure_cookie *, krb5_data **);
+
 /*************************************************************************
  * End of prototypes for krb5_encode.c
  *************************************************************************/
@@ -1641,6 +1649,9 @@ decode_krb5_pa_otp_enc_req(const krb5_data *, krb5_data **);
 
 krb5_error_code
 decode_krb5_kkdcp_message(const krb5_data *, krb5_kkdcp_message **);
+
+krb5_error_code
+decode_krb5_secure_cookie(const krb5_data *, krb5_secure_cookie **);
 
 struct _krb5_key_data;          /* kdb.h */
 

--- a/src/kdc/Makefile.in
+++ b/src/kdc/Makefile.in
@@ -9,6 +9,7 @@ all:: krb5kdc rtest
 LOCALINCLUDES = -I.
 SRCS= \
 	kdc5_err.c \
+	$(srcdir)/cookies.c \
 	$(srcdir)/dispatch.c \
 	$(srcdir)/do_as_req.c \
 	$(srcdir)/do_tgs_req.c \
@@ -29,6 +30,7 @@ SRCS= \
 
 OBJS= \
 	kdc5_err.o \
+	cookies.o \
 	dispatch.o \
 	do_as_req.o \
 	do_tgs_req.o \

--- a/src/kdc/cookies.c
+++ b/src/kdc/cookies.c
@@ -1,0 +1,251 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* kdc/cookie.c - Secure Cookies */
+/*
+ * Copyright 2015 Red Hat, Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "cookies.h"
+
+#include <kdb.h>
+
+/* Number from internal use reserved; see RFC 4120 7.5.1. */
+#define KEYUSAGE_PA_FX_COOKIE 513
+
+/* Let cookies be valid for one hour. */
+#define COOKIE_LIFETIME 3600
+
+static krb5_error_code
+load_key(krb5_context context, krb5_const_principal server,
+         krb5_enctype etype, krb5_keyblock **key)
+{
+    krb5_db_entry *entry = NULL;
+    krb5_key_data *kdata = NULL;
+    krb5_error_code retval = 0;
+    krb5_keyblock kblock = {};
+    krb5_int32 start = 0;
+
+    /* Look up the server's principal. */
+    retval = krb5_db_get_principal(context, server,
+                                   KRB5_KDB_FLAG_ALIAS_OK, &entry);
+    if (retval != 0)
+        return retval;
+
+    /* Find the key with the specified enctype. */
+    retval = krb5_dbe_search_enctype(context, entry, &start,
+                                     etype, -1, 0, &kdata);
+    /* Valgrind tells me that entry leaks here.
+     * What function should I use to free it? */
+    if (retval != 0)
+        return retval;
+
+    /* Decrypt the key. */
+    retval = krb5_dbe_decrypt_key_data(context, NULL, kdata, &kblock, NULL);
+    if (retval != 0)
+        return retval;
+
+    /* Copy the keyblock. */
+    retval = krb5_copy_keyblock(context, &kblock, key);
+    krb5_free_keyblock_contents(context, &kblock);
+    return retval;
+}
+
+static krb5_error_code
+cookie_decrypt(krb5_context context, const krb5_keyblock *key,
+               krb5_timestamp now, const krb5_enc_data *ed,
+               krb5_pa_data *padata)
+{
+    krb5_secure_cookie *sc = NULL;
+    krb5_error_code retval = 0;
+    krb5_data pt = {};
+
+    /* Prepare input for decryption. */
+    pt.length = ed->ciphertext.length;
+    pt.data = malloc(pt.length);
+    if (pt.data == NULL)
+        return ENOMEM;
+
+    /* Perform decryption. */
+    retval = krb5_c_decrypt(context, key, KEYUSAGE_PA_FX_COOKIE,
+                            NULL, ed, &pt);
+    if (retval != 0) {
+        krb5_free_data_contents(context, &pt);
+        return retval;
+    }
+
+    /* Decode the cookie. */
+    retval = decode_krb5_secure_cookie(&pt, &sc);
+    krb5_free_data_contents(context, &pt);
+    if (retval != 0)
+        return retval;
+
+    /* Determine if the cookie is expired. */
+    if (sc->time + COOKIE_LIFETIME < now) {
+        free(sc->data.contents);
+        free(sc);
+        return ETIMEDOUT;
+    }
+
+    free(padata->contents);
+    *padata = sc->data;
+    free(sc);
+    return 0;
+}
+
+static krb5_error_code
+cookie_encrypt(krb5_context context, const krb5_keyblock *key,
+               krb5_timestamp now, krb5_pa_data *padata)
+{
+    krb5_secure_cookie cookie = { .time = now, .data = *padata };
+    krb5_error_code retval = 0;
+    krb5_enc_data ct = {};
+    krb5_data *pt = NULL;
+    krb5_data *ed = NULL;
+    size_t ctlen;
+
+    /* Encode the cookie with a timestamp. */
+    retval = encode_krb5_secure_cookie(&cookie, &pt);
+    if (retval != 0)
+        return retval;
+
+    /* Find out how much buffer to allocate. */
+    retval = krb5_c_encrypt_length(context, key->enctype,
+                                   pt->length, &ctlen);
+    if (retval != 0) {
+        krb5_free_data(context, pt);
+        return retval;
+    }
+
+    /* Allocate the output buffer. */
+    ct.ciphertext.length = ctlen;
+    ct.ciphertext.data = malloc(ctlen);
+    if (ct.ciphertext.data == NULL) {
+        krb5_free_data(context, pt);
+        retval = ENOMEM;
+        return retval;
+    }
+
+    /* Perform the encryption. */
+    retval = krb5_c_encrypt(context, key, KEYUSAGE_PA_FX_COOKIE,
+                            NULL, pt, &ct);
+    krb5_free_data(context, pt);
+    if (retval != 0) {
+        free(ct.ciphertext.data);
+        return retval;
+    }
+
+    /* Encode to EncryptedData. */
+    retval = encode_krb5_enc_data(&ct, &ed);
+    free(ct.ciphertext.data);
+    if (retval != 0)
+        return retval;
+
+    /* Set the encryption in the cookie. */
+    free(padata->contents);
+    padata->contents = (krb5_octet *)ed->data;
+    padata->length = ed->length;
+    ed->data = NULL;
+    krb5_free_data(context, ed);
+    return 0;
+}
+
+krb5_error_code
+cookies_decrypt(krb5_context context, krb5_const_principal princ,
+                krb5_pa_data **padata)
+{
+    krb5_error_code retval = 0;
+    krb5_keyblock *key = NULL;
+    krb5_enc_data *ed = NULL;
+    krb5_timestamp now = 0;
+    size_t i;
+
+    /* Get the time. */
+    retval = krb5_timeofday(context, &now);
+    if (retval != 0)
+        return retval;
+
+    for (i = 0; padata[i] != NULL; i++) {
+        krb5_data pt = {
+            .data = (char *)padata[i]->contents,
+            .length = padata[i]->length
+        };
+
+        if (padata[i]->pa_type != KRB5_PADATA_FX_COOKIE)
+            continue;
+
+        /* Parse the incoming data. */
+        krb5_free_enc_data(context, ed);
+        ed = NULL;
+        retval = decode_krb5_enc_data(&pt, &ed);
+        if (retval != 0)
+            break;
+
+        /* Find a key. */
+        retval = load_key(context, princ, ed->enctype, &key);
+        if (retval != 0)
+            break;
+
+        /* Decrypt the cookie. */
+        retval = cookie_decrypt(context, key, now, ed, padata[i]);
+        krb5_free_keyblock(context, key);
+        if (retval != 0)
+            break;
+    }
+
+    krb5_free_enc_data(context, ed);
+    return retval;
+}
+
+krb5_error_code
+cookies_encrypt(krb5_context context, krb5_const_principal princ,
+                krb5_pa_data **padata)
+{
+    krb5_error_code retval = 0;
+    krb5_keyblock *key = NULL;
+    krb5_timestamp now = 0;
+    size_t i;
+
+    retval = krb5_timeofday(context, &now);
+    if (retval != 0)
+        return retval;
+
+    for (i = 0; padata[i] != NULL; i++) {
+        if (padata[i]->pa_type != KRB5_PADATA_FX_COOKIE)
+            continue;
+
+        if (key == NULL) {
+            retval = load_key(context, princ, -1, &key);
+            if (retval != 0)
+                break;
+        }
+
+        retval = cookie_encrypt(context, key, now, padata[i]);
+        if (retval != 0)
+            break;
+    }
+
+    krb5_free_keyblock(context, key);
+    return retval;
+}

--- a/src/kdc/cookies.h
+++ b/src/kdc/cookies.h
@@ -1,0 +1,43 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* kdc/cookie.h - Secure Cookies */
+/*
+ * Copyright 2015 Red Hat, Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef COOKIES_H_
+#define COOKIES_H_
+
+#include <k5-int.h>
+
+krb5_error_code
+cookies_decrypt(krb5_context context, krb5_const_principal princ,
+                krb5_pa_data **padata);
+
+krb5_error_code
+cookies_encrypt(krb5_context context, krb5_const_principal princ,
+                krb5_pa_data **padata);
+
+#endif

--- a/src/lib/krb5/asn.1/asn1_k_encode.c
+++ b/src/lib/krb5/asn.1/asn1_k_encode.c
@@ -1766,3 +1766,12 @@ DEFSEQTYPE(kkdcp_message, krb5_kkdcp_message,
            kkdcp_message_fields);
 MAKE_ENCODER(encode_krb5_kkdcp_message, kkdcp_message);
 MAKE_DECODER(decode_krb5_kkdcp_message, kkdcp_message);
+
+DEFFIELD(secure_cookie_0, krb5_secure_cookie, time, 0, kerberos_time);
+DEFFIELD(secure_cookie_1, krb5_secure_cookie, data, 1, pa_data);
+static const struct atype_info *secure_cookie_fields[] = {
+    &k5_atype_secure_cookie_0, &k5_atype_secure_cookie_1
+};
+DEFSEQTYPE(secure_cookie, krb5_secure_cookie, secure_cookie_fields);
+MAKE_ENCODER(encode_krb5_secure_cookie, secure_cookie);
+MAKE_DECODER(decode_krb5_secure_cookie, secure_cookie);

--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -41,6 +41,7 @@ decode_krb5_safe
 decode_krb5_sam_challenge_2
 decode_krb5_sam_challenge_2_body
 decode_krb5_sam_response_2
+decode_krb5_secure_cookie
 decode_krb5_setpw_req
 decode_krb5_tgs_rep
 decode_krb5_tgs_req
@@ -89,6 +90,7 @@ encode_krb5_safe
 encode_krb5_sam_challenge_2
 encode_krb5_sam_challenge_2_body
 encode_krb5_sam_response_2
+encode_krb5_secure_cookie
 encode_krb5_sp80056a_other_info
 encode_krb5_tgs_rep
 encode_krb5_tgs_req


### PR DESCRIPTION
RFC 6113 specifies the ability for the KDC to send a PA-FX-COOKIE
to the client which will be returned on the next AS-REQ. This permits
the KDC to retain state for the subsequent request. In the majority of
cases, this cookie must be encrypted.

This patch enables the transparent encryption/decryption of such
cookies. After the request is decoded, any cookies found are decrypted.
Any cookies set, either internally or by kdcpreauth plugins, will be
automatically encrypted before the reply is encoded.

Additionally, a timestamp is inserted into the cookie before encryption.
This timestamp is validated for freshness during decryption.