### PR TITLE
Check for the correct SPI function.

### DIFF
--- a/src/lib/gssapi/mechglue/g_acquire_cred_imp_name.c
+++ b/src/lib/gssapi/mechglue/g_acquire_cred_imp_name.c
@@ -353,7 +353,7 @@ gss_add_cred_impersonate_name(OM_uint32 *minor_status,
     mech = gssint_get_mechanism(desired_mech);
     if (!mech)
 	return GSS_S_BAD_MECH;
-    else if (!mech->gss_acquire_cred)
+    else if (!mech->gss_acquire_cred_impersonate_name)
 	return (GSS_S_UNAVAILABLE);
 
     if (input_cred_handle == GSS_C_NO_CREDENTIAL) {


### PR DESCRIPTION
Checking for the generic gss_acquire_cred function is no guarantee that
gss_acquire_cre_impersonate_name is also implemented.

Signed-off-by: Simo Sorce <simo@redhat.com>