### PR TITLE
Fix crash in libecho.c on win64 build

### DIFF
--- a/src/util/windows/libecho.c
+++ b/src/util/windows/libecho.c
@@ -38,7 +38,7 @@ main(int argc, char *argv[])
 void
 echo_files(char *prefix, char *f)
 {
-    long ff;
+    intptr_t ff;
     struct _finddata_t fdt;
     char *slash;
     char filepath[256];


### PR DESCRIPTION
Return value of _findfirst is intptr_t, see https://msdn.microsoft.com/en-us/library/zyzxfzac.aspx