### PR TITLE
Disallow IAKERB, old/wrong krb5 mechs in gss_accept_sec_context() with no acceptor cred

### DIFF
--- a/src/lib/gssapi/mechglue/g_accept_sec_context.c
+++ b/src/lib/gssapi/mechglue/g_accept_sec_context.c
@@ -86,6 +86,31 @@ val_acc_sec_ctx_args(
     return (GSS_S_COMPLETE);
 }
 
+/* Return true if mech should be accepted with no acceptor credential. */
+static int
+allow_mech_by_default(gss_OID mech)
+{
+    OM_uint32 status, minor;
+    gss_OID_set attrs;
+    int reject = 0, p;
+
+    status = gss_inquire_attrs_for_mech(&minor, mech, &attrs, NULL);
+    if (status)
+	return 0;
+
+    /* Check for each attribute which would cause us to exclude this mech from
+     * the default credential. */
+    if (generic_gss_test_oid_set_member(&minor, GSS_C_MA_DEPRECATED,
+					attrs, &p) != GSS_S_COMPLETE || p)
+	reject = 1;
+    else if (generic_gss_test_oid_set_member(&minor, GSS_C_MA_NOT_DFLT_MECH,
+					     attrs, &p) != GSS_S_COMPLETE || p)
+	reject = 1;
+
+    (void) gss_release_oid_set(&minor, &attrs);
+    return !reject;
+}
+
 OM_uint32 KRB5_CALLCONV
 gss_accept_sec_context (minor_status,
                         context_handle,
@@ -220,6 +245,9 @@ gss_cred_id_t *		d_cred;
 	    status = GSS_S_NO_CRED;
 	    goto error_out;
 	}
+    } else if (!allow_mech_by_default(selected_mech)) {
+	status = GSS_S_NO_CRED;
+	goto error_out;
     }
 
     /*


### PR DESCRIPTION
After tickets #8021 and #8217, a GSS server app which calls gss_acquire_cred(..., GSS_C_ACCEPT, ...) and gss_accept_sec_context() will not accept tokens framed with the old or wrong krb5 OIDs or IAKERB tokens; the intention is that you have to ask for those mech OIDs specifically in order to use them.  However, a server which calls gss_accept_sec_context() with no acceptor cred still accepts any mech.  This pull request makes the behavior consistent between the two usages, and finishes removing IAKERB from the exposed surface of a default GSS server application.

t_spnego.c needs a change for this to work.  Microsoft clients which use the wrong krb5 OID still use the correct OID in the mech token, and our test needs to match that behavior or the mech token will be rejected by the inner gss_accept_sec_context().  While visiting t_spnego.c, I noticed that it tries to exercise SPNEGO reselection and no longer does so.  Although we can't fix that with the currently available feature set, I added a comment to note that it isn't exercising what it intends to.