### PR TITLE
Remove form feed characters

### DIFF
--- a/src/include/k5-thread.h
+++ b/src/include/k5-thread.h
@@ -35,7 +35,7 @@
 # define KRB5_CALLCONV_C
 #endif
 
-/* Interface (tentative):
+/* Interface (tentative):
 
      Mutex support:
 
@@ -134,7 +134,6 @@
      More to be added, perhaps.  */
 
 #include <assert.h>
-
 
 /* The mutex structure we use, k5_mutex_t, is defined to some
    OS-specific bits.  The use of multiple layers of typedefs are an
@@ -362,9 +361,6 @@ static inline int k5_os_mutex_lock(k5_os_mutex *m)
 
 #endif
 
-
-
-
 typedef k5_os_mutex k5_mutex_t;
 #define K5_MUTEX_PARTIAL_INITIALIZER    K5_OS_MUTEX_PARTIAL_INITIALIZER
 static inline int k5_mutex_init(k5_mutex_t *m)
@@ -395,7 +391,6 @@ static inline void k5_mutex_unlock(k5_mutex_t *m)
 #define k5_assert_locked        k5_mutex_assert_locked
 #define k5_assert_unlocked      k5_mutex_assert_unlocked
 
-
 /* Thread-specific data; implemented in a support file, because we'll
    need to keep track of some global data for cleanup purposes.
 

--- a/src/lib/apputils/net-server.c
+++ b/src/lib/apputils/net-server.c
@@ -133,7 +133,6 @@ set_pktinfo(int sock, int family)
     return 0;
 }
 
-
 static const char *
 paddr(struct sockaddr *sa)
 {
@@ -197,7 +196,6 @@ struct connection {
     int rpc_force_close;
 };
 
-
 #define SET(TYPE) struct { TYPE *data; size_t n, max; }
 
 /* Start at the top and work down -- this should allow for deletions
@@ -369,7 +367,6 @@ loop_add_rpc_service(int port, u_long prognum,
     return 0;
 }
 
-
 #define USE_AF AF_INET
 #define USE_TYPE SOCK_DGRAM
 #define USE_PROTO 0
@@ -660,7 +657,7 @@ setkeepalive(int sock)
 {
     return setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &one, sizeof(one));
 }
-
+
 static int
 setnolinger(int s)
 {

--- a/src/lib/crypto/ISSUES
+++ b/src/lib/crypto/ISSUES
@@ -1,5 +1,6 @@
 Issues to be addressed for src/lib/crypto: -*- text -*-
-
+
+
 Many files here and in subdirectories pollute the namespace.
 However, some applications wanting to directly use some of those
 routines will expect those names to be available.
@@ -7,6 +8,7 @@ routines will expect those names to be available.
 Workaround: Shared library export lists?  Define and export internal
 names, and provide wrapper library code or weak functions under the
 polluting names?
-
+
+
 Some routines assume "int" is big enough to describe all buffers that
 may be supplied.

--- a/src/lib/crypto/builtin/des/ISSUES
+++ b/src/lib/crypto/builtin/des/ISSUES
@@ -1,9 +1,9 @@
 Issues to be addressed for src/lib/crypto/des: -*- text -*-
 
-
+
 "const" could be used in more places
 
-
+
 Array types are used in calling interfaces.  Under ANSI C, a value of
 type "arraytype *" cannot be assigned to a variable of type "const
 arraytype *", so we get compilation warnings.

--- a/src/lib/crypto/builtin/md4/ISSUES
+++ b/src/lib/crypto/builtin/md4/ISSUES
@@ -1,3 +1,4 @@
 Issues to be addressed for src/lib/crypto/md4: -*- text -*-
-
+
+
 Assumes int is >= 32 bits.

--- a/src/lib/crypto/builtin/md5/ISSUES
+++ b/src/lib/crypto/builtin/md5/ISSUES
@@ -1,3 +1,4 @@
 Issues to be addressed for src/lib/crypto/md5: -*- text -*-
-
+
+
 Assumes int is >= 32 bits.

--- a/src/lib/crypto/builtin/sha1/ISSUES
+++ b/src/lib/crypto/builtin/sha1/ISSUES
@@ -1,5 +1,6 @@
 Issues to be addressed for src/lib/crypto/sha1: -*- text -*-
-
+
+
 Assumes int (look for "count") is >= 32 bits.
 
 Changing the types of internal variables is easy, but shsUpdate takes

--- a/src/lib/kadm5/logger.c
+++ b/src/lib/kadm5/logger.c
@@ -66,7 +66,7 @@
 #define log_notice_string       _("Notice")
 #define log_info_string         _("info")
 #define log_debug_string        _("debug")
-
+
 /*
  * Output logging.
  *
@@ -161,7 +161,6 @@ static struct log_entry def_log_entry;
                                  -1)
 #define DEVICE_CLOSE(d)         fclose(d)
 
-
 /*
  * klog_com_err_proc()  - Handle com_err(3) messages as specified by the
  *                        profile.
@@ -326,7 +325,7 @@ klog_com_err_proc(const char *whoami, long int code, const char *format, va_list
         }
     }
 }
-
+
 /*
  * krb5_klog_init()     - Initialize logging.
  *

--- a/src/lib/kadm5/srv/server_acl.c
+++ b/src/lib/kadm5/srv/server_acl.c
@@ -93,7 +93,6 @@ static const char *acl_syn_err_msg = N_("%s: syntax error at line %d "
                                         "<%10s...>");
 static const char *acl_cantopen_msg = N_("%s while opening ACL file %s");
 
-
 /*
  * kadm5int_acl_get_line() - Get a line from the ACL file.
  *                      Lines ending with \ are continued on the next line
@@ -157,7 +156,7 @@ kadm5int_acl_get_line(fp, lnp)
     else
         return(acl_buf);
 }
-
+
 /*
  * kadm5int_acl_parse_line() - Parse the contents of an ACL line.
  */
