### PR TITLE
Send etype-info2 with MORE_PREAUTH_DATA_REQUIRED sometimes

### DIFF
--- a/src/plugins/preauth/test/cltest.c
+++ b/src/plugins/preauth/test/cltest.c
@@ -120,7 +120,22 @@ test_process(krb5_context context, krb5_clpreauth_moddata moddata,
     krb5_data plain;
     const char *indstr;
 
-    if (reqst->second_round_trip) {
+    if (pa_data->length == 0) {
+        /* This is an optimistic preauth test.  Send a recognizable padata
+         * value so the KDC knows not to expect a cookie. */
+        list = k5calloc(2, sizeof(*list), &ret);
+        assert(!ret);
+        pa = k5alloc(sizeof(*pa), &ret);
+        assert(!ret);
+        pa->pa_type = TEST_PA_TYPE;
+        pa->contents = (uint8_t *)strdup("optimistic");
+        assert(pa->contents != NULL);
+        pa->length = 10;
+        list[0] = pa;
+        list[1] = NULL;
+        *out_pa_data = list;
+        return 0;
+    } else if (reqst->second_round_trip) {
         printf("2rt: %.*s\n", pa_data->length, pa_data->contents);
     } else if (pa_data->length == 6 &&
                memcmp(pa_data->contents, "no key", 6) == 0) {

--- a/src/plugins/preauth/test/kdctest.c
+++ b/src/plugins/preauth/test/kdctest.c
@@ -120,12 +120,15 @@ test_verify(krb5_context context, krb5_data *req_pkt, krb5_kdc_req *request,
     assert(!ret);
 
     /* Check the incoming cookie value. */
-    if (!cb->get_cookie(context, rock, TEST_PA_TYPE, &cookie_data))
-        abort();
-    if (data_eq_string(cookie_data, "more"))
+    if (!cb->get_cookie(context, rock, TEST_PA_TYPE, &cookie_data)) {
+        /* Make sure we are seeing optimistic preauth and not a lost cookie. */
+        d = make_data(data->contents, data->length);
+        assert(data_eq_string(d, "optimistic"));
+    } else if (data_eq_string(cookie_data, "more")) {
         second_round_trip = TRUE;
-    else
+    } else {
         assert(data_eq_string(cookie_data, "method-data"));
+    }
 
     if (attr == NULL || second_round_trip) {
         /* Parse and assert the indicators. */

--- a/src/tests/t_etype_info.py
+++ b/src/tests/t_etype_info.py
@@ -73,4 +73,16 @@ test_etinfo('user', 'des-cbc-md5 rc4',
 test_etinfo('rc4user', 'des3', [])
 test_etinfo('nokeyuser', 'des3', [])
 
+# Verify that etype-info2 is included in a MORE_PREAUTH_DATA_REQUIRED
+# error if the client does optimistic preauth.
+realm.stop()
+testpreauth = os.path.join(buildtop, 'plugins', 'preauth', 'test', 'test.so')
+conf = {'plugins': {'kdcpreauth': {'module': 'test:' + testpreauth},
+                    'clpreauth': {'module': 'test:' + testpreauth}}}
+realm = K5Realm(create_host=False, get_creds=False, krb5_conf=conf)
+realm.run([kadminl, 'setstr', realm.user_princ, '2rt', '2rtval'])
+out = realm.run(['./etinfo', realm.user_princ, 'aes128-cts', '-123'])
+if out != 'more etype_info2 aes128-cts KRBTEST.COMuser\n':
+    fail('Unexpected output for MORE_PREAUTH_DATA_REQUIRED test')
+
 success('KDC etype-info tests')


### PR DESCRIPTION
These commits include etype-info2 information in a MORE_PREAUTH_DATA_REQUIRED error when the client performs optimistic preauth.  This is a preqrequisite for SPAKE preauth.
