### PR TITLE
Error on int-conversion with clang

### DIFF
--- a/src/aclocal.m4
+++ b/src/aclocal.m4
@@ -526,7 +526,7 @@ if test "$GCC" = yes ; then
     TRY_WARN_CC_FLAG(-Wno-format-zero-length)
     # Other flags here may not be supported on some versions of
     # gcc that people want to use.
-    for flag in overflow strict-overflow missing-format-attribute missing-prototypes return-type missing-braces parentheses switch unused-function unused-label unused-variable unused-value unknown-pragmas sign-compare newline-eof error=uninitialized error=pointer-arith ; do
+    for flag in overflow strict-overflow missing-format-attribute missing-prototypes return-type missing-braces parentheses switch unused-function unused-label unused-variable unused-value unknown-pragmas sign-compare newline-eof error=uninitialized error=pointer-arith error=int-conversion error=incompatible-pointer-types ; do
       TRY_WARN_CC_FLAG(-W$flag)
     done
     #  old-style-definition? generates many, many warnings

--- a/src/lib/kadm5/srv/server_acl.c
+++ b/src/lib/kadm5/srv/server_acl.c
@@ -69,8 +69,8 @@ static const aop_t acl_op_table[] = {
 };
 
 typedef struct _wildstate {
-    int         nwild;
-    krb5_data   *backref[9];
+    int nwild;
+    const krb5_data *backref[9];
 } wildstate_t;
 
 static aent_t   *acl_list_head = (aent_t *) NULL;
@@ -548,10 +548,8 @@ kadm5int_acl_load_acl_file()
  * Wildcarding is only supported for a whole component.
  */
 static krb5_boolean
-kadm5int_acl_match_data(e1, e2, targetflag, ws)
-    krb5_data   *e1, *e2;
-    int         targetflag;
-    wildstate_t *ws;
+kadm5int_acl_match_data(const krb5_data *e1, const krb5_data *e2,
+                        int targetflag, wildstate_t *ws)
 {
     krb5_boolean        retval;
 
@@ -594,10 +592,8 @@ kadm5int_acl_match_data(e1, e2, targetflag, ws)
  * kadm5int_acl_find_entry()    - Find a matching entry.
  */
 static aent_t *
-kadm5int_acl_find_entry(kcontext, principal, dest_princ)
-    krb5_context        kcontext;
-    krb5_principal      principal;
-    krb5_principal      dest_princ;
+kadm5int_acl_find_entry(krb5_context kcontext, krb5_const_principal principal,
+                        krb5_const_principal dest_princ)
 {
     aent_t              *entry;
     krb5_error_code     kret;

--- a/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.c
@@ -132,7 +132,7 @@ has_rootdse_ava(krb5_context context, const char *server_name,
     LDAPMessage *msg, *res = NULL;
     struct berval cred;
 
-    attrs[0] = attribute;
+    attrs[0] = (char *)attribute;
     attrs[1] = NULL;
 
     st = ldap_initialize(&ld, server_name);


### PR DESCRIPTION
gcc has no option (short of -Werror) to error on "makes pointer from
integer without a cast" warnings, but clang does.  In aclocal.m4, add
"error=int-conversion" to the warning flags we try to use.