### PR TITLE
Fail during configure if stdint.h missing

### DIFF
--- a/src/configure.in
+++ b/src/configure.in
@@ -22,6 +22,9 @@ AC_SUBST(KRB5_VERSION)
 
 AC_REQUIRE_CPP
 
+AC_CHECK_HEADER([stdint.h], [],
+  [AC_MSG_ERROR([stdint.h is required])])
+
 AC_CACHE_CHECK([whether integers are two's complement],
   [krb5_cv_ints_twos_compl],
   [AC_COMPILE_IFELSE(


### PR DESCRIPTION
We now require stdint.h to build this software.  Gracefully fail
during configure time if stdint.h is missing.

ticket: 8221
target_version: 1.14
tags: pullup