### PR TITLE
Do not allow retries on SOCK_STREAM sockets in libkrad

### DIFF
--- a/src/include/krad.h
+++ b/src/include/krad.h
@@ -251,7 +251,9 @@ krad_client_free(krad_client *client);
  *  - hostname:service
  *
  * The timeout parameter (milliseconds) is the total timeout across all remote
- * hosts (when DNS returns multiple entries) and all retries.
+ * hosts (when DNS returns multiple entries) and all retries. Note that for
+ * stream sockets (SOCK_STREAM), the retries parameter is ignored and no
+ * retries are performed.
  *
  * The cb function will be called with the data argument when either a response
  * is received or the request times out on all possible remote hosts.

--- a/src/lib/krad/remote.c
+++ b/src/lib/krad/remote.c
@@ -448,6 +448,9 @@ kr_remote_send(krad_remote *rr, krad_code code, krad_attrset *attrs,
     krb5_error_code retval;
     request *r;
 
+    if (rr->info->ai_socktype == SOCK_STREAM)
+        retries = 0;
+
     r = TAILQ_FIRST(&rr->list);
     retval = krad_packet_new_request(rr->kctx, rr->secret, code, attrs,
                                      (krad_packet_iter_cb)iterator, &r, &tmp);


### PR DESCRIPTION
Before this patch, libkrad would follow the same exact logic for
all socket types when the retries parameter was non-zero. This
meant that when connecting with SOCK_STREAM, multiple requests
were sent in case of packet drops, which, of course, cannot
happen for SOCK_STREAM.

Instead, we will just disable retries for SOCK_STREAM sockets.