### PR TITLE
Rename two test programs for consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -254,16 +254,16 @@ testlog
 /src/tests/gcred
 /src/tests/hist
 /src/tests/hrealm
+/src/tests/icred
 /src/tests/kdbtest
 /src/tests/kdc.conf
 /src/tests/krb5.conf
+/src/tests/localauth
 /src/tests/plugorder
 /src/tests/rdreq
 /src/tests/responder
 /src/tests/s2p
 /src/tests/s4u2proxy
-/src/tests/t_init_creds
-/src/tests/t_localauth
 
 /src/tests/asn.1/expected_encode.out
 /src/tests/asn.1/expected_trval.out

--- a/src/tests/Makefile.in
+++ b/src/tests/Makefile.in
@@ -6,10 +6,10 @@ SUBDIRS = resolve asn.1 create hammer verify gssapi dejagnu shlib \
 RUN_DB_TEST = $(RUN_SETUP) KRB5_KDC_PROFILE=kdc.conf KRB5_CONFIG=krb5.conf \
 	LC_ALL=C $(VALGRIND)
 
-OBJS= adata.o etinfo.o gcred.o hist.o hrealm.o kdbtest.o plugorder.o \
-	t_init_creds.o t_localauth.o rdreq.o responder.o s2p.o s4u2proxy.o
-EXTRADEPSRCS= adata.c etinfo.c gcred.c hist.c hrealm.c kdbtest.c plugorder.c \
-	t_init_creds.c t_localauth.c rdreq.o responder.c s2p.c s4u2proxy.c
+OBJS= adata.o etinfo.o gcred.o hist.o hrealm.o icred.o kdbtest.o localauth.o \
+	plugorder.o rdreq.o responder.o s2p.o s4u2proxy.o
+EXTRADEPSRCS= adata.c etinfo.c gcred.c hist.c hrealm.c icred.c kdbtest.c \
+	localauth.c plugorder.c rdreq.o responder.c s2p.c s4u2proxy.c
 
 TEST_DB = ./testdb
 TEST_REALM = FOO.TEST.REALM
@@ -36,9 +36,15 @@ hist: hist.o $(KDB5_DEPLIBS) $(KADMSRV_DEPLIBS) $(KRB5_BASE_DEPLIBS)
 hrealm: hrealm.o $(KRB5_BASE_DEPLIBS)
 	$(CC_LINK) -o $@ hrealm.o $(KRB5_BASE_LIBS)
 
+icred: icred.o $(KRB5_BASE_DEPLIBS)
+	$(CC_LINK) -o $@ icred.o $(KRB5_BASE_LIBS)
+
 kdbtest: kdbtest.o $(KDB5_DEPLIBS) $(KADMSRV_DEPLIBS) $(KRB5_BASE_DEPLIBS)
 	$(CC_LINK) -o $@ kdbtest.o $(KDB5_LIBS) $(KADMSRV_LIBS) \
 		$(KRB5_BASE_LIBS)
+
+localauth: localauth.o $(KRB5_BASE_DEPLIBS)
+	$(CC_LINK) -o $@ localauth.o $(KRB5_BASE_LIBS)
 
 plugorder: plugorder.o $(KRB5_BASE_DEPLIBS)
 	$(CC_LINK) -o $@ plugorder.o $(KRB5_BASE_LIBS)
@@ -54,12 +60,6 @@ s2p: s2p.o $(KRB5_BASE_DEPLIBS)
 
 s4u2proxy: s4u2proxy.o $(KRB5_BASE_DEPLIBS)
 	$(CC_LINK) -o $@ s4u2proxy.o $(KRB5_BASE_LIBS)
-
-t_init_creds: t_init_creds.o $(KRB5_BASE_DEPLIBS)
-	$(CC_LINK) -o $@ t_init_creds.o $(KRB5_BASE_LIBS)
-
-t_localauth: t_localauth.o $(KRB5_BASE_DEPLIBS)
-	$(CC_LINK) -o $@ t_localauth.o $(KRB5_BASE_LIBS)
 
 unlockiter: unlockiter.o $(KDB5_DEPLIBS) $(KADMSRV_DEPLIBS) $(KRB5_BASE_DEPLIBS)
 	$(CC_LINK) -o $@ unlockiter.o $(KDB5_LIBS) $(KADMSRV_LIBS) \
