### PR TITLE
Add .travis.yml [KRB-42]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: c
+
+sudo: required
+
+dist: trusty
+
+compiler:
+  - clang
+  - gcc
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y bison dejagnu gettext keyutils ldap-utils libldap2-dev libkeyutils-dev libssl-dev python-cjson python-paste python-pyrad slapd tcl-dev tcsh
+
+script: cd src && autoreconf && ./configure --with-ldap && make && make check


### PR DESCRIPTION
Do Travis CI testing with clang and gcc, on 64-bit Ubuntu Trusty.
Performance would probably be better using the container-based Travis
infrastructure, but that is currently limited to Precise, and we would
need some important apt packages whitelisted, e.g., dejagnu.