### PR TITLE
Add CAMMAC and authentication indicator helper functions to libkrb5

### DIFF
--- a/doc/admin/auth_indicator.rst
+++ b/doc/admin/auth_indicator.rst
@@ -51,3 +51,6 @@ but a user who authenticates with a password would not::
     $ kvno host/high.value.server
     kvno: KDC policy rejects request while getting credentials for
       host/high.value.server@KRBTEST.COM
+
+Indicators present in a ticket are exposed to GSSAPI through the
+:ref:`auth-indicator <gssapi_authind_attr>` name attribute.

--- a/doc/appdev/gssapi.rst
+++ b/doc/appdev/gssapi.rst
@@ -513,6 +513,39 @@ gss_get_mic_iov_length and gss_get_mic_iov::
     if (GSS_ERROR(major))
         handle_error(major, minor);
 
+Name Attributes
+---------------
+
+The following extensions (declared in ``<gssapi/gssapi_ext.h>``) can
+be used in release 1.8 or later to examine name attributes described
+in :rfc:`6680`::
+
+    OM_uint32 gss_inquire_name(OM_uint32 minor_status,
+                               gss_name_t name,
+                               int *name_is_MN,
+                               gss_OID *MN_mech,
+                               gss_buffer_set_t *attrs);
+
+    OM_uint32 gss_get_name_attribute(OM_uint32 minor_status,
+                                     gss_name_t name,
+                                     gss_buffer_t attr,
+                                     int *authenticated,
+                                     int *complete,
+                                     gss_buffer_t value,
+                                     gss_buffer_t display_value,
+                                     int *more);
+
+.. _gssapi_authind_attr:
+
+* "auth-indicator" attribute:
+
+In release 1.15 this name attribute type will be included in the
+gss_inquire_name output if the ticket contains :ref:`authentication
+indicators <auth_indicator>`.  When a client performs
+pre-authentication, the KDC may include authentication indicator values
+into the authorization data of a ticket.  These are site-defined strings
+that are intended to convey the type or strength of pre-authentication,
+allowing an application to make additional authorization policy checks.
 
 .. _gss_accept_sec_context: http://tools.ietf.org/html/rfc2744.html#section-5.1
 .. _gss_acquire_cred: http://tools.ietf.org/html/rfc2744.html#section-5.2

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -956,6 +956,12 @@ void k5_free_kkdcp_message(krb5_context context, krb5_kkdcp_message *val);
 void k5_free_cammac(krb5_context context, krb5_cammac *val);
 void k5_free_secure_cookie(krb5_context context, krb5_secure_cookie *val);
 
+krb5_error_code
+k5_unwrap_cammac_svc(krb5_context context, const krb5_authdata *ad,
+                     const krb5_keyblock *key, krb5_authdata ***adata_out);
+krb5_error_code
+k5_authind_decode(const krb5_authdata *ad, krb5_data ***indicators);
+
 /* #include "krb5/wordsize.h" -- comes in through base-defs.h. */
 #include "com_err.h"
 #include "k5-plugin.h"

--- a/src/include/krb5/authdata_plugin.h
+++ b/src/include/krb5/authdata_plugin.h
@@ -55,8 +55,9 @@ typedef krb5_error_code
 #define AD_USAGE_TGS_REQ        0x02
 #define AD_USAGE_AP_REQ         0x04
 #define AD_USAGE_KDC_ISSUED     0x08
-#define AD_USAGE_MASK           0x0F
 #define AD_INFORMATIONAL        0x10
+#define AD_CAMMAC_PROTECTED     0x20
+#define AD_USAGE_MASK           0x2F
 
 struct _krb5_authdata_context;
 

--- a/src/kdc/cammac.c
+++ b/src/kdc/cammac.c
@@ -171,24 +171,3 @@ cleanup:
     krb5_free_data(context, der_enctkt);
     return valid;
 }
-
-/* Return true if cammac's service verifier is valid for server_key. */
-krb5_boolean
-cammac_check_svcver(krb5_context context, krb5_cammac *cammac,
-                    krb5_keyblock *server_key)
-{
-    krb5_error_code ret;
-    krb5_verifier_mac *ver = cammac->svc_verifier;
-    krb5_boolean valid = FALSE;
-    krb5_data *der_authdata = NULL;
-
-    if (ver == NULL)
-        return FALSE;
-    ret = encode_krb5_authdata(cammac->elements, &der_authdata);
-    if (ret)
-        return FALSE;
-    ret = krb5_c_verify_checksum(context, server_key, KRB5_KEYUSAGE_CAMMAC,
-                                 der_authdata, &ver->checksum, &valid);
-    krb5_free_data(context, der_authdata);
-    return valid;
-}

--- a/src/kdc/kdc_util.h
+++ b/src/kdc/kdc_util.h
@@ -137,10 +137,6 @@ krb5_boolean
 cammac_check_kdcver(krb5_context context, krb5_cammac *cammac,
                     krb5_enc_tkt_part *enc_tkt, krb5_db_entry *krbtgt);
 
