### PR TITLE
Testing Fixes

### DIFF
--- a/src/tests/au_dict.json
+++ b/src/tests/au_dict.json
@@ -33,7 +33,7 @@
 	"type":0},
 "req_id":"",
 "req.kdc_options":0,
-"req.pa_type":[]
+"req.pa_type":[],
 "req.server":{
 	"components":[],
 	"realm":"",

--- a/src/tests/t_kdb.py
+++ b/src/tests/t_kdb.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 from k5test import *
 import time
+from itertools import imap
 
 # Run kdbtest against the BDB module.
 realm = K5Realm(create_kdb=False)
@@ -40,10 +41,15 @@ os.mkdir(dbdir)
 # directory.  Try to defeat this by copying the binary.
 shutil.copy(system_slapd, slapd)
 
+# Not really the ideal way to do this but I have not found some standard way of
+# finding ldap home for now
+ldap_homes = ['/etc/ldap', '/etc/openldap', '/usr/local/etc/openldap',
+              '/usr/local/etc/ldap']
+local_schema_path = '/schema/core.schema'
+
 # Find the core schema file if we can.
-core_schema = None
-if os.path.isfile('/etc/ldap/schema/core.schema'):
-    core_schema = '/etc/ldap/schema/core.schema'
+core_schema = next((i for i in imap(lambda x:x+local_schema_path, ldap_homes)
+                    if os.path.isfile(i)), None)
 
 # Make a slapd config file.  This is deprecated in OpenLDAP 2.3 and
 # later, but it's easier than using LDIF and slapadd.  Include some


### PR DESCRIPTION
Fixing a typo in the au_dict.json file where a comma was missing, and adding more locations for the ldap core.schema file to the t_kdb.py test.