### PR TITLE
Only run export-check.pl in maintainer mode

### DIFF
--- a/src/config/pre.in
+++ b/src/config/pre.in
@@ -561,6 +561,12 @@ SHLIB_EXPORT_FILE=$(srcdir)/$(LIBPREFIX)$(LIBBASE).exports
 # it to another, intermediate form for the linker.
 SHLIB_EXPORT_FILE_DEP=@SHLIB_EXPORT_FILE_DEP@
 
+# Export file checker to run when building in maintainer mode on
+# Linux.  This gets included in LDCOMBINE_TAIL.
+EXPORT_CHECK_CMD = && $(PERL) -w $(top_srcdir)/util/export-check.pl \
+	$(SHLIB_EXPORT_FILE) $@
+EXPORT_CHECK = @MAINT@ $(EXPORT_CHECK_CMD)
+
 # Command to run to build a shared library.
 # In systems that require multiple commands, like AIX, it may need
 # to change to rearrange where the various parameters fit in.

--- a/src/config/shlib.conf
+++ b/src/config/shlib.conf
@@ -423,8 +423,8 @@ mips-*-netbsd*)
 	# Linux ld doesn't default to stuffing the SONAME field...
 	# Use objdump -x to examine the fields of the library
 	LDCOMBINE='$(CC) -shared -fPIC -Wl,-h,$(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT),--no-undefined'
-	# 
-	LDCOMBINE_TAIL='-Wl,--version-script binutils.versions && $(PERL) -w $(top_srcdir)/util/export-check.pl $(SHLIB_EXPORT_FILE) $@'
+	# $(EXPORT_CHECK) runs export-check.pl when in maintainer mode.
+	LDCOMBINE_TAIL='-Wl,--version-script binutils.versions $(EXPORT_CHECK)'
 	SHLIB_EXPORT_FILE_DEP=binutils.versions
 	RPATH_FLAG='-Wl,--enable-new-dtags -Wl,-rpath -Wl,'
 	# For cases where we do have dependencies on other libraries


### PR DESCRIPTION
Cross compilation environments might not be using the default nm
command.  Rather than try to communicate the correct value to
util/export-check.pl, only run export-check.pl in maintainer mode.

This supersedes PR #271.