### PR TITLE
Keep valgrind happy after time_rec change

### DIFF
--- a/src/lib/gssapi/mechglue/g_acquire_cred.c
+++ b/src/lib/gssapi/mechglue/g_acquire_cred.c
@@ -133,7 +133,7 @@ OM_uint32 *			time_rec;
 {
     OM_uint32 major = GSS_S_FAILURE, tmpMinor;
     OM_uint32 first_major = GSS_S_COMPLETE, first_minor = 0;
-    OM_uint32 initTimeOut, acceptTimeOut, outTime = GSS_C_INDEFINITE;
+    OM_uint32 initTimeOut = 0, acceptTimeOut = 0, outTime = GSS_C_INDEFINITE;
     gss_OID_set mechs = GSS_C_NO_OID_SET;
     gss_OID_set_desc except_attrs;
     gss_OID_desc attr_oids[2];


### PR DESCRIPTION
Initialize the time variables so valgrind does not complain.
all these values are ignored if time_rec is NULL, so not having those
variables initialized is harmless, but it is annoying to get noise in
the valgrind output.

Signed-off-by: Simo Sorce <simo@redhat.com>