@@ -260,7 +259,7 @@ kadm5int_acl_parse_line(lp)
            ("X kadm5int_acl_parse_line() = %x\n", (long) acle));
     return(acle);
 }
-
+
 /*
  * kadm5int_acl_parse_restrictions() - Parse optional restrictions field
  *
@@ -360,7 +359,7 @@ kadm5int_acl_parse_restrictions(s, rpp)
             code, (*rpp) ? (*rpp)->mask : 0));
     return code;
 }
-
+
 /*
  * kadm5int_acl_impose_restrictions()   - impose restrictions, modifying *recp, *maskp
  *
@@ -434,7 +433,7 @@ kadm5int_acl_impose_restrictions(kcontext, recp, maskp, rp)
            ("X kadm5int_acl_impose_restrictions() = 0, *maskp=0x%08x\n", *maskp));
     return 0;
 }
-
+
 /*
  * kadm5int_acl_free_entries() - Free all ACL entries.
  */
@@ -468,7 +467,7 @@ kadm5int_acl_free_entries()
     acl_inited = 0;
     DPRINT(DEBUG_CALLS, acl_debug_level, ("X kadm5int_acl_free_entries()\n"));
 }
-
+
 /*
  * kadm5int_acl_load_acl_file() - Open and parse the ACL file.
  */
@@ -541,7 +540,7 @@ kadm5int_acl_load_acl_file()
            ("X kadm5int_acl_load_acl_file() = %d\n", retval));
     return(retval);
 }
-
+
 /*
  * kadm5int_acl_match_data()    - See if two data entries match.
  *
@@ -587,7 +586,7 @@ kadm5int_acl_match_data(const krb5_data *e1, const krb5_data *e2,
     DPRINT(DEBUG_CALLS, acl_debug_level, ("X acl_match_entry()=%d\n",retval));
     return(retval);
 }
-
+
 /*
  * kadm5int_acl_find_entry()    - Find a matching entry.
  */
@@ -693,7 +692,7 @@ kadm5int_acl_find_entry(krb5_context kcontext, krb5_const_principal principal,
     DPRINT(DEBUG_CALLS, acl_debug_level, ("X kadm5int_acl_find_entry()=%x\n",entry));
     return(entry);
 }
-
+
 /*
  * kadm5int_acl_init()  - Initialize ACL context.
  */
@@ -716,7 +715,7 @@ kadm5int_acl_init(kcontext, debug_level, acl_file)
     DPRINT(DEBUG_CALLS, acl_debug_level, ("X kadm5int_acl_init() = %d\n", kret));
     return(kret);
 }
