### PR TITLE
Implement password history in LDAP plugin [KRB-49]

### DIFF
--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -1,6 +1,6 @@
 /* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 /*
- * Copyright 1990,1991 by the Massachusetts Institute of Technology.
+ * Copyright 1990, 1991, 2016 by the Massachusetts Institute of Technology.
  * All Rights Reserved.
  *
  * Export of this software from the United States of America may
@@ -209,6 +209,8 @@ typedef struct _krb5_db_entry_new {
 
     krb5_principal        princ;                /* Length, data */
     krb5_tl_data        * tl_data;              /* Linked list */
+
+    /* key_data must be sorted by kvno in descending order */
     krb5_key_data       * key_data;             /* Array */
 } krb5_db_entry;
 
@@ -682,6 +684,18 @@ krb5_error_code krb5_db_check_allowed_to_delegate(krb5_context kcontext,
                                                   krb5_const_principal client,
                                                   const krb5_db_entry *server,
                                                   krb5_const_principal proxy);
+
+/**
+ * Sort an array of @a krb5_key_data keys in descending order by their kvno.
+ *
+ * @param key_data
+ *     The @a krb5_key_data array to sort.  This is sorted in place so the
+ *     array will be modified. Key data order within a kvno is preserved.
+ * @param key_data_length
+ *     The legnth of @a key_data.
+ */
+void
+krb5_dbe_sort_key_data(krb5_key_data *key_data, size_t key_data_length);
 
 /* default functions. Should not be directly called */
 /*

--- a/src/lib/kadm5/admin.h
+++ b/src/lib/kadm5/admin.h
@@ -110,7 +110,7 @@ typedef long            kadm5_ret_t;
 #define KADM5_RANDKEY_USED      0x100000
 #endif
 #define KADM5_LOAD              0x200000
-#define KADM5_NOKEY             0x400000
+#define KADM5_KEY_HIST          0x400000
 
 /* all but KEY_DATA, TL_DATA, LOAD */
 #define KADM5_PRINCIPAL_NORMAL_MASK 0x41ffff

--- a/src/lib/kadm5/srv/svr_principal.c
+++ b/src/lib/kadm5/srv/svr_principal.c
@@ -1614,6 +1614,9 @@ kadm5_chpass_principal_3(void *server_handle,
         KADM5_FAIL_AUTH_COUNT;
     /* | KADM5_CPW_FUNCTION */
 
+    if (hist_added == 1)
+        kdb->mask |= KADM5_KEY_HIST;
+
     ret = k5_kadm5_hook_chpass(handle->context, handle->hook_handles,
                                KADM5_HOOK_STAGE_PRECOMMIT, principal, keepold,
                                new_n_ks_tuple, new_ks_tuple, password);

--- a/src/lib/kadm5/srv/svr_principal.c
+++ b/src/lib/kadm5/srv/svr_principal.c
@@ -1084,6 +1084,16 @@ check_pw_reuse(krb5_context context,
     return(0);
 }
 
+static
+void free_history_entry(krb5_context context, osa_pw_hist_ent *hist)
+{
+    int i;
+
+    for (i = 0; i < hist->n_key_data; i++)
+        krb5_free_key_data_contents(context, &hist->key_data[i]);
+    free(hist->key_data);
+}
+
 /*
  * Function: create_history_entry
  *
@@ -1097,7 +1107,7 @@ check_pw_reuse(krb5_context context,
  *      hist_key        (r) history keyblock to encrypt key data with
  *      n_key_data      (r) number of elements in key_data
  *      key_data        (r) keys to add to the history entry
- *      hist            (w) history entry to fill in
+ *      hist_out        (w) history entry to fill in
  *
  * Effects:
  *
@@ -1109,45 +1119,64 @@ check_pw_reuse(krb5_context context,
 static
 int create_history_entry(krb5_context context,
                          krb5_keyblock *hist_key, int n_key_data,
-                         krb5_key_data *key_data, osa_pw_hist_ent *hist)
+                         krb5_key_data *key_data, osa_pw_hist_ent *hist_out)
 {
-    krb5_error_code ret;
+    int i;
+    krb5_error_code ret = 0;
     krb5_keyblock key;
     krb5_keysalt salt;
-    int i;
+    krb5_ui_2 kvno;
+    osa_pw_hist_ent hist;
 
-    hist->key_data = k5calloc(n_key_data, sizeof(krb5_key_data), &ret);
-    if (hist->key_data == NULL)
-        return ret;
+    hist_out->key_data = NULL;
+    hist_out->n_key_data = 0;
+
+    if (n_key_data < 0)
+        return EINVAL;
+
+    memset(&key, 0, sizeof(key));
+    memset(&hist, 0, sizeof(hist));
+
+    if (n_key_data == 0)
+        goto cleanup;
+
+    hist.key_data = k5calloc(n_key_data, sizeof(krb5_key_data), &ret);
+    if (hist.key_data == NULL)
+        goto cleanup;
+
+    /*
+     * We only want to store the most recent kvno, and key_data should already
+     * be sorted in descending order by kvno.
+     */
+    kvno = key_data[0].key_data_kvno;
 
     for (i = 0; i < n_key_data; i++) {
-        ret = krb5_dbe_decrypt_key_data(context, NULL, &key_data[i], &key,
+        if (key_data[i].key_data_kvno < kvno)
+            break;
+        ret = krb5_dbe_decrypt_key_data(context, NULL,
+                                        &key_data[i], &key,
                                         &salt);
         if (ret)
-            return ret;
+            goto cleanup;
 
         ret = krb5_dbe_encrypt_key_data(context, hist_key, &key, &salt,
                                         key_data[i].key_data_kvno,
-                                        &hist->key_data[i]);
+                                        &hist.key_data[hist.n_key_data]);
         if (ret)
-            return ret;
-
+            goto cleanup;
+        hist.n_key_data++;
         krb5_free_keyblock_contents(context, &key);
         /* krb5_free_keysalt(context, &salt); */
     }
 
-    hist->n_key_data = n_key_data;
-    return 0;
-}
+    *hist_out = hist;
+    hist.n_key_data = 0;
+    hist.key_data = NULL;
 
