### PR TITLE
Allow missing authdata checksum with GSSAPI

### DIFF
--- a/src/lib/gssapi/krb5/accept_sec_context.c
+++ b/src/lib/gssapi/krb5/accept_sec_context.c
@@ -670,13 +670,15 @@ kg_accept_krb5(minor_status, context_handle,
 #endif
 
     if (authdat->checksum == NULL) {
-        /* missing checksum counts as "inappropriate type" */
-        code = KRB5KRB_AP_ERR_INAPP_CKSUM;
-        major_status = GSS_S_FAILURE;
-        goto fail;
-    }
+        /* Some SMB client implementations use handcrafted GSSAPI code
+         * that does not provide a checksum. MS-KILE documents that the
+         * Microsoft implementation considers a missing checksum acceptable
+         * provided that the server assumes all flags are unset in this case,
+         * and that channel binding information should not be checked. */
 
-    if (authdat->checksum->checksum_type != CKSUMTYPE_KG_CB) {
+        gss_flags = 0;
+
+    } else if (authdat->checksum->checksum_type != CKSUMTYPE_KG_CB) {
         /* Samba does not send 0x8003 GSS-API checksums */
         krb5_boolean valid;
         krb5_key subkey;


### PR DESCRIPTION
Allow missing checksum for compatibility with bad SMB clients