-
+
 /*
  * kadm5int_acl_finish  - Terminate ACL context.
  */
@@ -729,7 +728,7 @@ kadm5int_acl_finish(kcontext, debug_level)
     kadm5int_acl_free_entries();
     DPRINT(DEBUG_CALLS, acl_debug_level, ("X kadm5int_acl_finish()\n"));
 }
-
+
 /*
  * kadm5int_acl_check_krb()     - Is this operation permitted for this principal?
  */

--- a/src/lib/krb5/ccache/ser_cc.c
+++ b/src/lib/krb5/ccache/ser_cc.c
@@ -49,7 +49,7 @@ static const krb5_ser_entry krb5_ccache_ser_entry = {
     krb5_ccache_externalize,            /* Externalize routine  */
     krb5_ccache_internalize             /* Internalize routine  */
 };
-
+
 /*
  * krb5_ccache_size()   - Determine the size required to externalize
  *                                this krb5_ccache variant.
@@ -84,7 +84,7 @@ krb5_ccache_size(krb5_context kcontext, krb5_pointer arg, size_t *sizep)
     }
     return(kret);
 }
-
+
 /*
  * krb5_ccache_externalize()    - Externalize the krb5_ccache.
  */
@@ -139,7 +139,7 @@ krb5_ccache_externalize(krb5_context kcontext, krb5_pointer arg, krb5_octet **bu
     }
     return(kret);
 }
-
+
 /*
  * krb5_ccache_internalize()    - Internalize the krb5_ccache.
  */
@@ -204,7 +204,7 @@ cleanup:
     free(ccname);
     return(kret);
 }
-
+
 /*
  * Register the ccache serializer.
  */

--- a/src/lib/krb5/keytab/kt_file.c
+++ b/src/lib/krb5/keytab/kt_file.c
@@ -567,7 +567,7 @@ const krb5_ser_entry krb5_ktfile_ser_entry = {
     krb5_ktf_keytab_externalize,        /* Externalize routine  */
     krb5_ktf_keytab_internalize         /* Internalize routine  */
 };
-
+
 /*
  * krb5_ktf_keytab_size()       - Determine the size required to externalize
  *                                this krb5_keytab variant.
@@ -612,7 +612,7 @@ krb5_ktf_keytab_size(krb5_context kcontext, krb5_pointer arg, size_t *sizep)
     }
     return(kret);
 }
-
+
 /*
  * krb5_ktf_keytab_externalize()        - Externalize the krb5_keytab.
  */
@@ -708,7 +708,7 @@ krb5_ktf_keytab_externalize(krb5_context kcontext, krb5_pointer arg, krb5_octet 
     }
     return(kret);
 }
-
+
 /*
  * krb5_ktf_keytab_internalize()        - Internalize the krb5_ktf_keytab.
  */

--- a/src/lib/krb5/krb/chk_trans.c
+++ b/src/lib/krb5/krb/chk_trans.c
@@ -285,7 +285,6 @@ foreach_realm (krb5_error_code (*fn)(krb5_data *comp,void *data), void *data,
     return 0;
 }
 
-
 struct check_data {
     krb5_context ctx;
     krb5_principal *tgs;
@@ -355,7 +354,7 @@ krb5_check_transited_list (krb5_context ctx, const krb5_data *trans_in,
     krb5_free_realm_tree (ctx, cdata.tgs);
     return r;
 }
-
+
 #ifdef TEST
 
 static krb5_error_code

--- a/src/lib/krb5/krb/ser_actx.c
+++ b/src/lib/krb5/krb/ser_actx.c
@@ -60,7 +60,7 @@ static const krb5_ser_entry krb5_auth_context_ser_entry = {
     krb5_auth_context_externalize,      /* Externalize routine  */
     krb5_auth_context_internalize       /* Internalize routine  */
 };
-
+
 /*
  * krb5_auth_context_size()     - Determine the size required to externalize
  *                                the krb5_auth_context.
@@ -172,7 +172,7 @@ krb5_auth_context_size(krb5_context kcontext, krb5_pointer arg, size_t *sizep)
         *sizep += required;
     return(kret);
 }
-
+
 /*
  * krb5_auth_context_externalize()      - Externalize the krb5_auth_context.
  */
@@ -316,7 +316,7 @@ krb5_auth_context_externalize(krb5_context kcontext, krb5_pointer arg, krb5_octe
     }
     return(kret);
 }
