### PR TITLE
Fix iprop server stub error management

### DIFF
--- a/src/kadmin/server/ipropd_svc.c
+++ b/src/kadmin/server/ipropd_svc.c
@@ -163,8 +163,6 @@ iprop_get_updates_1_svc(kdb_last_t *arg, struct svc_req *rqstp)
 	client_name = buf_to_string(&client_desc);
 	service_name = buf_to_string(&service_desc);
 	if (client_name == NULL || service_name == NULL) {
-	    free(client_name);
-	    free(service_name);
 	    krb5_klog_syslog(LOG_ERR,
 			     _("%s: out of memory recording principal names"),
 			     whoami);
@@ -291,8 +289,6 @@ ipropx_resync(uint32_t vers, struct svc_req *rqstp)
 	client_name = buf_to_string(&client_desc);
 	service_name = buf_to_string(&service_desc);
 	if (client_name == NULL || service_name == NULL) {
-	    free(client_name);
-	    free(service_name);
 	    DPRINT("%s: out of memory\n", whoami);
 	    krb5_klog_syslog(LOG_ERR,
 			     _("%s: out of memory recording principal names"),


### PR DESCRIPTION
The ipropd stubs free client_name and server_name in the cleanup
handler, so should not free them in out-of-memory conditions.
Reported by Will Fiveash.
