### PR TITLE
Add missing error mappings to new mechglue func

### DIFF
--- a/src/lib/gssapi/mechglue/g_unwrap_iov.c
+++ b/src/lib/gssapi/mechglue/g_unwrap_iov.c
@@ -133,6 +133,9 @@ gss_verify_mic_iov(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
 	return GSS_S_BAD_MECH;
     if (mech->gss_verify_mic_iov == NULL)
 	return GSS_S_UNAVAILABLE;
-    return mech->gss_verify_mic_iov(minor_status, ctx->internal_ctx_id,
-				    qop_state, iov, iov_count);
+    status = mech->gss_verify_mic_iov(minor_status, ctx->internal_ctx_id,
+				      qop_state, iov, iov_count);
+    if (status != GSS_S_COMPLETE)
+	map_error(minor_status, mech);
+    return status;
 }

--- a/src/lib/gssapi/mechglue/g_wrap_iov.c
+++ b/src/lib/gssapi/mechglue/g_wrap_iov.c
@@ -195,8 +195,11 @@ gss_get_mic_iov(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
 	return GSS_S_BAD_MECH;
     if (mech->gss_get_mic_iov == NULL)
 	return GSS_S_UNAVAILABLE;
-    return mech->gss_get_mic_iov(minor_status, ctx->internal_ctx_id, qop_req,
-				 iov, iov_count);
+    status = mech->gss_get_mic_iov(minor_status, ctx->internal_ctx_id, qop_req,
+				   iov, iov_count);
+    if (status != GSS_S_COMPLETE)
+	map_error(minor_status, mech);
+    return status;
 }
 
 OM_uint32 KRB5_CALLCONV
@@ -220,8 +223,11 @@ gss_get_mic_iov_length(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
 	return GSS_S_BAD_MECH;
     if (mech->gss_get_mic_iov_length == NULL)
 	return GSS_S_UNAVAILABLE;
-    return mech->gss_get_mic_iov_length(minor_status, ctx->internal_ctx_id,
-					qop_req, iov, iov_count);
+    status =  mech->gss_get_mic_iov_length(minor_status, ctx->internal_ctx_id,
+					   qop_req, iov, iov_count);
+    if (status != GSS_S_COMPLETE)
+	map_error(minor_status, mech);
+    return status;
 }
 
 OM_uint32 KRB5_CALLCONV


### PR DESCRIPTION
mechglue functions gss_get_mic_iov, gss_get_mic_iov_length and
gss_verify_mic_iov don't call map_error to map mechanism specific error
code.  As a result, on error subsequent call to gss_display_status fails
with GSS_S_BAD_MECH, because no translation for the error code is found
in the error table.

This patch adds the missing map_error call.