### PR TITLE
Add IPv6 address logging support to audit plugin

### DIFF
--- a/src/plugins/audit/j_dict.h
+++ b/src/plugins/audit/j_dict.h
@@ -44,7 +44,7 @@
 #define AU_FROMPORT           "fromport"
 #define AU_FROMADDR           "fromaddr"
 #define AU_TYPE               "type" /* used by fromaddr */
-#define AU_IPV4               "ipv4" /* used by fromaddr */
+#define AU_IP                 "ip" /* used by fromaddr */
 #define AU_SESS_ETYPE         "sess_etype"
 #define AU_SRV_ETYPE          "srv_etype"
 #define AU_REP_ETYPE          "rep_etype"

--- a/src/plugins/audit/kdc_j_encode.c
+++ b/src/plugins/audit/kdc_j_encode.c
@@ -616,7 +616,7 @@ addr_to_obj(krb5_address *a, k5_json_object obj)
     if (ret)
         goto error;
 
-    if (a->addrtype == ADDRTYPE_INET) {
+    if (a->addrtype == ADDRTYPE_INET || a->addrtype == ADDRTYPE_INET6) {
         ret = k5_json_array_create(&arr);
         if (ret)
             goto error;
@@ -629,7 +629,7 @@ addr_to_obj(krb5_address *a, k5_json_object obj)
             if (ret)
                 goto error;
         }
-        ret = k5_json_object_set(obj, AU_IPV4, arr);
+        ret = k5_json_object_set(obj, AU_IP, arr);
         if (ret)
             goto error;
     }

--- a/src/tests/au_dict.json
+++ b/src/tests/au_dict.json
@@ -6,7 +6,7 @@
 "fromaddr":{
 	"type":0,
 	"length":0,
-	"ipv4":[]},
+	"ip":[]},
 "kdc_status":"",
 "rep_etype":0,
 "rep.ticket":{


### PR DESCRIPTION
The jsonwalker.py test was failing due to the audit plugin only logging
the ip for IPv4. The audit plugin should log the ip address for both
IPv4 and IPv6. This commit renames the json "ipv4" field in the
"fromaddr" json object to "ip" and sets the field to both IPv4 and IPv6
addresses. Any parsers of the audit log can tell which address is stored
in the "ip" field by checking the "type" field in "fromaddr". The
jsonwalker.py reference json, au_dict.json, is also updated to handle
this new field name.

###### old audit:
```javascript
{"fromaddr":{"type":<int>,"length":<int>,"ipv4":[<4 int>]}
```
where "ipv4" only occurs when type is ADDRTYPE_INET

###### new audit:
```javascript
{"fromaddr":{"type":<int>,"length":<int>,"ip":[<<length> int>]}
```
where "ip" only occurs when type is ADDRTYPE_INET or ADDRTYPE_INET6

[ticket: 8298](https://krbdev.mit.edu/rt/Ticket/Display.html?id=8298)