### PR TITLE
Fix Kerberos Constrained Delegation in GSSAPI to re-use TGS

### DIFF
--- a/src/lib/gssapi/krb5/init_sec_context.c
+++ b/src/lib/gssapi/krb5/init_sec_context.c
@@ -139,37 +139,7 @@ static krb5_error_code get_credentials(context, cred, server, now,
 
     assert(cred->name != NULL);
 
-    /*
-     * Do constrained delegation if we have proxy credentials and
-     * we're not trying to get a ticket to ourselves (in which case
-     * we can just use the S4U2Self or evidence ticket directly).
-     */
-    if (cred->impersonator &&
-        !krb5_principal_compare(context, cred->impersonator, server->princ)) {
-        krb5_creds mcreds;
-
-        flags |= KRB5_GC_CANONICALIZE | KRB5_GC_CONSTRAINED_DELEGATION;
-
-        memset(&mcreds, 0, sizeof(mcreds));
-
-        mcreds.magic = KV5M_CREDS;
-        mcreds.server = cred->impersonator;
-        mcreds.client = cred->name->princ;
-
-        code = krb5_cc_retrieve_cred(context, cred->ccache,
-                                     KRB5_TC_MATCH_AUTHDATA, &mcreds,
-                                     &evidence_creds);
-        if (code)
-            goto cleanup;
-
-        assert(evidence_creds.ticket_flags & TKT_FLG_FORWARDABLE);
-
-        in_creds.client = cred->impersonator;
-        in_creds.second_ticket = evidence_creds.ticket;
-    } else {
-        in_creds.client = cred->name->princ;
-    }
-
+    in_creds.client = cred->name->princ;
     in_creds.server = server->princ;
     in_creds.times.endtime = endtime;
     in_creds.authdata = NULL;
@@ -188,12 +158,47 @@ static krb5_error_code get_credentials(context, cred, server, now,
             goto cleanup;
     }
 
+    /* Check for a cached ticket before trying constrained delegation */
+    if (cred->impersonator)
+        flags |= KRB5_GC_CACHED;
+
     /* Don't go out over the network if we used IAKERB */
     if (cred->iakerb_mech)
         flags |= KRB5_GC_CACHED;
 
     code = krb5_get_credentials(context, flags, cred->ccache,
                                 &in_creds, &result_creds);
+
+    /* Try constrained delegation if we have proxy credentials, unless
+     * we are trying to get a ticket to ourselves (in which case we could
+     * just use the evidence ticket directly from cache) */
+    if (code == KRB5_CC_NOTFOUND && cred->impersonator && !cred->iakerb_mech &&
+        !krb5_principal_compare(context, cred->impersonator, server->princ)) {
+        krb5_creds mcreds;
+
+        memset(&mcreds, 0, sizeof(mcreds));
+
+        flags = KRB5_GC_CANONICALIZE | KRB5_GC_CONSTRAINED_DELEGATION;
+
+        mcreds.magic = KV5M_CREDS;
+        mcreds.server = cred->impersonator;
+        mcreds.client = cred->name->princ;
+
+        code = krb5_cc_retrieve_cred(context, cred->ccache,
+                                     KRB5_TC_MATCH_AUTHDATA, &mcreds,
+                                     &evidence_creds);
+        if (code)
+            goto cleanup;
+
+        assert(evidence_creds.ticket_flags & TKT_FLG_FORWARDABLE);
+
+        in_creds.client = cred->impersonator;
+        in_creds.second_ticket = evidence_creds.ticket;
+
+        code = krb5_get_credentials(context, flags, cred->ccache,
+                                    &in_creds, &result_creds);
+    }
+
     if (code)
         goto cleanup;
 

--- a/src/lib/gssapi/krb5/init_sec_context.c
+++ b/src/lib/gssapi/krb5/init_sec_context.c
@@ -118,14 +118,13 @@ int krb5_gss_dbg_client_expcreds = 0;
  * ccache.
  */
 static krb5_error_code get_credentials(context, cred, server, now,
-                                       endtime, out_creds, probe)
+                                       endtime, out_creds)
     krb5_context context;
     krb5_gss_cred_id_t cred;
     krb5_gss_name_t server;
     krb5_timestamp now;
     krb5_timestamp endtime;
     krb5_creds **out_creds;
-    int probe;
 {
     krb5_error_code     code;
     krb5_creds          in_creds, evidence_creds, *result_creds = NULL;
@@ -145,11 +144,7 @@ static krb5_error_code get_credentials(context, cred, server, now,
      * we're not trying to get a ticket to ourselves (in which case
      * we can just use the S4U2Self or evidence ticket directly).
      */
-    if (probe) {
-        flags |= KRB5_GC_CACHED;
-        in_creds.client = cred->name->princ;
-    }
-    else if (cred->impersonator &&
+    if (cred->impersonator &&
         !krb5_principal_compare(context, cred->impersonator, server->princ)) {
         krb5_creds mcreds;
 
@@ -587,18 +582,8 @@ kg_new_connection(
                                   &ctx->there)))
         goto cleanup;
 
-    if (cred->impersonator) {
-        code = get_credentials(context, cred, ctx->there, now,
-                           ctx->krb_times.endtime, &k_cred, 1);
-
-        if (code == KRB5_CC_NOTFOUND)
-            code = get_credentials(context, cred, ctx->there, now,
-                               ctx->krb_times.endtime, &k_cred, 0);
-    }
-    else {
-        code = get_credentials(context, cred, ctx->there, now,
-                           ctx->krb_times.endtime, &k_cred, 0);
-    }
+    code = get_credentials(context, cred, ctx->there, now,
+                           ctx->krb_times.endtime, &k_cred);
     if (code)
         goto cleanup;
 


### PR DESCRIPTION
Currently, if we have impersonator credentials we insist on
getting proxy credentials via TGS exchange, but we might as well
already have cached credentials so we need to check for it first.

Signed-off-by: Isaac Boukris <iboukris@gmail.com>