### PR TITLE
Fix replay issue of AS-REQ with PKINIT

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_srv.c
+++ b/src/plugins/preauth/pkinit/pkinit_srv.c
@@ -429,6 +429,12 @@ pkinit_server_verify_padata(krb5_context context,
             goto cleanup;
         }
 
+        /* check pkAuthenticator timestamp */
+        retval = krb5_check_clockskew(context, auth_pack->pkAuthenticator.ctime)
+        if (retval) {
+            goto cleanup;
+        }
+
         /* check dh parameters */
         if (auth_pack->clientPublicValue != NULL) {
             retval = server_check_dh(context, plgctx->cryptoctx,

--- a/src/plugins/preauth/pkinit/pkinit_srv.c
+++ b/src/plugins/preauth/pkinit/pkinit_srv.c
@@ -430,7 +430,7 @@ pkinit_server_verify_padata(krb5_context context,
         }
 
         /* check pkAuthenticator timestamp */
-        retval = krb5_check_clockskew(context, auth_pack->pkAuthenticator.ctime)
+        retval = krb5_check_clockskew(context, auth_pack->pkAuthenticator.ctime);
         if (retval) {
             goto cleanup;
         }


### PR DESCRIPTION
  AS-REQ packets of clients using PKINIT can be replayed to the KDC. This is
  non-compliant with RFC 4556, since the timestamp in the pkAuthenticator
  is not checked. Hence, for each replayed packet, a fresh AS-REP is sent
  back by the KDC. However, no valid scenario to exploit this issue has been
  identified. This commit adds the missing check.