### PR TITLE
Fix and adjust t_kprop.py

### DIFF
--- a/src/tests/t_kprop.py
+++ b/src/tests/t_kprop.py
@@ -24,21 +24,21 @@ for realm in multipass_realms(create_user=False):
     realm.addprinc('wakawaka')
 
     # Start kpropd.
-    kpropd = realm.start_kpropd(slave, ['-d', '-t'])
+    kpropd = realm.start_kpropd(slave, ['-d'])
 
     realm.run([kdb5_util, 'dump', dumpfile])
     realm.run([kprop, '-f', dumpfile, '-P', str(realm.kprop_port()), hostname])
     output('*** kpropd output follows\n')
     while True:
         line = kpropd.stdout.readline()
-        if line == '':
+        if 'Database load process for full propagation completed' in line:
             break
         output('kpropd: ' + line)
         if 'Rejected connection' in line:
             fail('kpropd rejected connection from kprop')
 
-            out = realm.run([kadminl, 'listprincs', slave])
-            if 'wakawaka' not in out:
-                fail('Slave does not have all principals from master')
+    out = realm.run([kadminl, 'listprincs'], slave)
+    if 'wakawaka' not in out:
+        fail('Slave does not have all principals from master')
 
 success('kprop tests')


### PR DESCRIPTION
The listprincs check was at the wrong indentation level and had the
wrong argument grouping; fix it so we actually verify the propagation.

Stop using the -t (runonce) flag to kpropd, so that kpropd continues
to run until k5test.py terminates it.  Quit out of the read loop when
we see that the load process is completed, instead of looking for end
of input.  This change is needed in order to add hooks in k5test.py
for checking daemons for memory leaks before terminating them.