### PR TITLE
Fix memory leak in SPNEGO gss_init_sec_context()

### DIFF
--- a/src/lib/gssapi/spnego/spnego_mech.c
+++ b/src/lib/gssapi/spnego/spnego_mech.c
@@ -1032,7 +1032,8 @@ spnego_gss_init_sec_context(
 
 	/* Step 1: perform mechanism negotiation. */
 	spcred = (spnego_gss_cred_id_t)claimant_cred_handle;
-	if (*context_handle == GSS_C_NO_CONTEXT) {
+	spnego_ctx = (spnego_gss_ctx_id_t)*context_handle;
+	if (spnego_ctx == NULL) {
 		ret = init_ctx_new(minor_status, spcred,
 				   context_handle, &send_token);
 		if (ret != GSS_S_CONTINUE_NEEDED) {


### PR DESCRIPTION
After the initial call to spnego_gss_init_sec_context(), the context
handle can leak if init_ctx_cont() returns an error, because the
cleanup handler assumes that spnego_ctx contains the value of
*context_handle.  Fix this leak by setting spnego_ctx before the if
block which contains that call.  Reported by Adam Bernstein.
