### PR TITLE
Check internal context in init_context mechglue call on error.

### DIFF
--- a/src/lib/gssapi/mechglue/g_init_sec_context.c
+++ b/src/lib/gssapi/mechglue/g_init_sec_context.c
@@ -228,8 +228,13 @@ OM_uint32 *		time_rec;
 	 * context info on the first call to init, and on all
 	 * subsequent calls make the caller responsible for
 	 * calling gss_delete_sec_context
+	 * However if the mechanism decided to null the internal context
+	 * we should also null the union context to avoid dereferencing
+	 * a null pointer in other gssapi calls
 	 */
 	map_error(minor_status, mech);
+	if (union_ctx_id->internal_ctx_id == GSS_C_NO_CONTEXT)
+	    *context_handle = GSS_C_NO_CONTEXT;
 	if (*context_handle == GSS_C_NO_CONTEXT) {
 	    free(union_ctx_id->mech_type->elements);
 	    free(union_ctx_id->mech_type);

--- a/src/lib/gssapi/mechglue/g_inq_context.c
+++ b/src/lib/gssapi/mechglue/g_inq_context.c
@@ -104,6 +104,7 @@ gss_inquire_context(
      */
 
     ctx = (gss_union_ctx_id_t) context_handle;
+
     mech = gssint_get_mechanism (ctx->mech_type);
 
     if (!mech || !mech->gss_inquire_context || !mech->gss_display_name ||


### PR DESCRIPTION
Seen crashes in the wild without this check as some code seem to end up
calling gss_inquire_context via the spnego mech before while the internal
context is still NULL.

Signed-off-by: Simo Sorce <simo@redhat.com>