### PR TITLE
Improve PKINIT OpenSSL error reporting

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_trace.h
+++ b/src/plugins/preauth/pkinit/pkinit_trace.h
@@ -87,4 +87,8 @@
     TRACE(c, "PKINIT client found id-pkinit-san in KDC cert: {princ}", princ)
 #define TRACE_PKINIT_CLIENT_TRYAGAIN(c)                                 \
     TRACE(c, "PKINIT client trying again with KDC-provided parameters")
+
+#define TRACE_PKINIT_OPENSSL_ERROR(c, msg)              \
+    TRACE(c, "PKINIT OpenSSL error: {str}", msg)
+
 #endif /* PKINIT_TRACE_H */


### PR DESCRIPTION
When a non-trivial OpenSSL function fails during PKINIT processing,
try to ensure that the error message includes an indication of the
what PKINIT was doing and the reason for the first queued OpenSSL
error, and flush all queued OpenSSL errors to the trace log.  For
certificate verification failures, also include the higher-level error
from the cert store.  Add new helper functions oerr() and oerr_cert()
to minimize the amount of code needed to handle each error.

(Inspired by http://mailman.mit.edu/pipermail/kerberos/2015-September/020946.html and http://mailman.mit.edu/pipermail/kerberos/2015-September/020951.html)