### PR TITLE
Add rename method to kadm5_hook

### DIFF
--- a/src/include/krb5/kadm5_hook_plugin.h
+++ b/src/include/krb5/kadm5_hook_plugin.h
@@ -46,6 +46,9 @@
  * This interface depends on kadm5/admin.h. As such, the interface
  * does not provide strong guarantees of ABI stability.
  *
+ * The kadm5_hook interface currently has only one supported major version,
+ * which is 1.  Major version 1 has a current minor version number of 2.
+ *
  * kadm5_hook plugins should:
  * kadm5_hook_<modulename>_initvt, matching the signature:
  *
@@ -138,6 +141,14 @@ typedef struct kadm5_hook_vtable_1_st {
                           int stage, krb5_principal);
 
     /* End of minor version 1. */
+
+    /** Indicate a principal is renamed. */
+    kadm5_ret_t (*rename)(krb5_context,
+                          kadm5_hook_modinfo *modinfo,
+                          int stage, krb5_principal, krb5_principal);
+
+    /* End of minor version 2. */
+
 } kadm5_hook_vftable_1;
 
 #endif /*H_KRB5_KADM5_HOOK_PLUGIN*/

--- a/src/lib/kadm5/server_internal.h
+++ b/src/lib/kadm5/server_internal.h
@@ -255,6 +255,13 @@ k5_kadm5_hook_remove (krb5_context context,
                       int stage,
                       krb5_principal princ);
 
+/** Call rename kadm5_hook entry point. */
+kadm5_ret_t
+k5_kadm5_hook_rename (krb5_context context,
+                      kadm5_hook_handle *handles,
+                      int stage,
+                      krb5_principal oprinc, krb5_principal nprinc);
+
 /** @}*/
 
 #endif /* __KADM5_SERVER_INTERNAL_H__ */

--- a/src/lib/kadm5/srv/kadm5_hook.c
+++ b/src/lib/kadm5/srv/kadm5_hook.c
@@ -64,7 +64,7 @@ k5_kadm5_hook_load(krb5_context context,
         handle = k5alloc(sizeof(*handle), &ret);
         if (handle == NULL)
             goto cleanup;
-        ret = (*mod)(context, 1, 1, (krb5_plugin_vtable)&handle->vt);
+        ret = (*mod)(context, 1, 2, (krb5_plugin_vtable)&handle->vt);
         if (ret != 0) {         /* Failed vtable init is non-fatal. */
             free(handle);
             handle = NULL;
@@ -165,6 +165,14 @@ k5_kadm5_hook_modify(krb5_context context, kadm5_hook_handle *handles,
                      int stage, kadm5_principal_ent_t princ, long mask)
 {
     ITERATE(modify, (context, h->data, stage, princ, mask));
+    return 0;
+}
+
+kadm5_ret_t
+k5_kadm5_hook_rename(krb5_context context, kadm5_hook_handle *handles,
+                     int stage, krb5_principal oprinc, krb5_principal nprinc)
+{
+    ITERATE(rename, (context, h->data, stage, oprinc, nprinc));
     return 0;
 }
 

--- a/src/lib/kadm5/srv/svr_principal.c
+++ b/src/lib/kadm5/srv/svr_principal.c
@@ -835,8 +835,16 @@ kadm5_rename_principal(void *server_handle,
         goto done;
     }
 
+    ret = k5_kadm5_hook_rename(handle->context, handle->hook_handles,
+                               KADM5_HOOK_STAGE_PRECOMMIT, source, target);
+    if (ret)
+        goto done;
+
     if ((ret = kdb_put_entry(handle, kdb, &adb)))
         goto done;
+
+    (void) k5_kadm5_hook_rename(handle->context, handle->hook_handles,
+                                KADM5_HOOK_STAGE_POSTCOMMIT, source, target);
 
     ret = kdb_delete_entry(handle, source);
 

--- a/src/plugins/kadm5_hook/test/main.c
+++ b/src/plugins/kadm5_hook/test/main.c
@@ -81,6 +81,13 @@ create(krb5_context context,
     return 0;
 }
 
+static kadm5_ret_t
+rename_hook(krb5_context context, kadm5_hook_modinfo *modinfo, int stage,
+            krb5_principal oprinc, krb5_principal nprinc)
+{
+    log_call(context, "rename", stage, oprinc);
+    return 0;
+}
 
 krb5_error_code
 kadm5_hook_test_initvt(krb5_context context, int maj_ver, int min_ver,
@@ -97,5 +104,6 @@ kadm5_hook_test_initvt(krb5_context context, int maj_ver, int min_ver,
     vt->name = "test";
     vt->chpass = chpass;
     vt->create = create;
+    vt->rename = rename_hook;
     return 0;
 }

--- a/src/tests/t_kadm5_hook.py
+++ b/src/tests/t_kadm5_hook.py
@@ -11,4 +11,8 @@ output = realm.run([kadminl, 'addprinc', '-randkey', 'test'])
 if "create: stage precommit" not in output:
     fail('kadm5_hook test output not found')
 
+output = realm.run([kadminl, 'renprinc', 'test', 'test2'])
+if "rename: stage precommit" not in output:
+    fail('kadm5_hook test output not found')
+
 success('kadm5_hook')


### PR DESCRIPTION
Unmodified patch from John Hascall.  The versioning isn't right, and we should consider adding an automated test.
