### PR TITLE
Larger kvno support

### DIFF
--- a/doc/formats/keytab_file_format.rst
+++ b/doc/formats/keytab_file_format.rst
@@ -31,6 +31,7 @@ the key entry.  Key entries use the following informal grammar::
         enctype (16 bits)
         key length (32 bits)
         key contents
+        key version (32 bits) [in release 1.14 and later]
 
     principal ::=
         count of components (32 bits) [includes realm in version 1]
@@ -44,8 +45,7 @@ the key entry.  Key entries use the following informal grammar::
         length (16 bits)
         value (length bytes)
 
-Some implementations of Kerberos recognize a 32-bit key version at the
-end of an entry, if the record length is at least 4 bytes longer than
-the entry and the value of those 32 bits is not 0.  If present, this
-key version supersedes the 8-bit key version.  MIT krb5 does not yet
-implement this extension.
+The 32-bit key version overrides the 8-bit key version.  To determine
+if it is present, the implementation must check that at least 4 bytes
+remain in the record after the other fields are read, and that the
+value of the 32-bit integer contained in those bytes is non-zero.

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -1646,7 +1646,7 @@ struct _krb5_key_data;          /* kdb.h */
 
 struct ldap_seqof_key_data {
     krb5_int32 mkvno;           /* Master key version number */
-    krb5_int16 kvno;            /* kvno of key_data elements (all the same) */
+    krb5_ui_2 kvno;             /* kvno of key_data elements (all the same) */
     struct _krb5_key_data *key_data;
     krb5_int16 n_key_data;
 };

