### PR TITLE
Replace MD5 use in rcache with SHA1

### DIFF
--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -623,6 +623,12 @@ krb5int_arcfour_gsscrypt(const krb5_keyblock *keyblock, krb5_keyusage usage,
                          const krb5_data *kd_data, krb5_crypto_iov *data,
                          size_t num_data);
 
+#define K5_SHA256_HASHLEN (256/8)
+
+/* Write the SHA-256 hash of in to out. */
+krb5_error_code
+k5_sha256(const krb5_data *in, uint8_t out[K5_SHA256_HASHLEN]);
+
 /*
  * Attempt to zero memory in a way that compilers won't optimize out.
  *

--- a/src/lib/crypto/builtin/sha2/sha256.c
+++ b/src/lib/crypto/builtin/sha2/sha256.c
@@ -255,3 +255,14 @@ k5_sha256_final(void *res, SHA256_CTX *m)
 	}
     }
 }
+
+krb5_error_code
+k5_sha256(const krb5_data *in, uint8_t out[K5_SHA256_HASHLEN])
+{
+    SHA256_CTX ctx;
+
+    k5_sha256_init(&ctx);
+    k5_sha256_update(&ctx, in->data, in->length);
+    k5_sha256_final(out, &ctx);
+    return 0;
+}

--- a/src/lib/crypto/krb/crypto_int.h
+++ b/src/lib/crypto/krb/crypto_int.h
@@ -415,6 +415,8 @@ void k5_iov_cursor_put(struct iov_cursor *cursor, unsigned char *block);
 
 /*** Crypto module declarations ***/
 
+/* Modules must implement the k5_sha256() function prototyped in k5-int.h. */
+
 /* Modules must implement the following enc_providers and hash_providers: */
 extern const struct krb5_enc_provider krb5int_enc_des;
 extern const struct krb5_enc_provider krb5int_enc_des3;

--- a/src/lib/crypto/libk5crypto.exports
+++ b/src/lib/crypto/libk5crypto.exports
@@ -97,6 +97,7 @@ krb5int_enc_camellia256
 krb5int_derive_key
 krb5int_aes_enc_blk
 krb5int_aes_enc_key
+k5_sha256
 k5_sha256_final
 k5_sha256_init
 k5_sha256_update

--- a/src/lib/crypto/openssl/Makefile.in
+++ b/src/lib/crypto/openssl/Makefile.in
@@ -7,18 +7,21 @@ STLIBOBJS=\
 	hmac.o	\
 	init.o	\
 	pbkdf2.o \
+	sha256.o \
 	stubs.o
 
 OBJS=\
 	$(OUTPRE)hmac.$(OBJEXT)	\
 	$(OUTPRE)init.$(OBJEXT)	\
 	$(OUTPRE)pbkdf2.$(OBJEXT) \
+	$(OUTPRE)sha256.$(OBJEXT) \
 	$(OUTPRE)stubs.$(OBJEXT)
 
 SRCS=\
 	$(srcdir)/hmac.c	\
 	$(srcdir)/init.c	\
 	$(srcdir)/pbkdf2.c	\
+	$(srcdir)/sha256.c	\
 	$(srcdir)/stubs.c
 
 STOBJLISTS= des/OBJS.ST md4/OBJS.ST 	\

--- a/src/lib/crypto/openssl/sha256.c
+++ b/src/lib/crypto/openssl/sha256.c
@@ -1,0 +1,48 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* lib/crypto/openssl/sha256.c - k5_sha256() implementation */
+/*
+ * Copyright (C) 2016 by the Massachusetts Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "crypto_int.h"
+#include <openssl/evp.h>
+
+krb5_error_code
+k5_sha256(const krb5_data *in, uint8_t out[K5_SHA256_HASHLEN])
+{
+    EVP_MD_CTX ctx;
+    int ok;
+
+    EVP_MD_CTX_init(&ctx);
+    ok = EVP_DigestInit_ex(&ctx, EVP_sha256(), NULL);
+    ok = ok && EVP_DigestUpdate(&ctx, in->data, in->length);
+    ok = ok && EVP_DigestFinal_ex(&ctx, out, NULL);
+    EVP_MD_CTX_cleanup(&ctx);
+    return ok ? 0 : ENOMEM;
+}

--- a/src/lib/krb5/rcache/rc_dfl.c
+++ b/src/lib/krb5/rcache/rc_dfl.c
@@ -386,7 +386,7 @@ parse_counted_string(char **strptr, char **result)
 /*
  * Hash extension records have the format:
  *  client = <empty string>
- *  server = HASH:<msghash> <clientlen>:<client> <serverlen>:<server>
+ *  server = SHA256:<msghash> <clientlen>:<client> <serverlen>:<server>
  * Spaces in the client and server string are represented with
  * with backslashes.  Client and server lengths are represented in
  * ASCII decimal (which is different from the 32-bit binary we use
@@ -403,11 +403,11 @@ check_hash_extension(krb5_donot_replay *rep)
     /* Check if this appears to match the hash extension format. */
     if (*rep->client)
         return 0;
-    if (strncmp(rep->server, "HASH:", 5) != 0)
+    if (strncmp(rep->server, "SHA256:", 7) != 0)
         return 0;
 
     /* Parse out the message hash. */
-    str = rep->server + 5;
+    str = rep->server + 7;
     end = strchr(str, ' ');
     if (!end)
         return 0;
@@ -659,7 +659,7 @@ krb5_rc_io_store(krb5_context context, struct dfl_data *t,
 
         /* Format the extension value so we know its length. */
         k5_buf_init_dynamic(&extbuf);
-        k5_buf_add_fmt(&extbuf, "HASH:%s %lu:%s %lu:%s", rep->msghash,
+        k5_buf_add_fmt(&extbuf, "SHA256:%s %lu:%s %lu:%s", rep->msghash,
                        (unsigned long)clientlen, rep->client,
                        (unsigned long)serverlen, rep->server);
         if (k5_buf_status(&extbuf) != 0)


### PR DESCRIPTION
rcache uses an unkeyed MD5 hash of the authenticator to distinguish
between different request with equal client principal, server principal
and microsecond time. When OpenSSL crypto provider is used and
underlying OpenSSL is run in FIPS mode, MD5 algorithm is disabled and
gss_accept_sec_context() results in an abort in rcache processing.

This change effectively implements a different rcache extension.
The new extension identifier is 'SHA1:' (instead of 'HASH:')
and the checksum type is CKSUMTYPE_NIST_SHA (instead of CKSUMTYPE_RSA_MD5).