### PR TITLE
Fix scope of kadmind ACL wildcard back-references

### DIFF
--- a/src/lib/kadm5/srv/server_acl.c
+++ b/src/lib/kadm5/srv/server_acl.c
@@ -610,8 +610,8 @@ kadm5int_acl_find_entry(kcontext, principal, dest_princ)
     wildstate_t         state;
 
     DPRINT(DEBUG_CALLS, acl_debug_level, ("* kadm5int_acl_find_entry()\n"));
-    memset(&state, 0, sizeof state);
     for (entry=acl_list_head; entry; entry = entry->ae_next) {
+        memset(&state, 0, sizeof(state));
         if (entry->ae_name_bad)
             continue;
         if (!strcmp(entry->ae_name, "*")) {

--- a/src/tests/t_kadmin_acl.py
+++ b/src/tests/t_kadmin_acl.py
@@ -61,6 +61,8 @@ restricted_modify  im  *         +preauth
 restricted_rename  ad  *         +preauth
 
 */*                d   *2/*1
+# The next line is a regression test for #8154; it is not used directly.
+one/*/*/five       l
 */two/*/*          d   *3/*1/*2
 */admin            a
 wctarget           a   wild/*


### PR DESCRIPTION
In kadm5int_acl_find_entry(), clear the wildcard back-references list
for each acl entry.  Otherwise the wildcards we process can affect
back-references for later entries.