-static
-void free_history_entry(krb5_context context, osa_pw_hist_ent *hist)
-{
-    int i;
-
-    for (i = 0; i < hist->n_key_data; i++)
-        krb5_free_key_data_contents(context, &hist->key_data[i]);
-    free(hist->key_data);
+cleanup:
+    krb5_free_keyblock_contents(context, &key);
+    free_history_entry(context, &hist);
+    return ret;
 }
 
 /*
@@ -1526,11 +1555,14 @@ kadm5_chpass_principal_3(void *server_handle,
                     goto done;
             }
 
-            ret = add_to_history(handle->context, hist_kvno, &adb, &pol,
-                                 &hist);
-            if (ret)
-                goto done;
-            hist_added = 1;
+            /* Don't save empty history. */
+            if (hist.n_key_data > 0) {
+                ret = add_to_history(handle->context, hist_kvno, &adb, &pol,
+                                     &hist);
+                if (ret)
+                    goto done;
+                hist_added = 1;
+            }
         }
 
         if (pol.pw_max_life)

--- a/src/lib/kdb/libkdb5.exports
+++ b/src/lib/kdb/libkdb5.exports
@@ -99,3 +99,4 @@ ulog_get_sno_status
 ulog_replay
 ulog_set_last
 xdr_kdb_incr_update_t
+krb5_dbe_sort_key_data

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.h
@@ -32,6 +32,7 @@
 #define _LDAP_PRINCIPAL_H 1
 
 #include "ldap_tkt_policy.h"
+#include "princ_xdr.h"
 
 #define  KEYHEADER  12
 
@@ -82,6 +83,7 @@
 #define KDB_LAST_FAILED_ATTR                 0x001000
 #define KDB_FAIL_AUTH_COUNT_ATTR             0x002000
 #define KDB_LAST_ADMIN_UNLOCK_ATTR           0x004000