-
+
 /* Internalize a keyblock and convert it to a key. */
 static krb5_error_code
 intern_key(krb5_context ctx, krb5_key *key, krb5_octet **bp, size_t *sp)
@@ -515,7 +515,7 @@ krb5_auth_context_internalize(krb5_context kcontext, krb5_pointer *argp, krb5_oc
     }
     return(kret);
 }
-
+
 /*
  * Register the auth_context serializer.
  */

--- a/src/lib/krb5/krb/ser_adata.c
+++ b/src/lib/krb5/krb/ser_adata.c
@@ -47,7 +47,7 @@ static const krb5_ser_entry krb5_authdata_ser_entry = {
     krb5_authdata_externalize,          /* Externalize routine  */
     krb5_authdata_internalize           /* Internalize routine  */
 };
-
+
 /*
  * krb5_authdata_esize()        - Determine the size required to externalize
  *                                the krb5_authdata.
@@ -77,7 +77,7 @@ krb5_authdata_size(krb5_context kcontext, krb5_pointer arg, size_t *sizep)
     }
     return(kret);
 }
-
+
 /*
  * krb5_authdata_externalize()  - Externalize the krb5_authdata.
  */
@@ -123,7 +123,7 @@ krb5_authdata_externalize(krb5_context kcontext, krb5_pointer arg, krb5_octet **
     }
     return(kret);
 }
-
+
 /*
  * krb5_authdata_internalize()  - Internalize the krb5_authdata.
  */
@@ -183,7 +183,7 @@ krb5_authdata_internalize(krb5_context kcontext, krb5_pointer *argp, krb5_octet 
     }
     return(kret);
 }
-
+
 /*
  * Register the authdata serializer.
  */

--- a/src/lib/krb5/krb/ser_addr.c
+++ b/src/lib/krb5/krb/ser_addr.c
@@ -47,7 +47,7 @@ static const krb5_ser_entry krb5_address_ser_entry = {
     krb5_address_externalize,           /* Externalize routine  */
     krb5_address_internalize            /* Internalize routine  */
 };
-
+
 /*
  * krb5_address_size()  - Determine the size required to externalize
  *                                the krb5_address.
@@ -77,7 +77,7 @@ krb5_address_size(krb5_context kcontext, krb5_pointer arg, size_t *sizep)
     }
     return(kret);
 }
-
+
 /*
  * krb5_address_externalize()   - Externalize the krb5_address.
  */
@@ -124,7 +124,7 @@ krb5_address_externalize(krb5_context kcontext, krb5_pointer arg, krb5_octet **b
     }
     return(kret);
 }
-
+
 /*
  * krb5_address_internalize()   - Internalize the krb5_address.
  */
@@ -187,7 +187,7 @@ krb5_address_internalize(krb5_context kcontext, krb5_pointer *argp, krb5_octet *
     }
     return(kret);
 }
-
+
 /*
  * Register the address serializer.
  */

--- a/src/lib/krb5/krb/ser_auth.c
+++ b/src/lib/krb5/krb/ser_auth.c
@@ -49,7 +49,7 @@ static const krb5_ser_entry krb5_authenticator_ser_entry = {
     krb5_authenticator_externalize,     /* Externalize routine  */
     krb5_authenticator_internalize      /* Internalize routine  */
 };
-
+
 /*
  * krb5_authenticator_size()    - Determine the size required to externalize
  *                                the krb5_authenticator.
@@ -114,7 +114,7 @@ krb5_authenticator_size(krb5_context kcontext, krb5_pointer arg, size_t *sizep)
         *sizep += required;
     return(kret);
 }
-
+
 /*
  * krb5_authenticator_externalize()     - Externalize the krb5_authenticator.
  */
@@ -216,7 +216,7 @@ krb5_authenticator_externalize(krb5_context kcontext, krb5_pointer arg, krb5_oct
     }
     return(kret);
 }
-
+
 /*
  * krb5_authenticator_internalize()     - Internalize the krb5_authenticator.
  */

