### PR TITLE
Fix memory leak in DB2 iteration

### DIFF
--- a/src/plugins/kdb/db2/kdb_db2.c
+++ b/src/plugins/kdb/db2/kdb_db2.c
@@ -1078,7 +1078,7 @@ curs_run_cb(iter_curs *curs, ctx_iterate_cb func, krb5_pointer func_arg)
 
     k5_mutex_unlock(krb5_db2_mutex);
     retval = (*func)(func_arg, entry);
-    krb5_db2_free(ctx, entry);
+    krb5_dbe_free(ctx, entry);
     k5_mutex_lock(krb5_db2_mutex);
     if (dbc->unlockiter) {
         lockerr = curs_lock(curs);


### PR DESCRIPTION
Use the correct function to free the decoded principal entry in
curs_run_cb().