+#define KDB_PWD_HISTORY_ATTR                 0x008000
 
 /*
  * This is a private contract between krb5_ldap_lockout_audit()
@@ -112,6 +114,12 @@ krb5_ldap_iterate(krb5_context, char *,
                   krb5_pointer, krb5_flags);
 
 void
+k5_free_key_data(krb5_int16 n_key_data, krb5_key_data *key_data);
+
+void
+krb5_dbe_free_contents(krb5_context context, krb5_db_entry *entry);
+
+void
 krb5_dbe_free_contents(krb5_context, krb5_db_entry *);
 
 krb5_error_code
@@ -121,8 +129,11 @@ krb5_error_code
 krb5_ldap_parse_principal_name(char *, char **);
 
 krb5_error_code
+krb5_decode_histkey(krb5_context, struct berval **, osa_princ_ent_rec *);
+
+krb5_error_code
 krb5_decode_krbsecretkey(krb5_context, krb5_db_entry *, struct berval **,
-                         krb5_tl_data *, krb5_kvno *);
+                         krb5_kvno *);
 
 krb5_error_code
 berval2tl_data(struct berval *in, krb5_tl_data **out);

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
@@ -1,6 +1,29 @@
 /* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 /* plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c */
 /*
+ * Copyright 2016 by the Massachusetts Institute of Technology.
+ * All Rights Reserved.
+ *
+ * Export of this software from the United States of America may
+ *   require a specific license from the United States Government.
+ *   It is the responsibility of any person or organization contemplating
+ *   export to obtain such a license before exporting.
+ *
+ * WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+ * distribute this software and its documentation for any purpose and
+ * without fee is hereby granted, provided that the above copyright
+ * notice appear in all copies and that both that copyright notice and
+ * this permission notice appear in supporting documentation, and that
+ * the name of M.I.T. not be used in advertising or publicity pertaining
+ * to distribution of the software without specific, written prior
+ * permission.  Furthermore if you modify this software you must label
+ * your software as modified software and not distribute it in such a
+ * fashion that it might be confused with the original M.I.T. software.
+ * M.I.T. makes no representations about the suitability of
+ * this software for any purpose.  It is provided "as is" without express
+ * or implied warranty.
+ */
+/*
  * Copyright (c) 2004-2005, Novell, Inc.
  * All rights reserved.
  *
@@ -361,11 +384,10 @@ asn1_encode_sequence_of_keys(krb5_key_data *key_data, krb5_int16 n_key_data,
 }
 
 static krb5_error_code
-asn1_decode_sequence_of_keys(krb5_data *in, krb5_key_data **out,
-                             krb5_int16 *n_key_data, krb5_kvno *mkvno)
+asn1_decode_sequence_of_keys(krb5_data *in, ldap_seqof_key_data *out)
 {
     krb5_error_code err;
-    ldap_seqof_key_data *p;
+    ldap_seqof_key_data *p = NULL;
     int i;
 
     /*
@@ -374,11 +396,11 @@ asn1_decode_sequence_of_keys(krb5_data *in, krb5_key_data **out,
      */
     err = kldap_ensure_initialized ();
     if (err)
-        return err;
+        goto cleanup;
 
     err = accessor.asn1_ldap_decode_sequence_of_keys(in, &p);
     if (err)