--- a/src/lib/krb5/krb/ser_cksum.c
+++ b/src/lib/krb5/krb/ser_cksum.c
@@ -47,7 +47,7 @@ static const krb5_ser_entry krb5_checksum_ser_entry = {
     krb5_checksum_externalize,          /* Externalize routine  */
     krb5_checksum_internalize           /* Internalize routine  */
 };
-
+
 /*
  * krb5_checksum_esize()        - Determine the size required to externalize
  *                                the krb5_checksum.
@@ -77,7 +77,7 @@ krb5_checksum_esize(krb5_context kcontext, krb5_pointer arg, size_t *sizep)
     }
     return(kret);
 }
-
+
 /*
  * krb5_checksum_externalize()  - Externalize the krb5_checksum.
  */
@@ -124,7 +124,7 @@ krb5_checksum_externalize(krb5_context kcontext, krb5_pointer arg, krb5_octet **
     }
     return(kret);
 }
-
+
 /*
  * krb5_checksum_internalize()  - Internalize the krb5_checksum.
  */
@@ -185,7 +185,7 @@ krb5_checksum_internalize(krb5_context kcontext, krb5_pointer *argp, krb5_octet 
     }
     return(kret);
 }
-
+
 /*
  * Register the checksum serializer.
  */

--- a/src/lib/krb5/krb/ser_ctx.c
+++ b/src/lib/krb5/krb/ser_ctx.c
@@ -169,7 +169,7 @@ krb5_context_size(krb5_context kcontext, krb5_pointer arg, size_t *sizep)
         *sizep += required;
     return(kret);
 }
-
+
 /*
  * krb5_context_externalize()   - Externalize the krb5_context.
  */
@@ -335,7 +335,7 @@ krb5_context_externalize(krb5_context kcontext, krb5_pointer arg, krb5_octet **b
 
     return (0);
 }
-
+
 /*
  * krb5_context_internalize()   - Internalize the krb5_context.
  */
@@ -513,7 +513,7 @@ cleanup:
         krb5_free_context(context);
     return(kret);
 }
-
+
 /*
  * krb5_oscontext_size()        - Determine the size required to externalize
  *                                the krb5_os_context.
@@ -529,7 +529,7 @@ krb5_oscontext_size(krb5_context kcontext, krb5_pointer arg, size_t *sizep)
     *sizep += (5*sizeof(krb5_int32));
     return(0);
 }
-
+
 /*
  * krb5_oscontext_externalize() - Externalize the krb5_os_context.
  */
@@ -566,7 +566,7 @@ krb5_oscontext_externalize(krb5_context kcontext, krb5_pointer arg, krb5_octet *
     }
     return(kret);
 }
-
+
 /*
  * krb5_oscontext_internalize() - Internalize the krb5_os_context.
  */
@@ -619,7 +619,7 @@ krb5_oscontext_internalize(krb5_context kcontext, krb5_pointer *argp, krb5_octet
     }
     return(kret);
 }
-
+
 /*
  * Register the context serializers.
  */

--- a/src/lib/krb5/krb/ser_key.c
+++ b/src/lib/krb5/krb/ser_key.c
@@ -47,7 +47,7 @@ static const krb5_ser_entry krb5_keyblock_ser_entry = {
     krb5_keyblock_externalize,          /* Externalize routine  */
     krb5_keyblock_internalize           /* Internalize routine  */
 };
-
+
 /*
  * krb5_keyblock_size() - Determine the size required to externalize
  *                                the krb5_keyblock.
@@ -78,7 +78,7 @@ krb5_keyblock_size(krb5_context kcontext, krb5_pointer arg, size_t *sizep)
     }
     return(kret);
 }
-
+
 /*
  * krb5_keyblock_externalize()  - Externalize the krb5_keyblock.
  */
@@ -125,7 +125,7 @@ krb5_keyblock_externalize(krb5_context kcontext, krb5_pointer arg, krb5_octet **
     }
     return(kret);
 }
-
+
 /*
  * krb5_keyblock_internalize()  - Internalize the krb5_keyblock.
  */
@@ -183,7 +183,7 @@ krb5_keyblock_internalize(krb5_context kcontext, krb5_pointer *argp, krb5_octet 
     }
     return(kret);
 }
-
+
 /*
  * Register the keyblock serializer.
  */

