### PR TITLE
In gss_release_oid() just return on NULL oid

### DIFF
--- a/src/lib/gssapi/mechglue/g_initialize.c
+++ b/src/lib/gssapi/mechglue/g_initialize.c
@@ -175,6 +175,9 @@ gss_OID *oid;
 	if (*minor_status != 0)
 		return (GSS_S_FAILURE);
 
+	if (oid == NULL)
+		return (GSS_S_COMPLETE);
+
 	k5_mutex_lock(&g_mechListLock);
 	aMech = g_mechList;
 	while (aMech != NULL) {


### PR DESCRIPTION
It is useless to call actuall functions if we have no OID, and can
lead to segfaults as some mechanisms do not check for null oid but
immediately dereference it.

See https://github.com/modauthgssapi/mod_auth_gssapi/issues/34
for an example.

Signed-off-by: Simo Sorce <simo@redhat.com>