### PR TITLE
Expand interposer and some fixups

### DIFF
--- a/src/lib/gssapi/mechglue/g_inq_cred.c
+++ b/src/lib/gssapi/mechglue/g_inq_cred.c
@@ -169,7 +169,7 @@ gss_inquire_cred_by_mech(minor_status, cred_handle, mech_type, name,
     gss_mechanism	mech;
     OM_uint32		status, temp_minor_status;
     gss_name_t		internal_name;
-    gss_OID		selected_mech;
+    gss_OID		selected_mech, public_mech;
 
     if (minor_status != NULL)
 	*minor_status = 0;
@@ -198,8 +198,9 @@ gss_inquire_cred_by_mech(minor_status, cred_handle, mech_type, name,
 	return (GSS_S_DEFECTIVE_CREDENTIAL);
 #endif
 
+    public_mech = gssint_get_public_oid(selected_mech);
     status = mech->gss_inquire_cred_by_mech(minor_status,
-					    mech_cred, selected_mech,
+					    mech_cred, public_mech,
 					    name ? &internal_name : NULL,
 					    initiator_lifetime,
 					    acceptor_lifetime, cred_usage);

--- a/src/lib/gssapi/mechglue/g_inq_names.c
+++ b/src/lib/gssapi/mechglue/g_inq_names.c
@@ -40,7 +40,7 @@ gss_OID_set *	name_types;
 
 {
     OM_uint32		status;
-    gss_OID		selected_mech = GSS_C_NO_OID;
+    gss_OID		selected_mech = GSS_C_NO_OID, public_mech;
     gss_mechanism	mech;
 
     /* Initialize outputs. */
@@ -70,23 +70,17 @@ gss_OID_set *	name_types;
 	return (status);
 
     mech = gssint_get_mechanism(selected_mech);
+    if (mech == NULL)
+        return GSS_S_BAD_MECH;
+    else if (mech->gss_inquire_names_for_mech == NULL)
+        return GSS_S_UNAVAILABLE;
+    public_mech = gssint_get_public_oid(selected_mech);
+    status = mech->gss_inquire_names_for_mech(minor_status, public_mech,
+                                              name_types);
+    if (status != GSS_S_COMPLETE)
+        map_error(minor_status, mech);
 
-    if (mech) {
-
-	if (mech->gss_inquire_names_for_mech) {
-	    status = mech->gss_inquire_names_for_mech(
-				minor_status,
-				selected_mech,
-				name_types);
-	    if (status != GSS_S_COMPLETE)
-		map_error(minor_status, mech);
-	} else
-	    status = GSS_S_UNAVAILABLE;
-
-	return(status);
-    }
-
-    return (GSS_S_BAD_MECH);
+    return status;
 }
 
 static OM_uint32

--- a/src/lib/gssapi/mechglue/g_mechattr.c
+++ b/src/lib/gssapi/mechglue/g_mechattr.c
@@ -179,15 +179,16 @@ gss_inquire_attrs_for_mech(
         return status;
 
     mech = gssint_get_mechanism(selected_mech);
-    if (mech != NULL && mech->gss_inquire_attrs_for_mech != NULL) {
-        public_mech = gssint_get_public_oid(selected_mech);
-        status = mech->gss_inquire_attrs_for_mech(minor, public_mech,
-                                                  mech_attrs,
-                                                  known_mech_attrs);
-        if (GSS_ERROR(status)) {
-            map_error(minor, mech);
-            return status;
-        }
+    if (mech == NULL)
+        return GSS_S_BAD_MECH;
+    else if (mech->gss_inquire_attrs_for_mech == NULL)
+        return GSS_S_UNAVAILABLE;
+    public_mech = gssint_get_public_oid(selected_mech);
+    status = mech->gss_inquire_attrs_for_mech(minor, public_mech, mech_attrs,
+                                              known_mech_attrs);
+    if (GSS_ERROR(status)) {
+        map_error(minor, mech);
+        return status;
     }
 
     if (known_mech_attrs != NULL && *known_mech_attrs == GSS_C_NO_OID_SET) {

--- a/src/lib/gssapi/mechglue/g_saslname.c
+++ b/src/lib/gssapi/mechglue/g_saslname.c
@@ -113,7 +113,8 @@ OM_uint32 KRB5_CALLCONV gss_inquire_saslname_for_mech(
     gss_buffer_t   mech_name,
     gss_buffer_t   mech_description)
 {
-    OM_uint32       status = GSS_S_BAD_MECH;
+    OM_uint32       status;
+    gss_OID         selected_mech, public_mech;
     gss_mechanism   mech;
 
     if (minor_status == NULL)
@@ -136,14 +137,26 @@ OM_uint32 KRB5_CALLCONV gss_inquire_saslname_for_mech(
         mech_description->value = NULL;
     }
 
+    status = gssint_select_mech_type(minor_status,
+                                     desired_mech,
+                                     &selected_mech);
+    if (status != GSS_S_COMPLETE)
+        return status;
+
     mech = gssint_get_mechanism(desired_mech);
-    if (mech != NULL && mech->gss_inquire_saslname_for_mech != NULL) {
-        status = mech->gss_inquire_saslname_for_mech(minor_status,
-                                                     desired_mech,
-                                                     sasl_mech_name,
-                                                     mech_name,
+    if (mech == NULL) {
+        return GSS_S_BAD_MECH;
+    } else if (mech->gss_inquire_saslname_for_mech == NULL) {
+        status = GSS_S_BAD_MECH;
+    } else {
+        public_mech = gssint_get_public_oid(selected_mech);
+        status = mech->gss_inquire_saslname_for_mech(minor_status, public_mech,
+                                                     sasl_mech_name, mech_name,
                                                      mech_description);
+        if (status != GSS_S_COMPLETE)
+            map_error(minor_status, mech);
     }
+
     if (status == GSS_S_BAD_MECH) {
         if (sasl_mech_name != GSS_C_NO_BUFFER)
             status = oidToSaslNameAlloc(minor_status, desired_mech,
@@ -155,6 +168,8 @@ OM_uint32 KRB5_CALLCONV gss_inquire_saslname_for_mech(
     return status;
 }
 
+
+/* n.b. We cannot currently interpose this function. */
 OM_uint32 KRB5_CALLCONV gss_inquire_mech_for_saslname(
     OM_uint32           *minor_status,
     const gss_buffer_t   sasl_mech_name,

--- a/src/lib/gssapi/mechglue/g_store_cred.c
+++ b/src/lib/gssapi/mechglue/g_store_cred.c
@@ -24,15 +24,17 @@ store_cred_fallback(
 	gss_OID_set *elements_stored,
 	gss_cred_usage_t *cred_usage_stored)
 {
+	gss_OID public_mech = gssint_get_public_oid(desired_mech);
+
 	if (mech->gss_store_cred_into != NULL) {
 		return mech->gss_store_cred_into(minor_status, mech_cred,
-						 cred_usage, desired_mech,
+						 cred_usage, public_mech,
 						 overwrite_cred, default_cred,
 						 cred_store, elements_stored,
 						 cred_usage_stored);
 	} else if (cred_store == GSS_C_NO_CRED_STORE) {
 		return mech->gss_store_cred(minor_status, mech_cred,
-					    cred_usage, desired_mech,
+					    cred_usage, public_mech,
 					    overwrite_cred, default_cred,
 					    elements_stored,
 					    cred_usage_stored);

--- a/src/lib/gssapi/mechglue/gssd_pname_to_uid.c
+++ b/src/lib/gssapi/mechglue/gssd_pname_to_uid.c
@@ -123,7 +123,7 @@ gss_localname(OM_uint32 *minor,
     gss_mechanism mech;
     gss_union_name_t unionName;
     gss_name_t mechName = GSS_C_NO_NAME, mechNameP;
-    gss_OID selected_mech = GSS_C_NO_OID;
+    gss_OID selected_mech = GSS_C_NO_OID, public_mech;
 
     if (localname != GSS_C_NO_BUFFER) {
 	localname->length = 0;
@@ -152,7 +152,7 @@ gss_localname(OM_uint32 *minor,
         mech = gssint_get_mechanism(unionName->mech_type);
 
     if (mech == NULL)
-	return GSS_S_UNAVAILABLE;
+	return GSS_S_BAD_MECH;
 
     /* may need to create a mechanism specific name */
     if (unionName->mech_type == GSS_C_NO_OID ||
@@ -170,7 +170,8 @@ gss_localname(OM_uint32 *minor,
     major = GSS_S_UNAVAILABLE;
 
     if (mech->gss_localname != NULL) {
-        major = mech->gss_localname(minor, mechNameP, mech_type, localname);
+        public_mech = gssint_get_public_oid(selected_mech);
+        major = mech->gss_localname(minor, mechNameP, public_mech, localname);
         if (GSS_ERROR(major))
             map_error(minor, mech);
     }


### PR DESCRIPTION
This is the continuation of #370.  gss_inquire_names_for_mech() should now be interposed correctly, and gss_inquire_attrs_for_mech() and gss_inquire_saslname_for_mech() are newly interposable.  As gss_inquire_mech_for_saslname() cannot be made interposable per rfc5801, this is all of the functions in g_saslname.c as requested.

Thanks!