--- a/src/lib/krb5/krb/ser_princ.c
+++ b/src/lib/krb5/krb/ser_princ.c
@@ -47,7 +47,7 @@ static const krb5_ser_entry krb5_principal_ser_entry = {
     krb5_principal_externalize,         /* Externalize routine  */
     krb5_principal_internalize          /* Internalize routine  */
 };
-
+
 /*
  * krb5_principal_size()        - Determine the size required to externalize
  *                                the krb5_principal.
@@ -74,7 +74,7 @@ krb5_principal_size(krb5_context kcontext, krb5_pointer arg, size_t *sizep)
     }
     return(kret);
 }
-
+
 /*
  * krb5_principal_externalize() - Externalize the krb5_principal.
  */
@@ -113,7 +113,7 @@ krb5_principal_externalize(krb5_context kcontext, krb5_pointer arg, krb5_octet *
     }
     return(kret);
 }
-
+
 /*
  * krb5_principal_internalize() - Internalize the krb5_principal.
  */
@@ -166,7 +166,7 @@ cleanup:
     free(tmpname);
     return kret;
 }
-
+
 /*
  * Register the context serializer.
  */

--- a/src/lib/krb5/krb/serialize.c
+++ b/src/lib/krb5/krb/serialize.c
@@ -25,7 +25,7 @@
  */
 
 #include "k5-int.h"
-
+
 /*
  * krb5_find_serializer()       - See if a particular type is registered.
  */
@@ -46,7 +46,7 @@ krb5_find_serializer(krb5_context kcontext, krb5_magic odtype)
     }
     return(res);
 }
-
+
 /*
  * krb5_register_serializer()   - Register a particular serializer.
  */
@@ -83,7 +83,7 @@ krb5_register_serializer(krb5_context kcontext, const krb5_ser_entry *entry)
         *stable = *entry;
     return(kret);
 }
-
+
 /*
  * krb5_size_opaque()   - Determine the size necessary to serialize a given
  *                        piece of opaque data.
@@ -100,7 +100,7 @@ krb5_size_opaque(krb5_context kcontext, krb5_magic odtype, krb5_pointer arg, siz
         kret = (shandle->sizer) ? (*shandle->sizer)(kcontext, arg, sizep) : 0;
     return(kret);
 }
-
+
 /*
  * krb5_externalize_opaque()    - Externalize a piece of opaque data.
  */
@@ -117,7 +117,7 @@ krb5_externalize_opaque(krb5_context kcontext, krb5_magic odtype, krb5_pointer a
             (*shandle->externalizer)(kcontext, arg, bufpp, sizep) : 0;
     return(kret);
 }
-
+
 /*
  * Externalize a piece of arbitrary data.
  */
@@ -151,7 +151,7 @@ krb5_externalize_data(krb5_context kcontext, krb5_pointer arg, krb5_octet **bufp
     }
     return(kret);
 }
-
+
 /*
  * krb5_internalize_opaque()    - Convert external representation into a data
  *                                structure.
@@ -169,7 +169,7 @@ krb5_internalize_opaque(krb5_context kcontext, krb5_magic odtype, krb5_pointer *
             (*shandle->internalizer)(kcontext, argp, bufpp, sizep) : 0;
     return(kret);
 }
-
+
 /*
  * krb5_ser_pack_int32()        - Pack a 4-byte integer if space is available.
  *                                Update buffer pointer and remaining space.
@@ -186,7 +186,7 @@ krb5_ser_pack_int32(krb5_int32 iarg, krb5_octet **bufp, size_t *remainp)
     else
         return(ENOMEM);
 }
-
+
 /*
  * krb5_ser_pack_int64()        - Pack an 8-byte integer if space is available.
  *                                Update buffer pointer and remaining space.
@@ -203,7 +203,7 @@ krb5_ser_pack_int64(int64_t iarg, krb5_octet **bufp, size_t *remainp)
     else
         return(ENOMEM);
 }
-
+
 /*
  * krb5_ser_pack_bytes()        - Pack a string of bytes.
  */
@@ -219,7 +219,7 @@ krb5_ser_pack_bytes(krb5_octet *ostring, size_t osize, krb5_octet **bufp, size_t
     else
         return(ENOMEM);
 }
