### PR TITLE
Fix bindresvport_sa port byte swap bug

### DIFF
--- a/src/lib/rpc/bindresvport.c
+++ b/src/lib/rpc/bindresvport.c
@@ -76,7 +76,7 @@ bindresvport_sa(int sd, struct sockaddr *sa)
 	res = -1;
 	errno = EADDRINUSE;
 	for (i = 0; i < NPORTS && res < 0 && errno == EADDRINUSE; i++) {
-		sa_setport(sa, htons(port++));
+		sa_setport(sa, port++);
 		if (port > ENDPORT) {
 			port = STARTPORT;
 		}


### PR DESCRIPTION
The sa_setport() helper handles conversion to network byte order, so
bindresvport_sa() should not itself call htons() on the port argument.

(This bug was introduced in commit
0d04b60d159ab83b943e43802b1449a3b074bc83 when adding
bindresvport_sa().  It was my fault, not Andreas Schneider's.)