-        return err;
+        goto cleanup;
 
     /* Set kvno and key_data_ver in each key_data element. */
     for (i = 0; i < p->n_key_data; i++) {
@@ -389,11 +411,10 @@ asn1_decode_sequence_of_keys(krb5_data *in, krb5_key_data **out,
             p->key_data[i].key_data_ver = 2;
     }
 
-    *out = p->key_data;
-    *n_key_data = p->n_key_data;
-    *mkvno = p->mkvno;
+    *out = *p;
+cleanup:
     free(p);
-    return 0;
+    return err;
 }
 
 /*
@@ -415,19 +436,24 @@ free_berdata(struct berval **array)
     }
 }
 
-/* Decoding ASN.1 encoded key */
-static struct berval **
-krb5_encode_krbsecretkey(krb5_key_data *key_data_in, int n_key_data,
-                         krb5_kvno mkvno) {
-    struct berval **ret = NULL;
-    int currkvno;
-    int num_versions = 1;
-    int i, j, last;
+/*
+ * Encode krb5_key_data into a berval struct for ldap insertion.
+ */
+static krb5_error_code
+encode_keys(krb5_key_data *key_data_in, int n_key_data, krb5_kvno mkvno,
+            struct berval **bval_out)
+{
     krb5_error_code err = 0;
+    int i;
     krb5_key_data *key_data = NULL;
+    struct berval *bval = NULL;
+    krb5_data *code;
 
-    if (n_key_data < 0)
-        return NULL;
+    *bval_out = NULL;
+    if (n_key_data <= 0) {
+        err = EINVAL;
+        goto cleanup;
+    }
 
     /* Make a shallow copy of the key data so we can alter it. */
     key_data = k5calloc(n_key_data, sizeof(*key_data), &err);
@@ -446,31 +472,68 @@ krb5_encode_krbsecretkey(krb5_key_data *key_data_in, int n_key_data,
         }
     }
 
-    /* Find the number of key versions */
-    for (i = 0; i < n_key_data - 1; i++)
-        if (key_data[i].key_data_kvno != key_data[i + 1].key_data_kvno)
-            num_versions++;
+    bval = k5alloc(sizeof(struct berval), &err);
+    if (bval == NULL)
+        goto cleanup;
 
-    ret = (struct berval **) calloc (num_versions + 1, sizeof (struct berval *));
+    err = asn1_encode_sequence_of_keys(key_data, n_key_data, mkvno, &code);
+    if (err)
+        goto cleanup;
+
+    bval->bv_len = code->length;
+    bval->bv_val = code->data;
+
+    free(code);
+
+    *bval_out = bval;
+    bval = NULL;
+
+cleanup:
+    free(key_data);
+    free(bval);
+    return err;
+}
+
+/* Decoding ASN.1 encoded key */
+static struct berval **
+krb5_encode_krbsecretkey(krb5_key_data *key_data, int n_key_data,
+                         krb5_kvno mkvno)
+{
+    struct berval **ret = NULL;
+    int currkvno;
+    int num_versions = 0;
+    int i, j, last;
+    krb5_error_code err = 0;
+
+    if (n_key_data < 0)
+        return NULL;
+
+    /* Find the number of key versions */
+    if (n_key_data > 0) {
+        for (i = 0, num_versions = 1; i < n_key_data - 1; i++) {
+            if (key_data[i].key_data_kvno != key_data[i + 1].key_data_kvno)
+                num_versions++;
+        }
+    }
+
+    ret = calloc(num_versions + 1, sizeof(struct berval *));
     if (ret == NULL) {
         err = ENOMEM;
         goto cleanup;
     }
-    for (i = 0, last = 0, j = 0, currkvno = key_data[0].key_data_kvno; i < n_key_data; i++) {
-        krb5_data *code;
+    ret[num_versions] = NULL;
+
+    /* n_key_data may be 0 if a principal is created without a key. */
+    if (n_key_data == 0)
+        goto cleanup;
+
+    for (i = 0, last = 0, j = 0, currkvno = key_data[0].key_data_kvno;
+         i < n_key_data; i++) {
         if (i == n_key_data - 1 || key_data[i + 1].key_data_kvno != currkvno) {
-            ret[j] = k5alloc(sizeof(struct berval), &err);
-            if (ret[j] == NULL)
-                goto cleanup;
-            err = asn1_encode_sequence_of_keys(key_data + last,
-                                               (krb5_int16)i - last + 1,
-                                               mkvno, &code);
+            err = encode_keys(key_data + last, (krb5_int16)i - last + 1,
+                              mkvno, ret + j);
             if (err)
                 goto cleanup;
-            /*CHECK_NULL(ret[j]); */
-            ret[j]->bv_len = code->length;
-            ret[j]->bv_val = code->data;
-            free(code);
             j++;
             last = i + 1;
 
@@ -478,11 +541,48 @@ krb5_encode_krbsecretkey(krb5_key_data *key_data_in, int n_key_data,
                 currkvno = key_data[i + 1].key_data_kvno;
         }
     }
-    ret[num_versions] = NULL;
 
 cleanup:
+    if (err != 0) {
+        free_berdata(ret);
+        ret = NULL;
+    }
 
-    free(key_data);
+    return ret;
+}
+
+/*
+ * Encode a principal's key history for insertion into ldap.
+ */
+static struct berval **
+krb5_encode_histkey(osa_princ_ent_rec *princ_ent)
+{
+    unsigned int i;
+    krb5_error_code err = 0;
+    struct berval **ret = NULL;
+
+    if (princ_ent->old_key_len <= 0)
+        return NULL;
+
+    ret = k5calloc(princ_ent->old_key_len + 1, sizeof(struct berval *), &err);
+    if (ret == NULL)
+        goto cleanup;
+
+    for (i = 0; i < princ_ent->old_key_len; i++) {
+        if (princ_ent->old_keys[i].n_key_data <= 0) {
+            err = EINVAL;
+            goto cleanup;
+        }
+        err = encode_keys(princ_ent->old_keys[i].key_data,
+                          princ_ent->old_keys[i].n_key_data,
+                          princ_ent->admin_history_kvno, ret + i);
+        if (err)
+            goto cleanup;
+    }
+
+    ret[princ_ent->old_key_len] = NULL;
+
+cleanup:
     if (err != 0) {
         free_berdata(ret);
         ret = NULL;
@@ -1003,7 +1103,7 @@ krb5_ldap_put_principal(krb5_context context, krb5_db_entry *entry,
         free (strval[0]);
     }
 
-    if (entry->mask & KADM5_POLICY) {
+    if (entry->mask & KADM5_POLICY || entry->mask & KADM5_KEY_HIST) {
         memset(&princ_ent, 0, sizeof(princ_ent));
         for (tl_data=entry->tl_data; tl_data; tl_data=tl_data->tl_data_next) {
             if (tl_data->tl_data_type == KRB5_TL_KADM_DATA) {
@@ -1013,7 +1113,9 @@ krb5_ldap_put_principal(krb5_context context, krb5_db_entry *entry,
                 break;
             }
         }
+    }
 
+    if (entry->mask & KADM5_POLICY) {
         if (princ_ent.aux_attributes & KADM5_POLICY) {
             memset(strval, 0, sizeof(strval));
             if ((st = krb5_ldap_name_to_policydn (context, princ_ent.policy, &polname)) != 0)
@@ -1039,6 +1141,22 @@ krb5_ldap_put_principal(krb5_context context, krb5_db_entry *entry,
     if (entry->mask & KADM5_POLICY_CLR) {
         if ((st=krb5_add_str_mem_ldap_mod(&mods, "krbpwdpolicyreference", LDAP_MOD_DELETE, NULL)) != 0)
             goto cleanup;
+    }
+
+    if (entry->mask & KADM5_KEY_HIST) {
+        bersecretkey = krb5_encode_histkey(&princ_ent);
+        if (bersecretkey == NULL) {
+            st = ENOMEM;
+            goto cleanup;
+        }
+
+        st = krb5_add_ber_mem_ldap_mod(&mods, "krbpwdhistory",
+                                       LDAP_MOD_REPLACE | LDAP_MOD_BVALUES,
+                                       bersecretkey);
+        if (st != 0)
+            goto cleanup;
+        free_berdata(bersecretkey);
+        bersecretkey = NULL;
     }
 
     if (entry->mask & KADM5_KEY_DATA || entry->mask & KADM5_KVNO) {
@@ -1375,63 +1493,207 @@ cleanup:
     return st;
 }
 
-krb5_error_code
-krb5_decode_krbsecretkey(krb5_context context, krb5_db_entry *entries,
-                         struct berval **bvalues,
-                         krb5_tl_data *userinfo_tl_data, krb5_kvno *mkvno)
+static void
+free_ldap_seqof_key_data(ldap_seqof_key_data *keysets, krb5_int16 n_keysets)
 {
-    char                        *user=NULL;
-    int                         i=0, j=0, noofkeys=0;
-    krb5_key_data               *key_data=NULL, *tmp;
-    krb5_error_code             st=0;
+    int i;
 
-    if ((st=krb5_unparse_name(context, entries->princ, &user)) != 0)
+    if (keysets == NULL)
+        return;
+
+    for (i = 0; i < n_keysets; i++)
+        k5_free_key_data(keysets[i].n_key_data, keysets[i].key_data);
+    free(keysets);
+}
+
+/*
+ * Decode keys from ldap search results.
+ *
+ * Arguments:
+ *  - bvalues
+ *      The ldap search results containing the key data.
+ *  - mkvno
+ *      The master kvno that the keys were encrypted with.
+ *  - keysets_out
+ *      The decoded keys in a ldap_seqof_key_data struct. Must be freed using
+ *      free_ldap_seqof_key_data.
+ *  - n_keysets_out
+ *      The number of ldap_seqof_key_data's in keys_out.
+ *  - total_keys_out
+ *      An optional argument that if given will be set to the total number of
+ *      keys found throughout all the entries: sum(keys_out.n_key_data)
+ *      May be NULL.
+ */
+static krb5_error_code
+decode_keys(struct berval **bvalues, ldap_seqof_key_data **keysets_out,
+            krb5_int16 *n_keysets_out, /* NULL */ krb5_int16 *total_keys_out)
+{
+    krb5_error_code err = 0;
+    krb5_int16 n_keys, i, ki, total_keys;
+    ldap_seqof_key_data *keysets = NULL;
+
+    *keysets_out = NULL;
+    *n_keysets_out = 0;
+    if (total_keys_out)
+        *total_keys_out = 0;
+
+    /* Precount the number of keys. */
+    for (n_keys = 0, i = 0; bvalues[i] != NULL; i++) {
+        if (bvalues[i]->bv_len > 0)
+            n_keys++;
+    }
+
+    keysets = k5calloc(n_keys, sizeof(ldap_seqof_key_data), &err);
+    if (keysets == NULL)
         goto cleanup;
+    memset(keysets, 0, n_keys * sizeof(ldap_seqof_key_data));
 
-    for (i=0; bvalues[i] != NULL; ++i) {
-        krb5_int16 n_kd;
-        krb5_key_data *kd;
+    for (i = 0, ki = 0, total_keys = 0; bvalues[i] != NULL; i++) {
         krb5_data in;
 
         if (bvalues[i]->bv_len == 0)
             continue;
+
         in.length = bvalues[i]->bv_len;
         in.data = bvalues[i]->bv_val;
 
-        st = asn1_decode_sequence_of_keys (&in,
-                                           &kd,
-                                           &n_kd,
-                                           mkvno);
+        err = asn1_decode_sequence_of_keys(&in, &keysets[ki]);
+        if (err)
+            goto cleanup;
 
-        if (st != 0) {
-            const char *msg = error_message(st);
-            st = -1; /* Something more appropriate ? */
-            k5_setmsg(context, st,
-                      _("unable to decode stored principal key data (%s)"),
-                      msg);
-            goto cleanup;
-        }
-        noofkeys += n_kd;
-        tmp = key_data;
-        /* Allocate an extra key data to avoid allocating zero bytes. */
-        key_data = realloc(key_data, (noofkeys + 1) * sizeof (krb5_key_data));
-        if (key_data == NULL) {
-            key_data = tmp;
-            st = ENOMEM;
-            goto cleanup;
-        }
-        for (j = 0; j < n_kd; j++)
-            key_data[noofkeys - n_kd + j] = kd[j];
-        free (kd);
+        if (total_keys_out)
+            total_keys += keysets[ki].n_key_data;
+        ki++;
     }
 
-    entries->n_key_data = noofkeys;
-    entries->key_data = key_data;
+    if (total_keys_out)
+        *total_keys_out = total_keys;
+
+    *n_keysets_out = n_keys;
+    *keysets_out = keysets;
+    keysets = NULL;
+    n_keys = 0;
 
 cleanup:
-    free (user);
-    return st;
+    free_ldap_seqof_key_data(keysets, n_keys);
+    return err;
 }
+
+krb5_error_code
+krb5_decode_krbsecretkey(krb5_context context, krb5_db_entry *entries,
+                         struct berval **bvalues, krb5_kvno *mkvno)
+{
+    char *user = NULL;
+    krb5_key_data *key_data = NULL, *tmp;
+    krb5_error_code err = 0;
+    ldap_seqof_key_data *keysets = NULL;
+    krb5_int16 i, n_keysets = 0, total_keys = 0;
+
+    err = krb5_unparse_name(context, entries->princ, &user);
+    if (err)
+        goto cleanup;
+
+    err = decode_keys(bvalues, &keysets, &n_keysets, &total_keys);
+    if (err != 0) {
+        k5_prependmsg(context, err,
+                      _("unable to decode stored principal key data"));
+        goto cleanup;
+    }
+
+    key_data = k5calloc(total_keys, sizeof(krb5_key_data), &err);
+    if (key_data == NULL)
+        goto cleanup;
+    memset(key_data, 0, total_keys * sizeof(krb5_key_data));
+
+    if (n_keysets > 0)
+        *mkvno = keysets[0].mkvno;
+
+    tmp = key_data;
+    for (i = 0; i < n_keysets; i++) {
+        memcpy(tmp, keysets[i].key_data,
+               sizeof(krb5_key_data) * keysets[i].n_key_data);
+        tmp += keysets[i].n_key_data;
+
+        keysets[i].n_key_data = 0;
+    }
+    entries->n_key_data = total_keys;
+    entries->key_data = key_data;
+
+    key_data = NULL;
+
+cleanup:
+    free(user);
+    free_ldap_seqof_key_data(keysets, n_keysets);
+    k5_free_key_data(total_keys, key_data);
+    return err;
+}
+
+static int
+compare_osa_pw_hist_ent(const void *left_in, const void *right_in)
+{
+    int kvno_left, kvno_right;
+    osa_pw_hist_ent *left = (osa_pw_hist_ent *)left_in;
+    osa_pw_hist_ent *right = (osa_pw_hist_ent *)right_in;
+
+    kvno_left = left->n_key_data ? left->key_data[0].key_data_kvno : 0;
+    kvno_right = right->n_key_data ? right->key_data[0].key_data_kvno : 0;
+
+    return kvno_left - kvno_right;
+}
+
+/*
+ * Decode the key history entries from an ldap search.
+ *
+ * NOTE: princ_ent->old_keys must be freed even on error.
+ */
+krb5_error_code
+krb5_decode_histkey(krb5_context context, struct berval **bvalues,
+                    osa_princ_ent_rec *princ_ent)
+{
+    krb5_error_code err = 0;
+    krb5_int16 i, n_keysets = 0;
+    ldap_seqof_key_data *keysets = NULL;
+
+    err = decode_keys(bvalues, &keysets, &n_keysets, NULL);
+    if (err != 0) {
+        k5_prependmsg(context, err,
+                      _("unable to decode stored principal pw history"));
+        goto cleanup;
+    }
+
+    princ_ent->old_keys = k5calloc(n_keysets, sizeof(osa_pw_hist_ent), &err);
+    if (princ_ent->old_keys == NULL)
+        goto cleanup;
+    princ_ent->old_key_len = n_keysets;
+
+    if (n_keysets > 0)
+        princ_ent->admin_history_kvno = keysets[0].mkvno;
+
+    for (i = 0; i < n_keysets; i++) {
+        princ_ent->old_keys[i].n_key_data = keysets[i].n_key_data;
+        princ_ent->old_keys[i].key_data = keysets[i].key_data;
+        keysets[i].n_key_data = 0;
+        keysets[i].key_data = NULL;
+    }
+
+    /* Sort the principal entries by kvno in ascending order. */
+    qsort(princ_ent->old_keys, princ_ent->old_key_len, sizeof(osa_pw_hist_ent),
+          &compare_osa_pw_hist_ent);
+
+    princ_ent->aux_attributes |= KADM5_KEY_HIST;
+
+    /*
+     * Set the next key to be the one after the last to ensure the queue will
+     * be lengthened if the policy isn't full yet, or that the the first entry
+     * will be replaced in the case the history is full.
+     */
+    princ_ent->old_key_next = princ_ent->old_key_len;
+
+cleanup:
+    free_ldap_seqof_key_data(keysets, n_keysets);
+    return err;
+}
+
 
 static char *
 getstringtime(krb5_timestamp epochtime)

--- a/src/plugins/kdb/ldap/libkdb_ldap/princ_xdr.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/princ_xdr.c
@@ -200,20 +200,14 @@ krb5_lookup_tl_kadm_data(krb5_tl_data *tl_data, osa_princ_ent_rec *princ_entry)
 
 krb5_error_code
 krb5_update_tl_kadm_data(krb5_context context, krb5_db_entry *entry,
-			 char *policy_dn)
+			 osa_princ_ent_rec *princ_entry)
 {
     XDR xdrs;
-    osa_princ_ent_rec princ_entry;
     krb5_tl_data tl_data;
     krb5_error_code retval;
 
-    memset(&princ_entry, 0, sizeof(osa_princ_ent_rec));
-    princ_entry.admin_history_kvno = 2;
-    princ_entry.aux_attributes = KADM5_POLICY;
-    princ_entry.policy = policy_dn;
-
     xdralloc_create(&xdrs, XDR_ENCODE);
-    if (! ldap_xdr_osa_princ_ent_rec(&xdrs, &princ_entry)) {
+    if (! ldap_xdr_osa_princ_ent_rec(&xdrs, princ_entry)) {
 	xdr_destroy(&xdrs);
 	return KADM5_XDR_FAILURE;
     }

--- a/src/plugins/kdb/ldap/libkdb_ldap/princ_xdr.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/princ_xdr.h
@@ -57,6 +57,6 @@ krb5_lookup_tl_kadm_data(krb5_tl_data *tl_data, osa_princ_ent_rec *princ_entry);
 
 krb5_error_code
 krb5_update_tl_kadm_data(krb5_context context, krb5_db_entry *entry,
-			 char *policy_dn);
+			 osa_princ_ent_rec *princ_entry);
 
 #endif

--- a/src/tests/kdbtest.c
+++ b/src/tests/kdbtest.c
@@ -97,7 +97,7 @@ static krb5_tl_data tl3 = { &tl4, KRB5_TL_KADM_DATA, 32,
                             U("\x12\x34\x5C\x01\x00\x00\x00\x08"
                               "\x3C\x74\x65\x73\x74\x2A\x3E\x00"
                               "\x00\x00\x08\x00\x00\x00\x00\x00"
-                              "\x00\x00\x00\x02\x00\x00\x00\x00") };
+                              "\x00\x00\x00\x00\x00\x00\x00\x00") };
 static krb5_tl_data tl2 = { &tl3, KRB5_TL_MOD_PRINC, 8, U("\5\6\7\0x@Y\0") };
 static krb5_tl_data tl1 = { &tl2, KRB5_TL_LAST_PWD_CHANGE, 4, U("\1\2\3\4") };
 

--- a/src/tests/t_kdb.py
+++ b/src/tests/t_kdb.py
@@ -367,6 +367,13 @@ out = realm.run([kadminl, 'getprinc', 'keylessprinc'])
 if 'Number of keys: 0' not in out:
     fail('After purgekeys -all, keys remain')
 
+# Test for 8354 (old password history entries when -keepold is used)
+realm.run([kadminl, 'addpol', '-history', '2', 'keepoldpasspol'])
+realm.run([kadminl, 'addprinc', '-policy', 'keepoldpasspol', '-pw', 'aaaa',
+           'keepoldpassprinc'])
+map(lambda p: realm.run([kadminl, 'cpw', '-keepold', '-pw', p,
+                     'keepoldpassprinc']), ['bbbb', 'cccc', 'aaaa'])
+
 realm.stop()
 
 # Briefly test dump and load.


### PR DESCRIPTION
The password history is stored in the kerberos LDAP schema attribute 'krbPwdHistory', with one history entry per attribute.  When the history is decoded the history entries are sorted by kvno in descending order, with the next replacement key set to the last key entry, or the key history entry with the smallest kvno.

This commit is based on code commited by Tomas Kuthan <tkuthan@gmail.com>.
 
ticket: [5889](https://krbdev.mit.edu/rt/Ticket/Display.html?id=5889)