### PR TITLE
Fix kadmin with e2fsprogs libss

### DIFF
--- a/src/aclocal.m4
+++ b/src/aclocal.m4
@@ -1483,6 +1483,7 @@ int main(int argc, char *argv[]) {
 }], krb5_cv_system_ss_okay=yes, AC_MSG_ERROR(cannot run test program),
   krb5_cv_system_ss_okay="assumed")])
   LIBS="$old_LIBS"
+  KRB5_NEED_PROTO([#include <ss/ss.h>],ss_execute_command,1)
 else
   SS_VERSION=k5
   AC_MSG_RESULT(krb5)

--- a/src/kadmin/cli/ss_wrapper.c
+++ b/src/kadmin/cli/ss_wrapper.c
@@ -29,6 +29,10 @@
 #include <ss/ss.h>
 #include "kadmin.h"
 
+#ifdef NEED_SS_EXECUTE_COMMAND_PROTO
+int ss_execute_command(int, char **);
+#endif
+
 extern ss_request_table kadmin_cmds;
 extern int exit_status;
 extern char *whoami;


### PR DESCRIPTION
The libss in e2fsprogs exports ss_execute_command(), but does not
prototype it (as of this writing; a patch has been submitted
upstream).  When using the system ss library, check if a prototype is
needed and provide one if so.
