### PR TITLE
Fix NSS k5crypto iov procesing bug

### DIFF
--- a/src/lib/crypto/nss/enc_provider/enc_gen.c
+++ b/src/lib/crypto/nss/enc_provider/enc_gen.c
@@ -307,7 +307,7 @@ k5_nss_gen_stream_iov(krb5_key krb_key, krb5_data *state,
         int return_length;
         iov = &data[i];
         if (iov->data.length <= 0)
-            break;
+            continue;
 
         if (ENCRYPT_IOV(iov)) {
             rv = PK11_CipherOp(ctx, (unsigned char *)iov->data.data,


### PR DESCRIPTION
I ran across a bug in the NSS k5crypto back end while running it through the test suite.  I don't think anyone uses this back end, but here is a fix.
