### PR TITLE
Secure cookie memory hygiene and a couple of memory leak fixes

### DIFF
--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -979,6 +979,9 @@ typedef struct _krb5_authdata_context *krb5_authdata_context;
 void
 k5_free_data_ptr_list(krb5_data **list);
 
+void
+k5_zapfree_pa_data(krb5_pa_data **val);
+
 void KRB5_CALLCONV
 krb5int_free_data_list(krb5_context context, krb5_data *data);
 

--- a/src/kdc/fast_util.c
+++ b/src/kdc/fast_util.c
@@ -270,8 +270,8 @@ kdc_free_rstate (struct kdc_request_state *s)
         krb5_free_keyblock(kdc_context, s->armor_key);
     if (s->strengthen_key)
         krb5_free_keyblock(kdc_context, s->strengthen_key);
-    krb5_free_pa_data(NULL, s->in_cookie_padata);
-    krb5_free_pa_data(NULL, s->out_cookie_padata);
+    k5_zapfree_pa_data(s->in_cookie_padata);
+    k5_zapfree_pa_data(s->out_cookie_padata);
     free(s);
 }
 
@@ -620,7 +620,7 @@ kdc_fast_read_cookie(krb5_context context, struct kdc_request_state *state,
     cookie->data = NULL;
 
 cleanup:
-    krb5_free_data_contents(context, &plain);
+    zapfree(plain.data, plain.length);
     krb5_free_keyblock(context, key);
     k5_free_secure_cookie(context, cookie);
     return 0;
@@ -727,7 +727,11 @@ kdc_fast_make_cookie(krb5_context context, struct kdc_request_state *state,
     *cookie_out = pa;
 
 cleanup:
-    krb5_free_data(context, der_cookie);
+    krb5_free_keyblock(context, key);
+    if (der_cookie != NULL) {
+        zapfree(der_cookie->data, der_cookie->length);
+        free(der_cookie);
+    }
     krb5_free_data_contents(context, &enc.ciphertext);
     return ret;
 }

--- a/src/lib/krb5/krb/kfree.c
+++ b/src/lib/krb5/krb/kfree.c
@@ -366,6 +366,20 @@ krb5_free_last_req(krb5_context context, krb5_last_req_entry **val)
     free(val);
 }
 
+void
+k5_zapfree_pa_data(krb5_pa_data **val)
+{
+    krb5_pa_data **pa;
+
+    if (val == NULL)
+        return;
+    for (pa = val; *pa != NULL; pa++) {
+        zapfree((*pa)->contents, (*pa)->length);
+        zapfree(*pa, sizeof(**pa));
+    }
+    free(val);
+}
+
 void KRB5_CALLCONV
 krb5_free_pa_data(krb5_context context, krb5_pa_data **val)
 {
@@ -872,6 +886,6 @@ k5_free_secure_cookie(krb5_context context, krb5_secure_cookie *val)
 {
     if (val == NULL)
         return;
-    krb5_free_pa_data(context, val->data);
+    k5_zapfree_pa_data(val->data);
     free(val);
 }

--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -144,6 +144,7 @@ k5_plugin_register
 k5_plugin_register_dyn
 k5_unmarshal_cred
 k5_unmarshal_princ
+k5_zapfree_pa_data
 krb524_convert_creds_kdc
 krb524_init_ets
 krb5_425_conv_principal

--- a/src/plugins/preauth/test/kdctest.c
+++ b/src/plugins/preauth/test/kdctest.c
@@ -142,6 +142,7 @@ test_verify(krb5_context context, krb5_data *req_pkt, krb5_kdc_req *request,
         }
         free(str);
         enc_tkt_reply->flags |= TKT_FLG_PRE_AUTH;
+        cb->free_string(context, rock, attr);
         (*respond)(arg, 0, NULL, NULL, NULL);
     } else {
         d = string2data("more");


### PR DESCRIPTION
I noticed the lack of sanitization when making the prototype SPAKE preauth module, and noticed a couple of memory leaks while fixing the sanitization issue.