@@ -107,8 +107,8 @@ kdb_check: kdc.conf krb5.conf
 	$(RUN_DB_TEST) ../kadmin/dbutil/kdb5_util $(KADMIN_OPTS) destroy -f
 	$(RM) $(TEST_DB)* stash_file
 
-check-pytests:: adata etinfo gcred hist hrealm kdbtest plugorder rdreq
-check-pytests:: responder s2p s4u2proxy t_init_creds t_localauth unlockiter
+check-pytests:: adata etinfo gcred hist hrealm icred kdbtest localauth
+check-pytests:: plugorder rdreq responder s2p s4u2proxy unlockiter
 	$(RUNPYTEST) $(srcdir)/t_general.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_dump.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_iprop.py $(PYTESTFLAGS)
@@ -159,8 +159,7 @@ check-pytests:: responder s2p s4u2proxy t_init_creds t_localauth unlockiter
 	$(RUNPYTEST) $(srcdir)/t_tabdump.py $(PYTESTFLAGS)
 
 clean::
-	$(RM) gcred hist hrealm kdbtest plugorder rdreq responder s2p
-	$(RM) adata etinfo gcred hist hrealm kdbtest plugorder rdreq responder
-	$(RM) s2p s4u2proxy t_init_creds t_localauth krb5.conf kdc.conf
+	$(RM) adata etinfo gcred hist hrealm icred kdbtest localauth plugorder
+	$(RM) rdreq responder s2p s4u2proxy krb5.conf kdc.conf
 	$(RM) -rf kdc_realm/sandbox ldap
 	$(RM) au.log

--- a/src/tests/deps
+++ b/src/tests/deps
@@ -1,6 +1,26 @@
 #
 # Generated makefile dependencies follow.
 #
+$(OUTPRE)adata.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
+  $(BUILDTOP)/include/krb5/krb5.h $(BUILDTOP)/include/osconf.h \
+  $(BUILDTOP)/include/profile.h $(COM_ERR_DEPS) $(top_srcdir)/include/k5-buf.h \
+  $(top_srcdir)/include/k5-err.h $(top_srcdir)/include/k5-gmt_mktime.h \
+  $(top_srcdir)/include/k5-int-pkinit.h $(top_srcdir)/include/k5-int.h \
+  $(top_srcdir)/include/k5-platform.h $(top_srcdir)/include/k5-plugin.h \
+  $(top_srcdir)/include/k5-thread.h $(top_srcdir)/include/k5-trace.h \
+  $(top_srcdir)/include/krb5.h $(top_srcdir)/include/krb5/authdata_plugin.h \
+  $(top_srcdir)/include/krb5/plugin.h $(top_srcdir)/include/port-sockets.h \
+  $(top_srcdir)/include/socket-utils.h adata.c
+$(OUTPRE)etinfo.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
+  $(BUILDTOP)/include/krb5/krb5.h $(BUILDTOP)/include/osconf.h \
+  $(BUILDTOP)/include/profile.h $(COM_ERR_DEPS) $(top_srcdir)/include/k5-buf.h \
+  $(top_srcdir)/include/k5-err.h $(top_srcdir)/include/k5-gmt_mktime.h \
+  $(top_srcdir)/include/k5-int-pkinit.h $(top_srcdir)/include/k5-int.h \
+  $(top_srcdir)/include/k5-platform.h $(top_srcdir)/include/k5-plugin.h \
+  $(top_srcdir)/include/k5-thread.h $(top_srcdir)/include/k5-trace.h \
+  $(top_srcdir)/include/krb5.h $(top_srcdir)/include/krb5/authdata_plugin.h \
+  $(top_srcdir)/include/krb5/plugin.h $(top_srcdir)/include/port-sockets.h \
+  $(top_srcdir)/include/socket-utils.h etinfo.c
 $(OUTPRE)gcred.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
   $(BUILDTOP)/include/krb5/krb5.h $(BUILDTOP)/include/osconf.h \
   $(BUILDTOP)/include/profile.h $(COM_ERR_DEPS) $(top_srcdir)/include/k5-buf.h \
