### PR TITLE
Use blocking lock when creating db2 KDB

### DIFF
--- a/src/plugins/kdb/db2/kdb_db2.c
+++ b/src/plugins/kdb/db2/kdb_db2.c
@@ -701,8 +701,7 @@ ctx_create_db(krb5_context context, krb5_db2_context *dbc)
         retval = errno;
         goto cleanup;
     }
-    retval = krb5_lock_file(context, dbc->db_lf_file,
-                            KRB5_LOCKMODE_EXCLUSIVE | KRB5_LOCKMODE_DONTBLOCK);
+    retval = krb5_lock_file(context, dbc->db_lf_file, KRB5_LOCKMODE_EXCLUSIVE);
     if (retval != 0)
         goto cleanup;
     set_cloexec_fd(dbc->db_lf_file);


### PR DESCRIPTION
In 1.11 we switched from non-blocking to blocking locks in the DB2
module, but we missed one call to krb5_lock_file() in ctx_create_db().
This non-blocking lock can cause krb5_db_promote() to fail if the
database is locked when we try to promote the DB, in turn causing
kdb5_util load to fail.  Correct this call to make krb5_db_promote()
more robust.

ticket: 8367 (new)
target_version: 1.14-next
target_version: 1.13-next
tags: pullup