### PR TITLE
OpenSSL plugin: set hostname TLS extension to support SNI

### DIFF
--- a/src/plugins/tls/k5tls/openssl.c
+++ b/src/plugins/tls/k5tls/openssl.c
@@ -463,6 +463,10 @@ setup(krb5_context context, SOCKET fd, const char *servername,
 
     if (!SSL_set_fd(ssl, fd))
         goto error;
+#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
+    if (!SSL_set_tlsext_host_name(ssl, servername))
+        goto error;
+#endif
     SSL_set_connect_state(ssl);
 
     /* Create a handle and allow verify_callback to access it. */


### PR DESCRIPTION
This simple patch adds server name indicator support to the OpenSSL plugin. SNI is required for e.g. virtual hosting of a KDC proxy instance. With SNI the webserver can select the correct vhost and certificate.