-
+
 /*
  * krb5_ser_unpack_int32()      - Unpack a 4-byte integer if it's there.
  */
@@ -235,7 +235,7 @@ krb5_ser_unpack_int32(krb5_int32 *intp, krb5_octet **bufp, size_t *remainp)
     else
         return(ENOMEM);
 }
-
+
 /*
  * krb5_ser_unpack_int64()      - Unpack an 8-byte integer if it's there.
  */
@@ -251,7 +251,7 @@ krb5_ser_unpack_int64(int64_t *intp, krb5_octet **bufp, size_t *remainp)
     else
         return(ENOMEM);
 }
-
+
 /*
  * krb5_ser_unpack_bytes()      - Unpack a byte string if it's there.
  */

--- a/src/lib/krb5/krb/str_conv.c
+++ b/src/lib/krb5/krb/str_conv.c
@@ -114,7 +114,7 @@ krb5_salttype_to_string(krb5_int32 salttype, char *buffer, size_t buflen)
     else
         return(EINVAL);
 }
-
+
 /* (absolute) time conversions */
 
 #ifndef HAVE_STRFTIME
@@ -263,7 +263,7 @@ krb5_timestamp_to_sfstring(krb5_timestamp timestamp, char *buffer, size_t buflen
     }
     return((ndone) ? 0 : ENOMEM);
 }
-
+
 /* relative time (delta-t) conversions */
 
 /* string->deltat is in deltat.y */

--- a/src/lib/krb5/rcache/ser_rc.c
+++ b/src/lib/krb5/rcache/ser_rc.c
@@ -51,7 +51,7 @@ static const krb5_ser_entry krb5_rcache_ser_entry = {
     krb5_rcache_externalize,            /* Externalize routine  */
     krb5_rcache_internalize             /* Internalize routine  */
 };
-
+
 /*
  * krb5_rcache_size()   - Determine the size required to externalize
  *                                this krb5_rcache variant.
@@ -86,7 +86,7 @@ krb5_rcache_size(krb5_context kcontext, krb5_pointer arg, size_t *sizep)
     }
     return(kret);
 }
-
+
 /*
  * krb5_rcache_externalize()    - Externalize the krb5_rcache.
  */
@@ -141,7 +141,7 @@ krb5_rcache_externalize(krb5_context kcontext, krb5_pointer arg, krb5_octet **bu
     }
     return(kret);
 }
-
+
 /*
  * krb5_rcache_internalize()    - Internalize the krb5_rcache.
  */
@@ -201,7 +201,7 @@ cleanup:
         krb5_rc_close(kcontext, rcache);
     return kret;
 }
-
+
 /*
  * Register the rcache serializer.
  */

