### PR TITLE
Fix kdb5_ldap_util stashsrvpw password file logic

### DIFF
--- a/src/plugins/kdb/ldap/ldap_util/kdb5_ldap_services.h
+++ b/src/plugins/kdb/ldap/ldap_util/kdb5_ldap_services.h
@@ -32,8 +32,6 @@
 #define MAX_LEN                 1024
 #define MAX_SERVICE_PASSWD_LEN  256
 
-#define DEF_SERVICE_PASSWD_FILE "/usr/local/var/service_passwd"
-
 extern int tohex(krb5_data, krb5_data *);
 
 extern void kdb5_ldap_stash_service_password(int argc, char **argv);


### PR DESCRIPTION
kdb5_ldap_util stashsrvpw has several inconsistencies with the
password file determination in libkdb_ldap, and could try to fopen() a
NULL filename in some cases.  Factor out the determination of the
configured password file and make it consistent with libkdb_ldap.
DEF_SERVICE_PASSWD_FILE is no longer used after these changes, as it
is not respected by libkdb_ldap.
