### PR TITLE
Work around uninitialized warning in logger.c

### DIFF
--- a/src/lib/kadm5/logger.c
+++ b/src/lib/kadm5/logger.c
@@ -359,7 +359,7 @@ krb5_klog_init(krb5_context kcontext, char *ename, char *whoami, krb5_boolean do
     char        savec = '\0';
     int         error;
     int         do_openlog, log_facility;
-    FILE        *f;
+    FILE        *f = NULL;
 
     /* Initialize */
     do_openlog = 0;


### PR DESCRIPTION
gcc 4.6.3 erroneously detects uninitialized use of the variable f
after commit 9914b93516bbce9b1123ed5f9f796b7028944892.  Initialize it
to work around this warning.