--- a/src/plugins/preauth/pkinit/pkcs11.h
+++ b/src/plugins/preauth/pkinit/pkcs11.h
@@ -95,7 +95,6 @@ extern "C" {
 
 #endif
 
-
 #ifdef CRYPTOKI_COMPAT
   /* If we are in compatibility mode, switch all exposed names to the
      PKCS #11 variant.  There are corresponding #undefs below.  */
@@ -181,7 +180,6 @@ extern "C" {
 
 #endif	/* CRYPTOKI_COMPAT */
 
-
 
 typedef unsigned long ck_flags_t;
 
@@ -1182,7 +1180,6 @@ struct ck_c_initialize_args
 #define CKR_VENDOR_DEFINED			((unsigned long) (1 << 31))
 
 
-
 /* Compatibility layer.  */
 
 #ifdef CRYPTOKI_COMPAT
@@ -1344,7 +1341,6 @@ typedef struct ck_c_initialize_args *CK_C_INITIALIZE_ARGS_PTR;
 
 #endif	/* CRYPTOKI_COMPAT */
 
-
 /* System dependencies.  */
 #if defined(_WIN32) || defined(CRYPTOKI_FORCE_WIN32)
 #pragma pack(pop, cryptoki)

--- a/src/util/et/ISSUES
+++ b/src/util/et/ISSUES
@@ -1,5 +1,6 @@
 Issues to be addressed for src/util/et: -*- text -*-
-
+
+
 Non-thread-safe aspects:
 
 error_message uses a static buffer for "unknown error code" messages;
@@ -13,7 +14,8 @@ likewise, but can be changed without externally visible effect.
 
 Workaround: Use a global lock for all calls to error_message and
 com_err, and when adding or removing error tables.
-
+
+
 API divergence:
 
 Transarc and Heimdal both have APIs that are different from this
@@ -22,7 +24,8 @@ version.  (Specifics?)
 Karl Ramm has offered to try to combine them.
 
 Workaround:
-
+
+
 Reference counting:
 
 If libraries are dynamically loaded and unloaded, and the init/fini
@@ -37,7 +40,8 @@ discarded.
 It's not implemented as a reference count, but the effect is the same.
 
 Fix needed: Update documentation.
-
+
+
 64-bit support:
 
 Values are currently computed as 32-bit values, sign-extended to
@@ -52,9 +56,9 @@ to keep in mind....
 
 Workaround: Always use signed types of at least 32 bits for error
 codes.
-
+
+
 man page:
 
 No documentation on add_error_table/remove_error_table interfaces,
 even though they're the new, preferred interface.
-

--- a/src/util/t_array.pm
+++ b/src/util/t_array.pm
@@ -20,7 +20,7 @@ sub new { # no args
 }
 
 __DATA__
-
+
 /*
  * array type, derived from template
  *
@@ -75,7 +75,7 @@ static inline unsigned long
 	upper_bound = ULONG_MAX;
     return (unsigned long) upper_bound;
 }
-
+
 static inline int
 <NAME>_grow(<NAME> *arr, unsigned long newcount)
 {

--- a/src/util/t_bimap.pm
+++ b/src/util/t_bimap.pm
@@ -63,7 +63,7 @@ sub output {
 1;
 
 __DATA__
-
+
 /* for use in cases where text substitutions may not work, like putting
    "const" before a type that turns out to be "char *"  */
 typedef <LEFT> <NAME>__left_t;

--- a/src/util/t_enum.pm
+++ b/src/util/t_enum.pm
@@ -32,7 +32,7 @@ sub output {
 1;
 
 __DATA__
-
+
 /*
  * an enumerated collection type, generated from template
  *
@@ -108,7 +108,7 @@ static inline long
     en->used++;
     return en->used-1;
 }
-
+
 static inline <TYPE>
 <NAME>_get(<NAME> *en, size_t idx)
 {

--- a/src/util/t_tsenum.pm
+++ b/src/util/t_tsenum.pm
@@ -32,7 +32,7 @@ sub output {
 1;
 
 __DATA__
-
+
 /*
  */
 #include "k5-thread.h"
@@ -108,7 +108,7 @@ static inline int
     *added = 0;
     return 0;
 }
-
+
 static inline int
 <NAME>_get(<NAME> *en, size_t idx, <TYPE> *value)
 {

--- a/src/windows/lib/cacheapi.h
+++ b/src/windows/lib/cacheapi.h
@@ -90,7 +90,6 @@ typedef cc_int32  cc_time_t;
 #define CC_ERR_CACHE_FULL    15
 #define CC_ERR_CRED_VERSION  16
 
-
 /*
 ** types, structs, & constants
 */
@@ -142,7 +141,6 @@ typedef struct _cc_creds {
     cc_data **  authdata;
 } cc_creds;
 
-
 // begin V4 stuff
 // use an enumerated type so all callers infer the same meaning
 // these values are what krbv4win uses internally.
@@ -203,7 +201,6 @@ typedef struct _infoNC {
     cc_int32  vers;
 } infoNC;
 
-
 /*
 ** The official (externally visible) API
 */
@@ -236,7 +233,6 @@ cc_get_change_time(
     cc_time_t* time      // <  time of last change to main cache
     );
 
-
 /*
 ** Named Cache (NC) routines
 **   create, open, close, destroy, get_principal, get_cred_version, &
@@ -372,7 +368,6 @@ cc_lock_request(
                                 //   lock types
     );
 
-
 /*
 ** Credentials routines (work within an NC)
 ** store, remove_cred, seq_fetch_creds


### PR DESCRIPTION
Some older code in the tree uses form feed characters.  kdevelop does
not appear to preserve them, and it is not our current practice to use
them, so get rid of them in almost all files under src.  Leave alone
lib/gssapi/krb5/3des.txt, which is a formatted internet draft.