### PR TITLE
Pass down the new password as a const char pointer

### DIFF
--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -5037,9 +5037,9 @@ krb5_sname_match(krb5_context context, krb5_const_principal matching,
  * @retval 0 Success; otherwise - Kerberos error codes
  */
 krb5_error_code KRB5_CALLCONV
-krb5_change_password(krb5_context context, krb5_creds *creds, char *newpw,
-                     int *result_code, krb5_data *result_code_string,
-                     krb5_data *result_string);
+krb5_change_password(krb5_context context, krb5_creds *creds,
+                     const char *newpw, int *result_code,
+                     krb5_data *result_code_string, krb5_data *result_string);
 
 /**
  * Set a password for a principal using specified credentials.
@@ -5072,7 +5072,7 @@ krb5_change_password(krb5_context context, krb5_creds *creds, char *newpw,
  * Kerberos error codes.
  */
 krb5_error_code KRB5_CALLCONV
-krb5_set_password(krb5_context context, krb5_creds *creds, char *newpw,
+krb5_set_password(krb5_context context, krb5_creds *creds, const char *newpw,
                   krb5_principal change_password_for, int *result_code,
                   krb5_data *result_code_string, krb5_data *result_string);
 
@@ -5108,7 +5108,8 @@ krb5_set_password(krb5_context context, krb5_creds *creds, char *newpw,
  */
 krb5_error_code KRB5_CALLCONV
 krb5_set_password_using_ccache(krb5_context context, krb5_ccache ccache,
-                               char *newpw, krb5_principal change_password_for,
+                               const char *newpw,
+                               krb5_principal change_password_for,
                                int *result_code, krb5_data *result_code_string,
                                krb5_data *result_string);
 

--- a/src/lib/krb5/krb/chpw.c
+++ b/src/lib/krb5/krb/chpw.c
@@ -13,7 +13,7 @@ krb5_error_code
 krb5int_mk_chpw_req(krb5_context context,
                     krb5_auth_context auth_context,
                     krb5_data *ap_req,
-                    char *passwd,
+                    const char *passwd,
                     krb5_data *packet)
 {
     krb5_error_code ret = 0;
@@ -284,7 +284,7 @@ krb5int_mk_setpw_req(krb5_context context,
                      krb5_auth_context auth_context,
                      krb5_data *ap_req,
                      krb5_principal targprinc,
-                     char *passwd,
+                     const char *passwd,
                      krb5_data *packet)
 {
     krb5_error_code ret;

--- a/src/lib/krb5/krb/int-proto.h
+++ b/src/lib/krb5/krb/int-proto.h
@@ -152,7 +152,7 @@ k5_privsafe_check_addrs(krb5_context context, krb5_auth_context ac,
 
 krb5_error_code
 krb5int_mk_chpw_req(krb5_context context, krb5_auth_context auth_context,
-                    krb5_data *ap_req, char *passwd, krb5_data *packet);
+                    krb5_data *ap_req, const char *passwd, krb5_data *packet);
 
 krb5_error_code
 krb5int_rd_chpw_rep(krb5_context context, krb5_auth_context auth_context,
@@ -166,7 +166,7 @@ krb5_chpw_result_code_string(krb5_context context, int result_code,
 krb5_error_code
 krb5int_mk_setpw_req(krb5_context context, krb5_auth_context auth_context,
                      krb5_data *ap_req, krb5_principal targetprinc,
-                     char *passwd, krb5_data *packet);
+                     const char *passwd, krb5_data *packet);
 
 void
 k5_ccselect_free_context(krb5_context context);

--- a/src/lib/krb5/os/changepw.c
+++ b/src/lib/krb5/os/changepw.c
@@ -48,7 +48,7 @@ struct sendto_callback_context {
     krb5_context        context;
     krb5_auth_context   auth_context;
     krb5_principal      set_password_for;
-    char                *newpw;
+    const char          *newpw;
     krb5_data           ap_req;
     krb5_ui_4           remote_seq_num, local_seq_num;
 };
@@ -207,7 +207,7 @@ cleanup:
 static krb5_error_code
 change_set_password(krb5_context context,
                     krb5_creds *creds,
-                    char *newpw,
+                    const char *newpw,
                     krb5_principal set_password_for,
                     int *result_code,
                     krb5_data *result_code_string,
@@ -328,7 +328,7 @@ cleanup:
 krb5_error_code KRB5_CALLCONV
 krb5_change_password(krb5_context context,
                      krb5_creds *creds,
-                     char *newpw,
+                     const char *newpw,
                      int *result_code,
                      krb5_data *result_code_string,
                      krb5_data *result_string)
@@ -345,7 +345,7 @@ krb5_change_password(krb5_context context,
 krb5_error_code KRB5_CALLCONV
 krb5_set_password(krb5_context context,
                   krb5_creds *creds,
-                  char *newpw,
+                  const char *newpw,
                   krb5_principal change_password_for,
                   int *result_code,
                   krb5_data *result_code_string,
@@ -359,7 +359,7 @@ krb5_set_password(krb5_context context,
 krb5_error_code KRB5_CALLCONV
 krb5_set_password_using_ccache(krb5_context context,
                                krb5_ccache ccache,
-                               char *newpw,
+                               const char *newpw,
                                krb5_principal change_password_for,
                                int *result_code,
                                krb5_data *result_code_string,


### PR DESCRIPTION
The new password parameter which is passed down or passed around internally should be const. It gets never modified and shouldn't.