### PR TITLE
Remove a bunch of static variables in the kadmin client and server libraries

### DIFF
--- a/src/kadmin/server/kadm_rpc_svc.c
+++ b/src/kadmin/server/kadm_rpc_svc.c
@@ -61,9 +61,20 @@ void kadm_1(rqstp, transp)
 	  setkey4_arg setkey_principal4_2_arg;
 	  getpkeys_arg get_principal_keys_2_arg;
      } argument;
-     char *result;
+     union {
+	  generic_ret gen_ret;
+	  gprinc_ret get_principal_2_ret;
+	  chrand_ret chrand_principal_2_ret;
+	  gpol_ret get_policy_2_ret;
+	  getprivs_ret get_privs_2_ret;
+	  gprincs_ret get_princs_2_ret;
+	  gpols_ret get_pols_2_ret;
+	  chrand_ret chrand_principal3_2_ret;
+	  gstrings_ret get_string_2_ret;
+	  getpkeys_ret get_principal_keys_ret;
+     } result;
      bool_t (*xdr_argument)(), (*xdr_result)();
-     char *(*local)();
+     bool_t (*local)();
 
      if (rqstp->rq_cred.oa_flavor != AUTH_GSSAPI &&
 	 !check_rpcsec_auth(rqstp)) {
@@ -83,157 +94,157 @@ void kadm_1(rqstp, transp)
      case CREATE_PRINCIPAL:
 	  xdr_argument = xdr_cprinc_arg;
 	  xdr_result = xdr_generic_ret;
-	  local = (char *(*)()) create_principal_2_svc;
+	  local = (bool_t (*)()) create_principal_2_svc;
 	  break;
 
      case DELETE_PRINCIPAL:
 	  xdr_argument = xdr_dprinc_arg;
 	  xdr_result = xdr_generic_ret;
-	  local = (char *(*)()) delete_principal_2_svc;
+	  local = (bool_t (*)()) delete_principal_2_svc;
 	  break;
 
      case MODIFY_PRINCIPAL:
 	  xdr_argument = xdr_mprinc_arg;
 	  xdr_result = xdr_generic_ret;
-	  local = (char *(*)()) modify_principal_2_svc;
+	  local = (bool_t (*)()) modify_principal_2_svc;
 	  break;
 
      case RENAME_PRINCIPAL:
 	  xdr_argument = xdr_rprinc_arg;
 	  xdr_result = xdr_generic_ret;
-	  local = (char *(*)()) rename_principal_2_svc;
+	  local = (bool_t (*)()) rename_principal_2_svc;
 	  break;
 
      case GET_PRINCIPAL:
 	  xdr_argument = xdr_gprinc_arg;
 	  xdr_result = xdr_gprinc_ret;
-	  local = (char *(*)()) get_principal_2_svc;
+	  local = (bool_t (*)()) get_principal_2_svc;
 	  break;
 
      case GET_PRINCS:
 	  xdr_argument = xdr_gprincs_arg;
 	  xdr_result = xdr_gprincs_ret;
-	  local = (char *(*)()) get_princs_2_svc;
+	  local = (bool_t (*)()) get_princs_2_svc;
 	  break;
 
      case CHPASS_PRINCIPAL:
 	  xdr_argument = xdr_chpass_arg;
 	  xdr_result = xdr_generic_ret;
-	  local = (char *(*)()) chpass_principal_2_svc;
+	  local = (bool_t (*)()) chpass_principal_2_svc;
 	  break;
 
      case SETV4KEY_PRINCIPAL:
 	  xdr_argument = xdr_setv4key_arg;
 	  xdr_result = xdr_generic_ret;
-	  local = (char *(*)()) setv4key_principal_2_svc;
+	  local = (bool_t (*)()) setv4key_principal_2_svc;
 	  break;
 
      case SETKEY_PRINCIPAL:
 	  xdr_argument = xdr_setkey_arg;
 	  xdr_result = xdr_generic_ret;
-	  local = (char *(*)()) setkey_principal_2_svc;
+	  local = (bool_t (*)()) setkey_principal_2_svc;
 	  break;
 
      case CHRAND_PRINCIPAL:
 	  xdr_argument = xdr_chrand_arg;
 	  xdr_result = xdr_chrand_ret;
-	  local = (char *(*)()) chrand_principal_2_svc;
+	  local = (bool_t (*)()) chrand_principal_2_svc;
 	  break;
 
      case CREATE_POLICY:
 	  xdr_argument = xdr_cpol_arg;
 	  xdr_result = xdr_generic_ret;
-	  local = (char *(*)()) create_policy_2_svc;
+	  local = (bool_t (*)()) create_policy_2_svc;
 	  break;
 
      case DELETE_POLICY:
 	  xdr_argument = xdr_dpol_arg;
 	  xdr_result = xdr_generic_ret;
-	  local = (char *(*)()) delete_policy_2_svc;
+	  local = (bool_t (*)()) delete_policy_2_svc;
 	  break;
 
      case MODIFY_POLICY:
 	  xdr_argument = xdr_mpol_arg;
 	  xdr_result = xdr_generic_ret;
-	  local = (char *(*)()) modify_policy_2_svc;
+	  local = (bool_t (*)()) modify_policy_2_svc;
 	  break;
 
      case GET_POLICY:
 	  xdr_argument = xdr_gpol_arg;
 	  xdr_result = xdr_gpol_ret;
-	  local = (char *(*)()) get_policy_2_svc;
+	  local = (bool_t (*)()) get_policy_2_svc;
 	  break;
 
      case GET_POLS:
 	  xdr_argument = xdr_gpols_arg;
 	  xdr_result = xdr_gpols_ret;
-	  local = (char *(*)()) get_pols_2_svc;
+	  local = (bool_t (*)()) get_pols_2_svc;
 	  break;
 
      case GET_PRIVS:
 	  xdr_argument = xdr_u_int32;
 	  xdr_result = xdr_getprivs_ret;
-	  local = (char *(*)()) get_privs_2_svc;
+	  local = (bool_t (*)()) get_privs_2_svc;
 	  break;
 
      case INIT:
 	  xdr_argument = xdr_u_int32;
 	  xdr_result = xdr_generic_ret;
-	  local = (char *(*)()) init_2_svc;
+	  local = (bool_t (*)()) init_2_svc;
 	  break;
 
      case CREATE_PRINCIPAL3:
 	  xdr_argument = xdr_cprinc3_arg;
 	  xdr_result = xdr_generic_ret;
-	  local = (char *(*)()) create_principal3_2_svc;
+	  local = (bool_t (*)()) create_principal3_2_svc;
 	  break;
 
      case CHPASS_PRINCIPAL3:
 	  xdr_argument = xdr_chpass3_arg;
 	  xdr_result = xdr_generic_ret;
-	  local = (char *(*)()) chpass_principal3_2_svc;
+	  local = (bool_t (*)()) chpass_principal3_2_svc;
 	  break;
 
      case CHRAND_PRINCIPAL3:
 	  xdr_argument = xdr_chrand3_arg;
 	  xdr_result = xdr_chrand_ret;
-	  local = (char *(*)()) chrand_principal3_2_svc;
+	  local = (bool_t (*)()) chrand_principal3_2_svc;
 	  break;
 
      case SETKEY_PRINCIPAL3:
 	  xdr_argument = xdr_setkey3_arg;
 	  xdr_result = xdr_generic_ret;
-	  local = (char *(*)()) setkey_principal3_2_svc;
+	  local = (bool_t (*)()) setkey_principal3_2_svc;
 	  break;
 
      case PURGEKEYS:
 	  xdr_argument = xdr_purgekeys_arg;
 	  xdr_result = xdr_generic_ret;
-	  local = (char *(*)()) purgekeys_2_svc;
+	  local = (bool_t (*)()) purgekeys_2_svc;
 	  break;
 
      case GET_STRINGS:
 	  xdr_argument = xdr_gstrings_arg;
 	  xdr_result = xdr_gstrings_ret;
-	  local = (char *(*)()) get_strings_2_svc;
+	  local = (bool_t (*)()) get_strings_2_svc;
 	  break;
 
      case SET_STRING:
 	  xdr_argument = xdr_sstring_arg;
 	  xdr_result = xdr_generic_ret;
-	  local = (char *(*)()) set_string_2_svc;
+	  local = (bool_t (*)()) set_string_2_svc;
 	  break;
 
      case SETKEY_PRINCIPAL4:
 	  xdr_argument = xdr_setkey4_arg;
 	  xdr_result = xdr_generic_ret;
-	  local = (char *(*)()) setkey_principal4_2_svc;
+	  local = (bool_t (*)()) setkey_principal4_2_svc;
 	  break;
 
      case EXTRACT_KEYS:
 	  xdr_argument = xdr_getpkeys_arg;
 	  xdr_result = xdr_getpkeys_ret;
-	  local = (char *(*)()) get_principal_keys_2_svc;
+	  local = (bool_t (*)()) get_principal_keys_2_svc;
 	  break;
 
      default:
@@ -247,14 +258,19 @@ void kadm_1(rqstp, transp)
 	  svcerr_decode(transp);
 	  return;
      }
-     result = (*local)(&argument, rqstp);
-     if (result != NULL && !svc_sendreply(transp, xdr_result, result)) {
+     memset(&result, 0, sizeof(result));
+     (void)(*local)(&argument, &result, rqstp);
+     if (!svc_sendreply(transp, xdr_result, (void *)&result)) {
 	  krb5_klog_syslog(LOG_ERR, "WARNING! Unable to send function results, "
 		 "continuing.");
 	  svcerr_systemerr(transp);
      }
      if (!svc_freeargs(transp, xdr_argument, &argument)) {
 	  krb5_klog_syslog(LOG_ERR, "WARNING! Unable to free arguments, "
+		 "continuing.");
+     }
+     if (!svc_freeargs(transp, xdr_result, &result)) {
+	  krb5_klog_syslog(LOG_ERR, "WARNING! Unable to free results, "
 		 "continuing.");
      }
      return;

--- a/src/kadmin/server/server_stubs.c
+++ b/src/kadmin/server/server_stubs.c
@@ -270,6 +270,47 @@ gss_name_to_string(gss_name_t gss_name, gss_buffer_desc *str)
     return 0;
 }
 
+static kadm5_ret_t
+setup_stub_srv(krb5_ui_4 api_version, struct svc_req *rqstp,
+             kadm5_server_handle_t *handle, krb5_ui_4 *ret_api_version,
+             gss_buffer_t client_name, gss_buffer_t service_name,
+             krb5_principal princ, char **princ_str)
+{
+    kadm5_ret_t ret;
+
+    ret = new_server_handle(api_version, rqstp, handle);
+    if (ret)
+        return ret;
+
+    ret = check_handle(*handle);
+    if (ret)
+        return ret;
+
+    *ret_api_version = (*handle)->api_version;
+
+    if (setup_gss_names(rqstp, client_name, service_name) < 0)
+        return KADM5_FAILURE;
+
+    if (princ && princ_str) {
+        if (krb5_unparse_name((*handle)->context, princ, princ_str))
+            return KADM5_BAD_PRINCIPAL;
+    }
+
+    return KADM5_OK;
+}
+
+static void
+free_stub_srv(kadm5_server_handle_t handle, char *princ_str,
+              gss_buffer_t client_name, gss_buffer_t service_name)
+{
+    OM_uint32 minor_stat;
+
+    free_server_handle(handle);
+    free(princ_str);
+    gss_release_buffer(&minor_stat, client_name);
+    gss_release_buffer(&minor_stat, service_name);
+}
+
 static int
 log_unauth(
     char *op,
@@ -329,52 +370,37 @@ log_done(
                             client_addr(rqstp->rq_xprt));
 }
 
-generic_ret *
-create_principal_2_svc(cprinc_arg *arg, struct svc_req *rqstp)
+bool_t
+create_principal_2_svc(cprinc_arg *arg, generic_ret *ret,
+                       struct svc_req *rqstp)
 {
-    static generic_ret          ret;
-    char                        *prime_arg;
+    char                        *prime_arg = NULL;
     gss_buffer_desc             client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc             service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                   minor_stat;
     kadm5_server_handle_t       handle;
     restriction_t               *rp;
     const char                  *errmsg = NULL;
 
-    xdr_free(xdr_generic_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               arg->rec.principal, &prime_arg);
+    if (ret->code)
         goto exit_func;
-
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-    if (krb5_unparse_name(handle->context, arg->rec.principal, &prime_arg)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
-        goto exit_func;
-    }
 
     if (CHANGEPW_SERVICE(rqstp)
         || !kadm5int_acl_check(handle->context, rqst2name(rqstp), ACL_ADD,
                                arg->rec.principal, &rp)
         || kadm5int_acl_impose_restrictions(handle->context,
                                             &arg->rec, &arg->mask, rp)) {
-        ret.code = KADM5_AUTH_ADD;
+        ret->code = KADM5_AUTH_ADD;
         log_unauth("kadm5_create_principal", prime_arg,
                    &client_name, &service_name, rqstp);
     } else {
-        ret.code = kadm5_create_principal((void *)handle,
-                                          &arg->rec, arg->mask,
-                                          arg->passwd);
+        ret->code = kadm5_create_principal(handle, &arg->rec, arg->mask,
+                                           arg->passwd);
 
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_create_principal", prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -382,62 +408,45 @@ create_principal_2_svc(cprinc_arg *arg, struct svc_req *rqstp)
         if (errmsg != NULL)
             krb5_free_error_message(handle->context, errmsg);
     }
-    free(prime_arg);
 
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, prime_arg, &client_name, &service_name);
+    return TRUE;
 }
 
-generic_ret *
-create_principal3_2_svc(cprinc3_arg *arg, struct svc_req *rqstp)
+bool_t
+create_principal3_2_svc(cprinc3_arg *arg, generic_ret *ret,
+                        struct svc_req *rqstp)
 {
-    static generic_ret          ret;
-    char                        *prime_arg;
+    char                        *prime_arg = NULL;
     gss_buffer_desc             client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc             service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                   minor_stat;
     kadm5_server_handle_t       handle;
     restriction_t               *rp;
     const char                  *errmsg = NULL;
 
-    xdr_free(xdr_generic_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               arg->rec.principal, &prime_arg);
+    if (ret->code)
         goto exit_func;
-
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-    if (krb5_unparse_name(handle->context, arg->rec.principal, &prime_arg)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
-        goto exit_func;
-    }
 
     if (CHANGEPW_SERVICE(rqstp)
         || !kadm5int_acl_check(handle->context, rqst2name(rqstp), ACL_ADD,
                                arg->rec.principal, &rp)
         || kadm5int_acl_impose_restrictions(handle->context,
                                             &arg->rec, &arg->mask, rp)) {
-        ret.code = KADM5_AUTH_ADD;
+        ret->code = KADM5_AUTH_ADD;
         log_unauth("kadm5_create_principal", prime_arg,
                    &client_name, &service_name, rqstp);
     } else {
-        ret.code = kadm5_create_principal_3((void *)handle,
+        ret->code = kadm5_create_principal_3((void *)handle,
                                             &arg->rec, arg->mask,
                                             arg->n_ks_tuple,
                                             arg->ks_tuple,
                                             arg->passwd);
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_create_principal", prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -445,13 +454,10 @@ create_principal3_2_svc(cprinc3_arg *arg, struct svc_req *rqstp)
         if (errmsg != NULL)
             krb5_free_error_message(handle->context, errmsg);
     }
-    free(prime_arg);
 
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, prime_arg, &client_name, &service_name);
+    return TRUE;
 }
 
 /* Return KADM5_PROTECT_KEYS if KRB5_KDB_LOCKDOWN_KEYS is set for princ. */
@@ -469,56 +475,43 @@ check_lockdown_keys(kadm5_server_handle_t handle, krb5_principal princ)
     return ret;
 }
 
