### PR TITLE
Add hints for -A flag to klist and kdestroy

### DIFF
--- a/src/clients/kdestroy/kdestroy.c
+++ b/src/clients/kdestroy/kdestroy.c
@@ -66,6 +66,29 @@ static void usage()
     exit(2);
 }
 
+void
+print_remaining_cc_warning(krb5_context context)
+{
+    krb5_error_code code;
+    krb5_ccache cache;
+    krb5_cccol_cursor cursor;
+
+    code = krb5_cccol_cursor_new(context, &cursor);
+    if (code) {
+        com_err(progname, code, _("while listing credential caches"));
+        exit(1);
+    }
+
+    code = krb5_cccol_cursor_next(context, cursor, &cache);
+    if (code == 0 && cache != NULL) {
+        fprintf(stderr,
+                _("Other credential caches present, use -A to destroy all\n"));
+        krb5_cc_close(context, cache);
+    }
+
+    krb5_cccol_cursor_free(context, &cursor);
+}
+
 int
 main(argc, argv)
     int argc;
@@ -178,5 +201,9 @@ main(argc, argv)
             errflg = 1;
         }
     }
+
+    if (!quiet && !errflg)
+        print_remaining_cc_warning(kcontext);
+
     return errflg;
 }


### PR DESCRIPTION
When using DIR/keyring ccache, a user accustomed to the FILE ccache behavior
may not be aware of all active caches and the default klist/kdestroy commands
could make it seem like there is no active cache left. If there are multiple
caches, print a warning with the number of caches and hint at the -A flag.