### PR TITLE
Fix uncommon leak in krb5_init_creds_step()

### DIFF
--- a/src/lib/krb5/krb/get_in_tkt.c
+++ b/src/lib/krb5/krb/get_in_tkt.c
@@ -1428,6 +1428,8 @@ init_creds_step_reply(krb5_context context,
         ctx->request->client->type == KRB5_NT_ENTERPRISE_PRINCIPAL;
 
     if (ctx->err_reply != NULL) {
+        krb5_free_pa_data(context, ctx->err_padata);
+        ctx->err_padata = NULL;
         code = krb5int_fast_process_error(context, ctx->fast_state,
                                           &ctx->err_reply, &ctx->err_padata,
                                           &retry);


### PR DESCRIPTION
Release any previous value of ctx->err_padata before setting it in
init_creds_step_reply().  It could have a prior value after a realm
referral or retriable error.
