### PR TITLE
Fix uncommon null dereference in PKINIT client

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_clnt.c
+++ b/src/plugins/preauth/pkinit/pkinit_clnt.c
@@ -466,7 +466,7 @@ verify_kdc_san(krb5_context context,
 {
     krb5_error_code retval;
     char **certhosts = NULL, **cfghosts = NULL, **hostptr;
-    krb5_principal *princs = NULL, *princptr;
+    krb5_principal *princs = NULL;
     unsigned char ***get_dns;
     int i, j;
 
@@ -498,8 +498,8 @@ verify_kdc_san(krb5_context context,
         retval = KRB5KDC_ERR_KDC_NAME_MISMATCH;
         goto out;
     }
-    for (princptr = princs; *princptr != NULL; princptr++)
-        TRACE_PKINIT_CLIENT_SAN_KDCCERT_PRINC(context, *princptr);
+    for (i = 0; princs != NULL && princs[i] != NULL; i++)
+        TRACE_PKINIT_CLIENT_SAN_KDCCERT_PRINC(context, princs[i]);
     if (certhosts != NULL) {
         for (hostptr = certhosts; *hostptr != NULL; hostptr++)
             TRACE_PKINIT_CLIENT_SAN_KDCCERT_DNSNAME(context, *hostptr);


### PR DESCRIPTION
crypto_retrieve_cert_sans() is allowed to set its princs output to
NULL, although the OpenSSL implementation rarely does.  Fix the
TRACE_PKINIT_CLIENT_SAN_KDCCERT_PERT for loop to allow this like other
parts of the function do, and also get rid of the unnecessary princptr
variable by using an integer index like other parts of the function.