@@ -40,6 +60,8 @@ $(OUTPRE)hrealm.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
   $(top_srcdir)/include/krb5.h $(top_srcdir)/include/krb5/authdata_plugin.h \
   $(top_srcdir)/include/krb5/plugin.h $(top_srcdir)/include/port-sockets.h \
   $(top_srcdir)/include/socket-utils.h hrealm.c
+$(OUTPRE)icred.$(OBJEXT): $(BUILDTOP)/include/krb5/krb5.h \
+  $(COM_ERR_DEPS) $(top_srcdir)/include/krb5.h icred.c
 $(OUTPRE)kdbtest.$(OBJEXT): $(BUILDTOP)/include/gssapi/gssapi.h \
   $(BUILDTOP)/include/gssrpc/types.h $(BUILDTOP)/include/kadm5/admin.h \
   $(BUILDTOP)/include/kadm5/chpass_util_strings.h $(BUILDTOP)/include/kadm5/kadm_err.h \
@@ -50,6 +72,8 @@ $(OUTPRE)kdbtest.$(OBJEXT): $(BUILDTOP)/include/gssapi/gssapi.h \
   $(top_srcdir)/include/gssrpc/svc.h $(top_srcdir)/include/gssrpc/svc_auth.h \
   $(top_srcdir)/include/gssrpc/xdr.h $(top_srcdir)/include/kdb.h \
   $(top_srcdir)/include/krb5.h kdbtest.c
+$(OUTPRE)localauth.$(OBJEXT): $(BUILDTOP)/include/krb5/krb5.h \
+  $(COM_ERR_DEPS) $(top_srcdir)/include/krb5.h localauth.c
 $(OUTPRE)plugorder.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
   $(BUILDTOP)/include/gssapi/gssapi.h $(BUILDTOP)/include/gssrpc/types.h \
   $(BUILDTOP)/include/kadm5/admin.h $(BUILDTOP)/include/kadm5/chpass_util_strings.h \
@@ -69,13 +93,19 @@ $(OUTPRE)plugorder.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
   $(top_srcdir)/include/krb5/authdata_plugin.h $(top_srcdir)/include/krb5/plugin.h \
   $(top_srcdir)/include/krb5/pwqual_plugin.h $(top_srcdir)/include/port-sockets.h \
   $(top_srcdir)/include/socket-utils.h plugorder.c
-$(OUTPRE)t_init_creds.$(OBJEXT): $(BUILDTOP)/include/krb5/krb5.h \
-  $(COM_ERR_DEPS) $(top_srcdir)/include/krb5.h t_init_creds.c
-$(OUTPRE)t_localauth.$(OBJEXT): $(BUILDTOP)/include/krb5/krb5.h \
-  $(COM_ERR_DEPS) $(top_srcdir)/include/krb5.h t_localauth.c
 $(OUTPRE)responder.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
   $(BUILDTOP)/include/krb5/krb5.h $(COM_ERR_DEPS) $(top_srcdir)/include/k5-json.h \
   $(top_srcdir)/include/k5-platform.h $(top_srcdir)/include/k5-thread.h \
   $(top_srcdir)/include/krb5.h responder.c
 $(OUTPRE)s2p.$(OBJEXT): $(BUILDTOP)/include/krb5/krb5.h \
   $(COM_ERR_DEPS) $(top_srcdir)/include/krb5.h s2p.c
+$(OUTPRE)s4u2proxy.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
+  $(BUILDTOP)/include/krb5/krb5.h $(BUILDTOP)/include/osconf.h \
+  $(BUILDTOP)/include/profile.h $(COM_ERR_DEPS) $(top_srcdir)/include/k5-buf.h \
+  $(top_srcdir)/include/k5-err.h $(top_srcdir)/include/k5-gmt_mktime.h \
+  $(top_srcdir)/include/k5-int-pkinit.h $(top_srcdir)/include/k5-int.h \
+  $(top_srcdir)/include/k5-platform.h $(top_srcdir)/include/k5-plugin.h \
+  $(top_srcdir)/include/k5-thread.h $(top_srcdir)/include/k5-trace.h \
+  $(top_srcdir)/include/krb5.h $(top_srcdir)/include/krb5/authdata_plugin.h \
+  $(top_srcdir)/include/krb5/plugin.h $(top_srcdir)/include/port-sockets.h \
+  $(top_srcdir)/include/socket-utils.h s4u2proxy.c

