### PR TITLE
Fix renewable ticket lifetimes

### DIFF
--- a/src/kdc/do_tgs_req.c
+++ b/src/kdc/do_tgs_req.c
@@ -461,6 +461,7 @@ process_tgs_req(struct server_handle *handle, krb5_data *pkt,
     }
 
     if (isflagset(request->kdc_options, KDC_OPT_RENEW)) {
+        krb5_timestamp old_starttime;
         krb5_deltat old_life;
 
         assert(isflagset(c_flags, KRB5_KDB_FLAGS_S4U) == 0);
@@ -470,7 +471,9 @@ process_tgs_req(struct server_handle *handle, krb5_data *pkt,
         enc_tkt_reply = *(header_ticket->enc_part2);
         enc_tkt_reply.authorization_data = NULL;
 
-        old_life = enc_tkt_reply.times.endtime - enc_tkt_reply.times.starttime;
+        old_starttime = enc_tkt_reply.times.starttime ?
+            enc_tkt_reply.times.starttime : enc_tkt_reply.times.authtime;
+        old_life = enc_tkt_reply.times.endtime - old_starttime;
 
         enc_tkt_reply.times.starttime = kdc_time;
         enc_tkt_reply.times.endtime =

--- a/src/tests/t_renew.py
+++ b/src/tests/t_renew.py
@@ -27,6 +27,9 @@ realm.kinit(realm.user_princ, flags=['-R'])
 realm.kinit(realm.user_princ, flags=['-R'])
 realm.klist(realm.user_princ)
 
+# Make sure we can use a renewed ticket.
+realm.run([kvno, realm.user_princ])
+
 # Make sure we can't renew non-renewable tickets.
 test('non-renewable', '1h', '1h', False)
 out = realm.kinit(realm.user_princ, flags=['-R'], expected_code=1)


### PR DESCRIPTION
Commit b0661f9176f5eb2644ba459e1b1e87d3dd502174 removed the starttime
hack in the EncTicketPart decoder.  Take this into account when
computing the old lifetime of a ticket we are renewing.

This bug appeared only on master and not as part of any release, so
there is no associated ticket.