--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -167,7 +167,7 @@ typedef struct krb5_string_attr_st {
  */
 typedef struct _krb5_key_data {
     krb5_int16            key_data_ver;         /* Version */
-    krb5_int16            key_data_kvno;        /* Key Version */
+    krb5_ui_2             key_data_kvno;        /* Key Version */
     krb5_int16            key_data_type[2];     /* Array of types */
     krb5_ui_2             key_data_length[2];   /* Array of lengths */
     krb5_octet          * key_data_contents[2]; /* Array of pointers */

--- a/src/lib/kadm5/kadm_rpc_xdr.c
+++ b/src/lib/kadm5/kadm_rpc_xdr.c
@@ -262,7 +262,7 @@ bool_t xdr_krb5_key_data_nocontents(XDR *xdrs, krb5_key_data *objp)
      if (!xdr_krb5_int16(xdrs, &objp->key_data_ver)) {
 	  return (FALSE);
      }
-     if (!xdr_krb5_int16(xdrs, &objp->key_data_kvno)) {
+     if (!xdr_krb5_ui_2(xdrs, &objp->key_data_kvno)) {
 	  return (FALSE);
      }
      if (!xdr_krb5_int16(xdrs, &objp->key_data_type[0])) {

--- a/src/lib/kadm5/kadm_rpc_xdr.c
+++ b/src/lib/kadm5/kadm_rpc_xdr.c
@@ -136,20 +136,7 @@ xdr_krb5_timestamp(XDR *xdrs, krb5_timestamp *objp)
 bool_t
 xdr_krb5_kvno(XDR *xdrs, krb5_kvno *objp)
 {
-	unsigned char tmp;
-
-	tmp = '\0'; /* for purify, else xdr_u_char performs a umr */
-
-	if (xdrs->x_op == XDR_ENCODE)
-		tmp = (unsigned char) *objp;
-
-	if (!xdr_u_char(xdrs, &tmp))
-		return (FALSE);
-
-	if (xdrs->x_op == XDR_DECODE)
-		*objp = (krb5_kvno) tmp;
-
-	return (TRUE);
+	return xdr_u_int(xdrs, objp);
 }
 
 bool_t

--- a/src/lib/kadm5/srv/adb_xdr.c
+++ b/src/lib/kadm5/srv/adb_xdr.c
@@ -21,7 +21,7 @@ xdr_krb5_key_data(XDR *xdrs, krb5_key_data *objp)
 
     if (!xdr_krb5_int16(xdrs, &objp->key_data_ver))
 	return(FALSE);
-    if (!xdr_krb5_int16(xdrs, &objp->key_data_kvno))
+    if (!xdr_krb5_ui_2(xdrs, &objp->key_data_kvno))
 	return(FALSE);
     if (!xdr_krb5_int16(xdrs, &objp->key_data_type[0]))
 	return(FALSE);

--- a/src/lib/kdb/kdb_convert.c
+++ b/src/lib/kdb/kdb_convert.c
@@ -704,7 +704,7 @@ ulog_conv_2dbentry(krb5_context context, krb5_db_entry **entry,
                 krb5_key_data *kp = &ent->key_data[j];
                 kdbe_key_t *kv = &ULOG_ENTRY_KEYVAL(update, i, j);
                 kp->key_data_ver = (krb5_int16)kv->k_ver;
-                kp->key_data_kvno = (krb5_int16)kv->k_kvno;
+                kp->key_data_kvno = (krb5_ui_2)kv->k_kvno;
                 if (kp->key_data_ver > 2) {
                     return EINVAL; /* XXX ? */
                 }

--- a/src/lib/kdb/kdb_cpw.c
+++ b/src/lib/kdb/kdb_cpw.c
@@ -436,6 +436,10 @@ rekey(krb5_context context, krb5_keyblock *mkey, krb5_key_salt_tuple *ks_tuple,
     old_kvno = krb5_db_get_key_data_kvno(context, n_key_data, key_data);
     if (new_kvno < old_kvno + 1)
         new_kvno = old_kvno + 1;
+    /* Wrap from 65535 to 1; we can only store 16-bit kvno values in key_data,
+     * and we assign special meaning to kvno 0. */
+    if (new_kvno == (1 << 16))
+        new_kvno = 1;
 
     /* Add new keys to the front of the list. */
     if (password != NULL) {

--- a/src/lib/krb5/asn.1/ldap_key_seq.c
+++ b/src/lib/krb5/asn.1/ldap_key_seq.c
@@ -51,6 +51,7 @@
 IMPORT_TYPE(int32, krb5_int32);
 
 DEFINTTYPE(int16, krb5_int16);
+DEFINTTYPE(uint16, krb5_ui_2);
 
 DEFCOUNTEDSTRINGTYPE(ui2_octetstring, unsigned char *, krb5_ui_2,
                      k5_asn1_encode_bytestring, k5_asn1_decode_bytestring,
@@ -108,7 +109,7 @@ DEFCOUNTEDSEQOFTYPE(cseqof_key_data, krb5_int16, ptr_key_data);
 DEFINT_IMMEDIATE(one, 1, ASN1_BAD_FORMAT);
 DEFCTAGGEDTYPE(ldap_key_seq_0, 0, one);
 DEFCTAGGEDTYPE(ldap_key_seq_1, 1, one);
-DEFFIELD(ldap_key_seq_2, ldap_seqof_key_data, kvno, 2, int16);
+DEFFIELD(ldap_key_seq_2, ldap_seqof_key_data, kvno, 2, uint16);
 DEFFIELD(ldap_key_seq_3, ldap_seqof_key_data, mkvno, 3, int32);
 DEFCNFIELD(ldap_key_seq_4, ldap_seqof_key_data, key_data, n_key_data, 4,
            cseqof_key_data);

--- a/src/plugins/kdb/ldap/libkdb_ldap/princ_xdr.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/princ_xdr.c
@@ -98,7 +98,7 @@ ldap_xdr_krb5_key_data(XDR *xdrs, krb5_key_data *objp)
 
     if (!ldap_xdr_krb5_int16(xdrs, &objp->key_data_ver))
 	return(FALSE);
-    if (!ldap_xdr_krb5_int16(xdrs, &objp->key_data_kvno))
+    if (!ldap_xdr_krb5_ui_2(xdrs, &objp->key_data_kvno))
 	return(FALSE);
     if (!ldap_xdr_krb5_int16(xdrs, &objp->key_data_type[0]))
 	return(FALSE);


### PR DESCRIPTION
This started out as a plan to just implement the 32-bit keytab kvno extension, but wound up becoming a larger overhaul as I discovered other limitations.  Each of the five commits is still fairly short.  For more background, see:

http://k5wiki.kerberos.org/wiki/Projects/Larger_key_versions