### PR TITLE
Don't depend on system krb5.conf in test suite

### DIFF
--- a/src/lib/krad/Makefile.in
+++ b/src/lib/krad/Makefile.in
@@ -32,13 +32,15 @@ install-unix:: install-libs
 
 clean-unix:: clean-liblinks clean-libs clean-libobjs
 
+HIDE_CONFIG = KRB5_CONFIG=/dev/null
+
 check-unix:: t_attr t_attrset t_code t_packet t_remote t_client
-	$(RUN_SETUP) $(VALGRIND) ./t_attr
-	$(RUN_SETUP) $(VALGRIND) ./t_attrset
-	$(RUN_SETUP) $(VALGRIND) ./t_code
-	$(RUN_SETUP) $(VALGRIND) ./t_packet $(PYTHON) $(srcdir)/t_daemon.py
-	$(RUN_SETUP) $(VALGRIND) ./t_remote $(PYTHON) $(srcdir)/t_daemon.py
-	$(RUN_SETUP) $(VALGRIND) ./t_client $(PYTHON) $(srcdir)/t_daemon.py
+	$(RUN_SETUP) $(HIDE_CONFIG) $(VALGRIND) ./t_attr
+	$(RUN_SETUP) $(HIDE_CONFIG) $(VALGRIND) ./t_attrset
+	$(RUN_SETUP) $(HIDE_CONFIG) $(VALGRIND) ./t_code
+	$(RUN_SETUP) $(HIDE_CONFIG) $(VALGRIND) ./t_packet $(PYTHON) $(srcdir)/t_daemon.py
+	$(RUN_SETUP) $(HIDE_CONFIG) $(VALGRIND) ./t_remote $(PYTHON) $(srcdir)/t_daemon.py
+	$(RUN_SETUP) $(HIDE_CONFIG) $(VALGRIND) ./t_client $(PYTHON) $(srcdir)/t_daemon.py
 
 TESTDEPS=t_test.o $(KRB5_BASE_DEPLIBS)
 TESTLIBS=t_test.o $(KRB5_BASE_LIBS)

--- a/src/lib/krb5/krb/Makefile.in
+++ b/src/lib/krb5/krb/Makefile.in
@@ -437,9 +437,10 @@ TEST_PROGS= t_walk_rtree t_kerb t_ser t_deltat t_expand t_authdata t_pac \
 	t_in_ccache t_cc_config t_copy_context \
 	t_princ t_etypes t_vfy_increds t_response_items
 
+OWN_CONF = KRB5_CONFIG=$(srcdir)/t_krb5.conf
+
 check-unix:: $(TEST_PROGS)
-	KRB5_CONFIG=$(srcdir)/t_krb5.conf ; export KRB5_CONFIG ;\
-	$(RUN_SETUP) $(VALGRIND) ./t_kerb \
+	$(RUN_SETUP) $(OWN_CONF) $(VALGRIND) ./t_kerb \
 		parse_name tytso \
 		parse_name tytso@SHAZAAM \
 		parse_name tytso/root@VEGGIE.COM \
@@ -462,20 +463,16 @@ check-unix:: $(TEST_PROGS)
 		> test.out
 	cmp test.out $(srcdir)/t_ref_kerb.out
 	$(RM) test.out