--- a/src/tests/localauth.c
+++ b/src/tests/localauth.c
@@ -1,5 +1,5 @@
 /* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
-/* tests/t_init_creds.c - test harness for getting initial creds */
+/* tests/localauth.c - test harness for kuserok and aname_to_lname */
 /*
  * Copyright (C) 2013 by the Massachusetts Institute of Technology.
  * All rights reserved.
@@ -30,11 +30,6 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/*
- * This program exercises the init_creds APIs in ways kinit doesn't.  Right now
- * it is very simplistic, but it can be extended as needed.
- */
-
 #include <krb5.h>
 #include <stdio.h>
 
@@ -56,33 +51,22 @@ check(krb5_error_code code)
 int
 main(int argc, char **argv)
 {
-    const char *princstr, *password;
-    krb5_principal client;
-    krb5_init_creds_context icc;
-    krb5_creds creds;
+    krb5_principal princ;
+    char buf[1024];
 
-    if (argc != 3) {
-        fprintf(stderr, "Usage: t_init_creds princname password\n");
-        exit(1);
+    if (argc < 2 || argc > 3) {
+        fprintf(stderr, "Usage: localauth principal [localuser]\n");
+        return 1;
     }
-    princstr = argv[1];
-    password = argv[2];
-
     check(krb5_init_context(&ctx));
-    check(krb5_parse_name(ctx, princstr, &client));
-
-    /* Try once with the traditional interface. */
-    check(krb5_get_init_creds_password(ctx, &creds, client, password, NULL,
-                                       NULL, 0, NULL, NULL));
-    krb5_free_cred_contents(ctx, &creds);
-
-    /* Try again with the step interface. */
-    check(krb5_init_creds_init(ctx, client, NULL, NULL, 0, NULL, &icc));
-    check(krb5_init_creds_set_password(ctx, icc, password));
-    check(krb5_init_creds_get(ctx, icc));
-    krb5_init_creds_free(ctx, icc);
-
-    krb5_free_principal(ctx, client);
+    check(krb5_parse_name(ctx, argv[1], &princ));
+    if (argc == 3) {
+        printf("%s\n", krb5_kuserok(ctx, princ, argv[2]) ? "yes" : "no");
+    } else {
+        check(krb5_aname_to_localname(ctx, princ, sizeof(buf), buf));
+        printf("%s\n", buf);
+    }
+    krb5_free_principal(ctx, princ);
     krb5_free_context(ctx);
     return 0;
 }

--- a/src/tests/t_general.py
+++ b/src/tests/t_general.py
@@ -29,7 +29,7 @@ for realm in multipass_realms(create_host=False):
 conf={'plugins': {'pwqual': {'disable': 'empty'}}}
 realm = K5Realm(create_user=False, create_host=False, krb5_conf=conf)
 realm.run([kadminl, 'addprinc', '-pw', '', 'user'])
-realm.run(['./t_init_creds', 'user', ''])
+realm.run(['./icred', 'user', ''])
 realm.stop()
 
 realm = K5Realm(create_host=False)

--- a/src/tests/t_localauth.py
+++ b/src/tests/t_localauth.py
@@ -9,17 +9,17 @@ conf = {'plugins': {'localauth': { 'disable': 'k5login'}}}
 realm = K5Realm(create_kdb=False, krb5_conf=conf)
 
 def test_an2ln(env, aname, result, msg):
-    out = realm.run(['./t_localauth', aname], env=env)
+    out = realm.run(['./localauth', aname], env=env)
     if out != result + '\n':
         fail(msg)
 
 def test_an2ln_err(env, aname, err, msg):
-    out = realm.run(['./t_localauth', aname], env=env, expected_code=1)
+    out = realm.run(['./localauth', aname], env=env, expected_code=1)
     if err not in out:
         fail(msg)
 
 def test_userok(env, aname, lname, ok, msg):
-    out = realm.run(['./t_localauth', aname, lname], env=env)
+    out = realm.run(['./localauth', aname, lname], env=env)
     if ((ok and out != 'yes\n') or
         (not ok and out != 'no\n')):
         fail(msg)


### PR DESCRIPTION
I've been meaning to correct this minor annoyance for a while, and since I will be amending t_init_creds.c for SPAKE preauth tests, I figured now is a reasonable time.
