### PR TITLE
Correct major code for non-default QOP

### DIFF
--- a/src/lib/gssapi/krb5/k5seal.c
+++ b/src/lib/gssapi/krb5/k5seal.c
@@ -337,7 +337,7 @@ kg_seal(minor_status, context_handle, conf_req_flag, qop_req,
        them later.  */
     if (qop_req != 0) {
         *minor_status = (OM_uint32) G_UNKNOWN_QOP;
-        return GSS_S_FAILURE;
+        return GSS_S_BAD_QOP;
     }
 
     ctx = (krb5_gss_ctx_id_rec *) context_handle;

--- a/src/lib/gssapi/krb5/k5sealiov.c
+++ b/src/lib/gssapi/krb5/k5sealiov.c
@@ -277,7 +277,7 @@ kg_seal_iov(OM_uint32 *minor_status,
 
     if (qop_req != 0) {
         *minor_status = (OM_uint32)G_UNKNOWN_QOP;
-        return GSS_S_FAILURE;
+        return GSS_S_BAD_QOP;
     }
 
     ctx = (krb5_gss_ctx_id_rec *)context_handle;
@@ -342,7 +342,7 @@ kg_seal_iov_length(OM_uint32 *minor_status,
 
     if (qop_req != GSS_C_QOP_DEFAULT) {
         *minor_status = (OM_uint32)G_UNKNOWN_QOP;
-        return GSS_S_FAILURE;
+        return GSS_S_BAD_QOP;
     }
 
     ctx = (krb5_gss_ctx_id_rec *)context_handle;

--- a/src/lib/gssapi/krb5/wrap_size_limit.c
+++ b/src/lib/gssapi/krb5/wrap_size_limit.c
@@ -91,7 +91,7 @@ krb5_gss_wrap_size_limit(minor_status, context_handle, conf_req_flag,
     /* only default qop is allowed */
     if (qop_req != GSS_C_QOP_DEFAULT) {
         *minor_status = (OM_uint32) G_UNKNOWN_QOP;
-        return(GSS_S_FAILURE);
+        return GSS_S_BAD_QOP;
     }
 
     ctx = (krb5_gss_ctx_id_rec *) context_handle;


### PR DESCRIPTION
This patch fixes krb5_gss_wrap_size_limit return code to comply with
RFC 2743; non default QOP argument should result in GSS_S_BAD_QOP, not
GSS_S_FAILURE.

(This is the first of a batch of 6 fixes (mostly nits) that were reported by Solaris gss_api regression testsuite. Sorry for the (mini) flood.)