### PR TITLE
Fix ticket renewal of enterprise principals

### DIFF
--- a/src/lib/krb5/krb/pac.c
+++ b/src/lib/krb5/krb/pac.c
@@ -418,6 +418,7 @@ k5_pac_validate_client(krb5_context context,
     krb5_ui_2 pac_princname_length;
     int64_t pac_nt_authtime;
     krb5_principal pac_principal;
+    int flags;
 
     ret = k5_pac_locate_buffer(context, pac, KRB5_PAC_CLIENT_INFO,
                                &client_info);
@@ -446,8 +447,13 @@ k5_pac_validate_client(krb5_context context,
     if (ret != 0)
         return ret;
 
+    flags = KRB5_PRINCIPAL_PARSE_NO_REALM;
+    if (principal->type == KRB5_NT_ENTERPRISE_PRINCIPAL) {
+        flags |= KRB5_PRINCIPAL_PARSE_ENTERPRISE;
+    }
+
     ret = krb5_parse_name_flags(context, pac_princname,
-                                KRB5_PRINCIPAL_PARSE_NO_REALM, &pac_principal);
+                                flags, &pac_principal);
     if (ret != 0) {
         free(pac_princname);
         return ret;

--- a/src/tests/t_referral.py
+++ b/src/tests/t_referral.py
@@ -123,5 +123,6 @@ r1.kinit('user', password('user'), ['-C'])
 r1.klist('user@KRBTEST2.COM', 'krbtgt/KRBTEST2.COM')
 r1.kinit('abc@XYZ', 'pw', ['-E'])
 r1.klist('abc\@XYZ@KRBTEST2.COM', 'krbtgt/KRBTEST2.COM')
+r1.kinit('-R')
 
 success('KDC host referral tests')


### PR DESCRIPTION
While writing tests for Samba AD using the MIT KDC I discover that it isn't possible to renew tickets with enterprise principals. With the attached patch I can successfully do:

kinit -E user@ENTERPRISE.REALM
kinit -R

I was not able to get the test working in 'make check' of the MIT KRB5 source code. I'm posting it so maybe you can tell me if this can be tested or not.