### PR TITLE
MAXHOSTNAMELEN is too short for some FQDNs

### DIFF
--- a/src/appl/simple/client/sim_client.c
+++ b/src/appl/simple/client/sim_client.c
@@ -67,7 +67,6 @@ main(int argc, char *argv[])
     struct servent *serv;
     struct hostent *host;
     char *cp;
-    char full_hname[MAXHOSTNAMELEN];
 #ifdef BROKEN_STREAMS_SOCKETS
     char my_hostname[MAXHOSTNAMELEN];
 #endif
@@ -145,13 +144,6 @@ main(int argc, char *argv[])
         fprintf(stderr, "%s: unknown host\n", hostname);
         exit(1);
     }
-    strncpy(full_hname, host->h_name, sizeof(full_hname)-1);
-    full_hname[sizeof(full_hname)-1] = '\0';
-
-    /* lower-case to get name for "instance" part of service name */
-    for (cp = full_hname; *cp; cp++)
-        if (isupper((int) *cp))
-            *cp = tolower((int) *cp);
 
     /* Set server's address */
     (void) memset(&s_sock, 0, sizeof(s_sock));
@@ -212,7 +204,7 @@ main(int argc, char *argv[])
         exit(1);
     }
 
-    if ((retval = krb5_mk_req(context, &auth_context, 0, service, full_hname,
+    if ((retval = krb5_mk_req(context, &auth_context, 0, service, hostname,
                               &inbuf, ccdef, &packet))) {
         com_err(progname, retval, "while preparing AP_REQ");
         exit(1);

--- a/src/kadmin/server/ipropd_svc.c
+++ b/src/kadmin/server/ipropd_svc.c
@@ -250,7 +250,7 @@ ipropx_resync(uint32_t vers, struct svc_req *rqstp)
 {
     static kdb_fullresync_result_t ret;
     char *ubuf = 0;
-    char clhost[MAXHOSTNAMELEN] = {0};
+    char clhost[NI_MAXHOST] = {0};
     int pret, fret;
     FILE *p;
     kadm5_server_handle_t handle = global_server_handle;


### PR DESCRIPTION
Testing in Travis CI reveals that sim_client and iprop don't deal well with FQDNs longer than MAXHOSTNAMELEN.