### PR TITLE
Fix memleak in libverto:vfree

### DIFF
--- a/src/util/verto/verto.c
+++ b/src/util/verto/verto.c
@@ -132,6 +132,11 @@ vresize(void *mem, size_t size)
 {
     if (!resize_cb)
         resize_cb = &realloc;
+    if (size == 0 && resize_cb == &realloc) {
+        /* avoid memleak as realloc(X,0) can return a free-able pointer */
+        free(mem);
+        return NULL;
+    }
     return (*resize_cb)(mem, size);
 }
 

--- a/src/util/verto/verto.h
+++ b/src/util/verto/verto.h
@@ -195,7 +195,8 @@ verto_set_default(const char *impl, verto_ev_type reqtypes);
  * @see verto_add_idle()
  * @see verto_add_signal()
  * @see verto_add_child()
- * @param resize The allocator to use (behaves like realloc())
+ * @param resize The allocator to use (behaves like realloc(),
+ *        resize(ptr, 0) frees memory pointed by ptr.)
  * @param hierarchical Zero if the allocator is not hierarchical
  */
 int


### PR DESCRIPTION
verto_set_allocator(resize, hierarchical) has an unducumented
requirement on allocator function resize, that resize(ptr, 0) is
equivalent to free(ptr).

Some implementations of the default allocator realloc don't meet this
requirement. realloc(ptr, 0) may return a unique pointer that can be
successfully passed to free. This new pointer never gets freed and the
memory overhead leaks.

This fix replaces realloc(ptr, 0) with free(ptr) in vresize and
documents the allocator requirement.
