### PR TITLE
Kfw updates

### DIFF
--- a/src/lib/krb5/ccache/cc_mslsa.c
+++ b/src/lib/krb5/ccache/cc_mslsa.c
@@ -1568,8 +1568,8 @@ krb5_lcc_resolve (krb5_context context, krb5_ccache *id, const char *residual)
         /* Take the first client principal we find; they should all be the
          * same anyway. */
         for (i = 0; i < pResponse->CountOfTickets; i++) {
-            if (UnicodeStringToMITPrinc(&pResponse->Tickets[0].ClientName,
-                                        &pResponse->Tickets[0].ClientRealm,
+            if (UnicodeStringToMITPrinc(&pResponse->Tickets[i].ClientName,
+                                        &pResponse->Tickets[i].ClientRealm,
                                         context, &data->princ))
                 break;
 
@@ -1915,8 +1915,8 @@ krb5_lcc_get_principal(krb5_context context, krb5_ccache id, krb5_principal *pri
             /* Take the first client principal we find; they should all be the
              * same anyway. */
             for (i = 0; i < pResponse->CountOfTickets; i++) {
-                if (UnicodeStringToMITPrinc(&pResponse->Tickets[0].ClientName,
-                                            &pResponse->Tickets[0].ClientRealm,
+                if (UnicodeStringToMITPrinc(&pResponse->Tickets[i].ClientName,
+                                            &pResponse->Tickets[i].ClientRealm,
                                             context, &data->princ))
                     break;
             }

--- a/src/lib/krb5/os/Makefile.in
+++ b/src/lib/krb5/os/Makefile.in
@@ -25,6 +25,7 @@ STLIBOBJS= \
 	hostrealm_dns.o \
 	hostrealm_domain.o \
 	hostrealm_profile.o \
+	hostrealm_registry.o \
 	init_os_ctx.o	\
 	krbfileio.o	\
 	ktdefname.o	\
@@ -71,6 +72,7 @@ OBJS= \
 	$(OUTPRE)hostrealm_dns.$(OBJEXT) \
 	$(OUTPRE)hostrealm_domain.$(OBJEXT) \
 	$(OUTPRE)hostrealm_profile.$(OBJEXT) \
+	$(OUTPRE)hostrealm_registry.$(OBJEXT) \
 	$(OUTPRE)init_os_ctx.$(OBJEXT)	\
 	$(OUTPRE)krbfileio.$(OBJEXT)	\
 	$(OUTPRE)ktdefname.$(OBJEXT)	\
@@ -117,6 +119,7 @@ SRCS= \
 	$(srcdir)/hostrealm_dns.c \
 	$(srcdir)/hostrealm_domain.c \
 	$(srcdir)/hostrealm_profile.c \
+	$(srcdir)/hostrealm_registry.c \
 	$(srcdir)/init_os_ctx.c	\
 	$(srcdir)/krbfileio.c	\
 	$(srcdir)/ktdefname.c	\

--- a/src/lib/krb5/os/hostrealm.c
+++ b/src/lib/krb5/os/hostrealm.c
@@ -79,6 +79,10 @@ get_modules(krb5_context context, krb5_plugin_initvt_fn **modules_out)
                              hostrealm_profile_initvt);
     if (ret)
         return ret;
+    ret = k5_plugin_register(context, intf, "registry",
+                             hostrealm_registry_initvt);
+    if (ret)
+        return ret;
     ret = k5_plugin_register(context, intf, "dns", hostrealm_dns_initvt);
     if (ret)
         return ret;

--- a/src/lib/krb5/os/hostrealm_registry.c
+++ b/src/lib/krb5/os/hostrealm_registry.c
@@ -1,0 +1,135 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* lib/krb5/os/hostream_registry.c - registry hostrealm module */
+/*
+ * Copyright (C) 2015 by the Massachusetts Institute
+ * of Technology.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file implements the built-in registry module for the hostrealm
+ * interface, which uses Windows registry configuration to determine the
+ * local default realm.
+ */
+
+#include "k5-int.h"
+#include "os-proto.h"
+#include <krb5/hostrealm_plugin.h>
+
+#ifdef _WIN32
+/*
+ * Look up a default_realm entry starting from the given base key.
+ * The output *buf_out will be non-NULL if an entry was found; the
+ * caller is responsible for freeing *pbuffer.
+ *
+ * On success, return 0 and set *str_out to the default realm to be
+ * used.  Return KRB5_PLUGIN_NO_HANDLE if the registry key does not
+ * exist, or another code if it cannot be read.
+ */
+static krb5_error_code
+get_from_registry(HKEY hBaseKey, char **str_out)
+{
+    DWORD bsize = 0;
+    LONG rc;
+    krb5_error_code ret;
+    char *str = NULL;
+    const char *path = "Software\\MIT\\Kerberos5";
+    const char *value = "default_realm";
+
+    *str_out = NULL;
+
+    /* Call with zero size to determine the amount of storage needed. */
+    rc = RegGetValue(hBaseKey, path, value, RRF_RT_REG_SZ, NULL, str,
+                     &bsize);
+    if (rc == ERROR_FILE_NOT_FOUND)
+        return KRB5_PLUGIN_NO_HANDLE;
+    if (FAILED(rc) || bsize <= 0)
+        return EIO;
+    str = malloc(bsize);
+    if (str == NULL)
+        return ENOMEM;
+    rc = RegGetValue(hBaseKey, path, value, RRF_RT_REG_SZ, NULL, str,
+                     &bsize);
+    if (FAILED(rc)) {
+        ret = EIO;
+        goto cleanup;
+    }
+
+    ret = 0;
+    *str_out = str;
+    str = NULL;
+cleanup:
+    free(str);
+    return ret;
+}
+
+/* Look up the default_realm variable in the
+ * {HKLM,HKCU}\Software\MIT\Kerberos5\default_realm registry values. */
+static krb5_error_code
+registry_default_realm(krb5_context context, krb5_hostrealm_moddata data,
+                       char ***realms_out)
+{
+    krb5_error_code ret;
+    char *prof_realm;
+
+    *realms_out = NULL;
+    ret = get_from_registry(HKEY_LOCAL_MACHINE, &prof_realm);
+    if (ret == KRB5_PLUGIN_NO_HANDLE)
+        ret = get_from_registry(HKEY_CURRENT_USER, &prof_realm);
+    if (ret)
+        return ret;
+    ret = k5_make_realmlist(prof_realm, realms_out);
+    free(prof_realm);
+    return ret;
+}
+#else /* _WIN32 */
+static krb5_error_code
+registry_default_realm(krb5_context context, krb5_hostrealm_moddata data,
+                       char ***realms_out)
+{
+        return KRB5_PLUGIN_NO_HANDLE;
+}
+#endif /* _WIN32 */
+
+static void
+registry_free_realmlist(krb5_context context, krb5_hostrealm_moddata data,
+                       char **list)
+{
+    krb5_free_host_realm(context, list);
+}
+
+krb5_error_code
+hostrealm_registry_initvt(krb5_context context, int maj_ver, int min_ver,
+                         krb5_plugin_vtable vtable)
+{
+    krb5_hostrealm_vtable vt = (krb5_hostrealm_vtable)vtable;
+
+    vt->name = "registry";
+    vt->default_realm = registry_default_realm;
+    vt->free_list = registry_free_realmlist;
+    return 0;
+}

--- a/src/lib/krb5/os/os-proto.h
+++ b/src/lib/krb5/os/os-proto.h
@@ -171,6 +171,9 @@ void k5_hostrealm_free_context(krb5_context);
 krb5_error_code hostrealm_profile_initvt(krb5_context context, int maj_ver,
                                          int min_ver,
                                          krb5_plugin_vtable vtable);
+krb5_error_code hostrealm_registry_initvt(krb5_context context, int maj_ver,
+                                          int min_ver,
+                                          krb5_plugin_vtable vtable);
 krb5_error_code hostrealm_dns_initvt(krb5_context context, int maj_ver,
                                      int min_ver, krb5_plugin_vtable vtable);
 krb5_error_code hostrealm_domain_initvt(krb5_context context, int maj_ver,

--- a/src/windows/installer/wix/athena/krb5.ini
+++ b/src/windows/installer/wix/athena/krb5.ini
@@ -1,6 +1,5 @@
 [libdefaults]
 	default_realm = ATHENA.MIT.EDU
-	allow_weak_crypto = true
 
 [domain_realm]
 	mit.edu = ATHENA.MIT.EDU

--- a/src/windows/installer/wix/kfw.wxs
+++ b/src/windows/installer/wix/kfw.wxs
@@ -184,6 +184,7 @@
         <Custom Action="RollbackNetProvider" After="EnableTgtSessionKey">&amp;feaKfwClient=3</Custom>
         <Custom Action="InstallNetProvider" After="RollbackNetProvider">&amp;feaKfwClient=3</Custom>
         <Custom Action="RemoveNetProvider" After="InstallNetProvider">&amp;feaKfwClient=2</Custom>
+        <ScheduleReboot After="InstallFinalize" />
         </InstallExecuteSequence>
 
         <!-- Upgrade paths -->

--- a/src/windows/installer/wix/site-local.wxi
+++ b/src/windows/installer/wix/site-local.wxi
@@ -68,7 +68,7 @@
 
     <?ifndef VersionMajor?>
         <?define VersionMajor="4"?>
-        <?define VersionMinor="0"?>
+        <?define VersionMinor="1"?>
         <?define VersionPatch="0"?>
     <?else?>
         <?if Not ($(var.VersionMinor) And $(var.VersionPatch))?>

--- a/src/windows/kerberos.ver
+++ b/src/windows/kerberos.ver
@@ -50,7 +50,7 @@
  * organization.
  */
 #define KRB5_MAJOR_RELEASE 4
-#define KRB5_MINOR_RELEASE 0
+#define KRB5_MINOR_RELEASE 1
 #define KRB5_PATCHLEVEL 0
 #define KRB5_RELTAIL "prerelease"
 /* #undef KRB5_RELDATE */

--- a/src/windows/leash/Leash.rc
+++ b/src/windows/leash/Leash.rc
@@ -155,8 +155,10 @@ BEGIN
     "C",            ID_EDIT_COPY,           VIRTKEY, CONTROL, NOINVERT
     "D",            ID_DESTROY_TICKET,      VIRTKEY, CONTROL, NOINVERT
     "I",            ID_IMPORT_TICKET,       VIRTKEY, CONTROL, NOINVERT
+    "M",            ID_MAKE_DEFAULT,        VIRTKEY, CONTROL, NOINVERT
     "N",            ID_FILE_NEW,            VIRTKEY, CONTROL, NOINVERT
     "O",            ID_FILE_OPEN,           VIRTKEY, CONTROL, NOINVERT
+    "P",            ID_CHANGE_PASSWORD,     VIRTKEY, CONTROL, NOINVERT
     "R",            ID_RENEW_TICKET,        VIRTKEY, CONTROL, NOINVERT
     "S",            ID_FILE_SAVE,           VIRTKEY, CONTROL, NOINVERT
     "T",            ID_INIT_TICKET,         VIRTKEY, CONTROL, NOINVERT


### PR DESCRIPTION
A couple fixes that had been sitting around in my local branch, plus adding support for a registry value for the default realm, and bumping the release number to 4.1.x.  Notably, do not set allow_weak_crypto in the MIT-internal krb5.ini any more.