### PR TITLE
Fix mechglue on gss_inquire_attrs_for_mech()

### DIFF
--- a/src/lib/gssapi/mechglue/g_accept_sec_context.c
+++ b/src/lib/gssapi/mechglue/g_accept_sec_context.c
@@ -94,6 +94,12 @@ allow_mech_by_default(gss_OID mech)
     gss_OID_set attrs;
     int reject = 0, p;
 
+    /* Whether we accept an interposer mech depends on whether we accept the
+     * mech it interposes. */
+    mech = gssint_get_public_oid(mech);
+    if (mech == GSS_C_NO_OID)
+        return 0;
+
     status = gss_inquire_attrs_for_mech(&minor, mech, &attrs, NULL);
     if (status)
 	return 0;

--- a/src/lib/gssapi/mechglue/g_mechattr.c
+++ b/src/lib/gssapi/mechglue/g_mechattr.c
@@ -161,6 +161,7 @@ gss_inquire_attrs_for_mech(
 {
     OM_uint32       status, tmpMinor;
     gss_mechanism   mech;
+    gss_OID         selected_mech;
 
     if (minor == NULL)
         return GSS_S_CALL_INACCESSIBLE_WRITE;
@@ -173,7 +174,11 @@ gss_inquire_attrs_for_mech(
     if (known_mech_attrs != NULL)
         *known_mech_attrs = GSS_C_NO_OID_SET;
 
-    mech = gssint_get_mechanism((gss_OID)mech_oid);
+    status = gssint_select_mech_type(minor, mech_oid, &selected_mech);
+    if (status != GSS_S_COMPLETE)
+        return (status);
+
+    mech = gssint_get_mechanism(selected_mech);
     if (mech != NULL && mech->gss_inquire_attrs_for_mech != NULL) {
         status = mech->gss_inquire_attrs_for_mech(minor,
                                                   mech_oid,


### PR DESCRIPTION
This includes proper mechanism selection in `gss_inquire_attrs_for_mech()`
itself as well as passing the correct mech down from `gss_accept_sec_context()`
through `allow_mech_by_default()`.

1.14 introduces the new allow_mech_by_default() call which caused all sorts of excitement in GSS-Proxy land.