### PR TITLE
Extend kadmin timeout to one hour

### DIFF
--- a/src/lib/kadm5/clnt/client_init.c
+++ b/src/lib/kadm5/clnt/client_init.c
@@ -152,6 +152,7 @@ init_any(krb5_context context, char *client_name, enum init_type init_type,
     rpcvers_t rpc_vers;
     krb5_ccache ccache;
     krb5_principal client = NULL, server = NULL;
+    struct timeval timeout;
 
     kadm5_server_handle_t handle;
     kadm5_config_params params_local;
@@ -261,6 +262,12 @@ init_any(krb5_context context, char *client_name, enum init_type init_type,
 #endif
         goto error;
     }
+
+    /* Set a one-hour timeout. */
+    timeout.tv_sec = 3600;
+    timeout.tv_usec = 0;
+    (void)clnt_control(handle->clnt, CLSET_TIMEOUT, &timeout);
+
     handle->client_socket = fd;
     handle->lhandle->clnt = handle->clnt;
     handle->lhandle->client_socket = fd;

--- a/src/lib/kadm5/clnt/client_rpc.c
+++ b/src/lib/kadm5/clnt/client_rpc.c
@@ -10,7 +10,7 @@
 #endif
 
 /* Default timeout can be changed using clnt_control() */
-static struct timeval TIMEOUT = { 120, 0 };
+static struct timeval TIMEOUT = { 25, 0 };
 
 generic_ret *
 create_principal_2(cprinc_arg *argp, CLIENT *clnt)

--- a/src/lib/rpc/clnt_generic.c
+++ b/src/lib/rpc/clnt_generic.c
@@ -94,17 +94,12 @@ clnt_create(
 		if (client == NULL) {
 			return (NULL);
 		}
-		tv.tv_sec = 120;
-		clnt_control(client, CLSET_TIMEOUT, &tv);
 		break;
 	case IPPROTO_TCP:
 		client = clnttcp_create(&sockin, prog, vers, &sock, 0, 0);
 		if (client == NULL) {
 			return (NULL);
 		}
-		tv.tv_sec = 120;
-		tv.tv_usec = 0;
-		clnt_control(client, CLSET_TIMEOUT, &tv);
 		break;
 	default:
 		rpc_createerr.cf_stat = RPC_SYSTEMERROR;


### PR DESCRIPTION
The first commit is intended to be backportable by downstreams, although I'm not sure we need to backport it ourselves as it isn't really a bugfix.  The second commit is mostly just code hygiene, although it affects the behavior of clnt_create() which we don't use within the tree.
