### PR TITLE
Partial IAKERB, SPNEGO context export

### DIFF
--- a/src/lib/gssapi/spnego/gssapiP_spnego.h
+++ b/src/lib/gssapi/spnego/gssapiP_spnego.h
@@ -105,6 +105,7 @@ typedef struct {
 	int nego_done;
 	int initiate;
 	int opened;
+	int imported; /* Indicates need to release OIDs taken from token */
 	OM_uint32 ctx_flags;
 	gss_name_t internal_name;
 	gss_OID actual_mech;


### PR DESCRIPTION
Here is Nico's partial IAKERB and SPNEGO context export code, modified just enough to compile with the changes I made to his stack uncompression changes.  I also added two XXX comments where I saw problems, and removed an unused variable.

Although I haven't done any serious review, here are some problems which need to be resolved:

* The IAKERB token format uses a bitwise copy of a C structure.  Although we technically have the freedom to use architecture-specific formats, we don't normally marshal data that way.

* SPNEGO doesn't seem to set the initiate flag on import (XXX comment added).

* IAKERB doesn't seem to notice failures to import the krb5 context (XXX comment added).

* Automated test cases are required.