### PR TITLE
Work around uninitialized warning in cc_kcm.c

### DIFF
--- a/src/lib/krb5/ccache/cc_kcm.c
+++ b/src/lib/krb5/ccache/cc_kcm.c
@@ -379,7 +379,7 @@ static krb5_error_code
 kcmio_call(krb5_context context, struct kcmio *io, struct kcmreq *req)
 {
     krb5_error_code ret;
-    size_t reply_len;
+    size_t reply_len = 0;
 
     if (k5_buf_status(&req->reqbuf) != 0)
         return ENOMEM;


### PR DESCRIPTION
Some versions of clang erroneously detect use of an uninitialized
variable reply_len in kcmio_call() when building on non-Mac platforms.
Initialize it to work around this warning.

ticket: 8335 (new)