### PR TITLE
Fix krb5_rd_req() memory leak

### DIFF
--- a/src/lib/krb5/krb/rd_req_dec.c
+++ b/src/lib/krb5/krb/rd_req_dec.c
@@ -396,6 +396,7 @@ decrypt_ticket(krb5_context context, const krb5_ap_req *req,
         if (!krb5_sname_match(context, server, ent.principal)) {
             if (krb5_principal_compare(context, ent.principal, tkt_server))
                 tkt_server_mismatch = TRUE;
+            (void)krb5_free_keytab_entry_contents(context, &ent);
             continue;
         }
         found_server_match = TRUE;

--- a/src/tests/gssapi/t_accname.c
+++ b/src/tests/gssapi/t_accname.c
@@ -84,8 +84,10 @@ main(int argc, char *argv[])
 
     (void)gss_release_name(&minor, &target_name);
     (void)gss_release_name(&minor, &acceptor_name);
+    (void)gss_release_name(&minor, &real_acceptor_name);
     (void)gss_release_cred(&minor, &acceptor_cred);
     (void)gss_delete_sec_context(&minor, &initiator_context, NULL);
     (void)gss_delete_sec_context(&minor, &acceptor_context, NULL);
+    (void)gss_release_buffer(&minor, &namebuf);
     return 0;
 }


### PR DESCRIPTION
In release 1.13, commit eba8c4909ec7ba0d7054d5d1b1061319e9970cc7 (ticket #7232) introduced a memory leak when skipping keytab entries which do not match the application-provided server specification.  Fix it by freeing the keytab entry before continuing the loop on a failure to match.

The second commit is a less important fix to a test program, noticed while verifying the first commit.
