### PR TITLE
Correctly use k5_wrapmsg() in ldap_principal2.c

### DIFF
--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
@@ -684,8 +684,8 @@ krb5_ldap_put_principal(krb5_context context, krb5_db_entry *entry,
                 if (st == KRB5_KDB_NOENTRY || st == KRB5_KDB_CONSTRAINT_VIOLATION) {
                     int ost = st;
                     st = EINVAL;
-                    k5_prependmsg(context, ost, st, _("'%s' not found"),
-                                  xargs.containerdn);
+                    k5_wrapmsg(context, ost, st, _("'%s' not found"),
+                               xargs.containerdn);
                 }
                 goto cleanup;
             }


### PR DESCRIPTION
Commit ebcdf02f8ec212555b1762007fa8454615900f36 incorrectly used
k5_prependmsg() in an error handling clause in
krb5_ldap_get_principal().  Use k5_wrapmsg() instead.

ticket: 8301
target_version: 1.14-next
tags: pullup