### PR TITLE
inquire names for gss_mech_krb5_wrong

### DIFF
--- a/src/lib/gssapi/krb5/inq_names.c
+++ b/src/lib/gssapi/krb5/inq_names.c
@@ -40,6 +40,7 @@ krb5_gss_inquire_names_for_mech(minor_status, mechanism, name_types)
     if ((mechanism != GSS_C_NULL_OID) &&
         !g_OID_equal(gss_mech_krb5, mechanism) &&
         !g_OID_equal(gss_mech_krb5_old, mechanism) &&
+        !g_OID_equal(gss_mech_krb5_wrong, mechanism) &&
         !g_OID_equal(gss_mech_iakerb, mechanism)) {
         *minor_status = 0;
         return(GSS_S_BAD_MECH);


### PR DESCRIPTION
The GSS-API library indicates Kerberos mechanism under multiple OIDs
including gss_mech_krb5_wrong. But it is not able to inquire names for
this OID.

This patch modifies krb5_gss_inquire_names_for_mech not to fail with
GSS_S_BAD_MECH for mechanism = gss_mech_krb5_wrong.