-generic_ret *
-delete_principal_2_svc(dprinc_arg *arg, struct svc_req *rqstp)
+bool_t
+delete_principal_2_svc(dprinc_arg *arg, generic_ret *ret,
+                       struct svc_req *rqstp)
 {
-    static generic_ret              ret;
-    char                            *prime_arg;
+    char                            *prime_arg = NULL;
     gss_buffer_desc                 client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                 service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                       minor_stat;
     kadm5_server_handle_t           handle;
     const char                      *errmsg = NULL;
 
-    xdr_free(xdr_generic_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               arg->princ, &prime_arg);
+    if (ret->code)
         goto exit_func;
-
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-    if (krb5_unparse_name(handle->context, arg->princ, &prime_arg)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
-        goto exit_func;
-    }
 
     if (CHANGEPW_SERVICE(rqstp)
         || !kadm5int_acl_check(handle->context, rqst2name(rqstp), ACL_DELETE,
                                arg->princ, NULL)) {
-        ret.code = KADM5_AUTH_DELETE;
+        ret->code = KADM5_AUTH_DELETE;
         log_unauth("kadm5_delete_principal", prime_arg,
                    &client_name, &service_name, rqstp);
     } else {
-        ret.code = check_lockdown_keys(handle, arg->princ);
-        if (ret.code == KADM5_PROTECT_KEYS) {
+        ret->code = check_lockdown_keys(handle, arg->princ);
+        if (ret->code == KADM5_PROTECT_KEYS) {
             log_unauth("kadm5_delete_principal", prime_arg, &client_name,
                        &service_name, rqstp);
-            ret.code = KADM5_AUTH_DELETE;
+            ret->code = KADM5_AUTH_DELETE;
         }
     }
 
-    if (ret.code == KADM5_OK)
-        ret.code = kadm5_delete_principal((void *)handle, arg->princ);
-    if (ret.code != KADM5_AUTH_DELETE) {
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+    if (ret->code == KADM5_OK) {
+        ret->code = kadm5_delete_principal((void *)handle, arg->princ);
+    }
+    if (ret->code != KADM5_AUTH_DELETE) {
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_delete_principal", prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -527,67 +520,54 @@ delete_principal_2_svc(dprinc_arg *arg, struct svc_req *rqstp)
             krb5_free_error_message(handle->context, errmsg);
 
     }
-    free(prime_arg);
 
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, prime_arg, &client_name, &service_name);
+    return TRUE;
 }
 
-generic_ret *
-modify_principal_2_svc(mprinc_arg *arg, struct svc_req *rqstp)
+bool_t
+modify_principal_2_svc(mprinc_arg *arg, generic_ret *ret,
+                       struct svc_req *rqstp)
 {
-    static generic_ret              ret;
-    char                            *prime_arg;
+    char                            *prime_arg = NULL;
     gss_buffer_desc                 client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                 service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                       minor_stat;
     kadm5_server_handle_t           handle;
     restriction_t                   *rp;
     const char                      *errmsg = NULL;
 
-    xdr_free(xdr_generic_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               arg->rec.principal, &prime_arg);
+    if (ret->code)
         goto exit_func;
-
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-    if (krb5_unparse_name(handle->context, arg->rec.principal, &prime_arg)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
-        goto exit_func;
-    }
 
     if (CHANGEPW_SERVICE(rqstp)
         || !kadm5int_acl_check(handle->context, rqst2name(rqstp), ACL_MODIFY,
                                arg->rec.principal, &rp)
         || kadm5int_acl_impose_restrictions(handle->context,
                                             &arg->rec, &arg->mask, rp)) {
-        ret.code = KADM5_AUTH_MODIFY;
+        ret->code = KADM5_AUTH_MODIFY;
         log_unauth("kadm5_modify_principal", prime_arg,
                    &client_name, &service_name, rqstp);
     } else if ((arg->mask & KADM5_ATTRIBUTES) &&
                (!(arg->rec.attributes & KRB5_KDB_LOCKDOWN_KEYS))) {
-        ret.code = check_lockdown_keys(handle, arg->rec.principal);
-        if (ret.code == KADM5_PROTECT_KEYS) {
+        ret->code = check_lockdown_keys(handle, arg->rec.principal);
+        if (ret->code == KADM5_PROTECT_KEYS) {
             log_unauth("kadm5_modify_principal", prime_arg, &client_name,
                        &service_name, rqstp);
-            ret.code = KADM5_AUTH_MODIFY;
+            ret->code = KADM5_AUTH_MODIFY;
         }
+    } else {
+        ret->code = KADM5_OK;
     }
 
-    if (ret.code == KADM5_OK) {
-        ret.code = kadm5_modify_principal((void *)handle, &arg->rec,
+    if (ret->code == KADM5_OK) {
+        ret->code = kadm5_modify_principal((void *)handle, &arg->rec,
                                           arg->mask);
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_modify_principal", prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -595,43 +575,34 @@ modify_principal_2_svc(mprinc_arg *arg, struct svc_req *rqstp)
         if (errmsg != NULL)
             krb5_free_error_message(handle->context, errmsg);
     }
-    free(prime_arg);
+
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, prime_arg, &client_name, &service_name);
+    return TRUE;
 }
 
-generic_ret *
-rename_principal_2_svc(rprinc_arg *arg, struct svc_req *rqstp)
+bool_t
+rename_principal_2_svc(rprinc_arg *arg, generic_ret *ret,
+                       struct svc_req *rqstp)
 {
-    static generic_ret          ret;
     char                        *prime_arg1 = NULL, *prime_arg2 = NULL;
     gss_buffer_desc             client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc             service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                   minor_stat;
     kadm5_server_handle_t       handle;
     restriction_t               *rp;
     const char                  *errmsg = NULL;
     size_t                      tlen1, tlen2, clen, slen;
     char                        *tdots1, *tdots2, *cdots, *sdots;
 
-    xdr_free(xdr_generic_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               NULL, NULL);
+    if (ret->code)
         goto exit_func;
 
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
     if (krb5_unparse_name(handle->context, arg->src, &prime_arg1) ||
         krb5_unparse_name(handle->context, arg->dest, &prime_arg2)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
+        ret->code = KADM5_BAD_PRINCIPAL;
         goto exit_func;
     }
     tlen1 = strlen(prime_arg1);
@@ -643,30 +614,30 @@ rename_principal_2_svc(rprinc_arg *arg, struct svc_req *rqstp)
     slen = service_name.length;
     trunc_name(&slen, &sdots);
 
-    ret.code = KADM5_OK;
+    ret->code = KADM5_OK;
     if (! CHANGEPW_SERVICE(rqstp)) {
         if (!kadm5int_acl_check(handle->context, rqst2name(rqstp),
                                 ACL_DELETE, arg->src, NULL))
-            ret.code = KADM5_AUTH_DELETE;
+            ret->code = KADM5_AUTH_DELETE;
         /* any restrictions at all on the ADD kills the RENAME */
         if (!kadm5int_acl_check(handle->context, rqst2name(rqstp),
                                 ACL_ADD, arg->dest, &rp) || rp) {
-            if (ret.code == KADM5_AUTH_DELETE)
-                ret.code = KADM5_AUTH_INSUFFICIENT;
+            if (ret->code == KADM5_AUTH_DELETE)
+                ret->code = KADM5_AUTH_INSUFFICIENT;
             else
-                ret.code = KADM5_AUTH_ADD;
+                ret->code = KADM5_AUTH_ADD;
         }
-        if (ret.code == KADM5_OK) {
-            ret.code = check_lockdown_keys(handle, arg->src);
-            if (ret.code == KADM5_PROTECT_KEYS) {
+        if (ret->code == KADM5_OK) {
+            ret->code = check_lockdown_keys(handle, arg->src);
+            if (ret->code == KADM5_PROTECT_KEYS) {
                 log_unauth("kadm5_rename_principal", prime_arg1, &client_name,
                            &service_name, rqstp);
-                ret.code = KADM5_AUTH_DELETE;
+                ret->code = KADM5_AUTH_DELETE;
             }
         }
     } else
-        ret.code = KADM5_AUTH_INSUFFICIENT;
-    if (ret.code != KADM5_OK) {
+        ret->code = KADM5_AUTH_INSUFFICIENT;
+    if (ret->code != KADM5_OK) {
         /* okay to cast lengths to int because trunc_name limits max value */
         krb5_klog_syslog(LOG_NOTICE,
                          _("Unauthorized request: kadm5_rename_principal, "
@@ -678,10 +649,10 @@ rename_principal_2_svc(rprinc_arg *arg, struct svc_req *rqstp)
                          (int)slen, (char *)service_name.value, sdots,
                          client_addr(rqstp->rq_xprt));
     } else {
-        ret.code = kadm5_rename_principal((void *)handle, arg->src,
+        ret->code = kadm5_rename_principal((void *)handle, arg->src,
                                           arg->dest);
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         /* okay to cast lengths to int because trunc_name limits max value */
         krb5_klog_syslog(LOG_NOTICE,
@@ -702,43 +673,27 @@ rename_principal_2_svc(rprinc_arg *arg, struct svc_req *rqstp)
 exit_func:
     free(prime_arg1);
     free(prime_arg2);
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, NULL, &client_name, &service_name);
+    return TRUE;
 }
 
-gprinc_ret *
-get_principal_2_svc(gprinc_arg *arg, struct svc_req *rqstp)
+bool_t
+get_principal_2_svc(gprinc_arg *arg, gprinc_ret *ret, struct svc_req *rqstp)
 {
-    static gprinc_ret               ret;
-    char                            *prime_arg, *funcname;
+    char                            *prime_arg = NULL;
+    char                            *funcname;
     gss_buffer_desc                 client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                 service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                       minor_stat;
     kadm5_server_handle_t           handle;
     const char                      *errmsg = NULL;
 
-    xdr_free(xdr_gprinc_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               arg->princ, &prime_arg);
+    if (ret->code)
         goto exit_func;
-
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
 
     funcname = "kadm5_get_principal";
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-    if (krb5_unparse_name(handle->context, arg->princ, &prime_arg)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
-        goto exit_func;
-    }
 
     if (! cmp_gss_krb5_name(handle, rqst2name(rqstp), arg->princ) &&
         (CHANGEPW_SERVICE(rqstp) || !kadm5int_acl_check(handle->context,
@@ -746,15 +701,15 @@ get_principal_2_svc(gprinc_arg *arg, struct svc_req *rqstp)
                                                         ACL_INQUIRE,
                                                         arg->princ,
                                                         NULL))) {
-        ret.code = KADM5_AUTH_GET;
+        ret->code = KADM5_AUTH_GET;
         log_unauth(funcname, prime_arg,
                    &client_name, &service_name, rqstp);
     } else {
-        ret.code = kadm5_get_principal(handle, arg->princ, &ret.rec,
+        ret->code = kadm5_get_principal(handle, arg->princ, &ret->rec,
                                        arg->mask);
 
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done(funcname, prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -762,39 +717,27 @@ get_principal_2_svc(gprinc_arg *arg, struct svc_req *rqstp)
         if (errmsg != NULL)
             krb5_free_error_message(handle->context, errmsg);
     }
-    free(prime_arg);
+
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, prime_arg, &client_name, &service_name);
+    return TRUE;
 }
 
-gprincs_ret *
-get_princs_2_svc(gprincs_arg *arg, struct svc_req *rqstp)
+bool_t
+get_princs_2_svc(gprincs_arg *arg, gprincs_ret *ret, struct svc_req *rqstp)
 {
-    static gprincs_ret              ret;
-    char                            *prime_arg;
+    char                            *prime_arg = NULL;
     gss_buffer_desc                 client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                 service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                       minor_stat;
     kadm5_server_handle_t           handle;
     const char                      *errmsg = NULL;
 
-    xdr_free(xdr_gprincs_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               NULL, NULL);
+    if (ret->code)
         goto exit_func;
 
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
     prime_arg = arg->exp;
     if (prime_arg == NULL)
         prime_arg = "*";
@@ -804,15 +747,15 @@ get_princs_2_svc(gprincs_arg *arg, struct svc_req *rqstp)
                                                        ACL_LIST,
                                                        NULL,
                                                        NULL)) {
-        ret.code = KADM5_AUTH_LIST;
+        ret->code = KADM5_AUTH_LIST;
         log_unauth("kadm5_get_principals", prime_arg,
                    &client_name, &service_name, rqstp);
     } else {
-        ret.code  = kadm5_get_principals((void *)handle,
-                                         arg->exp, &ret.princs,
-                                         &ret.count);
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+        ret->code  = kadm5_get_principals((void *)handle,
+                                          arg->exp, &ret->princs,
+                                          &ret->count);
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_get_principals", prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -821,67 +764,52 @@ get_princs_2_svc(gprincs_arg *arg, struct svc_req *rqstp)
             krb5_free_error_message(handle->context, errmsg);
 
     }
+
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, NULL, &client_name, &service_name);
+    return TRUE;
 }
 
-generic_ret *
-chpass_principal_2_svc(chpass_arg *arg, struct svc_req *rqstp)
+bool_t
+chpass_principal_2_svc(chpass_arg *arg, generic_ret *ret,
+                       struct svc_req *rqstp)
 {
-    static generic_ret              ret;
-    char                            *prime_arg;
+    char                            *prime_arg = NULL;
     gss_buffer_desc                 client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                 service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                       minor_stat;
     kadm5_server_handle_t           handle;
     const char                      *errmsg = NULL;
 
-    xdr_free(xdr_generic_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               arg->princ, &prime_arg);
+    if (ret->code)
         goto exit_func;
 
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-    if (krb5_unparse_name(handle->context, arg->princ, &prime_arg)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
-        goto exit_func;
-    }
-
-    ret.code = check_lockdown_keys(handle, arg->princ);
-    if (ret.code != KADM5_OK) {
-        if (ret.code == KADM5_PROTECT_KEYS) {
+    ret->code = check_lockdown_keys(handle, arg->princ);
+    if (ret->code != KADM5_OK) {
+        if (ret->code == KADM5_PROTECT_KEYS) {
             log_unauth("kadm5_chpass_principal", prime_arg, &client_name,
                        &service_name, rqstp);
-            ret.code = KADM5_AUTH_CHANGEPW;
+            ret->code = KADM5_AUTH_CHANGEPW;
         }
     } else if (cmp_gss_krb5_name(handle, rqst2name(rqstp), arg->princ)) {
-        ret.code = chpass_principal_wrapper_3((void *)handle, arg->princ,
+        ret->code = chpass_principal_wrapper_3((void *)handle, arg->princ,
                                               FALSE, 0, NULL, arg->pass);
     } else if (!(CHANGEPW_SERVICE(rqstp)) &&
                kadm5int_acl_check(handle->context, rqst2name(rqstp),
                                   ACL_CHANGEPW, arg->princ, NULL)) {
-        ret.code = kadm5_chpass_principal((void *)handle, arg->princ,
+        ret->code = kadm5_chpass_principal((void *)handle, arg->princ,
                                           arg->pass);
     } else {
         log_unauth("kadm5_chpass_principal", prime_arg,
                    &client_name, &service_name, rqstp);
-        ret.code = KADM5_AUTH_CHANGEPW;
+        ret->code = KADM5_AUTH_CHANGEPW;
     }
 
-    if (ret.code != KADM5_AUTH_CHANGEPW) {
-        if (ret.code != 0)
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+    if (ret->code != KADM5_AUTH_CHANGEPW) {
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_chpass_principal", prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -890,53 +818,36 @@ chpass_principal_2_svc(chpass_arg *arg, struct svc_req *rqstp)
             krb5_free_error_message(handle->context, errmsg);
     }
 
-    free(prime_arg);
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, prime_arg, &client_name, &service_name);
+    return TRUE;
 }
 
-generic_ret *
-chpass_principal3_2_svc(chpass3_arg *arg, struct svc_req *rqstp)
+bool_t
+chpass_principal3_2_svc(chpass3_arg *arg, generic_ret *ret,
+                        struct svc_req *rqstp)
 {
-    static generic_ret              ret;
-    char                            *prime_arg;
+    char                            *prime_arg = NULL;
     gss_buffer_desc                 client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                 service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                       minor_stat;
     kadm5_server_handle_t           handle;
     const char                      *errmsg = NULL;
 
-    xdr_free(xdr_generic_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               arg->princ, &prime_arg);
+    if (ret->code)
         goto exit_func;
 
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-    if (krb5_unparse_name(handle->context, arg->princ, &prime_arg)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
-        goto exit_func;
-    }
-
-    ret.code = check_lockdown_keys(handle, arg->princ);
-    if (ret.code != KADM5_OK) {
-        if (ret.code == KADM5_PROTECT_KEYS) {
+    ret->code = check_lockdown_keys(handle, arg->princ);
+    if (ret->code != KADM5_OK) {
+        if (ret->code == KADM5_PROTECT_KEYS) {
             log_unauth("kadm5_chpass_principal", prime_arg, &client_name,
                        &service_name, rqstp);
-            ret.code = KADM5_AUTH_CHANGEPW;
+            ret->code = KADM5_AUTH_CHANGEPW;
         }
     } else if (cmp_gss_krb5_name(handle, rqst2name(rqstp), arg->princ)) {
-        ret.code = chpass_principal_wrapper_3((void *)handle, arg->princ,
+        ret->code = chpass_principal_wrapper_3((void *)handle, arg->princ,
                                               arg->keepold,
                                               arg->n_ks_tuple,
                                               arg->ks_tuple,
@@ -944,7 +855,7 @@ chpass_principal3_2_svc(chpass3_arg *arg, struct svc_req *rqstp)
     } else if (!(CHANGEPW_SERVICE(rqstp)) &&
                kadm5int_acl_check(handle->context, rqst2name(rqstp),
                                   ACL_CHANGEPW, arg->princ, NULL)) {
-        ret.code = kadm5_chpass_principal_3((void *)handle, arg->princ,
+        ret->code = kadm5_chpass_principal_3((void *)handle, arg->princ,
                                             arg->keepold,
                                             arg->n_ks_tuple,
                                             arg->ks_tuple,
@@ -952,12 +863,12 @@ chpass_principal3_2_svc(chpass3_arg *arg, struct svc_req *rqstp)
     } else {
         log_unauth("kadm5_chpass_principal", prime_arg,
                    &client_name, &service_name, rqstp);
-        ret.code = KADM5_AUTH_CHANGEPW;
+        ret->code = KADM5_AUTH_CHANGEPW;
     }
 
-    if(ret.code != KADM5_AUTH_CHANGEPW) {
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+    if (ret->code != KADM5_AUTH_CHANGEPW) {
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_chpass_principal", prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -966,65 +877,48 @@ chpass_principal3_2_svc(chpass3_arg *arg, struct svc_req *rqstp)
             krb5_free_error_message(handle->context, errmsg);
     }
 
-    free(prime_arg);
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, prime_arg, &client_name, &service_name);
+    return TRUE;
 }
 
-generic_ret *
-setv4key_principal_2_svc(setv4key_arg *arg, struct svc_req *rqstp)
+bool_t
+setv4key_principal_2_svc(setv4key_arg *arg, generic_ret *ret,
+                         struct svc_req *rqstp)
 {
-    static generic_ret              ret;
-    char                            *prime_arg;
+    char                            *prime_arg = NULL;
     gss_buffer_desc                 client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                 service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                       minor_stat;
     kadm5_server_handle_t           handle;
     const char                      *errmsg = NULL;
 
-    xdr_free(xdr_generic_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               arg->princ, &prime_arg);
+    if (ret->code)
         goto exit_func;
 
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-    if (krb5_unparse_name(handle->context, arg->princ, &prime_arg)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
-        goto exit_func;
-    }
-
-    ret.code = check_lockdown_keys(handle, arg->princ);
-    if (ret.code != KADM5_OK) {
-        if (ret.code == KADM5_PROTECT_KEYS) {
+    ret->code = check_lockdown_keys(handle, arg->princ);
+    if (ret->code != KADM5_OK) {
+        if (ret->code == KADM5_PROTECT_KEYS) {
             log_unauth("kadm5_setv4key_principal", prime_arg, &client_name,
                        &service_name, rqstp);
-            ret.code = KADM5_AUTH_SETKEY;
+            ret->code = KADM5_AUTH_SETKEY;
         }
     } else if (!(CHANGEPW_SERVICE(rqstp)) &&
         kadm5int_acl_check(handle->context, rqst2name(rqstp),
                            ACL_SETKEY, arg->princ, NULL)) {
-        ret.code = kadm5_setv4key_principal((void *)handle, arg->princ,
+        ret->code = kadm5_setv4key_principal((void *)handle, arg->princ,
                                             arg->keyblock);
     } else {
         log_unauth("kadm5_setv4key_principal", prime_arg,
                    &client_name, &service_name, rqstp);
-        ret.code = KADM5_AUTH_SETKEY;
+        ret->code = KADM5_AUTH_SETKEY;
     }
 
-    if(ret.code != KADM5_AUTH_SETKEY) {
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+    if (ret->code != KADM5_AUTH_SETKEY) {
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_setv4key_principal", prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -1033,65 +927,49 @@ setv4key_principal_2_svc(setv4key_arg *arg, struct svc_req *rqstp)
             krb5_free_error_message(handle->context, errmsg);
     }
 
-    free(prime_arg);
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, prime_arg, &client_name, &service_name);
+    return TRUE;
 }
 
-generic_ret *
-setkey_principal_2_svc(setkey_arg *arg, struct svc_req *rqstp)
+
+bool_t
+setkey_principal_2_svc(setkey_arg *arg, generic_ret *ret,
+                       struct svc_req *rqstp)
 {
-    static generic_ret              ret;
-    char                            *prime_arg;
+    char                            *prime_arg = NULL;
     gss_buffer_desc                 client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                 service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                       minor_stat;
     kadm5_server_handle_t           handle;
     const char                      *errmsg = NULL;
 
-    xdr_free(xdr_generic_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               arg->princ, &prime_arg);
+    if (ret->code)
         goto exit_func;
 
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-    if (krb5_unparse_name(handle->context, arg->princ, &prime_arg)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
-        goto exit_func;
-    }
-
-    ret.code = check_lockdown_keys(handle, arg->princ);
-    if (ret.code != KADM5_OK) {
-        if (ret.code == KADM5_PROTECT_KEYS) {
+    ret->code = check_lockdown_keys(handle, arg->princ);
+    if (ret->code != KADM5_OK) {
+        if (ret->code == KADM5_PROTECT_KEYS) {
             log_unauth("kadm5_setkey_principal", prime_arg, &client_name,
                        &service_name, rqstp);
-            ret.code = KADM5_AUTH_SETKEY;
+            ret->code = KADM5_AUTH_SETKEY;
         }
     } else if (!(CHANGEPW_SERVICE(rqstp)) &&
         kadm5int_acl_check(handle->context, rqst2name(rqstp),
                            ACL_SETKEY, arg->princ, NULL)) {
-        ret.code = kadm5_setkey_principal((void *)handle, arg->princ,
+        ret->code = kadm5_setkey_principal((void *)handle, arg->princ,
                                           arg->keyblocks, arg->n_keys);
     } else {
         log_unauth("kadm5_setkey_principal", prime_arg,
                    &client_name, &service_name, rqstp);
-        ret.code = KADM5_AUTH_SETKEY;
+        ret->code = KADM5_AUTH_SETKEY;
     }
 
-    if(ret.code != KADM5_AUTH_SETKEY) {
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+    if (ret->code != KADM5_AUTH_SETKEY) {
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_setkey_principal", prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -1100,55 +978,38 @@ setkey_principal_2_svc(setkey_arg *arg, struct svc_req *rqstp)
             krb5_free_error_message(handle->context, errmsg);
     }
 
-    free(prime_arg);
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, prime_arg, &client_name, &service_name);
+    return TRUE;
 }
 
-generic_ret *
-setkey_principal3_2_svc(setkey3_arg *arg, struct svc_req *rqstp)
+bool_t
+setkey_principal3_2_svc(setkey3_arg *arg, generic_ret *ret,
+                        struct svc_req *rqstp)
 {
-    static generic_ret              ret;
-    char                            *prime_arg;
+    char                            *prime_arg = NULL;
     gss_buffer_desc                 client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                 service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                       minor_stat;
     kadm5_server_handle_t           handle;
     const char                      *errmsg = NULL;
 
-    xdr_free(xdr_generic_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               arg->princ, &prime_arg);
+    if (ret->code)
         goto exit_func;
 
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-    if (krb5_unparse_name(handle->context, arg->princ, &prime_arg)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
-        goto exit_func;
-    }
-
-    ret.code = check_lockdown_keys(handle, arg->princ);
-    if (ret.code != KADM5_OK) {
-        if (ret.code == KADM5_PROTECT_KEYS) {
+    ret->code = check_lockdown_keys(handle, arg->princ);
+    if (ret->code != KADM5_OK) {
+        if (ret->code == KADM5_PROTECT_KEYS) {
             log_unauth("kadm5_setkey_principal", prime_arg, &client_name,
                        &service_name, rqstp);
-            ret.code = KADM5_AUTH_SETKEY;
+            ret->code = KADM5_AUTH_SETKEY;
         }
     } else if (!(CHANGEPW_SERVICE(rqstp)) &&
         kadm5int_acl_check(handle->context, rqst2name(rqstp),
                            ACL_SETKEY, arg->princ, NULL)) {
-        ret.code = kadm5_setkey_principal_3((void *)handle, arg->princ,
+        ret->code = kadm5_setkey_principal_3((void *)handle, arg->princ,
                                             arg->keepold,
                                             arg->n_ks_tuple,
                                             arg->ks_tuple,
@@ -1156,12 +1017,12 @@ setkey_principal3_2_svc(setkey3_arg *arg, struct svc_req *rqstp)
     } else {
         log_unauth("kadm5_setkey_principal", prime_arg,
                    &client_name, &service_name, rqstp);
-        ret.code = KADM5_AUTH_SETKEY;
+        ret->code = KADM5_AUTH_SETKEY;
     }
 
-    if(ret.code != KADM5_AUTH_SETKEY) {
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+    if (ret->code != KADM5_AUTH_SETKEY) {
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_setkey_principal", prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -1170,66 +1031,49 @@ setkey_principal3_2_svc(setkey3_arg *arg, struct svc_req *rqstp)
             krb5_free_error_message(handle->context, errmsg);
     }
 
-    free(prime_arg);
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, prime_arg, &client_name, &service_name);
+    return TRUE;
 }
 
-generic_ret *
-setkey_principal4_2_svc(setkey4_arg *arg, struct svc_req *rqstp)
+bool_t
+setkey_principal4_2_svc(setkey4_arg *arg, generic_ret *ret,
+                        struct svc_req *rqstp)
 {
-    static generic_ret              ret;
-    char                            *prime_arg;
+    char                            *prime_arg = NULL;
     gss_buffer_desc                 client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                 service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                       minor_stat;
     kadm5_server_handle_t           handle;
     const char                      *errmsg = NULL;
 
-    xdr_free(xdr_generic_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               arg->princ, &prime_arg);
+    if (ret->code)
         goto exit_func;
 
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-    if (krb5_unparse_name(handle->context, arg->princ, &prime_arg)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
-        goto exit_func;
-    }
-
-    ret.code = check_lockdown_keys(handle, arg->princ);
-    if (ret.code != KADM5_OK) {
-        if (ret.code == KADM5_PROTECT_KEYS) {
+    ret->code = check_lockdown_keys(handle, arg->princ);
+    if (ret->code != KADM5_OK) {
+        if (ret->code == KADM5_PROTECT_KEYS) {
             log_unauth("kadm5_setkey_principal", prime_arg, &client_name,
                        &service_name, rqstp);
-            ret.code = KADM5_AUTH_SETKEY;
+            ret->code = KADM5_AUTH_SETKEY;
         }
     } else if (!(CHANGEPW_SERVICE(rqstp)) &&
-        kadm5int_acl_check(handle->context, rqst2name(rqstp), ACL_SETKEY,
-                           arg->princ, NULL)) {
-        ret.code = kadm5_setkey_principal_4((void *)handle, arg->princ,
-                                            arg->keepold, arg->key_data,
-                                            arg->n_key_data);
+        kadm5int_acl_check(handle->context, rqst2name(rqstp),
+                           ACL_SETKEY, arg->princ, NULL)) {
+        ret->code = kadm5_setkey_principal_4((void *)handle, arg->princ,
+                                             arg->keepold, arg->key_data,
+                                             arg->n_key_data);
     } else {
         log_unauth("kadm5_setkey_principal", prime_arg, &client_name,
                    &service_name, rqstp);
-        ret.code = KADM5_AUTH_SETKEY;
+        ret->code = KADM5_AUTH_SETKEY;
     }
 
-    if (ret.code != KADM5_AUTH_SETKEY) {
-        if (ret.code != 0)
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+    if (ret->code != KADM5_AUTH_SETKEY) {
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_setkey_principal", prime_arg, errmsg, &client_name,
                  &service_name, rqstp);
@@ -1238,12 +1082,9 @@ setkey_principal4_2_svc(setkey4_arg *arg, struct svc_req *rqstp)
             krb5_free_error_message(handle->context, errmsg);
     }
 
-    free(prime_arg);
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, prime_arg, &client_name, &service_name);
+    return TRUE;
 }
 
 /* Empty out *keys/*nkeys if princ is protected with the lockdown attribute, or
@@ -1267,64 +1108,51 @@ chrand_check_lockdown(kadm5_server_handle_t handle, krb5_principal princ,
     return (ret == KADM5_PROTECT_KEYS) ? KADM5_OK : ret;
 }
 
-chrand_ret *
-chrand_principal_2_svc(chrand_arg *arg, struct svc_req *rqstp)
+bool_t
+chrand_principal_2_svc(chrand_arg *arg, chrand_ret *ret, struct svc_req *rqstp)
 {
-    static chrand_ret           ret;
-    krb5_keyblock               *k;
-    int                         nkeys;
-    char                        *prime_arg, *funcname;
+    char                        *prime_arg = NULL;
+    char                        *funcname;
     gss_buffer_desc             client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc             service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                   minor_stat;
+    krb5_keyblock               *k;
+    int                         nkeys;
     kadm5_server_handle_t       handle;
     const char                  *errmsg = NULL;
 
-    xdr_free(xdr_chrand_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               arg->princ, &prime_arg);
+    if (ret->code)
         goto exit_func;
-
-
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
 
     funcname = "kadm5_randkey_principal";
 
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-    if (krb5_unparse_name(handle->context, arg->princ, &prime_arg)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
-        goto exit_func;
-    }
-
     if (cmp_gss_krb5_name(handle, rqst2name(rqstp), arg->princ)) {
-        ret.code = randkey_principal_wrapper_3((void *)handle, arg->princ,
+        ret->code = randkey_principal_wrapper_3((void *)handle, arg->princ,
                                                FALSE, 0, NULL, &k, &nkeys);
     } else if (!(CHANGEPW_SERVICE(rqstp)) &&
                kadm5int_acl_check(handle->context, rqst2name(rqstp),
                                   ACL_CHANGEPW, arg->princ, NULL)) {
-        ret.code = kadm5_randkey_principal((void *)handle, arg->princ,
+        ret->code = kadm5_randkey_principal((void *)handle, arg->princ,
                                            &k, &nkeys);
     } else {
         log_unauth(funcname, prime_arg,
                    &client_name, &service_name, rqstp);
-        ret.code = KADM5_AUTH_CHANGEPW;
+        ret->code = KADM5_AUTH_CHANGEPW;
     }
 
-    if(ret.code == KADM5_OK) {
-        ret.code = chrand_check_lockdown(handle, arg->princ, &k, &nkeys);
-        ret.keys = k;
-        ret.n_keys = nkeys;
+    if (ret->code == KADM5_OK) {
+        ret->code = chrand_check_lockdown(handle, arg->princ, &k, &nkeys);
+        if (ret->code == KADM5_PROTECT_KEYS)
+            ret->code = KADM5_OK;
+        ret->keys = k;
+        ret->n_keys = nkeys;
     }
 
-    if(ret.code != KADM5_AUTH_CHANGEPW) {
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+    if (ret->code != KADM5_AUTH_CHANGEPW) {
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done(funcname, prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -1332,50 +1160,35 @@ chrand_principal_2_svc(chrand_arg *arg, struct svc_req *rqstp)
         if (errmsg != NULL)
             krb5_free_error_message(handle->context, errmsg);
     }
-    free(prime_arg);
+
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, prime_arg, &client_name, &service_name);
+    return TRUE;
 }
 
-chrand_ret *
-chrand_principal3_2_svc(chrand3_arg *arg, struct svc_req *rqstp)
+bool_t
+chrand_principal3_2_svc(chrand3_arg *arg, chrand_ret *ret,
+                        struct svc_req *rqstp)
 {
-    static chrand_ret           ret;
-    krb5_keyblock               *k;
-    int                         nkeys;
-    char                        *prime_arg, *funcname;
+    char                        *prime_arg = NULL;
+    char                        *funcname;
     gss_buffer_desc             client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc             service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                   minor_stat;
+    krb5_keyblock               *k;
+    int                         nkeys;
     kadm5_server_handle_t       handle;
     const char                  *errmsg = NULL;
 
-    xdr_free(xdr_chrand_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               arg->princ, &prime_arg);
+    if (ret->code)
         goto exit_func;
-
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
 
     funcname = "kadm5_randkey_principal";
 
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-    if (krb5_unparse_name(handle->context, arg->princ, &prime_arg)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
-        goto exit_func;
-    }
-
     if (cmp_gss_krb5_name(handle, rqst2name(rqstp), arg->princ)) {
-        ret.code = randkey_principal_wrapper_3((void *)handle, arg->princ,
+        ret->code = randkey_principal_wrapper_3((void *)handle, arg->princ,
                                                arg->keepold,
                                                arg->n_ks_tuple,
                                                arg->ks_tuple,
@@ -1383,7 +1196,7 @@ chrand_principal3_2_svc(chrand3_arg *arg, struct svc_req *rqstp)
     } else if (!(CHANGEPW_SERVICE(rqstp)) &&
                kadm5int_acl_check(handle->context, rqst2name(rqstp),
                                   ACL_CHANGEPW, arg->princ, NULL)) {
-        ret.code = kadm5_randkey_principal_3((void *)handle, arg->princ,
+        ret->code = kadm5_randkey_principal_3((void *)handle, arg->princ,
                                              arg->keepold,
                                              arg->n_ks_tuple,
                                              arg->ks_tuple,
@@ -1391,18 +1204,20 @@ chrand_principal3_2_svc(chrand3_arg *arg, struct svc_req *rqstp)
     } else {
         log_unauth(funcname, prime_arg,
                    &client_name, &service_name, rqstp);
-        ret.code = KADM5_AUTH_CHANGEPW;
+        ret->code = KADM5_AUTH_CHANGEPW;
     }
 
-    if(ret.code == KADM5_OK) {
-        ret.code = chrand_check_lockdown(handle, arg->princ, &k, &nkeys);
-        ret.keys = k;
-        ret.n_keys = nkeys;
+    if (ret->code == KADM5_OK) {
+        ret->code = chrand_check_lockdown(handle, arg->princ, &k, &nkeys);
+        if (ret->code == KADM5_PROTECT_KEYS)
+            ret->code = KADM5_OK;
+        ret->keys = k;
+        ret->n_keys = nkeys;
     }
 
-    if(ret.code != KADM5_AUTH_CHANGEPW) {
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+    if (ret->code != KADM5_AUTH_CHANGEPW) {
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done(funcname, prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -1410,53 +1225,41 @@ chrand_principal3_2_svc(chrand3_arg *arg, struct svc_req *rqstp)
         if (errmsg != NULL)
             krb5_free_error_message(handle->context, errmsg);
     }
-    free(prime_arg);
+
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, prime_arg, &client_name, &service_name);
+    return TRUE;
 }
 
-generic_ret *
-create_policy_2_svc(cpol_arg *arg, struct svc_req *rqstp)
+bool_t
+create_policy_2_svc(cpol_arg *arg, generic_ret *ret, struct svc_req *rqstp)
 {
-    static generic_ret              ret;
-    char                            *prime_arg;
+    char                            *prime_arg = NULL;
     gss_buffer_desc                 client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                 service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                       minor_stat;
     kadm5_server_handle_t           handle;
     const char                      *errmsg = NULL;
 
-    xdr_free(xdr_generic_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               NULL, NULL);
+    if (ret->code)
         goto exit_func;
 
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
     prime_arg = arg->rec.policy;
 
     if (CHANGEPW_SERVICE(rqstp) || !kadm5int_acl_check(handle->context,
                                                        rqst2name(rqstp),
                                                        ACL_ADD, NULL, NULL)) {
-        ret.code = KADM5_AUTH_ADD;
+        ret->code = KADM5_AUTH_ADD;
         log_unauth("kadm5_create_policy", prime_arg,
                    &client_name, &service_name, rqstp);
 
     } else {
-        ret.code = kadm5_create_policy((void *)handle, &arg->rec,
+        ret->code = kadm5_create_policy((void *)handle, &arg->rec,
                                        arg->mask);
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_create_policy",
                  ((prime_arg == NULL) ? "(null)" : prime_arg), errmsg,
@@ -1465,38 +1268,27 @@ create_policy_2_svc(cpol_arg *arg, struct svc_req *rqstp)
         if (errmsg != NULL)
             krb5_free_error_message(handle->context, errmsg);
     }
+
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, NULL, &client_name, &service_name);
+    return TRUE;
 }
 
-generic_ret *
-delete_policy_2_svc(dpol_arg *arg, struct svc_req *rqstp)
+bool_t
+delete_policy_2_svc(dpol_arg *arg, generic_ret *ret, struct svc_req *rqstp)
 {
-    static generic_ret              ret;
-    char                            *prime_arg;
+    char                            *prime_arg = NULL;
     gss_buffer_desc                 client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                 service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                       minor_stat;
     kadm5_server_handle_t           handle;
     const char                      *errmsg = NULL;
 
-    xdr_free(xdr_generic_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               NULL, NULL);
+    if (ret->code)
         goto exit_func;
 
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
     prime_arg = arg->name;
 
     if (CHANGEPW_SERVICE(rqstp) || !kadm5int_acl_check(handle->context,
@@ -1504,11 +1296,11 @@ delete_policy_2_svc(dpol_arg *arg, struct svc_req *rqstp)
                                                        ACL_DELETE, NULL, NULL)) {
         log_unauth("kadm5_delete_policy", prime_arg,
                    &client_name, &service_name, rqstp);
-        ret.code = KADM5_AUTH_DELETE;
+        ret->code = KADM5_AUTH_DELETE;
     } else {
-        ret.code = kadm5_delete_policy((void *)handle, arg->name);
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+        ret->code = kadm5_delete_policy((void *)handle, arg->name);
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_delete_policy",
                  ((prime_arg == NULL) ? "(null)" : prime_arg), errmsg,
@@ -1517,38 +1309,27 @@ delete_policy_2_svc(dpol_arg *arg, struct svc_req *rqstp)
         if (errmsg != NULL)
             krb5_free_error_message(handle->context, errmsg);
     }
+
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, NULL, &client_name, &service_name);
+    return TRUE;
 }
 
-generic_ret *
-modify_policy_2_svc(mpol_arg *arg, struct svc_req *rqstp)
+bool_t
+modify_policy_2_svc(mpol_arg *arg, generic_ret *ret, struct svc_req *rqstp)
 {
-    static generic_ret              ret;
-    char                            *prime_arg;
+    char                            *prime_arg = NULL;
     gss_buffer_desc                 client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                 service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                       minor_stat;
     kadm5_server_handle_t           handle;
     const char                      *errmsg = NULL;
 
-    xdr_free(xdr_generic_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               NULL, NULL);
+    if (ret->code)
         goto exit_func;
 
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
     prime_arg = arg->rec.policy;
 
     if (CHANGEPW_SERVICE(rqstp) || !kadm5int_acl_check(handle->context,
@@ -1556,12 +1337,12 @@ modify_policy_2_svc(mpol_arg *arg, struct svc_req *rqstp)
                                                        ACL_MODIFY, NULL, NULL)) {
         log_unauth("kadm5_modify_policy", prime_arg,
                    &client_name, &service_name, rqstp);
-        ret.code = KADM5_AUTH_MODIFY;
+        ret->code = KADM5_AUTH_MODIFY;
     } else {
-        ret.code = kadm5_modify_policy((void *)handle, &arg->rec,
+        ret->code = kadm5_modify_policy((void *)handle, &arg->rec,
                                        arg->mask);
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_modify_policy",
                  ((prime_arg == NULL) ? "(null)" : prime_arg), errmsg,
@@ -1570,70 +1351,60 @@ modify_policy_2_svc(mpol_arg *arg, struct svc_req *rqstp)
         if (errmsg != NULL)
             krb5_free_error_message(handle->context, errmsg);
     }
+
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, NULL, &client_name, &service_name);
+    return TRUE;
 }
 
-gpol_ret *
-get_policy_2_svc(gpol_arg *arg, struct svc_req *rqstp)
+bool_t
+get_policy_2_svc(gpol_arg *arg, gpol_ret *ret, struct svc_req *rqstp)
 {
-    static gpol_ret             ret;
-    kadm5_ret_t         ret2;
-    char                        *prime_arg, *funcname;
+    char                        *prime_arg = NULL;
+    char                        *funcname;
     gss_buffer_desc             client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc             service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                   minor_stat;
+    kadm5_ret_t         ret2;
     kadm5_principal_ent_rec     caller_ent;
     kadm5_server_handle_t       handle;
     const char                  *errmsg = NULL;
 
-    xdr_free(xdr_gpol_ret,  &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               NULL, NULL);
+    if (ret->code)
         goto exit_func;
-
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
 
     funcname = "kadm5_get_policy";
 
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
     prime_arg = arg->name;
 
-    ret.code = KADM5_AUTH_GET;
+    ret->code = KADM5_AUTH_GET;
     if (!CHANGEPW_SERVICE(rqstp) && kadm5int_acl_check(handle->context,
                                                        rqst2name(rqstp),
                                                        ACL_INQUIRE, NULL, NULL))
-        ret.code = KADM5_OK;
+        ret->code = KADM5_OK;
     else {
-        ret.code = kadm5_get_principal(handle->lhandle,
+        ret->code = kadm5_get_principal(handle->lhandle,
                                        handle->current_caller,
                                        &caller_ent,
                                        KADM5_PRINCIPAL_NORMAL_MASK);
-        if (ret.code == KADM5_OK) {
+        if (ret->code == KADM5_OK) {
             if (caller_ent.aux_attributes & KADM5_POLICY &&
                 strcmp(caller_ent.policy, arg->name) == 0) {
-                ret.code = KADM5_OK;
-            } else ret.code = KADM5_AUTH_GET;
+                ret->code = KADM5_OK;
+            } else ret->code = KADM5_AUTH_GET;
             ret2 = kadm5_free_principal_ent(handle->lhandle,
                                             &caller_ent);
-            ret.code = ret.code ? ret.code : ret2;
+            ret->code = ret->code ? ret->code : ret2;
         }
     }
 
-    if (ret.code == KADM5_OK) {
-        ret.code = kadm5_get_policy(handle, arg->name, &ret.rec);
+    if (ret->code == KADM5_OK) {
+        ret->code = kadm5_get_policy(handle, arg->name, &ret->rec);
 
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done(funcname,
                  ((prime_arg == NULL) ? "(null)" : prime_arg), errmsg,
@@ -1645,39 +1416,27 @@ get_policy_2_svc(gpol_arg *arg, struct svc_req *rqstp)
         log_unauth(funcname, prime_arg,
                    &client_name, &service_name, rqstp);
     }
-exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
 
+exit_func:
+    free_stub_srv(handle, NULL, &client_name, &service_name);
+    return TRUE;
 }
 
-gpols_ret *
-get_pols_2_svc(gpols_arg *arg, struct svc_req *rqstp)
+bool_t
+get_pols_2_svc(gpols_arg *arg, gpols_ret *ret, struct svc_req *rqstp)
 {
-    static gpols_ret                ret;
-    char                            *prime_arg;
+    char                            *prime_arg = NULL;
     gss_buffer_desc                 client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                 service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                       minor_stat;
     kadm5_server_handle_t           handle;
     const char                      *errmsg = NULL;
 
-    xdr_free(xdr_gpols_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               NULL, NULL);
+    if (ret->code)
         goto exit_func;
 
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
     prime_arg = arg->exp;
     if (prime_arg == NULL)
         prime_arg = "*";
@@ -1685,15 +1444,15 @@ get_pols_2_svc(gpols_arg *arg, struct svc_req *rqstp)
     if (CHANGEPW_SERVICE(rqstp) || !kadm5int_acl_check(handle->context,
                                                        rqst2name(rqstp),
                                                        ACL_LIST, NULL, NULL)) {
-        ret.code = KADM5_AUTH_LIST;
+        ret->code = KADM5_AUTH_LIST;
         log_unauth("kadm5_get_policies", prime_arg,
                    &client_name, &service_name, rqstp);
     } else {
-        ret.code  = kadm5_get_policies((void *)handle,
-                                       arg->exp, &ret.pols,
-                                       &ret.count);
-        if( ret.code != 0 )
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+        ret->code  = kadm5_get_policies(handle,
+                                        arg->exp, &ret->pols,
+                                        &ret->count);
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_get_policies", prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -1701,40 +1460,29 @@ get_pols_2_svc(gpols_arg *arg, struct svc_req *rqstp)
         if (errmsg != NULL)
             krb5_free_error_message(handle->context, errmsg);
     }
+
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, NULL, &client_name, &service_name);
+    return TRUE;
 }
 
-getprivs_ret * get_privs_2_svc(krb5_ui_4 *arg, struct svc_req *rqstp)
+bool_t
+get_privs_2_svc(krb5_ui_4 *arg, getprivs_ret *ret, struct svc_req *rqstp)
 {
-    static getprivs_ret            ret;
     gss_buffer_desc                client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                      minor_stat;
     kadm5_server_handle_t          handle;
     const char                     *errmsg = NULL;
 
-    xdr_free(xdr_getprivs_ret, &ret);
-
-    if ((ret.code = new_server_handle(*arg, rqstp, &handle)))
+    ret->code = setup_stub_srv(*arg, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               NULL, NULL);
+    if (ret->code)
         goto exit_func;
 
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-
-    ret.code = kadm5_get_privs((void *)handle, &ret.privs);
-    if( ret.code != 0 )
-        errmsg = krb5_get_error_message(handle->context, ret.code);
+    ret->code = kadm5_get_privs((void *)handle, &ret->privs);
+    if (ret->code != 0)
+        errmsg = krb5_get_error_message(handle->context, ret->code);
 
     log_done("kadm5_get_privs", client_name.value, errmsg,
              &client_name, &service_name, rqstp);
@@ -1743,56 +1491,40 @@ getprivs_ret * get_privs_2_svc(krb5_ui_4 *arg, struct svc_req *rqstp)
         krb5_free_error_message(handle->context, errmsg);
 
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, NULL, &client_name, &service_name);
+    return TRUE;
 }
 
-generic_ret *
-purgekeys_2_svc(purgekeys_arg *arg, struct svc_req *rqstp)
+bool_t
+purgekeys_2_svc(purgekeys_arg *arg, generic_ret *ret, struct svc_req *rqstp)
 {
-    static generic_ret          ret;
-    char                        *prime_arg, *funcname;
+    char                        *prime_arg = NULL;
+    char                        *funcname;
     gss_buffer_desc             client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc             service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                   minor_stat;
     kadm5_server_handle_t       handle;
 
     const char                  *errmsg = NULL;
 
-    xdr_free(xdr_generic_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               arg->princ, &prime_arg);
+    if (ret->code)
         goto exit_func;
-
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
 
     funcname = "kadm5_purgekeys";
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-    if (krb5_unparse_name(handle->context, arg->princ, &prime_arg)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
-        goto exit_func;
-    }
 
     if (!cmp_gss_krb5_name(handle, rqst2name(rqstp), arg->princ) &&
         (CHANGEPW_SERVICE(rqstp)
          || !kadm5int_acl_check(handle->context, rqst2name(rqstp), ACL_MODIFY,
                                 arg->princ, NULL))) {
-        ret.code = KADM5_AUTH_MODIFY;
+        ret->code = KADM5_AUTH_MODIFY;
         log_unauth(funcname, prime_arg, &client_name, &service_name, rqstp);
     } else {
-        ret.code = kadm5_purgekeys((void *)handle, arg->princ,
+        ret->code = kadm5_purgekeys((void *)handle, arg->princ,
                                    arg->keepkvno);
-        if (ret.code != 0)
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done(funcname, prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -1800,43 +1532,26 @@ purgekeys_2_svc(purgekeys_arg *arg, struct svc_req *rqstp)
         if (errmsg != NULL)
             krb5_free_error_message(handle->context, errmsg);
     }
-    free(prime_arg);
+
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, prime_arg, &client_name, &service_name);
+    return TRUE;
 }
 
-gstrings_ret *
-get_strings_2_svc(gstrings_arg *arg, struct svc_req *rqstp)
+bool_t
+get_strings_2_svc(gstrings_arg *arg, gstrings_ret *ret, struct svc_req *rqstp)
 {
-    static gstrings_ret             ret;
-    char                            *prime_arg;
+    char                            *prime_arg = NULL;
     gss_buffer_desc                 client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                 service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                       minor_stat;
     kadm5_server_handle_t           handle;
     const char                      *errmsg = NULL;
 
-    xdr_free(xdr_gstrings_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               arg->princ, &prime_arg);
+    if (ret->code)
         goto exit_func;
-
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-    if (krb5_unparse_name(handle->context, arg->princ, &prime_arg)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
-        goto exit_func;
-    }
 
     if (! cmp_gss_krb5_name(handle, rqst2name(rqstp), arg->princ) &&
         (CHANGEPW_SERVICE(rqstp) || !kadm5int_acl_check(handle->context,
@@ -1844,14 +1559,14 @@ get_strings_2_svc(gstrings_arg *arg, struct svc_req *rqstp)
                                                         ACL_INQUIRE,
                                                         arg->princ,
                                                         NULL))) {
-        ret.code = KADM5_AUTH_GET;
+        ret->code = KADM5_AUTH_GET;
         log_unauth("kadm5_get_strings", prime_arg,
                    &client_name, &service_name, rqstp);
     } else {
-        ret.code = kadm5_get_strings((void *)handle, arg->princ, &ret.strings,
-                                     &ret.count);
-        if (ret.code != 0)
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+        ret->code = kadm5_get_strings((void *)handle, arg->princ,
+                                      &ret->strings, &ret->count);
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_get_strings", prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -1859,55 +1574,38 @@ get_strings_2_svc(gstrings_arg *arg, struct svc_req *rqstp)
         if (errmsg != NULL)
             krb5_free_error_message(handle->context, errmsg);
     }
-    free(prime_arg);
+
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, prime_arg, &client_name, &service_name);
+    return TRUE;
 }
 
-generic_ret *
-set_string_2_svc(sstring_arg *arg, struct svc_req *rqstp)
+bool_t
+set_string_2_svc(sstring_arg *arg, generic_ret *ret, struct svc_req *rqstp)
 {
-    static generic_ret              ret;
-    char                            *prime_arg;
+    char                            *prime_arg = NULL;
     gss_buffer_desc                 client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                 service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                       minor_stat;
     kadm5_server_handle_t           handle;
     const char                      *errmsg = NULL;
 
-    xdr_free(xdr_generic_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               arg->princ, &prime_arg);
+    if (ret->code)
         goto exit_func;
-
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-    if (krb5_unparse_name(handle->context, arg->princ, &prime_arg)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
-        goto exit_func;
-    }
 
     if (CHANGEPW_SERVICE(rqstp)
         || !kadm5int_acl_check(handle->context, rqst2name(rqstp), ACL_MODIFY,
                                arg->princ, NULL)) {
-        ret.code = KADM5_AUTH_MODIFY;
+        ret->code = KADM5_AUTH_MODIFY;
         log_unauth("kadm5_mod_strings", prime_arg,
                    &client_name, &service_name, rqstp);
     } else {
-        ret.code = kadm5_set_string((void *)handle, arg->princ, arg->key,
+        ret->code = kadm5_set_string((void *)handle, arg->princ, arg->key,
                                     arg->value);
-        if (ret.code != 0)
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_mod_strings", prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -1915,42 +1613,30 @@ set_string_2_svc(sstring_arg *arg, struct svc_req *rqstp)
         if (errmsg != NULL)
             krb5_free_error_message(handle->context, errmsg);
     }
-    free(prime_arg);
+
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, prime_arg, &client_name, &service_name);
+    return TRUE;
 }
 
-generic_ret *init_2_svc(krb5_ui_4 *arg, struct svc_req *rqstp)
+bool_t
+init_2_svc(krb5_ui_4 *arg, generic_ret *ret, struct svc_req *rqstp)
 {
-    static generic_ret         ret;
     gss_buffer_desc            client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc            service_name = GSS_C_EMPTY_BUFFER;
     kadm5_server_handle_t      handle;
-    OM_uint32                  minor_stat;
     const char                 *errmsg = NULL;
     size_t clen, slen;
     char *cdots, *sdots;
 
-    xdr_free(xdr_generic_ret, &ret);
-
-    if ((ret.code = new_server_handle(*arg, rqstp, &handle)))
+    ret->code = setup_stub_srv(*arg, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               NULL, NULL);
+    if (ret->code)
         goto exit_func;
-    if (! (ret.code = check_handle((void *)handle))) {
-        ret.api_version = handle->api_version;
-    }
 
-    free_server_handle(handle);
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-
-    if (ret.code != 0)
-        errmsg = krb5_get_error_message(NULL, ret.code);
+    if (ret->code != 0)
+        errmsg = krb5_get_error_message(handle->context, ret->code);
 
     clen = client_name.length;
     trunc_name(&clen, &cdots);
@@ -1965,15 +1651,14 @@ generic_ret *init_2_svc(krb5_ui_4 *arg, struct svc_req *rqstp)
                      (int)clen, (char *)client_name.value, cdots,
                      (int)slen, (char *)service_name.value, sdots,
                      client_addr(rqstp->rq_xprt),
-                     ret.api_version & ~(KADM5_API_VERSION_MASK),
+                     ret->api_version & ~(KADM5_API_VERSION_MASK),
                      rqstp->rq_cred.oa_flavor);
     if (errmsg != NULL)
-        krb5_free_error_message(NULL, errmsg);
+        krb5_free_error_message(handle->context, errmsg);
 
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    return(&ret);
+    free_stub_srv(handle, NULL, &client_name, &service_name);
+    return TRUE;
 }
 
 gss_name_t
@@ -1986,66 +1671,52 @@ rqst2name(struct svc_req *rqstp)
         return rqstp->rq_clntcred;
 }
 
-getpkeys_ret *
-get_principal_keys_2_svc(getpkeys_arg *arg, struct svc_req *rqstp)
+bool_t
+get_principal_keys_2_svc(getpkeys_arg *arg, getpkeys_ret *ret,
+                         struct svc_req *rqstp)
 {
-    static getpkeys_ret             ret;
-    char                            *prime_arg;
+    char                            *prime_arg = NULL;
     gss_buffer_desc                 client_name = GSS_C_EMPTY_BUFFER;
     gss_buffer_desc                 service_name = GSS_C_EMPTY_BUFFER;
-    OM_uint32                       minor_stat;
     kadm5_server_handle_t           handle;
     const char                      *errmsg = NULL;
 
-    xdr_free(xdr_getpkeys_ret, &ret);
-
-    if ((ret.code = new_server_handle(arg->api_version, rqstp, &handle)))
+    ret->code = setup_stub_srv(arg->api_version, rqstp, &handle,
+                               &ret->api_version, &client_name, &service_name,
+                               arg->princ, &prime_arg);
+    if (ret->code)
         goto exit_func;
-
-    if ((ret.code = check_handle((void *)handle)))
-        goto exit_func;
-
-    ret.api_version = handle->api_version;
-
-    if (setup_gss_names(rqstp, &client_name, &service_name) < 0) {
-        ret.code = KADM5_FAILURE;
-        goto exit_func;
-    }
-    if (krb5_unparse_name(handle->context, arg->princ, &prime_arg)) {
-        ret.code = KADM5_BAD_PRINCIPAL;
-        goto exit_func;
-    }
 
     if (!(CHANGEPW_SERVICE(rqstp)) &&
         kadm5int_acl_check(handle->context, rqst2name(rqstp),
                            ACL_EXTRACT, arg->princ, NULL)) {
-        ret.code = kadm5_get_principal_keys((void *)handle, arg->princ,
-                                            arg->kvno, &ret.key_data,
-                                            &ret.n_key_data);
+        ret->code = kadm5_get_principal_keys((void *)handle, arg->princ,
+                                             arg->kvno, &ret->key_data,
+                                             &ret->n_key_data);
     } else {
         log_unauth("kadm5_get_principal_keys", prime_arg,
                    &client_name, &service_name, rqstp);
-        ret.code = KADM5_AUTH_EXTRACT;
+        ret->code = KADM5_AUTH_EXTRACT;
     }
 
-    if (ret.code == KADM5_OK) {
-        ret.code = check_lockdown_keys(handle, arg->princ);
-        if (ret.code != KADM5_OK) {
-            kadm5_free_kadm5_key_data(handle->context, ret.n_key_data,
-                                      ret.key_data);
-            ret.key_data = NULL;
-            ret.n_key_data = 0;
+    if (ret->code == KADM5_OK) {
+        ret->code = check_lockdown_keys(handle, arg->princ);
+        if (ret->code != KADM5_OK) {
+            kadm5_free_kadm5_key_data(handle->context, ret->n_key_data,
+                                      ret->key_data);
+            ret->key_data = NULL;
+            ret->n_key_data = 0;
         }
-        if (ret.code == KADM5_PROTECT_KEYS) {
+        if (ret->code == KADM5_PROTECT_KEYS) {
             log_unauth("kadm5_get_principal_keys", prime_arg,
                        &client_name, &service_name, rqstp);
-            ret.code = KADM5_AUTH_EXTRACT;
+            ret->code = KADM5_AUTH_EXTRACT;
         }
     }
 
-    if (ret.code != KADM5_AUTH_EXTRACT) {
-        if (ret.code != 0)
-            errmsg = krb5_get_error_message(handle->context, ret.code);
+    if (ret->code != KADM5_AUTH_EXTRACT) {
+        if (ret->code != 0)
+            errmsg = krb5_get_error_message(handle->context, ret->code);
 
         log_done("kadm5_get_principal_keys", prime_arg, errmsg,
                  &client_name, &service_name, rqstp);
@@ -2054,10 +1725,7 @@ get_principal_keys_2_svc(getpkeys_arg *arg, struct svc_req *rqstp)
             krb5_free_error_message(handle->context, errmsg);
     }
 
-    free(prime_arg);
 exit_func:
-    gss_release_buffer(&minor_stat, &client_name);
-    gss_release_buffer(&minor_stat, &service_name);
-    free_server_handle(handle);
-    return &ret;
+    free_stub_srv(handle, prime_arg, &client_name, &service_name);
+    return TRUE;
 }

--- a/src/lib/kadm5/clnt/client_init.c
+++ b/src/lib/kadm5/clnt/client_init.c
@@ -158,7 +158,8 @@ init_any(krb5_context context, char *client_name, enum init_type init_type,
     kadm5_config_params params_local;
 
     int code = 0;
-    generic_ret *r;
+    generic_ret r = { 0, 0 };
+    enum clnt_stat s;
 
     initialize_ovk_error_table();
 /*      initialize_adb_error_table(); */
@@ -295,8 +296,8 @@ init_any(krb5_context context, char *client_name, enum init_type init_type,
         goto cleanup;
     }
 
-    r = init_2(&handle->api_version, handle->clnt);
-    if (r == NULL) {
+    s = init_2(&handle->api_version, &r, handle->clnt);
+    if (s != RPC_SUCCESS) {
         code = KADM5_RPC_ERROR;
 #ifdef DEBUG
         clnt_perror(handle->clnt, "init_2 null resp");
@@ -304,27 +305,29 @@ init_any(krb5_context context, char *client_name, enum init_type init_type,
         goto error;
     }
     /* Drop down to v3 wire protocol if server does not support v4 */
-    if (r->code == KADM5_NEW_SERVER_API_VERSION &&
+    if (r.code == KADM5_NEW_SERVER_API_VERSION &&
         handle->api_version == KADM5_API_VERSION_4) {
         handle->api_version = KADM5_API_VERSION_3;
-        r = init_2(&handle->api_version, handle->clnt);
-        if (r == NULL) {
+        memset(&r, 0, sizeof(generic_ret));
+        s = init_2(&handle->api_version, &r, handle->clnt);
+        if (s != RPC_SUCCESS) {
             code = KADM5_RPC_ERROR;
             goto error;
         }
     }
     /* Drop down to v2 wire protocol if server does not support v3 */
-    if (r->code == KADM5_NEW_SERVER_API_VERSION &&
+    if (r.code == KADM5_NEW_SERVER_API_VERSION &&
         handle->api_version == KADM5_API_VERSION_3) {
         handle->api_version = KADM5_API_VERSION_2;
-        r = init_2(&handle->api_version, handle->clnt);
-        if (r == NULL) {
+        memset(&r, 0, sizeof(generic_ret));
+        s = init_2(&handle->api_version, &r, handle->clnt);
+        if (s != RPC_SUCCESS) {
             code = KADM5_RPC_ERROR;
             goto error;
         }
     }
-    if (r->code) {
-        code = r->code;
+    if (r.code) {
+        code = r.code;
         goto error;
     }
 

--- a/src/lib/kadm5/clnt/client_principal.c
+++ b/src/lib/kadm5/clnt/client_principal.c
@@ -26,7 +26,8 @@ kadm5_create_principal(void *server_handle,
                        kadm5_principal_ent_t princ, long mask,
                        char *pw)
 {
-    generic_ret         *r;
+    generic_ret         r = { 0, 0 };
+    enum clnt_stat      s;
     cprinc_arg          arg;
     kadm5_server_handle_t handle = server_handle;
 
@@ -54,11 +55,11 @@ kadm5_create_principal(void *server_handle,
         arg.rec.tl_data = NULL;
     }
 
-    r = create_principal_2(&arg, handle->clnt);
+    s = create_principal_2(&arg, &r, handle->clnt);
 
-    if(r == NULL)
+    if (s != RPC_SUCCESS)
         eret();
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
@@ -68,7 +69,8 @@ kadm5_create_principal_3(void *server_handle,
                          krb5_key_salt_tuple *ks_tuple,
                          char *pw)
 {
-    generic_ret         *r;
+    generic_ret         r = { 0, 0 };
+    enum clnt_stat      s;
     cprinc3_arg         arg;
     kadm5_server_handle_t handle = server_handle;
 
@@ -98,18 +100,19 @@ kadm5_create_principal_3(void *server_handle,
         arg.rec.tl_data = NULL;
     }
 
-    r = create_principal3_2(&arg, handle->clnt);
+    s = create_principal3_2(&arg, &r, handle->clnt);
 
-    if(r == NULL)
+    if (s != RPC_SUCCESS)
         eret();
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
 kadm5_delete_principal(void *server_handle, krb5_principal principal)
 {
     dprinc_arg          arg;
-    generic_ret         *r;
+    generic_ret         r = { 0, 0 };
+    enum clnt_stat      s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
@@ -118,10 +121,10 @@ kadm5_delete_principal(void *server_handle, krb5_principal principal)
         return EINVAL;
     arg.princ = principal;
     arg.api_version = handle->api_version;
-    r = delete_principal_2(&arg, handle->clnt);
-    if(r == NULL)
+    s = delete_principal_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         eret();
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
@@ -129,7 +132,8 @@ kadm5_modify_principal(void *server_handle,
                        kadm5_principal_ent_t princ, long mask)
 {
     mprinc_arg          arg;
-    generic_ret         *r;
+    generic_ret         r = { 0, 0 };
+    enum clnt_stat      s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
@@ -153,11 +157,11 @@ kadm5_modify_principal(void *server_handle,
 
     arg.rec.mod_name = NULL;
 
-    r = modify_principal_2(&arg, handle->clnt);
+    s = modify_principal_2(&arg, &r, handle->clnt);
 
-    if(r == NULL)
+    if (s != RPC_SUCCESS)
         eret();
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
@@ -166,7 +170,8 @@ kadm5_get_principal(void *server_handle,
                     long mask)
 {
     gprinc_arg  arg;
-    gprinc_ret  *r;
+    gprinc_ret  r;
+    enum clnt_stat s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
@@ -176,13 +181,14 @@ kadm5_get_principal(void *server_handle,
     arg.princ = princ;
     arg.mask = mask;
     arg.api_version = handle->api_version;
-    r = get_principal_2(&arg, handle->clnt);
-    if(r == NULL)
+    memset(&r, 0, sizeof(gprinc_ret));
+    s = get_principal_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         eret();
-    if (r->code == 0)
-        memcpy(ent, &r->rec, sizeof(r->rec));
+    if (r.code == 0)
+        memcpy(ent, &r.rec, sizeof(r.rec));
 
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
@@ -190,7 +196,8 @@ kadm5_get_principals(void *server_handle,
                      char *exp, char ***princs, int *count)
 {
     gprincs_arg arg;
-    gprincs_ret *r;
+    gprincs_ret r;
+    enum clnt_stat s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
@@ -199,18 +206,19 @@ kadm5_get_principals(void *server_handle,
         return EINVAL;
     arg.exp = exp;
     arg.api_version = handle->api_version;
-    r = get_princs_2(&arg, handle->clnt);
-    if(r == NULL)
+    memset(&r, 0, sizeof(gprincs_ret));
+    s = get_princs_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         eret();
-    if(r->code == 0) {
-        *count = r->count;
-        *princs = r->princs;
+    if (r.code == 0) {
+        *count = r.count;
+        *princs = r.princs;
     } else {
         *count = 0;
         *princs = NULL;
     }
 
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
@@ -218,7 +226,8 @@ kadm5_rename_principal(void *server_handle,
                        krb5_principal source, krb5_principal dest)
 {
     rprinc_arg          arg;
-    generic_ret         *r;
+    generic_ret         r = { 0, 0 };
+    enum clnt_stat      s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
@@ -228,10 +237,10 @@ kadm5_rename_principal(void *server_handle,
     arg.api_version = handle->api_version;
     if (source == NULL || dest == NULL)
         return EINVAL;
-    r = rename_principal_2(&arg, handle->clnt);
-    if(r == NULL)
+    s = rename_principal_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         eret();
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
@@ -239,7 +248,8 @@ kadm5_chpass_principal(void *server_handle,
                        krb5_principal princ, char *password)
 {
     chpass_arg          arg;
-    generic_ret         *r;
+    generic_ret         r = { 0, 0 };
+    enum clnt_stat      s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
@@ -250,10 +260,10 @@ kadm5_chpass_principal(void *server_handle,
 
     if(princ == NULL)
         return EINVAL;
-    r = chpass_principal_2(&arg, handle->clnt);
-    if(r == NULL)
+    s = chpass_principal_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         eret();
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
@@ -263,7 +273,8 @@ kadm5_chpass_principal_3(void *server_handle,
                          char *password)
 {
     chpass3_arg         arg;
-    generic_ret         *r;
+    generic_ret         r = { 0, 0 };
+    enum clnt_stat      s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
@@ -277,10 +288,10 @@ kadm5_chpass_principal_3(void *server_handle,
 
     if(princ == NULL)
         return EINVAL;
-    r = chpass_principal3_2(&arg, handle->clnt);
-    if(r == NULL)
+    s = chpass_principal3_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         eret();
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
@@ -289,7 +300,8 @@ kadm5_setv4key_principal(void *server_handle,
                          krb5_keyblock *keyblock)
 {
     setv4key_arg        arg;
-    generic_ret         *r;
+    generic_ret         r = { 0, 0 };
+    enum clnt_stat      s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
@@ -300,10 +312,10 @@ kadm5_setv4key_principal(void *server_handle,
 
     if(princ == NULL || keyblock == NULL)
         return EINVAL;
-    r = setv4key_principal_2(&arg, handle->clnt);
-    if(r == NULL)
+    s = setv4key_principal_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         eret();
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
@@ -313,7 +325,8 @@ kadm5_setkey_principal(void *server_handle,
                        int n_keys)
 {
     setkey_arg          arg;
-    generic_ret         *r;
+    generic_ret         r = { 0, 0 };
+    enum clnt_stat      s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
@@ -325,10 +338,10 @@ kadm5_setkey_principal(void *server_handle,
 
     if(princ == NULL || keyblocks == NULL)
         return EINVAL;
-    r = setkey_principal_2(&arg, handle->clnt);
-    if(r == NULL)
+    s = setkey_principal_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         eret();
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
@@ -340,7 +353,8 @@ kadm5_setkey_principal_3(void *server_handle,
                          int n_keys)
 {
     setkey3_arg         arg;
-    generic_ret         *r;
+    generic_ret         r = { 0, 0 };
+    enum clnt_stat      s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
@@ -355,10 +369,10 @@ kadm5_setkey_principal_3(void *server_handle,
 
     if(princ == NULL || keyblocks == NULL)
         return EINVAL;
-    r = setkey_principal3_2(&arg, handle->clnt);
-    if(r == NULL)
+    s = setkey_principal3_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         eret();
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
@@ -369,7 +383,8 @@ kadm5_setkey_principal_4(void *server_handle,
                          int n_key_data)
 {
     setkey4_arg         arg;
-    generic_ret         *r;
+    generic_ret         r = { 0, 0 };
+    enum clnt_stat      s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
@@ -382,10 +397,10 @@ kadm5_setkey_principal_4(void *server_handle,
 
     if (princ == NULL || key_data == NULL || n_key_data == 0)
         return EINVAL;
-    r = setkey_principal4_2(&arg, handle->clnt);
-    if (r == NULL)
+    s = setkey_principal4_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         eret();
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
@@ -396,43 +411,37 @@ kadm5_randkey_principal_3(void *server_handle,
                           krb5_keyblock **key, int *n_keys)
 {
     chrand3_arg         arg;
-    chrand_ret          *r;
+    chrand_ret          r;
+    enum clnt_stat      s;
     kadm5_server_handle_t handle = server_handle;
-    int                 i, ret;
+    int                 i;
 
     CHECK_HANDLE(server_handle);
+
+    if (princ == NULL)
+        return EINVAL;
 
     arg.princ = princ;
     arg.api_version = handle->api_version;
     arg.keepold = keepold;
     arg.n_ks_tuple = n_ks_tuple;
     arg.ks_tuple = ks_tuple;
+    memset(&r, 0, sizeof(chrand_ret));
 
-    if(princ == NULL)
-        return EINVAL;
-    r = chrand_principal3_2(&arg, handle->clnt);
-    if(r == NULL)
+    s = chrand_principal3_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         eret();
     if (n_keys)
-        *n_keys = r->n_keys;
+        *n_keys = r.n_keys;
     if (key) {
-        if(r->n_keys) {
-            *key = malloc(r->n_keys * sizeof(krb5_keyblock));
-            if (*key == NULL)
-                return ENOMEM;
-            for (i = 0; i < r->n_keys; i++) {
-                ret = krb5_copy_keyblock_contents(handle->context, &r->keys[i],
-                                                  &(*key)[i]);
-                if (ret) {
-                    free(*key);
-                    return ENOMEM;
-                }
-            }
-        } else
-            *key = NULL;
+        *key = r.keys;
+    } else {
+        for (i = 0; i < r.n_keys; i++) {
+            krb5_free_keyblock_contents(handle->context, &r.keys[i]);
+        }
+        free(r.keys);
     }
-
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
@@ -441,40 +450,34 @@ kadm5_randkey_principal(void *server_handle,
                         krb5_keyblock **key, int *n_keys)
 {
     chrand_arg          arg;
-    chrand_ret          *r;
+    chrand_ret          r;
+    enum clnt_stat      s;
     kadm5_server_handle_t handle = server_handle;
-    int                 i, ret;
+    int                 i;
 
     CHECK_HANDLE(server_handle);
 
+    if (princ == NULL)
+        return EINVAL;
+
     arg.princ = princ;
     arg.api_version = handle->api_version;
+    memset(&r, 0, sizeof(chrand_ret));
 
-    if(princ == NULL)
-        return EINVAL;
-    r = chrand_principal_2(&arg, handle->clnt);
-    if(r == NULL)
+    s = chrand_principal_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         eret();
     if (n_keys)
-        *n_keys = r->n_keys;
+        *n_keys = r.n_keys;
     if (key) {
-        if(r->n_keys) {
-            *key = malloc(r->n_keys * sizeof(krb5_keyblock));
-            if (*key == NULL)
-                return ENOMEM;
-            for (i = 0; i < r->n_keys; i++) {
-                ret = krb5_copy_keyblock_contents(handle->context, &r->keys[i],
-                                                  &(*key)[i]);
-                if (ret) {
-                    free(*key);
-                    return ENOMEM;
-                }
-            }
-        } else
-            *key = NULL;
+        *key = r.keys;
+    } else {
+        for (i = 0; i < r.n_keys; i++) {
+            krb5_free_keyblock_contents(handle->context, &r.keys[i]);
+        }
+        free(r.keys);
     }
-
-    return r->code;
+    return r.code;
 }
 
 /* not supported on client side */
@@ -493,7 +496,8 @@ kadm5_purgekeys(void *server_handle,
                 int keepkvno)
 {
     purgekeys_arg       arg;
-    generic_ret         *r;
+    generic_ret         r = { 0, 0 };
+    enum clnt_stat      s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
@@ -504,10 +508,10 @@ kadm5_purgekeys(void *server_handle,
 
     if (princ == NULL)
         return EINVAL;
-    r = purgekeys_2(&arg, handle->clnt);
-    if(r == NULL)
+    s = purgekeys_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         eret();
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
@@ -515,7 +519,8 @@ kadm5_get_strings(void *server_handle, krb5_principal principal,
                   krb5_string_attr **strings_out, int *count_out)
 {
     gstrings_arg arg;
-    gstrings_ret *r;
+    gstrings_ret r;
+    enum clnt_stat s;
     kadm5_server_handle_t handle = server_handle;
 
     *strings_out = NULL;
@@ -526,14 +531,15 @@ kadm5_get_strings(void *server_handle, krb5_principal principal,
 
     arg.princ = principal;
     arg.api_version = handle->api_version;
-    r = get_strings_2(&arg, handle->clnt);
-    if (r == NULL)
+    memset(&r, 0, sizeof(gstrings_ret));
+    s = get_strings_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         eret();
-    if (r->code == 0) {
-        *strings_out = r->strings;
-        *count_out = r->count;
+    if (r.code == 0) {
+        *strings_out = r.strings;
+        *count_out = r.count;
     }
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
@@ -541,7 +547,8 @@ kadm5_set_string(void *server_handle, krb5_principal principal,
                  const char *key, const char *value)
 {
     sstring_arg arg;
-    generic_ret *r;
+    generic_ret r = { 0, 0 };
+    enum clnt_stat s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
@@ -552,10 +559,10 @@ kadm5_set_string(void *server_handle, krb5_principal principal,
     arg.key = (char *)key;
     arg.value = (char *)value;
     arg.api_version = handle->api_version;
-    r = set_string_2(&arg, handle->clnt);
-    if (r == NULL)
+    s = set_string_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         eret();
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
@@ -564,23 +571,27 @@ kadm5_get_principal_keys(void *server_handle, krb5_principal princ,
                          int *n_key_data)
 {
     getpkeys_arg        arg;
-    getpkeys_ret        *r;
+    getpkeys_ret        r;
+    enum clnt_stat      s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
 
+    if (princ == NULL || key_data == NULL || n_key_data == 0)
+        return EINVAL;
+
     arg.api_version = handle->api_version;
     arg.princ = princ;
     arg.kvno = kvno;
+    memset(&r, 0, sizeof(getpkeys_ret));
 
-    if (princ == NULL || key_data == NULL || n_key_data == 0)
-        return EINVAL;
-    r = get_principal_keys_2(&arg, handle->clnt);
-    if (r == NULL)
+    s = get_principal_keys_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         eret();
-    if (r->code == 0) {
-        *key_data = r->key_data;
-        *n_key_data = r->n_key_data;
+
+    if (r.code == 0) {
+        *key_data = r.key_data;
+        *n_key_data = r.n_key_data;
     }
-    return r->code;
+    return r.code;
 }

--- a/src/lib/kadm5/clnt/client_rpc.c
+++ b/src/lib/kadm5/clnt/client_rpc.c
@@ -9,395 +9,213 @@
 #include <memory.h>
 #endif
 
-/* Default timeout can be changed using clnt_control() */
+/* Default timeout can be changed using clnt_control()*/
 static struct timeval TIMEOUT = { 25, 0 };
 
-generic_ret *
-create_principal_2(cprinc_arg *argp, CLIENT *clnt)
+enum clnt_stat
+create_principal_2(cprinc_arg *argp, generic_ret *res, CLIENT *clnt)
 {
-	static generic_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, CREATE_PRINCIPAL,
-		      (xdrproc_t) xdr_cprinc_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_generic_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, CREATE_PRINCIPAL,
+			 (xdrproc_t)xdr_cprinc_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
 }
 
-generic_ret *
-create_principal3_2(cprinc3_arg *argp, CLIENT *clnt)
+enum clnt_stat
+create_principal3_2(cprinc3_arg *argp, generic_ret *res, CLIENT *clnt)
 {
-	static generic_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, CREATE_PRINCIPAL3,
-		      (xdrproc_t) xdr_cprinc3_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_generic_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, CREATE_PRINCIPAL3,
+			 (xdrproc_t)xdr_cprinc3_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
 }
 
-generic_ret *
-delete_principal_2(dprinc_arg *argp, CLIENT *clnt)
+enum clnt_stat
+delete_principal_2(dprinc_arg *argp, generic_ret *res, CLIENT *clnt)
 {
-	static generic_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, DELETE_PRINCIPAL,
-		      (xdrproc_t) xdr_dprinc_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_generic_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, DELETE_PRINCIPAL,
+			 (xdrproc_t)xdr_dprinc_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
 }
 
-generic_ret *
-modify_principal_2(mprinc_arg *argp, CLIENT *clnt)
+enum clnt_stat
+modify_principal_2(mprinc_arg *argp, generic_ret *res, CLIENT *clnt)
 {
-	static generic_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, MODIFY_PRINCIPAL,
-		      (xdrproc_t) xdr_mprinc_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_generic_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, MODIFY_PRINCIPAL,
+			 (xdrproc_t)xdr_mprinc_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
 }
 
-generic_ret *
-rename_principal_2(rprinc_arg *argp, CLIENT *clnt)
+enum clnt_stat
+rename_principal_2(rprinc_arg *argp, generic_ret *res, CLIENT *clnt)
 {
-	static generic_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, RENAME_PRINCIPAL,
-		      (xdrproc_t) xdr_rprinc_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_generic_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, RENAME_PRINCIPAL,
+			 (xdrproc_t)xdr_rprinc_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
 }
 
-gprinc_ret *
-get_principal_2(gprinc_arg *argp, CLIENT *clnt)
+enum clnt_stat
+get_principal_2(gprinc_arg *argp, gprinc_ret *res, CLIENT *clnt)
 {
-	static gprinc_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, GET_PRINCIPAL,
-		      (xdrproc_t) xdr_gprinc_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_gprinc_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, GET_PRINCIPAL,
+			 (xdrproc_t)xdr_gprinc_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_gprinc_ret, (caddr_t)res, TIMEOUT);
 }
 
-gprincs_ret *
-get_princs_2(gprincs_arg *argp, CLIENT *clnt)
+enum clnt_stat
+get_princs_2(gprincs_arg *argp, gprincs_ret *res, CLIENT *clnt)
 {
-	static gprincs_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, GET_PRINCS,
-		      (xdrproc_t) xdr_gprincs_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_gprincs_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-	     return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, GET_PRINCS,
+			 (xdrproc_t)xdr_gprincs_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_gprincs_ret, (caddr_t)res, TIMEOUT);
 }
 
-generic_ret *
-chpass_principal_2(chpass_arg *argp, CLIENT *clnt)
+enum clnt_stat
+chpass_principal_2(chpass_arg *argp, generic_ret *res, CLIENT *clnt)
 {
-	static generic_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, CHPASS_PRINCIPAL,
-		      (xdrproc_t) xdr_chpass_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_generic_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, CHPASS_PRINCIPAL,
+			 (xdrproc_t)xdr_chpass_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
 }
 
-generic_ret *
-chpass_principal3_2(chpass3_arg *argp, CLIENT *clnt)
+enum clnt_stat
+chpass_principal3_2(chpass3_arg *argp, generic_ret *res, CLIENT *clnt)
 {
-	static generic_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, CHPASS_PRINCIPAL3,
-		      (xdrproc_t) xdr_chpass3_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_generic_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, CHPASS_PRINCIPAL3,
+			 (xdrproc_t)xdr_chpass3_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
 }
 
-generic_ret *
-setv4key_principal_2(setv4key_arg *argp, CLIENT *clnt)
+enum clnt_stat
+setv4key_principal_2(setv4key_arg *argp, generic_ret *res, CLIENT *clnt)
 {
-	static generic_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, SETV4KEY_PRINCIPAL,
-		      (xdrproc_t) xdr_setv4key_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_generic_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, SETV4KEY_PRINCIPAL,
+			 (xdrproc_t)xdr_setv4key_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
 }
 
-generic_ret *
-setkey_principal_2(setkey_arg *argp, CLIENT *clnt)
+enum clnt_stat
+setkey_principal_2(setkey_arg *argp, generic_ret *res, CLIENT *clnt)
 {
-	static generic_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, SETKEY_PRINCIPAL,
-		      (xdrproc_t) xdr_setkey_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_generic_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, SETKEY_PRINCIPAL,
+			 (xdrproc_t)xdr_setkey_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
 }
 
-generic_ret *
-setkey_principal3_2(setkey3_arg *argp, CLIENT *clnt)
+enum clnt_stat
+setkey_principal3_2(setkey3_arg *argp, generic_ret *res, CLIENT *clnt)
 {
-	static generic_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, SETKEY_PRINCIPAL3,
-		      (xdrproc_t) xdr_setkey3_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_generic_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, SETKEY_PRINCIPAL3,
+			 (xdrproc_t)xdr_setkey3_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
 }
 
-generic_ret *
-setkey_principal4_2(setkey4_arg *argp, CLIENT *clnt)
+enum clnt_stat
+setkey_principal4_2(setkey4_arg *argp, generic_ret *res, CLIENT *clnt)
 {
-	static generic_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, SETKEY_PRINCIPAL4,
-		      (xdrproc_t)xdr_setkey4_arg, (caddr_t)argp,
-		      (xdrproc_t)xdr_generic_ret, (caddr_t)&clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return NULL;
-	}
-	return &clnt_res;
+	return clnt_call(clnt, SETKEY_PRINCIPAL4,
+			 (xdrproc_t)xdr_setkey4_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
 }
 
-chrand_ret *
-chrand_principal_2(chrand_arg *argp, CLIENT *clnt)
+enum clnt_stat
+chrand_principal_2(chrand_arg *argp, chrand_ret *res, CLIENT *clnt)
 {
-	static chrand_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, CHRAND_PRINCIPAL,
-		      (xdrproc_t) xdr_chrand_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_chrand_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, CHRAND_PRINCIPAL,
+			 (xdrproc_t)xdr_chrand_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_chrand_ret, (caddr_t)res, TIMEOUT);
 }
 
-chrand_ret *
-chrand_principal3_2(chrand3_arg *argp, CLIENT *clnt)
+enum clnt_stat
+chrand_principal3_2(chrand3_arg *argp, chrand_ret *res, CLIENT *clnt)
 {
-	static chrand_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, CHRAND_PRINCIPAL3,
-		      (xdrproc_t) xdr_chrand3_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_chrand_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, CHRAND_PRINCIPAL3,
+			 (xdrproc_t)xdr_chrand3_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_chrand_ret, (caddr_t)res, TIMEOUT);
 }
 
-generic_ret *
-create_policy_2(cpol_arg *argp, CLIENT *clnt)
+enum clnt_stat
+create_policy_2(cpol_arg *argp, generic_ret *res, CLIENT *clnt)
 {
-	static generic_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, CREATE_POLICY,
-		      (xdrproc_t) xdr_cpol_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_generic_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, CREATE_POLICY,
+			 (xdrproc_t)xdr_cpol_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
 }
 
-generic_ret *
-delete_policy_2(dpol_arg *argp, CLIENT *clnt)
+enum clnt_stat
+delete_policy_2(dpol_arg *argp, generic_ret *res, CLIENT *clnt)
 {
-	static generic_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, DELETE_POLICY,
-		      (xdrproc_t) xdr_dpol_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_generic_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, DELETE_POLICY,
+			 (xdrproc_t)xdr_dpol_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
 }
 
-generic_ret *
-modify_policy_2(mpol_arg *argp, CLIENT *clnt)
+enum clnt_stat
+modify_policy_2(mpol_arg *argp, generic_ret *res, CLIENT *clnt)
 {
-	static generic_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, MODIFY_POLICY,
-		      (xdrproc_t) xdr_mpol_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_generic_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, MODIFY_POLICY,
+			 (xdrproc_t)xdr_mpol_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
 }
 
-gpol_ret *
-get_policy_2(gpol_arg *argp, CLIENT *clnt)
+enum clnt_stat
+get_policy_2(gpol_arg *argp, gpol_ret *res, CLIENT *clnt)
 {
-	static gpol_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, GET_POLICY,
-		      (xdrproc_t) xdr_gpol_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_gpol_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-		return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, GET_POLICY,
+			 (xdrproc_t)xdr_gpol_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_gpol_ret, (caddr_t)res, TIMEOUT);
 }
 
-gpols_ret *
-get_pols_2(gpols_arg *argp, CLIENT *clnt)
+enum clnt_stat
+get_pols_2(gpols_arg *argp, gpols_ret *res, CLIENT *clnt)
 {
-	static gpols_ret clnt_res;
-
-	memset(&clnt_res, 0, sizeof(clnt_res));
-	if (clnt_call(clnt, GET_POLS,
-		      (xdrproc_t) xdr_gpols_arg, (caddr_t) argp,
-		      (xdrproc_t) xdr_gpols_ret, (caddr_t) &clnt_res,
-		      TIMEOUT) != RPC_SUCCESS) {
-	     return (NULL);
-	}
-	return (&clnt_res);
+	return clnt_call(clnt, GET_POLS,
+			 (xdrproc_t)xdr_gpols_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_gpols_ret, (caddr_t)res, TIMEOUT);
 }
 
-getprivs_ret *
-get_privs_2(void *argp, CLIENT *clnt)
+enum clnt_stat
+get_privs_2(void *argp, getprivs_ret *res, CLIENT *clnt)
 {
-     static getprivs_ret clnt_res;
-
-     memset(&clnt_res, 0, sizeof(clnt_res));
-     if (clnt_call(clnt, GET_PRIVS,
-		   (xdrproc_t) xdr_u_int32, (caddr_t) argp,
-		   (xdrproc_t) xdr_getprivs_ret, (caddr_t) &clnt_res,
-		   TIMEOUT) != RPC_SUCCESS) {
-	  return (NULL);
-     }
-     return (&clnt_res);
+	return clnt_call(clnt, GET_PRIVS,
+			 (xdrproc_t)xdr_u_int32, (caddr_t)argp,
+			 (xdrproc_t)xdr_getprivs_ret, (caddr_t)res, TIMEOUT);
 }
 
-generic_ret *
-init_2(void *argp, CLIENT *clnt)
+enum clnt_stat
+init_2(void *argp, generic_ret *res, CLIENT *clnt)
 {
-     static generic_ret clnt_res;
-
-     memset(&clnt_res, 0, sizeof(clnt_res));
-     if (clnt_call(clnt, INIT,
-		   (xdrproc_t) xdr_u_int32, (caddr_t) argp,
-		   (xdrproc_t) xdr_generic_ret, (caddr_t) &clnt_res,
-		   TIMEOUT) != RPC_SUCCESS) {
-	  return (NULL);
-     }
-     return (&clnt_res);
+	return clnt_call(clnt, INIT,
+			 (xdrproc_t)xdr_u_int32, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
 }
 
-generic_ret *
-purgekeys_2(purgekeys_arg *argp, CLIENT *clnt)
+enum clnt_stat
+purgekeys_2(purgekeys_arg *argp, generic_ret *res, CLIENT *clnt)
 {
-     static generic_ret clnt_res;
-
-     memset(&clnt_res, 0, sizeof(clnt_res));
-     if (clnt_call(clnt, PURGEKEYS,
-		   (xdrproc_t) xdr_purgekeys_arg, (caddr_t) argp,
-		   (xdrproc_t) xdr_generic_ret, (caddr_t) &clnt_res,
-		   TIMEOUT) != RPC_SUCCESS) {
-	  return (NULL);
-     }
-     return (&clnt_res);
+	return clnt_call(clnt, PURGEKEYS,
+			 (xdrproc_t)xdr_purgekeys_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
 }
 
-gstrings_ret *
-get_strings_2(gstrings_arg *argp, CLIENT *clnt)
+enum clnt_stat
+get_strings_2(gstrings_arg *argp, gstrings_ret *res, CLIENT *clnt)
 {
-     static gstrings_ret clnt_res;
-
-     memset(&clnt_res, 0, sizeof(clnt_res));
-     if (clnt_call(clnt, GET_STRINGS,
-		   (xdrproc_t) xdr_gstrings_arg, (caddr_t) argp,
-		   (xdrproc_t) xdr_gstrings_ret, (caddr_t) &clnt_res,
-		   TIMEOUT) != RPC_SUCCESS) {
-	  return (NULL);
-     }
-     return (&clnt_res);
+	return clnt_call(clnt, GET_STRINGS,
+			 (xdrproc_t)xdr_gstrings_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_gstrings_ret, (caddr_t)res, TIMEOUT);
 }
 
-generic_ret *
-set_string_2(sstring_arg *argp, CLIENT *clnt)
+enum clnt_stat
+set_string_2(sstring_arg *argp, generic_ret *res, CLIENT *clnt)
 {
-     static generic_ret clnt_res;
-
-     memset(&clnt_res, 0, sizeof(clnt_res));
-     if (clnt_call(clnt, SET_STRING,
-		   (xdrproc_t) xdr_sstring_arg, (caddr_t) argp,
-		   (xdrproc_t) xdr_generic_ret, (caddr_t) &clnt_res,
-		   TIMEOUT) != RPC_SUCCESS) {
-	  return (NULL);
-     }
-     return (&clnt_res);
+	return clnt_call(clnt, SET_STRING,
+			 (xdrproc_t)xdr_sstring_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
 }
 
-getpkeys_ret *
-get_principal_keys_2(getpkeys_arg *argp, CLIENT *clnt)
+enum clnt_stat
+get_principal_keys_2(getpkeys_arg *argp, getpkeys_ret *res, CLIENT *clnt)
 {
-     static getpkeys_ret clnt_res;
-
-     memset(&clnt_res, 0, sizeof(clnt_res));
-     if (clnt_call(clnt, EXTRACT_KEYS,
-		   (xdrproc_t)xdr_getpkeys_arg, (caddr_t)argp,
-		   (xdrproc_t)xdr_getpkeys_ret, (caddr_t)&clnt_res,
-		   TIMEOUT) != RPC_SUCCESS) {
-	  return NULL;
-     }
-     return &clnt_res;
+	return clnt_call(clnt, EXTRACT_KEYS,
+			 (xdrproc_t)xdr_getpkeys_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_getpkeys_ret, (caddr_t)res, TIMEOUT);
 }

--- a/src/lib/kadm5/clnt/clnt_policy.c
+++ b/src/lib/kadm5/clnt/clnt_policy.c
@@ -18,7 +18,8 @@ kadm5_create_policy(void *server_handle,
                     kadm5_policy_ent_t policy, long mask)
 {
     cpol_arg            arg;
-    generic_ret         *r;
+    generic_ret         r = { 0, 0 };
+    enum clnt_stat      s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
@@ -29,18 +30,18 @@ kadm5_create_policy(void *server_handle,
     arg.mask = mask;
     arg.api_version = handle->api_version;
     memcpy(&arg.rec, policy, sizeof(kadm5_policy_ent_rec));
-    r = create_policy_2(&arg, handle->clnt);
-    if(r == NULL)
+    s = create_policy_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         return KADM5_RPC_ERROR;
-
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
 kadm5_delete_policy(void *server_handle, char *name)
 {
     dpol_arg            arg;
-    generic_ret         *r;
+    generic_ret         r = { 0, 0 };
+    enum clnt_stat      s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
@@ -51,11 +52,10 @@ kadm5_delete_policy(void *server_handle, char *name)
     arg.name = name;
     arg.api_version = handle->api_version;
 
-    r = delete_policy_2(&arg, handle->clnt);
-    if(r == NULL)
+    s = delete_policy_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         return KADM5_RPC_ERROR;
-
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
@@ -63,7 +63,8 @@ kadm5_modify_policy(void *server_handle,
                     kadm5_policy_ent_t policy, long mask)
 {
     mpol_arg            arg;
-    generic_ret         *r;
+    generic_ret         r = { 0, 0 };
+    enum clnt_stat      s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
@@ -75,18 +76,18 @@ kadm5_modify_policy(void *server_handle,
     arg.api_version = handle->api_version;
 
     memcpy(&arg.rec, policy, sizeof(kadm5_policy_ent_rec));
-    r = modify_policy_2(&arg, handle->clnt);
-    if(r == NULL)
+    s = modify_policy_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         return KADM5_RPC_ERROR;
-
-    return r->code;
+    return r.code;
 }
 
 kadm5_ret_t
 kadm5_get_policy(void *server_handle, char *name, kadm5_policy_ent_t ent)
 {
     gpol_arg        arg;
-    gpol_ret        *r;
+    gpol_ret        r;
+    enum clnt_stat  s;
     kadm5_server_handle_t handle = server_handle;
 
     memset(ent, 0, sizeof(*ent));
@@ -99,13 +100,14 @@ kadm5_get_policy(void *server_handle, char *name, kadm5_policy_ent_t ent)
     if(name == NULL)
         return EINVAL;
 
-    r = get_policy_2(&arg, handle->clnt);
-    if(r == NULL)
-        return KADM5_RPC_ERROR;
-    if (r->code == 0)
-        memcpy(ent, &r->rec, sizeof(r->rec));
+    memset(&r, 0, sizeof(gpol_ret));
 
-    return r->code;
+    s = get_policy_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
+        return KADM5_RPC_ERROR;
+    if (r.code == 0)
+        memcpy(ent, &r.rec, sizeof(r.rec));
+    return r.code;
 }
 
 kadm5_ret_t
@@ -113,25 +115,29 @@ kadm5_get_policies(void *server_handle,
                    char *exp, char ***pols, int *count)
 {
     gpols_arg   arg;
-    gpols_ret   *r;
+    gpols_ret   r;
+    enum clnt_stat s;
     kadm5_server_handle_t handle = server_handle;
 
     CHECK_HANDLE(server_handle);
 
     if(pols == NULL || count == NULL)
         return EINVAL;
+
     arg.exp = exp;
     arg.api_version = handle->api_version;
-    r = get_pols_2(&arg, handle->clnt);
-    if(r == NULL)
+    memset(&r, 0, sizeof(gpols_ret));
+
+    s = get_pols_2(&arg, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
         return KADM5_RPC_ERROR;
-    if(r->code == 0) {
-        *count = r->count;
-        *pols = r->pols;
+    if (r.code == 0) {
+        *count = r.count;
+        *pols = r.pols;
     } else {
         *count = 0;
         *pols = NULL;
     }
 
-    return r->code;
+    return r.code;
 }

--- a/src/lib/kadm5/clnt/clnt_privs.c
+++ b/src/lib/kadm5/clnt/clnt_privs.c
@@ -11,17 +11,21 @@
 #include    <kadm5/admin.h>
 #include    <kadm5/kadm_rpc.h>
 #include    "client_internal.h"
+#include    <string.h>
 
 kadm5_ret_t kadm5_get_privs(void *server_handle, long *privs)
 {
-    getprivs_ret *r;
+    getprivs_ret r;
+    enum clnt_stat s;
     kadm5_server_handle_t handle = server_handle;
 
-    r = get_privs_2(&handle->api_version, handle->clnt);
-    if (r == NULL)
-        return KADM5_RPC_ERROR;
-    else if (r->code == KADM5_OK)
-        *privs = r->privs;
+    memset(&r, 0, sizeof(getprivs_ret));
 
-    return r->code;
+    s = get_privs_2(&handle->api_version, &r, handle->clnt);
+    if (s != RPC_SUCCESS)
+        return KADM5_RPC_ERROR;
+    else if (r.code == KADM5_OK)
+        *privs = r.privs;
+
+    return r.code;
 }

--- a/src/lib/kadm5/kadm_rpc.h
+++ b/src/lib/kadm5/kadm_rpc.h
@@ -256,83 +256,98 @@ typedef struct getpkeys_ret getpkeys_ret;
 #define KADM 2112
 #define KADMVERS 2
 #define CREATE_PRINCIPAL 1
-extern  generic_ret * create_principal_2(cprinc_arg *, CLIENT *);
+extern  enum clnt_stat create_principal_2(cprinc_arg *, generic_ret *,
+					  CLIENT *);
 extern  generic_ret * create_principal_2_svc(cprinc_arg *, struct svc_req *);
 #define DELETE_PRINCIPAL 2
-extern  generic_ret * delete_principal_2(dprinc_arg *, CLIENT *);
+extern  enum clnt_stat delete_principal_2(dprinc_arg *, generic_ret *,
+					  CLIENT *);
 extern  generic_ret * delete_principal_2_svc(dprinc_arg *, struct svc_req *);
 #define MODIFY_PRINCIPAL 3
-extern  generic_ret * modify_principal_2(mprinc_arg *, CLIENT *);
+extern  enum clnt_stat modify_principal_2(mprinc_arg *, generic_ret *,
+					  CLIENT *);
 extern  generic_ret * modify_principal_2_svc(mprinc_arg *, struct svc_req *);
 #define RENAME_PRINCIPAL 4
-extern  generic_ret * rename_principal_2(rprinc_arg *, CLIENT *);
+extern  enum clnt_stat rename_principal_2(rprinc_arg *, generic_ret *,
+					  CLIENT *);
 extern  generic_ret * rename_principal_2_svc(rprinc_arg *, struct svc_req *);
 #define GET_PRINCIPAL 5
-extern  gprinc_ret * get_principal_2(gprinc_arg *, CLIENT *);
+extern  enum clnt_stat get_principal_2(gprinc_arg *, gprinc_ret *, CLIENT *);
 extern  gprinc_ret * get_principal_2_svc(gprinc_arg *, struct svc_req *);
 #define CHPASS_PRINCIPAL 6
-extern  generic_ret * chpass_principal_2(chpass_arg *, CLIENT *);
+extern  enum clnt_stat chpass_principal_2(chpass_arg *, generic_ret *,
+					  CLIENT *);
 extern  generic_ret * chpass_principal_2_svc(chpass_arg *, struct svc_req *);
 #define CHRAND_PRINCIPAL 7
-extern  chrand_ret * chrand_principal_2(chrand_arg *, CLIENT *);
+extern  enum clnt_stat chrand_principal_2(chrand_arg *, chrand_ret *,
+					  CLIENT *);
 extern  chrand_ret * chrand_principal_2_svc(chrand_arg *, struct svc_req *);
 #define CREATE_POLICY 8
-extern  generic_ret * create_policy_2(cpol_arg *, CLIENT *);
+extern  enum clnt_stat create_policy_2(cpol_arg *, generic_ret *, CLIENT *);
 extern  generic_ret * create_policy_2_svc(cpol_arg *, struct svc_req *);
 #define DELETE_POLICY 9
-extern  generic_ret * delete_policy_2(dpol_arg *, CLIENT *);
+extern  enum clnt_stat delete_policy_2(dpol_arg *, generic_ret *, CLIENT *);
 extern  generic_ret * delete_policy_2_svc(dpol_arg *, struct svc_req *);
 #define MODIFY_POLICY 10
-extern  generic_ret * modify_policy_2(mpol_arg *, CLIENT *);
+extern  enum clnt_stat modify_policy_2(mpol_arg *, generic_ret *, CLIENT *);
 extern  generic_ret * modify_policy_2_svc(mpol_arg *, struct svc_req *);
 #define GET_POLICY 11
-extern  gpol_ret * get_policy_2(gpol_arg *, CLIENT *);
+extern  enum clnt_stat get_policy_2(gpol_arg *, gpol_ret *, CLIENT *);
 extern  gpol_ret * get_policy_2_svc(gpol_arg *, struct svc_req *);
 #define GET_PRIVS 12
-extern  getprivs_ret * get_privs_2(void *, CLIENT *);
+extern  enum clnt_stat get_privs_2(void *, getprivs_ret *, CLIENT *);
 extern  getprivs_ret * get_privs_2_svc(krb5_ui_4 *, struct svc_req *);
 #define INIT 13
-extern  generic_ret * init_2(void *, CLIENT *);
+extern  enum clnt_stat init_2(void *, generic_ret *, CLIENT *);
 extern  generic_ret * init_2_svc(krb5_ui_4 *, struct svc_req *);
 #define GET_PRINCS 14
-extern  gprincs_ret * get_princs_2(gprincs_arg *, CLIENT *);
+extern  enum clnt_stat get_princs_2(gprincs_arg *, gprincs_ret *, CLIENT *);
 extern  gprincs_ret * get_princs_2_svc(gprincs_arg *, struct svc_req *);
 #define GET_POLS 15
-extern  gpols_ret * get_pols_2(gpols_arg *, CLIENT *);
+extern  enum clnt_stat get_pols_2(gpols_arg *, gpols_ret *, CLIENT *);
 extern  gpols_ret * get_pols_2_svc(gpols_arg *, struct svc_req *);
 #define SETKEY_PRINCIPAL 16
-extern  generic_ret * setkey_principal_2(setkey_arg *, CLIENT *);
+extern  enum clnt_stat setkey_principal_2(setkey_arg *, generic_ret *,
+					  CLIENT *);
 extern  generic_ret * setkey_principal_2_svc(setkey_arg *, struct svc_req *);
 #define SETV4KEY_PRINCIPAL 17
-extern  generic_ret * setv4key_principal_2(setv4key_arg *, CLIENT *);
+extern  enum clnt_stat setv4key_principal_2(setv4key_arg *, generic_ret *,
+					    CLIENT *);
 extern  generic_ret * setv4key_principal_2_svc(setv4key_arg *, struct svc_req *);
 #define CREATE_PRINCIPAL3 18
-extern  generic_ret * create_principal3_2(cprinc3_arg *, CLIENT *);
+extern  enum clnt_stat create_principal3_2(cprinc3_arg *, generic_ret *,
+					   CLIENT *);
 extern  generic_ret * create_principal3_2_svc(cprinc3_arg *, struct svc_req *);
 #define CHPASS_PRINCIPAL3 19
-extern  generic_ret * chpass_principal3_2(chpass3_arg *, CLIENT *);
+extern  enum clnt_stat chpass_principal3_2(chpass3_arg *, generic_ret *,
+					   CLIENT *);
 extern  generic_ret * chpass_principal3_2_svc(chpass3_arg *, struct svc_req *);
 #define CHRAND_PRINCIPAL3 20
-extern  chrand_ret * chrand_principal3_2(chrand3_arg *, CLIENT *);
+extern  enum clnt_stat chrand_principal3_2(chrand3_arg *, chrand_ret *,
+					   CLIENT *);
 extern  chrand_ret * chrand_principal3_2_svc(chrand3_arg *, struct svc_req *);
 #define SETKEY_PRINCIPAL3 21
-extern  generic_ret * setkey_principal3_2(setkey3_arg *, CLIENT *);
+extern  enum clnt_stat setkey_principal3_2(setkey3_arg *, generic_ret *,
+					   CLIENT *);
 extern  generic_ret * setkey_principal3_2_svc(setkey3_arg *, struct svc_req *);
 #define PURGEKEYS 22
-extern  generic_ret * purgekeys_2(purgekeys_arg *, CLIENT *);
+extern  enum clnt_stat purgekeys_2(purgekeys_arg *, generic_ret *, CLIENT *);
 extern  generic_ret * purgekeys_2_svc(purgekeys_arg *, struct svc_req *);
 #define GET_STRINGS 23
-extern  gstrings_ret * get_strings_2(gstrings_arg *, CLIENT *);
+extern  enum clnt_stat get_strings_2(gstrings_arg *, gstrings_ret *, CLIENT *);
 extern  gstrings_ret * get_strings_2_svc(gstrings_arg *, struct svc_req *);
 #define SET_STRING 24
-extern  generic_ret * set_string_2(sstring_arg *, CLIENT *);
+extern  enum clnt_stat set_string_2(sstring_arg *, generic_ret *, CLIENT *);
 extern  generic_ret * set_string_2_svc(sstring_arg *, struct svc_req *);
 #define SETKEY_PRINCIPAL4 25
-extern  generic_ret * setkey_principal4_2(setkey4_arg *, CLIENT *);
+extern  enum clnt_stat setkey_principal4_2(setkey4_arg *, generic_ret *,
+					   CLIENT *);
 extern  generic_ret * setkey_principal4_2_svc(setkey4_arg *, struct svc_req *);
 #define EXTRACT_KEYS 26
-extern  getpkeys_ret * get_principal_keys_2(getpkeys_arg *, CLIENT *);
-extern  getpkeys_ret * get_principal_keys_2_svc(getpkeys_arg *, struct svc_req *);
+extern enum clnt_stat get_principal_keys_2(getpkeys_arg *, getpkeys_ret *,
+					   CLIENT *);
+extern  getpkeys_ret * get_principal_keys_2_svc(getpkeys_arg *,
+						struct svc_req *);
 
 extern bool_t xdr_cprinc_arg ();
 extern bool_t xdr_cprinc3_arg ();

--- a/src/lib/kadm5/kadm_rpc.h
+++ b/src/lib/kadm5/kadm_rpc.h
@@ -258,96 +258,117 @@ typedef struct getpkeys_ret getpkeys_ret;
 #define CREATE_PRINCIPAL 1
 extern  enum clnt_stat create_principal_2(cprinc_arg *, generic_ret *,
 					  CLIENT *);
-extern  generic_ret * create_principal_2_svc(cprinc_arg *, struct svc_req *);
+extern  bool_t create_principal_2_svc(cprinc_arg *, generic_ret *,
+				      struct svc_req *);
 #define DELETE_PRINCIPAL 2
 extern  enum clnt_stat delete_principal_2(dprinc_arg *, generic_ret *,
 					  CLIENT *);
-extern  generic_ret * delete_principal_2_svc(dprinc_arg *, struct svc_req *);
+extern  bool_t delete_principal_2_svc(dprinc_arg *, generic_ret *,
+				      struct svc_req *);
 #define MODIFY_PRINCIPAL 3
 extern  enum clnt_stat modify_principal_2(mprinc_arg *, generic_ret *,
 					  CLIENT *);
-extern  generic_ret * modify_principal_2_svc(mprinc_arg *, struct svc_req *);
+extern  bool_t modify_principal_2_svc(mprinc_arg *, generic_ret *,
+				      struct svc_req *);
 #define RENAME_PRINCIPAL 4
 extern  enum clnt_stat rename_principal_2(rprinc_arg *, generic_ret *,
 					  CLIENT *);
-extern  generic_ret * rename_principal_2_svc(rprinc_arg *, struct svc_req *);
+extern  bool_t rename_principal_2_svc(rprinc_arg *, generic_ret *,
+				      struct svc_req *);
 #define GET_PRINCIPAL 5
 extern  enum clnt_stat get_principal_2(gprinc_arg *, gprinc_ret *, CLIENT *);
-extern  gprinc_ret * get_principal_2_svc(gprinc_arg *, struct svc_req *);
+extern  bool_t get_principal_2_svc(gprinc_arg *, gprinc_ret *,
+				   struct svc_req *);
 #define CHPASS_PRINCIPAL 6
 extern  enum clnt_stat chpass_principal_2(chpass_arg *, generic_ret *,
 					  CLIENT *);
-extern  generic_ret * chpass_principal_2_svc(chpass_arg *, struct svc_req *);
+extern  bool_t chpass_principal_2_svc(chpass_arg *, generic_ret *,
+				      struct svc_req *);
 #define CHRAND_PRINCIPAL 7
 extern  enum clnt_stat chrand_principal_2(chrand_arg *, chrand_ret *,
 					  CLIENT *);
-extern  chrand_ret * chrand_principal_2_svc(chrand_arg *, struct svc_req *);
+extern  bool_t chrand_principal_2_svc(chrand_arg *, chrand_ret *,
+				      struct svc_req *);
 #define CREATE_POLICY 8
 extern  enum clnt_stat create_policy_2(cpol_arg *, generic_ret *, CLIENT *);
-extern  generic_ret * create_policy_2_svc(cpol_arg *, struct svc_req *);
+extern  bool_t create_policy_2_svc(cpol_arg *, generic_ret *,
+				   struct svc_req *);
 #define DELETE_POLICY 9
 extern  enum clnt_stat delete_policy_2(dpol_arg *, generic_ret *, CLIENT *);
-extern  generic_ret * delete_policy_2_svc(dpol_arg *, struct svc_req *);
+extern  bool_t delete_policy_2_svc(dpol_arg *, generic_ret *,
+				   struct svc_req *);
 #define MODIFY_POLICY 10
 extern  enum clnt_stat modify_policy_2(mpol_arg *, generic_ret *, CLIENT *);
-extern  generic_ret * modify_policy_2_svc(mpol_arg *, struct svc_req *);
+extern  bool_t modify_policy_2_svc(mpol_arg *, generic_ret *,
+				   struct svc_req *);
 #define GET_POLICY 11
 extern  enum clnt_stat get_policy_2(gpol_arg *, gpol_ret *, CLIENT *);
-extern  gpol_ret * get_policy_2_svc(gpol_arg *, struct svc_req *);
+extern  bool_t get_policy_2_svc(gpol_arg *, gpol_ret *, struct svc_req *);
 #define GET_PRIVS 12
 extern  enum clnt_stat get_privs_2(void *, getprivs_ret *, CLIENT *);
-extern  getprivs_ret * get_privs_2_svc(krb5_ui_4 *, struct svc_req *);
+extern  bool_t get_privs_2_svc(krb5_ui_4 *, getprivs_ret *, struct svc_req *);
 #define INIT 13
 extern  enum clnt_stat init_2(void *, generic_ret *, CLIENT *);
-extern  generic_ret * init_2_svc(krb5_ui_4 *, struct svc_req *);
+extern  bool_t init_2_svc(krb5_ui_4 *, generic_ret *, struct svc_req *);
 #define GET_PRINCS 14
 extern  enum clnt_stat get_princs_2(gprincs_arg *, gprincs_ret *, CLIENT *);
-extern  gprincs_ret * get_princs_2_svc(gprincs_arg *, struct svc_req *);
+extern  bool_t get_princs_2_svc(gprincs_arg *, gprincs_ret *,
+				struct svc_req *);
 #define GET_POLS 15
 extern  enum clnt_stat get_pols_2(gpols_arg *, gpols_ret *, CLIENT *);
-extern  gpols_ret * get_pols_2_svc(gpols_arg *, struct svc_req *);
+extern  bool_t get_pols_2_svc(gpols_arg *, gpols_ret *, struct svc_req *);
 #define SETKEY_PRINCIPAL 16
 extern  enum clnt_stat setkey_principal_2(setkey_arg *, generic_ret *,
 					  CLIENT *);
-extern  generic_ret * setkey_principal_2_svc(setkey_arg *, struct svc_req *);
+extern  bool_t setkey_principal_2_svc(setkey_arg *, generic_ret *,
+				      struct svc_req *);
 #define SETV4KEY_PRINCIPAL 17
 extern  enum clnt_stat setv4key_principal_2(setv4key_arg *, generic_ret *,
 					    CLIENT *);
-extern  generic_ret * setv4key_principal_2_svc(setv4key_arg *, struct svc_req *);
+extern  bool_t setv4key_principal_2_svc(setv4key_arg *, generic_ret *,
+					struct svc_req *);
 #define CREATE_PRINCIPAL3 18
 extern  enum clnt_stat create_principal3_2(cprinc3_arg *, generic_ret *,
 					   CLIENT *);
-extern  generic_ret * create_principal3_2_svc(cprinc3_arg *, struct svc_req *);
+extern  bool_t create_principal3_2_svc(cprinc3_arg *, generic_ret *,
+				       struct svc_req *);
 #define CHPASS_PRINCIPAL3 19
 extern  enum clnt_stat chpass_principal3_2(chpass3_arg *, generic_ret *,
 					   CLIENT *);
-extern  generic_ret * chpass_principal3_2_svc(chpass3_arg *, struct svc_req *);
+extern  bool_t chpass_principal3_2_svc(chpass3_arg *, generic_ret *,
+				       struct svc_req *);
 #define CHRAND_PRINCIPAL3 20
 extern  enum clnt_stat chrand_principal3_2(chrand3_arg *, chrand_ret *,
 					   CLIENT *);
-extern  chrand_ret * chrand_principal3_2_svc(chrand3_arg *, struct svc_req *);
+extern  bool_t chrand_principal3_2_svc(chrand3_arg *, chrand_ret *,
+				       struct svc_req *);
 #define SETKEY_PRINCIPAL3 21
 extern  enum clnt_stat setkey_principal3_2(setkey3_arg *, generic_ret *,
 					   CLIENT *);
-extern  generic_ret * setkey_principal3_2_svc(setkey3_arg *, struct svc_req *);
+extern  bool_t setkey_principal3_2_svc(setkey3_arg *, generic_ret *,
+				       struct svc_req *);
 #define PURGEKEYS 22
 extern  enum clnt_stat purgekeys_2(purgekeys_arg *, generic_ret *, CLIENT *);
-extern  generic_ret * purgekeys_2_svc(purgekeys_arg *, struct svc_req *);
+extern  bool_t purgekeys_2_svc(purgekeys_arg *, generic_ret *,
+			       struct svc_req *);
 #define GET_STRINGS 23
 extern  enum clnt_stat get_strings_2(gstrings_arg *, gstrings_ret *, CLIENT *);
-extern  gstrings_ret * get_strings_2_svc(gstrings_arg *, struct svc_req *);
+extern  bool_t get_strings_2_svc(gstrings_arg *, gstrings_ret *,
+				 struct svc_req *);
 #define SET_STRING 24
 extern  enum clnt_stat set_string_2(sstring_arg *, generic_ret *, CLIENT *);
-extern  generic_ret * set_string_2_svc(sstring_arg *, struct svc_req *);
+extern  bool_t set_string_2_svc(sstring_arg *, generic_ret *,
+				struct svc_req *);
 #define SETKEY_PRINCIPAL4 25
 extern  enum clnt_stat setkey_principal4_2(setkey4_arg *, generic_ret *,
 					   CLIENT *);
-extern  generic_ret * setkey_principal4_2_svc(setkey4_arg *, struct svc_req *);
+extern  bool_t setkey_principal4_2_svc(setkey4_arg *, generic_ret *,
+				       struct svc_req *);
 #define EXTRACT_KEYS 26
 extern enum clnt_stat get_principal_keys_2(getpkeys_arg *, getpkeys_ret *,
 					   CLIENT *);
-extern  getpkeys_ret * get_principal_keys_2_svc(getpkeys_arg *,
-						struct svc_req *);
+extern  bool_t get_principal_keys_2_svc(getpkeys_arg *, getpkeys_ret *,
+					struct svc_req *);
 
 extern bool_t xdr_cprinc_arg ();
 extern bool_t xdr_cprinc3_arg ();


### PR DESCRIPTION
Also fixes a couple memleaks in the client, and removes a to of duplicated code in the server.

This patchset depends (and incorporates until pushed) on the one in PR #375 