### PR TITLE
kpropd -t full dump patch

### DIFF
--- a/doc/admin/admin_commands/kpropd.rst
+++ b/doc/admin/admin_commands/kpropd.rst
@@ -15,6 +15,7 @@ SYNOPSIS
 [**-p** *kdb5_util_prog*]
 [**-P** *port*]
 [**-d**]
+[**-t**]
 
 DESCRIPTION
 -----------
@@ -88,6 +89,12 @@ OPTIONS
     itself from the current job and run in the background.  Instead,
     it will run in the foreground and print out debugging messages
     during the database propagation.
+
+**-t**
+    In standalone mode without incremental propagation, exit after one
+    dump file is received.  In incremental propagation mode, exit as
+    soon as the database is up to date, or if the master returns an
+    error.
 
 **-P**
     Allow for an alternate port number for kpropd to listen on.  This

--- a/src/slave/kpropd.c
+++ b/src/slave/kpropd.c
@@ -298,7 +298,7 @@ main(int argc, char **argv)
     /*
      * This is the iprop case.  We'll fork a child to run do_standalone().  The
      * parent will run do_iprop().  We try to kill the child if we get killed.
-     * Catch SIGUSR1 so tests can use it to interrupt the sleep timer and force
+     * Catch SIGUSR1, which can be used to interrupt the sleep timer and force
      * an iprop request.
      */
     signal_wrapper(SIGHUP, kill_do_standalone);
@@ -440,6 +440,10 @@ do_standalone()
 
             close(s);
 
+            /* If we are the fullprop child in iprop mode, notify the parent
+             * process that it should poll for incremental updates. */
+            if (fullprop_child == 0)
+                kill(getppid(), SIGUSR1);
             if (runonce)
                 exit(0);
         }

--- a/src/slave/kpropd.c
+++ b/src/slave/kpropd.c
@@ -444,7 +444,7 @@ do_standalone()
              * process that it should poll for incremental updates. */
             if (fullprop_child == 0)
                 kill(getppid(), SIGUSR1);
-            if (runonce)
+            else if (runonce)
                 exit(0);
         }
     }
@@ -963,7 +963,7 @@ reinit:
             break;
         }
 
-        if (runonce == 1)
+        if (runonce == 1 && incr_ret->ret != UPDATE_FULL_RESYNC_NEEDED)
             goto done;
 
         /*

--- a/src/tests/t_iprop.py
+++ b/src/tests/t_iprop.py
@@ -10,7 +10,7 @@ from k5test import *
 # versa.
 def wait_for_prop(kpropd, full_expected, expected_old, expected_new):
     output('*** Waiting for sync from kpropd\n')
-    full_seen = sleep_seen = prodded_after_dump = False
+    full_seen = sleep_seen = False
     old_sno = new_sno = -1
     while True:
         line = kpropd.stdout.readline()
@@ -39,12 +39,6 @@ def wait_for_prop(kpropd, full_expected, expected_old, expected_new):
             sleep_seen = True
         if 'load process for full propagation completed' in line:
             full_seen = True
-        if sleep_seen and full_seen and not prodded_after_dump:
-            # Prod the kpropd parent into getting incrementals after
-            # it finishes a DB load.  This will be unnecessary if
-            # kpropd is simplified to use a single process.
-            kpropd.send_signal(signal.SIGUSR1)
-            prodded_after_dump = True
 
         # Detect some failure conditions.
         if 'Still waiting for full resync' in line:


### PR DESCRIPTION
Here is John Devitofranceschi's commit from RT #8161, unmodified.

It's a good proof of concept; it demonstrates that since the listener child process will exit after accepting a full dump, the master process can simply wait for it to exit.  However, in addition to having some style issues, it is a bit too hackish:

* Most problematically, it contains a recursive call to main(), which is not a  safe practice.

* The meaning of waitfor_do_standalone is not well-stated; it begins at 0, is incremented to 1 when the first full dump is requested, and is incremented again to 2 after the full dump is complete (and possibly again to 3 if another dump is requested).  When the patch uses it, it specifically compares it to 1.  So it's implicitly a tri-state, beginning life at "no dump was requested", incrementing to "a dump was requested and should be waited for," and then from there to "a dump was already waited for and we shouldn't do that again."

* Nothing prevents a second full dump from being requested in the second invocation of main().  If this happens, we won't wait for it and will instead kill the child at some random point during its execution, hopefully (but not necessarily) before it does very much.  That's not very airtight design.

I will see if I can come up with something backportable and more safe.  I will also see about implementing the item from http://k5wiki.kerberos.org/wiki/Cleanups about simplifying kpropd back down to one process, which would make runonce easier to implement correctly.