### PR TITLE
Fix Makefiles for VS2010 KfW build

### DIFF
--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -51,8 +51,10 @@ clean-windows::
 ##WIN32##KRB5RC = krb5.rc
 ##WIN32##VERSIONRC = $(BUILDTOP)\windows\version.rc
 
-##WIN32##!if defined(VISUALSTUDIOVERSION) && $(VISUALSTUDIOVERSION:.=) >= 140
+##WIN32##!if defined(VISUALSTUDIOVERSION)
+##WIN32##!if $(VISUALSTUDIOVERSION:.=) >= 140
 ##WIN32##WINCRTEXTRA = ucrt.lib vcruntime.lib
+##WIN32##!endif
 ##WIN32##!endif
 ##WIN32##WINLIBS = kernel32.lib ws2_32.lib user32.lib shell32.lib oldnames.lib \
 ##WIN32##	version.lib secur32.lib advapi32.lib gdi32.lib delayimp.lib \

--- a/src/windows/kfwlogon/Makefile.in
+++ b/src/windows/kfwlogon/Makefile.in
@@ -7,8 +7,10 @@ DEFINES = -DNO_KRB4
 LOCALINCLUDES = -I$(BUILDTOP) -I$(BUILDTOP)\include -I$(BUILDTOP)\windows\include
 PROG_LIBPATH=-L$(TOPLIBD) -L$(KRB5_LIBDIR)
 
-!if defined(VISUALSTUDIOVERSION) && $(VISUALSTUDIOVERSION:.=) >= 140
+!if defined(VISUALSTUDIOVERSION)
+!if $(VISUALSTUDIOVERSION:.=) >= 140
 WINCRTEXTRA = ucrt.lib vcruntime.lib
+!endif
 !endif
 SYSLIBS = kernel32.lib user32.lib advapi32.lib wsock32.lib secur32.lib userenv.lib $(WINCRTEXTRA)
 


### PR DESCRIPTION
The new Makefile conditionals in commit
4552159e97007a45370dd49fa6b9fb963bb7d160 don't behave properly if
VISUALSTUDIOVERSION isn't set, probably due to the way nmake orders
macro expansion and boolean short circuiting.  Use nested conditionals
instead.