### PR TITLE
Cast away constness when assigning to krb5_data

### DIFF
--- a/src/lib/kdb/kdb_cpw.c
+++ b/src/lib/kdb/kdb_cpw.c
@@ -299,7 +299,7 @@ add_key_pwd(context, master_key, ks_tuple, ks_tuple_count, passwd,
     krb5_keyblock       * master_key;
     krb5_key_salt_tuple * ks_tuple;
     int                   ks_tuple_count;
-    char                * passwd;
+    const char          * passwd;
     krb5_db_entry       * db_entry;
     int                   kvno;
 {
@@ -383,8 +383,7 @@ add_key_pwd(context, master_key, ks_tuple, ks_tuple_count, passwd,
             return(KRB5_KDB_BAD_SALTTYPE);
         }
 
-        pwd.data = passwd;
-        pwd.length = strlen(passwd);
+        pwd = string2data((char *)passwd);
 
         retval = krb5_c_string_to_key_with_params(context,
                                                   ks_tuple[i].ks_enctype,

--- a/src/lib/krb5/krb/chpw.c
+++ b/src/lib/krb5/krb/chpw.c
@@ -28,8 +28,7 @@ krb5int_mk_chpw_req(krb5_context context,
                                       KRB5_AUTH_CONTEXT_DO_SEQUENCE)))
         goto cleanup;
 
-    clearpw.length = strlen(passwd);
-    clearpw.data = passwd;
+    clearpw = string2data((char *)passwd);
 
     if ((ret = krb5_mk_priv(context, auth_context,
                             &clearpw, &cipherpw, &replay)))
@@ -302,8 +301,7 @@ krb5int_mk_setpw_req(krb5_context context,
         return(ret);
 
     req.target = targprinc;
-    req.password.data = passwd;
-    req.password.length = strlen(passwd);
+    req.password = string2data((char *)passwd);
     ret = encode_krb5_setpw_req(&req, &encoded_setpw);
     if (ret) {
         return ret;


### PR DESCRIPTION
Some password-changing library functions take a const char * parameter
but try to assign it to krb5_data.data, which isn't const.  PR #364
causes some compilers to produce errors in such situations, so cast
away the constness.  This is almost certainly safe because of the
nature of the code that consumes these krb5_data values.

The first commit in this PR is already included in #367.