### PR TITLE
Use the appropriate nm via the exported variable to help/fix cross compiling

### DIFF
--- a/src/util/export-check.pl
+++ b/src/util/export-check.pl
@@ -32,13 +32,15 @@ $0 =~ s/^.*?([\w.-]+)$/$1/;
 # This code assumes the GNU version of nm.
 # For now, we'll only run it on GNU/Linux systems, so that's okay.
 
+my $nm = $ENV{'NM'} || "nm";
+
 if ($#ARGV != 1) {
     die "usage: $0 exportfile libfoo.so\n";
 }
 my($exfile, $libfile) = @ARGV;
 
 @missing = ();
-open NM, "nm -Dg --defined-only $libfile |" || die "can't run nm on $libfile: $!";
+open NM, "$nm -Dg --defined-only $libfile |" || die "can't run nm on $libfile: $!";
 open EXPORT, "< $exfile" || die "can't read $exfile: $!";
 
 @export = <EXPORT>;


### PR DESCRIPTION
Reason explained here: https://galileo.mailstation.de/gerrit/#/c/1117/
Idea for the fix taken from: http://opensource.apple.com/source/llvmgcc42/llvmgcc42-2336.9/libstdc++-v3/scripts/make_exports.pl