### PR TITLE
Add libkrb5support dependencies to test plugins

### DIFF
--- a/src/plugins/hostrealm/test/Makefile.in
+++ b/src/plugins/hostrealm/test/Makefile.in
@@ -5,9 +5,9 @@ LIBBASE=hostrealm_test
 LIBMAJOR=0
 LIBMINOR=0
 RELDIR=../plugins/hostrealm/test
-# Depends on libkrb5
-SHLIB_EXPDEPS= $(KRB5_DEPLIB)
-SHLIB_EXPLIBS= $(KRB5_LIB)
+# Depends on libkrb5 and possibly libkrb5support
+SHLIB_EXPDEPS= $(KRB5_BASE_DEPLIBS)
+SHLIB_EXPLIBS= $(KRB5_BASE_LIBS)
 
 STLIBOBJS=main.o
 

--- a/src/plugins/pwqual/test/Makefile.in
+++ b/src/plugins/pwqual/test/Makefile.in
@@ -5,9 +5,9 @@ LIBBASE=pwqual_test
 LIBMAJOR=0
 LIBMINOR=0
 RELDIR=../plugins/pwqual/test
-# Depends on libkrb5
-SHLIB_EXPDEPS= $(KRB5_DEPLIB)
-SHLIB_EXPLIBS= $(KRB5_LIB)
+# Depends on libkrb5 and possibly libkrb5support
+SHLIB_EXPDEPS= $(KRB5_BASE_DEPLIBS)
+SHLIB_EXPLIBS= $(KRB5_BASE_LIBS)
 
 STLIBOBJS=main.o
 


### PR DESCRIPTION
In some build environments, dependencies on libkrb5support can be
generated just from static inline functions in our header files, even
if those functions aren't used.  In two test plugin modules, use
$(KRB5_BASE_DEPLIBS) and $(KRB5_BASE_LIBS) to depend on libkrb5support
as well as libkrb5.  (This also pulls in libk5crypto, which is
unnecessary for these modules, but is inconsequential for a test
module.)  Reported by Will Fiveash.
