### PR TITLE
Remove ANSI_STDIO conditional

### DIFF
--- a/src/configure.in
+++ b/src/configure.in
@@ -722,31 +722,6 @@ AC_CACHE_CHECK([for in6addr_any definition in library],
   fi
 fi
 
-
-
-# check for ANSI stdio, esp "b" option to fopen().  This (unfortunately)
-# requires a run check...
-
-AC_MSG_CHECKING([for ANSI stdio])
-AC_CACHE_VAL(krb5_cv_has_ansi_stdio,
-[AC_TRY_RUN(
-[#include <stdio.h>
-int main()
-{
-  FILE *conftest;
-  if ((conftest = fopen("conftest.dat", "w")) == NULL) exit(1);
-  if (fclose(conftest)) exit(1);
-  if ((conftest = fopen("conftest.dat", "rb+")) == NULL) exit(1);
-  if (fputs("testing ANSI for stdio\n", conftest) == EOF) exit(1);
-  exit(0);
-}],
-krb5_cv_has_ansi_stdio=yes, krb5_cv_has_ansi_stdio=no,
-krb5_cv_has_ansi_stdio=yes)])# assume ANSI in cross environment
-AC_MSG_RESULT($krb5_cv_has_ansi_stdio)
-if test $krb5_cv_has_ansi_stdio = yes; then
-AC_DEFINE(ANSI_STDIO,1,[Define if ANSI stdio is present (in particular "b" option to fopen)])
-fi
-
 # then from osconf.h, we have
 
 AC_HEADER_TIME

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -109,7 +109,6 @@
 #define INI_FILES       "Files"
 #define INI_KRB_CCACHE  "krb5cc"        /* Location of the ccache */
 #define INI_KRB5_CONF   "krb5.ini"      /* Location of krb5.conf file */
-#define ANSI_STDIO
 #endif
 
 #include "autoconf.h"

--- a/src/lib/kdb/kdb_default.c
+++ b/src/lib/kdb/kdb_default.c
@@ -250,12 +250,8 @@ krb5_db_def_fetch_mkey_stash(krb5_context   context,
     krb5_ui_4 keylength;
     FILE *kf = NULL;
 
-#ifdef ANSI_STDIO
     if (!(kf = fopen(keyfile, "rb")))
-#else
-        if (!(kf = fopen(keyfile, "r")))
-#endif
-            return KRB5_KDB_CANTREAD_STORED;
+        return KRB5_KDB_CANTREAD_STORED;
     set_cloexec_file(kf);
 
     if (fread((krb5_pointer) &enctype, 2, 1, kf) != 1) {

--- a/src/lib/krb5/keytab/kt_file.c
+++ b/src/lib/krb5/keytab/kt_file.c
@@ -1013,14 +1013,6 @@ typedef krb5_int16  krb5_kt_vno;
 
 #define krb5_kt_default_vno ((krb5_kt_vno)KRB5_KT_DEFAULT_VNO)
 
-#ifdef ANSI_STDIO
-static char *const fopen_mode_rbplus= "rb+";
-static char *const fopen_mode_rb = "rb";
-#else
-static char *const fopen_mode_rbplus= "r+";
-static char *const fopen_mode_rb = "r";
-#endif
-
 static krb5_error_code
 krb5_ktfileint_open(krb5_context context, krb5_keytab id, int mode)
 {
@@ -1031,14 +1023,13 @@ krb5_ktfileint_open(krb5_context context, krb5_keytab id, int mode)
     KTCHECKLOCK(id);
     errno = 0;
     KTFILEP(id) = fopen(KTFILENAME(id),
-                        (mode == KRB5_LOCKMODE_EXCLUSIVE) ?
-                        fopen_mode_rbplus : fopen_mode_rb);
+                        (mode == KRB5_LOCKMODE_EXCLUSIVE) ? "rb+" : "rb");
     if (!KTFILEP(id)) {
         if ((mode == KRB5_LOCKMODE_EXCLUSIVE) && (errno == ENOENT)) {
             /* try making it first time around */
             k5_create_secure_file(context, KTFILENAME(id));
             errno = 0;
-            KTFILEP(id) = fopen(KTFILENAME(id), fopen_mode_rbplus);
+            KTFILEP(id) = fopen(KTFILENAME(id), "rb+");
             if (!KTFILEP(id))
                 goto report_errno;
             writevno = 1;

--- a/src/lib/krb5/keytab/kt_srvtab.c
+++ b/src/lib/krb5/keytab/kt_srvtab.c
@@ -341,12 +341,6 @@ const struct _krb5_kt_ops krb5_kts_ops = {
 
 #include <stdio.h>
 
-#ifdef ANSI_STDIO
-#define         READ_MODE       "rb"
-#else
-#define         READ_MODE       "r"
-#endif
-
 /* The maximum sizes for V4 aname, realm, sname, and instance +1 */
 /* Taken from krb.h */
 #define         ANAME_SZ        40
@@ -373,7 +367,7 @@ read_field(FILE *fp, char *s, int len)
 krb5_error_code
 krb5_ktsrvint_open(krb5_context context, krb5_keytab id)
 {
-    KTFILEP(id) = fopen(KTFILENAME(id), READ_MODE);
+    KTFILEP(id) = fopen(KTFILENAME(id), "rb");
     if (!KTFILEP(id))
         return errno;
     set_cloexec_file(KTFILEP(id));


### PR DESCRIPTION
As we no longer support pre-C89 platforms, assume that the fopen "b"
flag is always allowed.

Supersedes PR #353.
