### PR TITLE
Import names immediately with COMPOSITE_EXPORT

### DIFF
--- a/src/lib/gssapi/mechglue/g_imp_name.c
+++ b/src/lib/gssapi/mechglue/g_imp_name.c
@@ -36,7 +36,7 @@
 #include <errno.h>
 
 /* local function to import GSS_C_EXPORT_NAME names */
-static OM_uint32 importExportName(OM_uint32 *, gss_union_name_t);
+static OM_uint32 importExportName(OM_uint32 *, gss_union_name_t, gss_OID);
 
 static OM_uint32
 val_imp_name_args(
@@ -151,8 +151,9 @@ gss_name_t *		output_name;
      * do however make this an MN for names of GSS_C_NT_EXPORT_NAME type.
      */
     if (input_name_type != GSS_C_NULL_OID &&
-	g_OID_equal(input_name_type, GSS_C_NT_EXPORT_NAME)) {
-	major_status = importExportName(minor_status, union_name);
+	(g_OID_equal(input_name_type, GSS_C_NT_EXPORT_NAME) ||
+	 g_OID_equal(input_name_type, GSS_C_NT_COMPOSITE_EXPORT))) {
+	major_status = importExportName(minor_status, union_name, input_name_type);
 	if (major_status != GSS_S_COMPLETE)
 	    goto allocation_failure;
     }
@@ -188,9 +189,10 @@ static const unsigned int mechOidLenLen = 2;
 static const unsigned int nameTypeLenLen = 2;
 
 static OM_uint32
-importExportName(minor, unionName)
+importExportName(minor, unionName, inputNameType)
     OM_uint32 *minor;
     gss_union_name_t unionName;
+    gss_OID inputNameType;
 {
     gss_OID_desc mechOid;
     gss_buffer_desc expName;
@@ -263,11 +265,11 @@ importExportName(minor, unionName)
     if (mech->gss_export_name) {
 	if (mech->gssspi_import_name_by_mech) {
 	    major = mech->gssspi_import_name_by_mech(minor, &mechOid, &expName,
-						     GSS_C_NT_EXPORT_NAME,
+						     inputNameType,
 						     &unionName->mech_name);
 	} else {
 	    major = mech->gss_import_name(minor, &expName,
-					  GSS_C_NT_EXPORT_NAME,
+					  inputNameType,
 					  &unionName->mech_name);
 	}
 	if (major != GSS_S_COMPLETE)

--- a/src/tests/gssapi/t_export_name.c
+++ b/src/tests/gssapi/t_export_name.c
@@ -57,6 +57,8 @@ main(int argc, char *argv[])
     gss_OID mech = (gss_OID)gss_mech_krb5;
     gss_name_t name, mechname, impname;
     gss_buffer_desc buf, buf2;
+    krb5_boolean use_composite = FALSE;
+    gss_OID target_nt = GSS_C_NT_EXPORT_NAME;
     const char *name_arg;
     char opt;
 
@@ -68,6 +70,8 @@ main(int argc, char *argv[])
             mech = &mech_krb5;
         else if (opt == 's')
             mech = &mech_spnego;
+        else if (opt == 'c')
+            use_composite = TRUE;
         else
             usage();
     }
@@ -81,13 +85,21 @@ main(int argc, char *argv[])
     /* Canonicalize and export the name. */
     major = gss_canonicalize_name(&minor, name, mech, &mechname);
     check_gsserr("gss_canonicalize_name", major, minor);
-    major = gss_export_name(&minor, mechname, &buf);
+    if (use_composite)
+        major = gss_export_name_composite(&minor, mechname, &buf);
+    else
+        major = gss_export_name(&minor, mechname, &buf);
     check_gsserr("gss_export_name", major, minor);
 
     /* Import and re-export the name, and compare the results. */
-    major = gss_import_name(&minor, &buf, GSS_C_NT_EXPORT_NAME, &impname);
+    if (use_composite)
+        target_nt = GSS_C_NT_COMPOSITE_EXPORT;
+    major = gss_import_name(&minor, &buf, target_nt, &impname);
     check_gsserr("gss_export_name", major, minor);
-    major = gss_export_name(&minor, impname, &buf2);
+    if (use_composite)
+        major = gss_export_name_composite(&minor, mechname, &buf2);
+    else
+        major = gss_export_name(&minor, mechname, &buf2);
     check_gsserr("gss_export_name", major, minor);
     if (buf.length != buf2.length ||
         memcmp(buf.value, buf2.value, buf.length) != 0) {

--- a/src/tests/gssapi/t_gssapi.py
+++ b/src/tests/gssapi/t_gssapi.py
@@ -191,6 +191,11 @@ output = realm.run(['./t_export_name', '-s', 'p:a@b'])
 if output != '0401000806062B060105050200000003614062\n':
     fail('Unexpected output from t_export_name (SPNEGO krb5 principal)')
 
+# test composite export imports correctly
+output = realm.run(['./t_export_name', '-c', 'p:a@b'])
+if (output != '0402000B06092A864886F7120102020000000361406200000000\n'):
+    fail('Unexpected output from t_export_name (using COMPOSITE_EXPORT)')
+
 # Test gss_inquire_mechs_for_name behavior.
 krb5_mech = '{ 1 2 840 113554 1 2 2 }'
 spnego_mech = '{ 1 3 6 1 5 5 2 }'


### PR DESCRIPTION
RFC 6680 specifies that GSS_Export_name_composite() "outputs a token that
"can be imported with GSS_Import_name(), using GSS_C_NT_COMPOSITE_EXPORT
as the name type...".  Therefore, in the gss_import_name mechglue, we
should perform the import process imediately when either
GSS_C_NT_COMPOSITE_EXPORT or GSS_C_NT_EXPORT_NAME are used (not just
for the later, as is the current functionality).

The naming extension test was also updated to display the result
of importing with GSS_C_NT_COMPOSITE_EXPORT in addition to
GSS_C_NT_EXPORT_NAME.