### PR TITLE
Avoid using system libraries during testing

### DIFF
--- a/src/kadmin/testing/proto/krb5.conf.proto
+++ b/src/kadmin/testing/proto/krb5.conf.proto
@@ -2,6 +2,7 @@
 	default_realm = __REALM__
 	default_keytab_name = FILE:__K5ROOT__/v5srvtab
 	dns_fallback = no
+	plugin_base_dir = __PLUGIN_DIR__
 
 [realms]
 	__REALM__ = {

--- a/src/kadmin/testing/scripts/start_servers
+++ b/src/kadmin/testing/scripts/start_servers
@@ -40,6 +40,7 @@ if [ $local = 0 ]; then
 		-e "s/__KDCHOST__/$hostname/g" \
 		-e "s/__LOCALHOST__/$localname/g" \
 		-e "s#__MODDIR__#$TOP/../plugins/kdb#g"\
+		-e "s#__PLUGIN_DIR__#$TOP/../plugins#g"\
 		< $STESTDIR/proto/krb5.conf.proto > $K5ROOT/krb5.conf
 
 # Using /usr/ucb/rsh and getting rid of "-k $REALM" until we get


### PR DESCRIPTION
We want to ensure that we test what we have built, rather than the system configuration.

This is a fix originally from [rhbz#1164304](https://bugzilla.redhat.com/show_bug.cgi?id=1164304).