### PR TITLE
Make ksu work with prompting clpreauth modules

### DIFF
--- a/src/clients/ksu/krb_auth_su.c
+++ b/src/clients/ksu/krb_auth_su.c
@@ -195,7 +195,8 @@ krb5_boolean ksu_get_tgt_via_passwd(context, client, options, zero_password,
     }
 
     code = krb5_get_init_creds_password(context, &creds, client, password,
-                                        NULL, NULL, 0, NULL, options);
+                                        krb5_prompter_posix, NULL, 0, NULL,
+                                        options);
     memset(password, 0, sizeof(password));
 
 


### PR DESCRIPTION
Commit 5fd5a67c5a93514e7d0a64425baa007ad91f57de switched ksu from
using krb5_get_in_tkt_with_password() to
krb5_get_init_creds_password(), but did not supply a prompter
argument.  Pass krb5_prompter_posix so that clpreauth modules can
prompt for additional information during authentication.