-	KRB5_CONFIG=$(srcdir)/t_krb5.conf ; export KRB5_CONFIG ;\
-		$(RUN_SETUP) $(VALGRIND) ./t_ser
-	$(RUN_SETUP) $(VALGRIND) ./t_deltat
-	$(RUN_SETUP) $(VALGRIND) sh $(srcdir)/transit-tests
-	KRB5_CONFIG=$(srcdir)/t_krb5.conf ; export KRB5_CONFIG ;\
-		$(RUN_SETUP) $(VALGRIND) sh $(srcdir)/walktree-tests
-	KRB5_CONFIG=$(srcdir)/t_krb5.conf ; export KRB5_CONFIG ;\
-	$(RUN_SETUP) $(VALGRIND) ./t_authdata
-	$(RUN_SETUP) $(VALGRIND) ./t_pac
-	$(RUN_SETUP) $(VALGRIND) ./t_princ
-	$(RUN_SETUP) $(VALGRIND) ./t_etypes
-	$(RUN_SETUP) $(VALGRIND) ./t_response_items
-	KRB5_CONFIG=$(srcdir)/t_krb5.conf ; export KRB5_CONFIG ;\
-		$(RUN_SETUP) $(VALGRIND) ./t_copy_context
+	$(RUN_SETUP) $(OWN_CONF) $(VALGRIND) ./t_ser
+	$(RUN_SETUP) $(OWN_CONF) $(VALGRIND) ./t_deltat
+	$(RUN_SETUP) $(OWN_CONF) $(VALGRIND) sh $(srcdir)/transit-tests
+	$(RUN_SETUP) $(OWN_CONF) $(VALGRIND) sh $(srcdir)/walktree-tests
+	$(RUN_SETUP) $(OWN_CONF) $(VALGRIND) ./t_authdata
+	$(RUN_SETUP) $(OWN_CONF) $(VALGRIND) ./t_pac
+	$(RUN_SETUP) $(OWN_CONF) $(VALGRIND) ./t_princ
+	$(RUN_SETUP) $(OWN_CONF) $(VALGRIND) ./t_etypes
+	$(RUN_SETUP) $(OWN_CONF) $(VALGRIND) ./t_response_items
+	$(RUN_SETUP) $(OWN_CONF) $(VALGRIND) ./t_copy_context
 
 check-pytests:: t_expire_warn t_vfy_increds
 	$(RUNPYTEST) $(srcdir)/t_expire_warn.py $(PYTESTFLAGS)

--- a/src/lib/krb5/os/Makefile.in
+++ b/src/lib/krb5/os/Makefile.in
@@ -232,8 +232,8 @@ check-unix-locate:: t_locate_kdc
 
 check-unix-trace:: t_trace
 	rm -f t_trace.out
-	KRB5_TRACE=t_trace.out ; export KRB5_TRACE ; \
-	$(RUN_SETUP) $(VALGRIND) ./t_trace
+	$(RUN_SETUP) KRB5_TRACE=t_trace.out KRB5_CONFIG=/dev/null \
+		$(VALGRIND) ./t_trace
 	sed -e 's/^[^:]*: //' t_trace.out | cmp - $(srcdir)/t_trace.ref
 	rm -f t_trace.out
 

--- a/src/tests/misc/Makefile.in
+++ b/src/tests/misc/Makefile.in
@@ -17,14 +17,16 @@ SRCS=\
 
 all:: test_getpw test_chpw_message
 
+HIDE_CONF = KRB5_CONFIG=/dev/null
+
 check:: test_getpw test_chpw_message test_cxx_krb5 test_cxx_gss test_cxx_rpc test_cxx_k5int test_cxx_kadm5
-	$(RUN_SETUP) $(VALGRIND) ./test_getpw
-	$(RUN_SETUP) $(VALGRIND) ./test_chpw_message
-	$(RUN_SETUP) $(VALGRIND) ./test_cxx_krb5
-	$(RUN_SETUP) $(VALGRIND) ./test_cxx_k5int
-	$(RUN_SETUP) $(VALGRIND) ./test_cxx_gss
-	$(RUN_SETUP) $(VALGRIND) ./test_cxx_rpc
-	$(RUN_SETUP) $(VALGRIND) ./test_cxx_kadm5
+	$(RUN_SETUP) $(HIDE_CONF) $(VALGRIND) ./test_getpw
+	$(RUN_SETUP) $(HIDE_CONF) $(VALGRIND) ./test_chpw_message
+	$(RUN_SETUP) $(HIDE_CONF) $(VALGRIND) ./test_cxx_krb5
+	$(RUN_SETUP) $(HIDE_CONF) $(VALGRIND) ./test_cxx_k5int
+	$(RUN_SETUP) $(HIDE_CONF) $(VALGRIND) ./test_cxx_gss
+	$(RUN_SETUP) $(HIDE_CONF) $(VALGRIND) ./test_cxx_rpc
+	$(RUN_SETUP) $(HIDE_CONF) $(VALGRIND) ./test_cxx_kadm5
 
 test_getpw: $(OUTPRE)test_getpw.$(OBJEXT) $(SUPPORT_DEPLIB)
 	$(CC_LINK) $(ALL_CFLAGS) -o test_getpw $(OUTPRE)test_getpw.$(OBJEXT) $(SUPPORT_LIB)


### PR DESCRIPTION
It's my own fault that I ended up caring about this behavior, but this may be more broadly useful in case anyone hits it again.  Anyway, this fixes tests which break if there are problems parsing /etc/krb5.conf from the system.