### PR TITLE
Check input of oid_set manipulating functions

### DIFF
--- a/src/lib/gssapi/generic/oid_ops.c
+++ b/src/lib/gssapi/generic/oid_ops.c
@@ -137,6 +137,9 @@ generic_gss_create_empty_oid_set(OM_uint32 *minor_status, gss_OID_set *oid_set)
 {
     *minor_status = 0;
 
+    if (oid_set == NULL)
+        return GSS_S_CALL_INACCESSIBLE_WRITE;
+
     if ((*oid_set = (gss_OID_set) gssalloc_malloc(sizeof(gss_OID_set_desc)))) {
         memset(*oid_set, 0, sizeof(gss_OID_set_desc));
         return(GSS_S_COMPLETE);
@@ -160,6 +163,9 @@ generic_gss_add_oid_set_member(OM_uint32 *minor_status,
     if (member_oid == NULL || member_oid->length == 0 ||
         member_oid->elements == NULL)
         return (GSS_S_CALL_INACCESSIBLE_READ);
+
+    if (oid_set == NULL)
+        return GSS_S_CALL_INACCESSIBLE_WRITE;
 
     elist = (*oid_set)->elements;
     /* Get an enlarged copy of the array */


### PR DESCRIPTION
This patch adds additional argument sanity checks to oid_set
manipulating functions generic_gss_create_empty_oid_set and
generic_gss_add_oid_set_member.