### PR TITLE
Conditionalize iprop stderr output in kadmind

### DIFF
--- a/src/kadmin/server/ipropd_svc.c
+++ b/src/kadmin/server/ipropd_svc.c
@@ -51,6 +51,7 @@ static char *reply_unknown_str	= "<UNKNOWN_CODE>";
 #ifdef	DPRINT
 #undef	DPRINT
 #endif
+#ifdef DEBUG
 #define	DPRINT(...)				\
     do {					\
 	if (nofork) {				\
@@ -58,7 +59,9 @@ static char *reply_unknown_str	= "<UNKNOWN_CODE>";
 	    fflush(stderr);			\
 	}					\
     } while (0)
-
+#else
+#define	DPRINT(...)
+#endif
 
 static void
 debprret(char *w, update_status_t ret, kdb_sno_t sno)


### PR DESCRIPTION
kadmind should be quiet in nofork mode after it prints the
"starting..." sentinel line, or it can fill the pipe buffer when run
from k5test.py.  Since there is currently no run-time debuf flag,
conditionalize the DPRINT macro in ipropd_svc.c on DEBUG at compile
time.
