### PR TITLE
Fix kdcpreauth counting bug

### DIFF
--- a/src/kdc/kdc_preauth.c
+++ b/src/kdc/kdc_preauth.c
@@ -235,7 +235,7 @@ get_plugin_vtables(krb5_context context,
             n_tables++;
     }
     for (i = 0, n_systems = 0; i < n_tables; i++) {
-        for (count = 0; vtables[i].pa_type_list[count] > 0; count++);
+        for (count = 0; vtables[i].pa_type_list[count] != 0; count++);
         n_systems += count;
     }
     *vtables_out = vtables;


### PR DESCRIPTION
Commit be20a5f5cee8d6c4072d1b81712520dbf9f6eefd made
load_preauth_plugins() handle negative preauth type numbers.
get_plugin_vtables() also needs to handle negative preauth type
numbers, or it returns the wrong count.
