### PR TITLE
Ensure pwsize is initialized in chpass_util.c

### DIFF
--- a/src/lib/kadm5/chpass_util.c
+++ b/src/lib/kadm5/chpass_util.c
@@ -74,6 +74,7 @@ kadm5_ret_t _kadm5_chpass_principal_util(void *server_handle,
     if (ret_pw)
         *ret_pw = NULL;
 
+    pwsize = 0;
     if (new_pw != NULL) {
         new_password = new_pw;
     } else { /* read the password */


### PR DESCRIPTION
This got lost in the CVE shuffle, but one of the things needed to get 1.14 building happily was initialization of pwsize.  This is how I'm currently doing it in Fedora.