### PR TITLE
Simplify test preauth module use

### DIFF
--- a/src/plugins/preauth/test/kdctest.c
+++ b/src/plugins/preauth/test/kdctest.c
@@ -42,11 +42,6 @@
  * - It receives a space-separated list from the clpreauth module and asserts
  *   each string as an authentication indicator.  It always succeeds in
  *   pre-authenticating the request.
- *
- * To use this module, a test script should:
- * - Register this module and the corresponding clpreauth module
- * - Disable the encrypted_timestamp clpreauth or kdcpreauth module
- * - Set the requires_preauth flag on the client principal
  */
 
 #include "k5-int.h"

--- a/src/tests/t_authdata.py
+++ b/src/tests/t_authdata.py
@@ -81,8 +81,7 @@ realm.stop()
 # can control the indicators asserted.
 testpreauth = os.path.join(buildtop, 'plugins', 'preauth', 'test', 'test.so')
 krb5conf = {'plugins': {'kdcpreauth': {'module': 'test:' + testpreauth},
-                        'clpreauth': {'module': 'test:' + testpreauth,
-                                      'disable': 'encrypted_timestamp'}}}
+                        'clpreauth': {'module': 'test:' + testpreauth}}}
 realm, realm2 = cross_realms(2, args=({'realm': 'LOCAL'},
                                       {'realm': 'FOREIGN'}),
                              krb5_conf=krb5conf, get_creds=False)

--- a/src/tests/t_etype_info.py
+++ b/src/tests/t_etype_info.py
@@ -79,8 +79,7 @@ realm.stop()
 # indicated by the etype info, and returns NULL if key was selected.
 testpreauth = os.path.join(buildtop, 'plugins', 'preauth', 'test', 'test.so')
 plugconf = {'plugins': {'kdcpreauth': {'module': 'test:' + testpreauth},
-                        'clpreauth': {'module': 'test:' + testpreauth,
-                                      'disable': 'encrypted_timestamp'}}}
+                        'clpreauth': {'module': 'test:' + testpreauth}}}
 conf.update(plugconf)
 realm = K5Realm(create_host=False, get_creds=False, krb5_conf=conf)
 realm.run([kadminl, 'modprinc', '+requires_preauth', realm.user_princ])


### PR DESCRIPTION
I made an outdated assumption when writing and using the test preauth module, leading to a small amount of unnecessary complexity.  This commit fixes that.
