### PR TITLE
Avoid unnecessary iprop full resyncs after resets

### DIFF
--- a/src/lib/kdb/t_ulog.c
+++ b/src/lib/kdb/t_ulog.c
@@ -77,12 +77,12 @@ main(int argc, char **argv)
     ulog->kdb_first_sno = ulog->kdb_last_sno - ulog->kdb_num + 1;
 
     /* Add an empty update.  This should reinitialize the ulog, then add the
-     * update with serial number 1. */
+     * update with serial number 2. */
     memset(&upd, 0, sizeof(kdb_incr_update_t));
     if (ulog_add_update(context, &upd) != 0)
         abort();
-    assert(ulog->kdb_num == 1);
+    assert(ulog->kdb_num == 2);
     assert(ulog->kdb_first_sno == 1);
-    assert(ulog->kdb_last_sno == 1);
+    assert(ulog->kdb_last_sno == 2);
     return 0;
 }

--- a/src/slave/kproplog.c
+++ b/src/slave/kproplog.c
@@ -357,6 +357,17 @@ print_update(kdb_hlog_t *ulog, uint32_t entry, uint32_t ulogentries,
             exit(1);
         }
 
+        printf("---\n");
+        printf(_("Update Entry\n"));
+
+        printf(_("\tUpdate serial # : %u\n"), indx_log->kdb_entry_sno);
+
+        /* The initial entry after a reset is a dummy entry; skip it. */
+        if (indx_log->kdb_entry_size == 0) {
+            printf(_("\tDummy entry\n"));
+            continue;
+        }
+
         memset(&upd, 0, sizeof(kdb_incr_update_t));
         xdrmem_create(&xdrs, (char *)indx_log->entry_data,
                       indx_log->kdb_entry_size, XDR_DECODE);
@@ -364,11 +375,6 @@ print_update(kdb_hlog_t *ulog, uint32_t entry, uint32_t ulogentries,
             printf(_("Entry data decode failure\n\n"));
             exit(1);
         }
-
-        printf("---\n");
-        printf(_("Update Entry\n"));
-
-        printf(_("\tUpdate serial # : %u\n"), indx_log->kdb_entry_sno);
 
         printf(_("\tUpdate operation : "));
         if (upd.kdb_deleted)


### PR DESCRIPTION
The first three commits are from PR #267.

The last commit resolves the second "related problem" documented at http://k5wiki.kerberos.org/wiki/Projects/Hierarchical_iprop#Related_problems
(the first problem is resolved by PR #267) by creating dummy entries after header resets.
