### PR TITLE
Improve kadmind ACL restriction docs and diagnostics

### DIFF
--- a/doc/admin/conf_files/kadm5_acl.rst
+++ b/doc/admin/conf_files/kadm5_acl.rst
@@ -72,8 +72,8 @@ ignored.  Lines containing ACL entries have the format::
 
         {+\|-}\ *flagname*
             flag is forced to the indicated value.  The permissible flags
-            are the same as the + and - flags for the kadmin
-            :ref:`add_principal` and :ref:`modify_principal` commands.
+            are the same as those for the **default_principal_flags**
+            variable in :ref:`kdc.conf(5)`.
 
         *-clearpolicy*
             policy is forced to be empty.

--- a/src/lib/kadm5/srv/server_acl.c
+++ b/src/lib/kadm5/srv/server_acl.c
@@ -349,6 +349,10 @@ kadm5int_acl_parse_restrictions(s, rpp)
                     }
                 }
             }
+            if (code) {
+                krb5_klog_syslog(LOG_ERR, _("%s: invalid restrictions: %s"),
+                                 acl_acl_file, s);
+            }
         }
     }
     if (sp)


### PR DESCRIPTION
The first commit changes kadm5_acl.rst to reference the correct flags namespace.  Tom may be combining these namespaces, but that may not be backportable, whereas the documentation fix definitely is.

The second commit issues a diagnostic to the kadmind logs if we fail to parse restrictions.  It's not as good of a diagnostic as we could get with a better parsing function, but it's way better than nothing.

There are lots and lots of opportunities for cleanup in this code.  I will add some entries to the Cleanups page on the wiki but will not be engaging in home renovations for the moment.