### PR TITLE
gss_display_name_ext: check for NULL name_type

### DIFF
--- a/src/lib/gssapi/mechglue/g_dsp_name_ext.c
+++ b/src/lib/gssapi/mechglue/g_dsp_name_ext.c
@@ -94,6 +94,7 @@ gss_display_name_ext (OM_uint32 *minor_status,
             status = GSS_S_BAD_NAME;
         else if (mech->gss_display_name_ext == NULL) {
             if (mech->gss_display_name != NULL &&
+                union_name->name_type != GSS_C_NO_OID &&
                 g_OID_equal(display_as_name_type, union_name->name_type)) {
                 status = (*mech->gss_display_name)(minor_status,
                                                    union_name->mech_name,
@@ -114,7 +115,8 @@ gss_display_name_ext (OM_uint32 *minor_status,
         return status;
     }
 
-    if (!g_OID_equal(display_as_name_type, union_name->name_type))
+    if (union_name->name_type == GSS_C_NO_OID ||
+        !g_OID_equal(display_as_name_type, union_name->name_type))
         return GSS_S_UNAVAILABLE;
 
     if ((output_name_buffer->value =


### PR DESCRIPTION
It is possible for the input name's name_type to be GSS_C_NO_OID.
`g_OID_equal` does not account for GSS_C_NO_OID, so we have to
manually check before use to prevent null pointer dereferences.