### PR TITLE
Don't ignore kadm5.acl without trailing \n on non-x86

### DIFF
--- a/src/lib/kadm5/srv/server_acl.c
+++ b/src/lib/kadm5/srv/server_acl.c
@@ -115,7 +115,9 @@ kadm5int_acl_get_line(fp, lnp)
             int byte;
             byte = fgetc(fp);
             acl_buf[i] = byte;
-            if (byte == (char)EOF) {
+
+            /* fgetc()'s return value, EOF, and `byte` are all ints. */
+            if (byte == EOF) {
                 if (i > 0 && acl_buf[i-1] == '\\')
                     i--;
                 break;          /* it gets nulled-out below */


### PR DESCRIPTION
On platforms where the char type is unsigned, the check for EOF (which is
negative) will always fail.  This causes the contents of kadm5.acl to be ignored.

To reproduce (courtesy of Patrik Kis):

```
# uname -p
s390x
# cat /var/kerberos/krb5kdc/kadm5.acl 
alice@EXAMPLE.COM	*
# service kadmin start
Redirecting to /bin/systemctl start  kadmin.service
# kadmin -p alice -q 'addprinc -pw test test'
Authenticating as principal alice with password.
Password for alice@EXAMPLE.COM: 
WARNING: no policy specified for test@EXAMPLE.COM; defaulting to no policy
Principal "test@EXAMPLE.COM" created.
# kadmin -p alice -q 'delprinc -force test'
Authenticating as principal alice with password.
Password for alice@EXAMPLE.COM: 
Principal "test@EXAMPLE.COM" deleted.
Make sure that you have removed this principal from all ACLs before reusing.
#
#
# echo -n 'alice@EXAMPLE.COM     *' >/var/kerberos/krb5kdc/kadm5.acl
# cat /var/kerberos/krb5kdc/kadm5.acl 
alice@EXAMPLE.COM     *#
# service kadmin restart
Redirecting to /bin/systemctl restart  kadmin.service
# kadmin -p alice -q 'addprinc -pw test test'
Authenticating as principal alice with password.
Password for alice@EXAMPLE.COM: 
WARNING: no policy specified for test@EXAMPLE.COM; defaulting to no policy
add_principal: Operation requires ``add'' privilege while creating "test@EXAMPLE.COM".
```

I have also reproduced this on ppc64, and am given to understand it affects ppc64-le and aarch64 as well.  This problem was originally uncovered by [running t_pkinit.py](https://github.com/krb5/krb5/blob/master/src/tests/t_pkinit.py#L75-L78).