### PR TITLE
Fix minor utf8-to-ucs2s read overrun bug

### DIFF
--- a/src/util/support/utf8_conv.c
+++ b/src/util/support/utf8_conv.c
@@ -84,7 +84,7 @@ k5_utf8s_to_ucs2s(krb5_ucs2 *ucs2str,
     }
 
     /* Examine next UTF-8 character.  */
-    while (*utf8str && ucs2len < count) {
+    while (ucs2len < count && *utf8str != '\0') {
         /* Get UTF-8 sequence length from 1st byte */
         utflen = KRB5_UTF8_CHARLEN2(utf8str, utflen);
 


### PR DESCRIPTION
k5_utf8s_to_ucs2s() reads and discards one extra byte from the input
string before terminating its loop, possibly overrunning the input
buffer of its caller.  This overrun is typically without consequence,
but can show up in tools like asan or valgrind during RC4
string-to-key operations.  Fix the bug by swapping the order of the
loop conditions.
