### PR TITLE
Increase initial DNS buffer size

### DIFF
--- a/src/lib/krb5/os/dnsglue.c
+++ b/src/lib/krb5/os/dnsglue.c
@@ -128,7 +128,7 @@ krb5int_dns_init(struct krb5int_dns_state **dsp,
     ds->ansp = NULL;
     ds->anslen = 0;
     ds->ansmax = 0;
-    nextincr = 2048;
+    nextincr = 4096;
     maxincr = INT_MAX;
 
 #if HAVE_NS_INITPARSE


### PR DESCRIPTION
In dnsglue.c (which is used to look up SRV and TXT records), increase
the initial buffer size guess from 2048 to 4096 to accomodate DNSSEC
signatures.  Suggested by Daniel Colascione.
