### PR TITLE
Fix new doxygen parameter lists

### DIFF
--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -648,7 +648,7 @@ krb5_c_prf_length(krb5_context context, krb5_enctype enctype, size_t *len);
  * @param [in]  context         Library context
  * @param [in]  k               KDC contribution key
  * @param [in]  input           Input data
- * @param [in]  output          Pseudo-random output buffer
+ * @param [out] output          Pseudo-random output buffer
  *
  * This function fills @a output with PRF+(k, input) as defined in RFC 6113
  * section 5.1.  The caller must preinitialize @a output and allocate the
@@ -673,7 +673,7 @@ krb5_c_prfplus(krb5_context context, const krb5_keyblock *k,
  * @param [in]  k               KDC contribution key
  * @param [in]  input           Input string
  * @param [in]  enctype         Output key enctype (or @c ENCTYPE_NULL)
- * @param [in]  output          Derived keyblock
+ * @param [out] out             Derived keyblock
  *
  * This function uses PRF+ as defined in RFC 6113 to derive a key from another
  * key and an input string.  If @a enctype is @c ENCTYPE_NULL, the output key
@@ -682,7 +682,7 @@ krb5_c_prfplus(krb5_context context, const krb5_keyblock *k,
 krb5_error_code KRB5_CALLCONV
 krb5_c_derive_prfplus(krb5_context context, const krb5_keyblock *k,
                       const krb5_data *input, krb5_enctype enctype,
-                      krb5_keyblock **output);
+                      krb5_keyblock **out);
 
 /**
  * Compute the KRB-FX-CF2 combination of two keys and pepper strings.


### PR DESCRIPTION
Use [out] instead of [in] for the output parameters of
krb5_c_prfplus() and krb5_c_derive_prfplus().  Also use "out" instead
of "output" for krb5_c_derive_prfplus() to match the parameter name in
the definition.
