### PR TITLE
Fix LDAP ticket policies on big-endian LP64

### DIFF
--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.c
@@ -1402,19 +1402,18 @@ populate_krb5_db_entry(krb5_context context, krb5_ldap_context *ldap_context,
         entry->fail_auth_count = val;
         mask |= KDB_FAIL_AUTH_COUNT_ATTR;
     }
-
-    if (krb5_ldap_get_value(ld, ent, "krbmaxticketlife",
-                            &entry->max_life) == 0)
+    if (krb5_ldap_get_value(ld, ent, "krbmaxticketlife", &val) == 0) {
+        entry->max_life = val;
         mask |= KDB_MAX_LIFE_ATTR;
-
-    if (krb5_ldap_get_value(ld, ent, "krbmaxrenewableage",
-                            &entry->max_renewable_life) == 0)
+    }
+    if (krb5_ldap_get_value(ld, ent, "krbmaxrenewableage", &val) == 0) {
+        entry->max_renewable_life = val;
         mask |= KDB_MAX_RLIFE_ATTR;
-
-    if (krb5_ldap_get_value(ld, ent, "krbticketflags",
-                            &entry->attributes) == 0)
+    }
+    if (krb5_ldap_get_value(ld, ent, "krbticketflags", &val) == 0) {
+        entry->attributes = val;
         mask |= KDB_TKT_FLAGS_ATTR;
-
+    }
     ret = get_time(ld, ent, "krbprincipalexpiration", &entry->expiration,
                    &attr_present);
     if (ret)

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_tkt_policy.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_tkt_policy.c
@@ -193,7 +193,7 @@ krb5_ldap_read_policy(krb5_context context, char *policyname,
                       krb5_ldap_policy_params **policy, int *omask)
 {
     krb5_error_code             st=0, tempst=0;
-    int                         objectmask=0;
+    int                         objectmask=0, val=0;
     LDAP                        *ld=NULL;
     LDAPMessage                 *result=NULL,*ent=NULL;
     char                        *attributes[] = { "krbMaxTicketLife", "krbMaxRenewableAge", "krbTicketFlags", NULL};
@@ -240,14 +240,18 @@ krb5_ldap_read_policy(krb5_context context, char *policyname,
 
     ent=ldap_first_entry(ld, result);
     if (ent != NULL) {
-        if (krb5_ldap_get_value(ld, ent, "krbmaxticketlife", (int *) &(lpolicy->maxtktlife)) == 0)
+        if (krb5_ldap_get_value(ld, ent, "krbmaxticketlife", &val) == 0) {
+            lpolicy->maxtktlife = val;
             *omask |= LDAP_POLICY_MAXTKTLIFE;
-
-        if (krb5_ldap_get_value(ld, ent, "krbmaxrenewableage", (int *) &(lpolicy->maxrenewlife)) == 0)
+        }
+        if (krb5_ldap_get_value(ld, ent, "krbmaxrenewableage", &val) == 0) {
+            lpolicy->maxrenewlife = val;
             *omask |= LDAP_POLICY_MAXRENEWLIFE;
-
-        if (krb5_ldap_get_value(ld, ent, "krbticketflags", (int *) &(lpolicy->tktflags)) == 0)
+        }
+        if (krb5_ldap_get_value(ld, ent, "krbticketflags", &val) == 0) {
+            lpolicy->tktflags = val;
             *omask |= LDAP_POLICY_TKTFLAGS;
+        }
     }
 
     lpolicy->mask = *omask;


### PR DESCRIPTION
krb5_ldap_get_value() takes a pointer to int, and should not be passed
a pointer to any integral type which might have a different width.
Use an intermediate variable for each call.

The erroneous calls in ldap_misc.c were passing pointers to int32_t,
which is harmless on all common platforms.  The calls in
ldap_tkt_policy.c were passing pointers to long; on big-endian LP64
platforms, the result would be written to the high 32 bits of the long
value.