-krb5_boolean
-cammac_check_svcver(krb5_context context, krb5_cammac *cammac,
-                    krb5_keyblock *server_key);
-
 /* do_as_req.c */
 void
 process_as_req (krb5_kdc_req *, krb5_data *,

--- a/src/lib/krb5/krb/Makefile.in
+++ b/src/lib/krb5/krb/Makefile.in
@@ -18,6 +18,7 @@ STLIBOBJS= \
 	allow_weak.o	\
 	appdefault.o	\
 	auth_con.o	\
+	cammac_util.o	\
 	authdata.o	\
 	authdata_exp.o	\
 	authdata_enc.o	\
@@ -128,6 +129,7 @@ OBJS=	$(OUTPRE)addr_comp.$(OBJEXT)	\
 	$(OUTPRE)allow_weak.$(OBJEXT)	\
 	$(OUTPRE)appdefault.$(OBJEXT)	\
 	$(OUTPRE)auth_con.$(OBJEXT)	\
+	$(OUTPRE)cammac_util.$(OBJEXT)	\
 	$(OUTPRE)authdata.$(OBJEXT)	\
 	$(OUTPRE)authdata_exp.$(OBJEXT)	\
 	$(OUTPRE)authdata_enc.$(OBJEXT)	\
@@ -237,6 +239,7 @@ SRCS=	$(srcdir)/addr_comp.c	\
 	$(srcdir)/addr_srch.c	\
 	$(srcdir)/appdefault.c	\
 	$(srcdir)/auth_con.c	\
+	$(srcdir)/cammac_util.c	\
 	$(srcdir)/authdata.c	\
 	$(srcdir)/authdata_exp.c	\
 	$(srcdir)/authdata_enc.c	\

--- a/src/lib/krb5/krb/Makefile.in
+++ b/src/lib/krb5/krb/Makefile.in
@@ -17,6 +17,7 @@ STLIBOBJS= \
 	addr_srch.o	\
 	allow_weak.o	\
 	appdefault.o	\
+	ai_authdata.o   \
 	auth_con.o	\
 	cammac_util.o	\
 	authdata.o	\
@@ -128,6 +129,7 @@ OBJS=	$(OUTPRE)addr_comp.$(OBJEXT)	\
 	$(OUTPRE)addr_srch.$(OBJEXT)	\
 	$(OUTPRE)allow_weak.$(OBJEXT)	\
 	$(OUTPRE)appdefault.$(OBJEXT)	\
+	$(OUTPRE)ai_authdata.$(OBJEXT)  \
 	$(OUTPRE)auth_con.$(OBJEXT)	\
 	$(OUTPRE)cammac_util.$(OBJEXT)	\
 	$(OUTPRE)authdata.$(OBJEXT)	\
@@ -240,6 +242,7 @@ SRCS=	$(srcdir)/addr_comp.c	\
 	$(srcdir)/appdefault.c	\
 	$(srcdir)/auth_con.c	\
 	$(srcdir)/cammac_util.c	\
+	$(srcdir)/ai_authdata.c \
 	$(srcdir)/authdata.c	\
 	$(srcdir)/authdata_exp.c	\
 	$(srcdir)/authdata_enc.c	\
@@ -385,7 +388,7 @@ T_KERB_OBJS= t_kerb.o conv_princ.o unparse.o set_realm.o str_conv.o
 
 T_SER_OBJS= t_ser.o ser_actx.o ser_adata.o ser_addr.o ser_auth.o ser_cksum.o \
 	ser_ctx.o ser_key.o ser_princ.o serialize.o authdata.o pac.o \
-	pac_sign.o authdata_exp.o s4u_authdata.o copy_data.o etype_list.o
+	pac_sign.o ai_authdata.o authdata_exp.o s4u_authdata.o copy_data.o etype_list.o
 
 T_DELTAT_OBJS= t_deltat.o deltat.o
 

--- a/src/lib/krb5/krb/ai_authdata.c
+++ b/src/lib/krb5/krb/ai_authdata.c
@@ -1,0 +1,376 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* src/lib/krb5/krb/ai_authdata.c - Auth indicator AD backend */
+/*
+ * Copyright (C) 2016 by the Massachusetts Institute of Technology.
+ * Copyright (C) 2016 by Red Hat, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Authdata backend for authentication indicators.
+ */
+
+#include "k5-int.h"
+#include "authdata.h"
+#include "auth_con.h"
+#include "int-proto.h"
+
+struct authind_context {
+    krb5_data **indicators;      /* Decoded. */
+    int count;
+};
+
+static krb5_error_code
+authind_init(krb5_context kcontext, void **plugin_context)
+{
+    *plugin_context = NULL;
+    return 0;
+}
+
+static void
+authind_flags(krb5_context kcontext, void *plugin_context,
+              krb5_authdatatype ad_type, krb5_flags *flags)
+{
+    *flags = AD_CAMMAC_PROTECTED;
+}
+
+static krb5_error_code
+authind_request_init(krb5_context kcontext, krb5_authdata_context context,
+                     void *plugin_context, void **request_context)
+{
+    krb5_error_code ret = 0;
+    struct authind_context *aictx;
+
+    aictx = k5alloc(sizeof(*aictx), &ret);
+    if (aictx == NULL)
+        return ret;
+
+    aictx->indicators = NULL;
+    aictx->count = 0;
+
+    *request_context = aictx;
+
+    return ret;
+}
+
+static krb5_error_code
+authind_import_authdata(krb5_context kcontext, krb5_authdata_context context,
+                        void *plugin_context, void *request_context,
+                        krb5_authdata **authdata, krb5_boolean kdc_issued,
+                        krb5_const_principal kdc_issuer)
+{
+    struct authind_context *aictx = (struct authind_context *)request_context;
+    krb5_error_code ret = 0;
+    krb5_data **indps;
+    int count, i;
+
+    /* Explicitly set to NULL for k5_authind_decode(). */
+    indps = NULL;
+
+    for (i = 0; authdata != NULL && authdata[i] != NULL; i++) {
+        ret = k5_authind_decode(authdata[i], &indps);
+        if (ret)
+            goto cleanup;
+    }
+
+    for (count = 0; indps != NULL && indps[count] != NULL; count++);
+
+    if (count != 0) {
+        aictx->indicators = indps;
+        aictx->count = count;
+        indps = NULL;
+    }
+
+cleanup:
+    k5_free_data_ptr_list(indps);
+    return ret;
+}
+
+static void
+authind_request_fini(krb5_context kcontext, krb5_authdata_context context,
+                     void *plugin_context, void *request_context)
+{
+    struct authind_context *aictx = (struct authind_context *)request_context;
+
+    if (aictx != NULL) {
+        k5_free_data_ptr_list(aictx->indicators);
+        free(aictx);
+    }
+}
+
+/* This is a non-URI "local attribute" that is implementation defined. */
+static krb5_data authind_attr = {
+    KV5M_DATA,
+    sizeof("auth-indicators") - 1,
+    "auth-indicators"
+};
+
+static krb5_error_code
+authind_get_attribute_types(krb5_context kcontext,
+                            krb5_authdata_context context,
+                            void *plugin_context, void *request_context,
+                            krb5_data **out_attrs)
+{
+    struct authind_context *aictx = (struct authind_context *)request_context;
+    krb5_error_code ret;
+    krb5_data *attrs;
+
+    *out_attrs = NULL;
+
+    if (aictx->count == 0)
+        return ENOENT;
+
+    attrs = k5calloc(2, sizeof(*attrs), &ret);
+    if (attrs == NULL)
+        return ENOMEM;
+
+    ret = krb5int_copy_data_contents(kcontext, &authind_attr, &attrs[0]);
+    if (ret)
+        goto cleanup;
+
+    attrs[1].data = NULL;
+    attrs[1].length = 0;
+
+    *out_attrs = attrs;
+    attrs = NULL;
+
+cleanup:
+    krb5int_free_data_list(kcontext, attrs);
+    return ret;
+}
+
+static krb5_error_code
+authind_get_attribute(krb5_context kcontext, krb5_authdata_context context,
+                      void *plugin_context, void *request_context,
+                      const krb5_data *attribute, krb5_boolean *authenticated,
+                      krb5_boolean *complete, krb5_data *value,
+                      krb5_data *display_value, int *more)
+{
+    struct authind_context *aictx = (struct authind_context *)request_context;
+    krb5_error_code ret;
+    krb5_data *value_out;
+    int left;
+
+    if (!data_eq(*attribute, authind_attr))
+        return ENOENT;
+
+    /* The caller should set more to -1 before the first call.  Successive
+     * calls return the number of indicators left, ending at 0. */
+    if (*more < 0)
+        left = aictx->count;
+    else
+        left = *more;
+
+    if (left <= 0)
+        return ENOENT;
+    else if (left > aictx->count)
+        return EINVAL;
+
+    ret = krb5_copy_data(kcontext, aictx->indicators[aictx->count - left],
+                         &value_out);
+    if (ret)
+        return ret;
+
+    *more = left - 1;
+    *value = *value_out;
+    /* Indicators are delivered in a CAMMAC verified outside of this module,
+     * so these are authenticated values. */
+    *authenticated = TRUE;
+    *complete = TRUE;
+
+    free(value_out);
+    return ret;
+}
+
+static krb5_error_code
+authind_set_attribute(krb5_context kcontext, krb5_authdata_context context,
+                      void *plugin_context, void *request_context,
+                      krb5_boolean complete, const krb5_data *attribute,
+                      const krb5_data *value)
+{
+    /* Indicators are imported from ticket authdata, not set by this module. */
+    if (!data_eq(*attribute, authind_attr))
+        return ENOENT;
+
+    return EPERM;
+}
+
+static krb5_error_code
+authind_size(krb5_context kcontext, krb5_authdata_context context,
+             void *plugin_context, void *request_context, size_t *sizep)
+{
+    struct authind_context *aictx = (struct authind_context *)request_context;
+    krb5_error_code ret = 0;
+    int i;
+
+    /* Indicator count. */
+    *sizep += sizeof(krb5_int32);
+
+    for (i = 0; i < aictx->count; i++) {
+        /* Length + indicator size. */
+        *sizep += sizeof(krb5_int32) + (size_t)aictx->indicators[i]->length;
+    }
+
+    return ret;
+}
+
+static krb5_error_code
+authind_externalize(krb5_context kcontext, krb5_authdata_context context,
+                    void *plugin_context, void *request_context,
+                    krb5_octet **buffer, size_t *lenremain)
+{
+    struct authind_context *aictx = (struct authind_context *)request_context;
+    krb5_error_code ret = 0;
+    size_t required = 0;
+    uint8_t *bp;
+    size_t remain;
+    int i;
+
+    bp = (uint8_t *)*buffer;
+    remain = *lenremain;
+
+    authind_size(kcontext, context, plugin_context, request_context,
+                 &required);
+
+    if (required > remain)
+        return ENOMEM;
+
+    /* Indicator count. */
+    krb5_ser_pack_int32(aictx->count, &bp, &remain);
+
+    for (i = 0; i < aictx->count; i++) {
+        /* Length + indicator. */
+        krb5_ser_pack_int32(aictx->indicators[i]->length, &bp, &remain);
+        ret = krb5_ser_pack_bytes((krb5_octet *)aictx->indicators[i]->data,
+                                  (size_t)aictx->indicators[i]->length,
+                                  &bp, &remain);
+        if (ret)
+            return ret;
+    }
+
+    *buffer = bp;
+    *lenremain = remain;
+
+    return ret;
+}
+
+
+static krb5_error_code
+authind_internalize(krb5_context kcontext, krb5_authdata_context context,
+                    void *plugin_context, void *request_context,
+                    krb5_octet **buffer, size_t *lenremain)
+{
+    struct authind_context *aictx = (struct authind_context *)request_context;
+    krb5_error_code ret;
+    krb5_int32 count, len;
+    uint8_t *bp;
+    size_t remain;
+    krb5_data **inds = NULL;
+    int i;
+
+    bp = (uint8_t *)*buffer;
+    remain = *lenremain;
+
+    /* Get the count. */
+    ret = krb5_ser_unpack_int32(&count, &bp, &remain);
+    if (ret)
+        return ret;
+
+    if (count > (krb5_int32)remain)
+        return ERANGE;
+
+    inds = k5calloc(count, sizeof(*inds), &ret);
+    if (inds == NULL)
+        return errno;
+
+    for (i = 0; i < count; i++) {
+        /* Get the length. */
+        ret = krb5_ser_unpack_int32(&len, &bp, &remain);
+        if (ret)
+            goto cleanup;
+
+        if (len > (krb5_int32)remain) {
+            ret = ERANGE;
+            goto cleanup;
+        }
+
+        inds[i] = k5alloc(sizeof(*(inds[i])), &ret);
+        if (inds[i] == NULL)
+            goto cleanup;
+
+        ret = alloc_data(inds[i], len);
+        if (ret)
+            goto cleanup;
+
+        /* Get the indicator. */
+        ret = krb5_ser_unpack_bytes((krb5_octet *)inds[i]->data, (size_t)len,
+                                    &bp, &remain);
+        if (ret)
+            goto cleanup;
+    }
+
+    k5_free_data_ptr_list(aictx->indicators);
+
+    aictx->count = (int)count;
+    aictx->indicators = inds;
+    inds = NULL;
+
+    *buffer = bp;
+    *lenremain = remain;
+
+cleanup:
+    k5_free_data_ptr_list(inds);
+    return ret;
+}
+
+static krb5_authdatatype authind_ad_types[] = {
+    KRB5_AUTHDATA_AUTH_INDICATOR, 0
+};
+
+krb5plugin_authdata_client_ftable_v0 k5_authind_ad_client_ftable = {
+    "authentication-indicators",
+    authind_ad_types,
+    authind_init,
+    NULL, /* fini */
+    authind_flags,
+    authind_request_init,
+    authind_request_fini,
+    authind_get_attribute_types,
+    authind_get_attribute,
+    authind_set_attribute,
+    NULL, /* delete_attribute_proc */
+    NULL, /* export_authdata */
+    authind_import_authdata,
+    NULL, /* export_internal */
+    NULL, /* free_internal */
+    NULL, /* verify */
+    authind_size,
+    authind_externalize,
+    authind_internalize,
+    NULL /* authind_copy */
+};

--- a/src/lib/krb5/krb/authdata.c
+++ b/src/lib/krb5/krb/authdata.c
@@ -43,8 +43,8 @@ static const char *objdirs[] = {
 
 /* Internal authdata systems */
 static krb5plugin_authdata_client_ftable_v0 *authdata_systems[] = {
-    &krb5int_mspac_authdata_client_ftable,
-    &krb5int_s4u2proxy_authdata_client_ftable,
+    &k5_mspac_ad_client_ftable,
+    &k5_s4u2proxy_ad_client_ftable,
     &k5_authind_ad_client_ftable,
     NULL
 };

--- a/src/lib/krb5/krb/authdata.c
+++ b/src/lib/krb5/krb/authdata.c
@@ -536,6 +536,72 @@ k5_get_kdc_issued_authdata(krb5_context kcontext,
     return code;
 }
 
+/* Decode and verify each CAMMAC and collect the resulting authdata,
+ * ignoring those that failed verification. */
+static krb5_error_code
+extract_cammacs(krb5_context kcontext, krb5_authdata **cammacs,
+                const krb5_keyblock *key, krb5_authdata ***ad_out)
+{
+    krb5_error_code ret;
+    krb5_authdata **list = NULL, **elements = NULL, **new_list;
+    size_t i, n_elements, count = 0;
+
+    *ad_out = NULL;
+
+    for (i = 0; cammacs != NULL && cammacs[i] != NULL; i++) {
+        ret = k5_unwrap_cammac_svc(kcontext, cammacs[i], key, &elements);
+        if (ret && ret != KRB5KRB_AP_ERR_BAD_INTEGRITY)
+            goto cleanup;
+        ret = 0;
+
+        /* Add the verified elements to list and free the container array. */
+        for (n_elements = 0; elements[n_elements] != NULL; n_elements++);
+        new_list = realloc(list, (count + n_elements + 1) * sizeof(list));
+        if (new_list == NULL) {
+            ret = ENOMEM;
+            goto cleanup;
+        }
+        list = new_list;
+        memcpy(list + count, elements, n_elements * sizeof(list));
+        count += n_elements;
+        list[count] = NULL;
+        free(elements);
+        elements = NULL;
+    }
+
+    *ad_out = list;
+    list = NULL;
+
+cleanup:
+    krb5_free_authdata(kcontext, list);
+    krb5_free_authdata(kcontext, elements);
+    return ret;
+}
+
+/* Retrieve verified CAMMAC contained elements. */
+static krb5_error_code
+get_cammac_authdata(krb5_context kcontext, const krb5_ap_req *ap_req,
+                    const krb5_keyblock *key, krb5_authdata ***elems_out)
+{
+    krb5_error_code ret = 0;
+    krb5_authdata **ticket_authdata, **cammacs, **elements;
+
+    *elems_out = NULL;
+
+    ticket_authdata = ap_req->ticket->enc_part2->authorization_data;
+    ret = krb5_find_authdata(kcontext, ticket_authdata, NULL,
+                             KRB5_AUTHDATA_CAMMAC, &cammacs);
+    if (ret || cammacs == NULL)
+        return ret;
+
+    ret = extract_cammacs(kcontext, cammacs, key, &elements);
+    if (!ret)
+        *elems_out = elements;
+
+    krb5_free_authdata(kcontext, cammacs);
+    return ret;
+}
+
 krb5_error_code
 krb5int_authdata_verify(krb5_context kcontext,
                         krb5_authdata_context context,
@@ -550,11 +616,16 @@ krb5int_authdata_verify(krb5_context kcontext,
     krb5_authdata **ticket_authdata;
     krb5_principal kdc_issuer = NULL;
     krb5_authdata **kdc_issued_authdata = NULL;
+    krb5_authdata **cammac_authdata = NULL;
 
     authen_authdata = (*auth_context)->authentp->authorization_data;
     ticket_authdata = ap_req->ticket->enc_part2->authorization_data;
     k5_get_kdc_issued_authdata(kcontext, ap_req,
                                &kdc_issuer, &kdc_issued_authdata);
+
+    code = get_cammac_authdata(kcontext, ap_req, key, &cammac_authdata);
+    if (code)
+        goto cleanup;
 
     for (i = 0; i < context->n_modules; i++) {
         struct _krb5_authdata_context_module *module = &context->modules[i];
@@ -574,6 +645,11 @@ krb5int_authdata_verify(krb5_context kcontext,
             if (code != 0)
                 break;
 
+            kdc_issued_flag = TRUE;
+        }
+
+        if (cammac_authdata != NULL && (module->flags & AD_CAMMAC_PROTECTED)) {
+            authdata = cammac_authdata;
             kdc_issued_flag = TRUE;
         }
 
@@ -628,6 +704,7 @@ krb5int_authdata_verify(krb5_context kcontext,
             break;
     }
 
+cleanup:
     krb5_free_principal(kcontext, kdc_issuer);
     krb5_free_authdata(kcontext, kdc_issued_authdata);
 

--- a/src/lib/krb5/krb/authdata.c
+++ b/src/lib/krb5/krb/authdata.c
@@ -45,6 +45,7 @@ static const char *objdirs[] = {
 static krb5plugin_authdata_client_ftable_v0 *authdata_systems[] = {
     &krb5int_mspac_authdata_client_ftable,
     &krb5int_s4u2proxy_authdata_client_ftable,
+    &k5_authind_ad_client_ftable,
     NULL
 };
 

--- a/src/lib/krb5/krb/authdata.h
+++ b/src/lib/krb5/krb/authdata.h
@@ -78,6 +78,7 @@ struct krb5_pac_data {
 
 extern krb5plugin_authdata_client_ftable_v0 krb5int_mspac_authdata_client_ftable;
 extern krb5plugin_authdata_client_ftable_v0 krb5int_s4u2proxy_authdata_client_ftable;
+extern krb5plugin_authdata_client_ftable_v0 k5_authind_ad_client_ftable;
 
 krb5_error_code
 k5_pac_locate_buffer(krb5_context context,

--- a/src/lib/krb5/krb/authdata.h
+++ b/src/lib/krb5/krb/authdata.h
@@ -76,8 +76,8 @@ struct krb5_pac_data {
 
 #define NT_TIME_EPOCH               11644473600LL
 
-extern krb5plugin_authdata_client_ftable_v0 krb5int_mspac_authdata_client_ftable;
-extern krb5plugin_authdata_client_ftable_v0 krb5int_s4u2proxy_authdata_client_ftable;
+extern krb5plugin_authdata_client_ftable_v0 k5_mspac_ad_client_ftable;
+extern krb5plugin_authdata_client_ftable_v0 k5_s4u2proxy_ad_client_ftable;
 extern krb5plugin_authdata_client_ftable_v0 k5_authind_ad_client_ftable;
 
 krb5_error_code

--- a/src/lib/krb5/krb/authdata_dec.c
+++ b/src/lib/krb5/krb/authdata_dec.c
@@ -249,3 +249,48 @@ krb5_verify_authdata_kdc_issued(krb5_context context,
 
     return 0;
 }
+
+/*
+ * Decode authentication indicator strings from authdata and return as an
+ * allocated array of krb5_data pointers.  The caller must initialize
+ * *indicators to NULL for the first call, and successive calls will reallocate
+ * and append to the indicators array.
+ */
+krb5_error_code
+k5_authind_decode(const krb5_authdata *ad, krb5_data ***indicators)
+{
+    krb5_error_code ret = 0;
+    krb5_data der_ad, **strdata = NULL, **ai_list = *indicators;
+    size_t count, scount;
+
+    if (ad == NULL || ad->ad_type != KRB5_AUTHDATA_AUTH_INDICATOR)
+        goto cleanup;
+
+    /* Count existing auth indicators. */
+    for (count = 0; ai_list != NULL && ai_list[count] != NULL; count++);
+
+    der_ad = make_data(ad->contents, ad->length);
+    ret = decode_utf8_strings(&der_ad, &strdata);
+    if (ret)
+        return ret;
+
+    /* Count new auth indicators. */
+    for (scount = 0; strdata[scount] != NULL; scount++);
+
+    ai_list = realloc(ai_list, (count + scount + 1) * sizeof(*ai_list));
+    if (ai_list == NULL) {
+        ret = ENOMEM;
+        goto cleanup;
+    }
+    *indicators = ai_list;
+
+    /* Steal decoder-allocated pointers and free the container array. */
+    memcpy(ai_list + count, strdata, scount * sizeof(*strdata));
+    ai_list[count + scount] = NULL;
+    free(strdata);
+    strdata = NULL;
+
+cleanup:
+    k5_free_data_ptr_list(strdata);
+    return ret;
+}

--- a/src/lib/krb5/krb/cammac_util.c
+++ b/src/lib/krb5/krb/cammac_util.c
@@ -1,0 +1,86 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* cammac_util.c - CAMMAC related functions */
+/*
+ * Copyright (C) 2016 by Red Hat, Inc.
+ * All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "k5-int.h"
+
+/* Return 0 if cammac's service verifier is valid for server_key. */
+static krb5_error_code
+check_svcver(krb5_context context, const krb5_cammac *cammac,
+             const krb5_keyblock *server_key)
+{
+    krb5_error_code ret;
+    krb5_boolean valid = FALSE;
+    krb5_verifier_mac *ver = cammac->svc_verifier;
+    krb5_data *der_authdata = NULL;
+
+    if (ver == NULL)
+        return EINVAL;
+
+    ret = encode_krb5_authdata(cammac->elements, &der_authdata);
+    if (ret)
+        return ret;
+
+    ret = krb5_c_verify_checksum(context, server_key, KRB5_KEYUSAGE_CAMMAC,
+                                 der_authdata, &ver->checksum, &valid);
+    if (!ret && !valid)
+        ret = KRB5KRB_AP_ERR_BAD_INTEGRITY;
+
+    krb5_free_data(context, der_authdata);
+    return ret;
+}
+
+/* Decode and verify CAMMAC authdata using the svc verifier,
+ * and return the contents as an allocated array of authdata pointers. */
+krb5_error_code
+k5_unwrap_cammac_svc(krb5_context context, const krb5_authdata *ad,
+                     const krb5_keyblock *key, krb5_authdata ***adata_out)
+{
+    krb5_data ad_data;
+    krb5_error_code ret;
+    krb5_cammac *cammac = NULL;
+
+    *adata_out = NULL;
+
+    ad_data = make_data(ad->contents, ad->length);
+    ret = decode_krb5_cammac(&ad_data, &cammac);
+    if (ret)
+        return ret;
+
+    ret = check_svcver(context, cammac, key);
+    if (!ret) {
+        *adata_out = cammac->elements;
+        cammac->elements = NULL;
+    }
+
+    k5_free_cammac(context, cammac);
+    return ret;
+}

--- a/src/lib/krb5/krb/deps
+++ b/src/lib/krb5/krb/deps
@@ -45,6 +45,18 @@ appdefault.so appdefault.po $(OUTPRE)appdefault.$(OBJEXT): \
   $(top_srcdir)/include/krb5/authdata_plugin.h $(top_srcdir)/include/krb5/plugin.h \
   $(top_srcdir)/include/port-sockets.h $(top_srcdir)/include/socket-utils.h \
   appdefault.c
+ai_authdata.so ai_authdata.po $(OUTPRE)ai_authdata.$(OBJEXT): \
+  $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/krb5/krb5.h \
+  $(BUILDTOP)/include/osconf.h $(BUILDTOP)/include/profile.h \
+  $(COM_ERR_DEPS) $(top_srcdir)/include/k5-buf.h $(top_srcdir)/include/k5-err.h \
+  $(top_srcdir)/include/k5-gmt_mktime.h $(top_srcdir)/include/k5-int-pkinit.h \
+  $(top_srcdir)/include/k5-int.h $(top_srcdir)/include/k5-platform.h \
+  $(top_srcdir)/include/k5-plugin.h $(top_srcdir)/include/k5-thread.h \
+  $(top_srcdir)/include/k5-trace.h $(top_srcdir)/include/k5-utf8.h \
+  $(top_srcdir)/include/krb5.h $(top_srcdir)/include/krb5/authdata_plugin.h \
+  $(top_srcdir)/include/krb5/plugin.h $(top_srcdir)/include/port-sockets.h \
+  $(top_srcdir)/include/socket-utils.h auth_con.h authdata.h \
+  int-proto.h ai_authdata.c
 auth_con.so auth_con.po $(OUTPRE)auth_con.$(OBJEXT): \
   $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/krb5/krb5.h \
   $(BUILDTOP)/include/osconf.h $(BUILDTOP)/include/profile.h \

--- a/src/lib/krb5/krb/pac.c
+++ b/src/lib/krb5/krb/pac.c
@@ -1233,7 +1233,7 @@ mspac_copy(krb5_context kcontext,
 
 static krb5_authdatatype mspac_ad_types[] = { KRB5_AUTHDATA_WIN2K_PAC, 0 };
 
-krb5plugin_authdata_client_ftable_v0 krb5int_mspac_authdata_client_ftable = {
+krb5plugin_authdata_client_ftable_v0 k5_mspac_ad_client_ftable = {
     "mspac",
     mspac_ad_types,
     mspac_init,

--- a/src/lib/krb5/krb/s4u_authdata.c
+++ b/src/lib/krb5/krb/s4u_authdata.c
@@ -577,7 +577,7 @@ s4u2proxy_copy(krb5_context kcontext,
 
 static krb5_authdatatype s4u2proxy_ad_types[] = { KRB5_AUTHDATA_SIGNTICKET, 0 };
 
-krb5plugin_authdata_client_ftable_v0 krb5int_s4u2proxy_authdata_client_ftable = {
+krb5plugin_authdata_client_ftable_v0 k5_s4u2proxy_ad_client_ftable = {
     "constrained-delegation",
     s4u2proxy_ad_types,
     s4u2proxy_init,

--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -113,6 +113,7 @@ initialize_krb5_error_table
 initialize_k5e1_error_table
 initialize_kv5m_error_table
 initialize_prof_error_table
+k5_authind_decode
 k5_build_conf_principals
 k5_ccselect_free_context
 k5_change_error_message_code
@@ -145,6 +146,7 @@ k5_plugin_register
 k5_plugin_register_dyn
 k5_unmarshal_cred
 k5_unmarshal_princ
+k5_unwrap_cammac_svc
 k5_zapfree_pa_data
 krb524_convert_creds_kdc
 krb524_init_ets

--- a/src/tests/gssapi/Makefile.in
+++ b/src/tests/gssapi/Makefile.in
@@ -17,13 +17,15 @@ SRCS=	$(srcdir)/ccinit.c $(srcdir)/ccrefresh.c $(srcdir)/common.c \
 	$(srcdir)/t_inq_mechs_name.c $(srcdir)/t_iov.c \
 	$(srcdir)/t_namingexts.c $(srcdir)/t_oid.c $(srcdir)/t_pcontok.c \
 	$(srcdir)/t_prf.c $(srcdir)/t_s4u.c $(srcdir)/t_s4u2proxy_krb5.c \
-	$(srcdir)/t_saslname.c $(srcdir)/t_spnego.c
+	$(srcdir)/t_saslname.c $(srcdir)/t_spnego.c \
+	$(srcdir)/t_accname_authind.c
 
 OBJS=	ccinit.o ccrefresh.o common.o t_accname.o t_ccselect.o t_ciflags.o \
 	t_credstore.o t_enctypes.o t_err.o t_export_cred.o t_export_name.o \
 	t_gssexts.o t_imp_cred.o t_imp_name.o t_invalid.o t_inq_cred.o \
 	t_inq_ctx.o t_inq_mechs_name.o t_iov.o t_namingexts.o t_oid.o \
-	t_pcontok.o t_prf.o t_s4u.o t_s4u2proxy_krb5.o t_saslname.o t_spnego.o
+	t_pcontok.o t_prf.o t_s4u.o t_s4u2proxy_krb5.o t_saslname.o t_spnego.o \
+	t_accname_authind.o
 
 COMMON_DEPS= common.o $(GSS_DEPLIBS) $(KRB5_BASE_DEPLIBS)
 COMMON_LIBS= common.o $(GSS_LIBS) $(KRB5_BASE_LIBS)
@@ -31,7 +33,8 @@ COMMON_LIBS= common.o $(GSS_LIBS) $(KRB5_BASE_LIBS)
 all:: ccinit ccrefresh t_accname t_ccselect t_ciflags t_credstore t_enctypes \
 	t_err t_export_cred t_export_name t_gssexts t_imp_cred t_imp_name \
 	t_invalid t_inq_cred t_inq_ctx t_inq_mechs_name t_iov t_namingexts \
-	t_oid t_pcontok t_prf t_s4u t_s4u2proxy_krb5 t_saslname t_spnego
+	t_oid t_pcontok t_prf t_s4u t_s4u2proxy_krb5 t_saslname t_spnego \
+	t_accname_authind
 
 check-unix:: t_oid
 	$(RUN_TEST) ./t_invalid
@@ -48,6 +51,7 @@ check-pytests:: ccinit ccrefresh t_accname t_ccselect t_ciflags t_credstore \
 	$(RUNPYTEST) $(srcdir)/t_enctypes.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_export_cred.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_s4u.py $(PYTESTFLAGS)
+	$(RUNPYTEST) $(srcdir)/t_authind.py $(PYTESTFLAGS)
 
 ccinit: ccinit.o $(KRB5_BASE_DEPLIBS)
 	$(CC_LINK) -o ccinit ccinit.o $(KRB5_BASE_LIBS)
@@ -55,6 +59,8 @@ ccrefresh: ccrefresh.o $(KRB5_BASE_DEPLIBS)
 	$(CC_LINK) -o ccrefresh ccrefresh.o $(KRB5_BASE_LIBS)
 t_accname: t_accname.o $(COMMON_DEPS)
 	$(CC_LINK) -o $@ t_accname.o $(COMMON_LIBS)
+t_accname_authind: t_accname_authind.o $(COMMON_DEPS)
+	$(CC_LINK) -o $@ t_accname_authind.o $(COMMON_LIBS)
 t_ccselect: t_ccselect.o $(COMMON_DEPS)
 	$(CC_LINK) -o $@ t_ccselect.o $(COMMON_LIBS)
 t_ciflags: t_ciflags.o $(COMMON_DEPS)
@@ -107,4 +113,4 @@ clean::
 	$(RM) t_enctypes t_err t_export_cred t_export_name t_gssexts t_imp_cred
 	$(RM) t_imp_name t_invalid t_inq_cred t_inq_ctx t_inq_mechs_name t_iov
 	$(RM) t_namingexts t_oid t_pcontok t_prf t_s4u t_s4u2proxy_krb5
-	$(RM) t_saslname t_spnego
+	$(RM) t_saslname t_spnego t_accname_authind

--- a/src/tests/gssapi/t_accname_authind.c
+++ b/src/tests/gssapi/t_accname_authind.c
@@ -1,0 +1,89 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* src/tests/gssapi/t_accname_authind.c - t_authind.py helper */
+/*
+ * Copyright (C) 2016 by the Massachusetts Institute of Technology.
+ * Copyright (C) 2016 by Red Hat, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "common.h"
+
+int
+main(int argc, char *argv[])
+{
+    OM_uint32 minor, major, flags;
+    gss_cred_id_t acceptor_cred;
+    gss_name_t target_name, acceptor_name = GSS_C_NO_NAME, real_acceptor_name;
+    gss_name_t src_name = GSS_C_NO_NAME;
+    gss_buffer_desc namebuf;
+    gss_ctx_id_t initiator_context, acceptor_context;
+
+    if (argc < 1 || argc > 2) {
+        fprintf(stderr, "Usage: %s targetname\n", argv[0]);
+        return 1;
+    }
+
+    /* Import target. */
+    target_name = import_name(argv[1]);
+
+    /* Get acceptor cred. */
+    major = gss_acquire_cred(&minor, acceptor_name, GSS_C_INDEFINITE,
+                             GSS_C_NO_OID_SET, GSS_C_ACCEPT,
+                             &acceptor_cred, NULL, NULL);
+    check_gsserr("gss_acquire_cred", major, minor);
+
+    flags = GSS_C_REPLAY_FLAG | GSS_C_SEQUENCE_FLAG;
+    establish_contexts(&mech_krb5, GSS_C_NO_CREDENTIAL, acceptor_cred,
+                       target_name, flags, &initiator_context,
+                       &acceptor_context, &src_name, NULL, NULL);
+
+    major = gss_inquire_context(&minor, acceptor_context, NULL,
+                                &real_acceptor_name, NULL, NULL, NULL, NULL,
+                                NULL);
+    check_gsserr("gss_inquire_context", major, minor);
+
+    namebuf.value = NULL;
+    namebuf.length = 0;
+    major = gss_display_name(&minor, src_name, &namebuf, NULL);
+    check_gsserr("gss_display_name", major, minor);
+
+    printf("%.*s\n", (int)namebuf.length, (char *)namebuf.value);
+    enumerate_attributes(src_name, 1);
+
+    (void)gss_release_name(&minor, &target_name);
+    (void)gss_release_name(&minor, &acceptor_name);
+    (void)gss_release_name(&minor, &real_acceptor_name);
+    (void)gss_release_name(&minor, &src_name);
+    (void)gss_release_cred(&minor, &acceptor_cred);
+    (void)gss_delete_sec_context(&minor, &initiator_context, NULL);
+    (void)gss_delete_sec_context(&minor, &acceptor_context, NULL);
+    (void)gss_release_buffer(&minor, &namebuf);
+    return 0;
+}

--- a/src/tests/gssapi/t_authind.py
+++ b/src/tests/gssapi/t_authind.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python
+from k5test import *
+
+# Test authentication indicators.  Load the test preauth module so we
+# can control the indicators asserted.
+testpreauth = os.path.join(buildtop, 'plugins', 'preauth', 'test', 'test.so')
+conf = {'plugins': {'kdcpreauth': {'module': 'test:' + testpreauth},
+                        'clpreauth': {'module': 'test:' + testpreauth}}}
+realm = K5Realm(krb5_conf=conf)
+realm.run([kadminl, 'addprinc', '-randkey', 'service/1'])
+realm.run([kadminl, 'addprinc', '-randkey', 'service/2'])
+realm.run([kadminl, 'modprinc', '+requires_preauth', realm.user_princ])
+realm.run([kadminl, 'setstr', 'service/1', 'require_auth', 'superstrong'])
+realm.run([kadminl, 'setstr', 'service/2', 'require_auth', 'one two'])
+realm.run([kadminl, 'xst', 'service/1'])
+realm.run([kadminl, 'xst', 'service/2'])
+
+realm.kinit(realm.user_princ, password('user'), ['-X', 'indicators=superstrong'])
+out = realm.run(['./t_accname_authind', 'p:service/1'])
+
+if ('Attribute auth-indicators ' \
+    'Authenticated Complete') not in out:
+    fail('Expected attribute type data not seen')
+
+# UTF8 "superstrong"
+if '73757065727374726f6e67' not in out:
+    fail('Expected auth indicator not seen in name attributes')
+
+out = realm.run(['./t_accname_authind', 'p:service/2'], expected_code=1)
+if 'gss_init_sec_context: KDC policy rejects request' not in out:
+    fail('Expected error message not seen for indicator mismatch')
+
+realm.kinit(realm.user_princ, password('user'), ['-X', 'indicators=one two'])
+out = realm.run(['./t_accname_authind', 'p:service/2'])
+
+# UTF8 "one", "two"
+if '6f6e65' not in out or '74776f' not in out:
+    fail('Expected auth indicator not seen in name attributes')
+
+realm.stop()
+success('GSSAPI auth indicator tests')

--- a/src/tests/t_authdata.py
+++ b/src/tests/t_authdata.py
@@ -115,6 +115,13 @@ out = realm.run(['./adata', 'krbtgt/FOREIGN'])
 if '+97: [indcl]' not in out:
     fail('auth-indicator not seen for AS req to cross-realm TGT')
 
+# Multiple indicators
+realm.kinit(realm.user_princ, password('user'),
+            ['-X', 'indicators=indcl indcl2 indcl3'])
+out = realm.run(['./adata', realm.krbtgt_princ])
+if '+97: [indcl, indcl2, indcl3]' not in out:
+    fail('multiple auth-indicators not seen for normal AS req')
+
 # AS request to local TGT (resulting creds are used for TGS tests)
 realm.kinit(realm.user_princ, password('user'), ['-X', 'indicators=indcl'])
 out = realm.run(['./adata', realm.krbtgt_princ])


### PR DESCRIPTION
This adds krb5_unwrap_cammac_svc() to verify and decode a CAMMAC,
and krb5_authind_decode() to obtain an array of auth indicator strings
from the resulting authdata.

Also move the kdc function cammac_check_svcver() to the internal lib
as k5_cammac_check_svcver() to use in the above code.