### PR TITLE
Allow "includedir" to accept config files ending with ".conf"

### DIFF
--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -52,11 +52,11 @@ following directives at the beginning of a line::
     includedir DIRNAME
 
 *FILENAME* or *DIRNAME* should be an absolute path. The named file or
-directory must exist and be readable.  Including a directory includes
-all files within the directory whose names consist solely of
-alphanumeric characters, dashes, or underscores.  Included profile
-files are syntactically independent of their parents, so each included
-file must begin with a section header.
+directory must exist and be readable.  Including a directory includes all files
+within the directory whose names consist solely of alphanumeric characters,
+dashes, or underscores, or any filename ending in ".conf".  Included profile
+files are syntactically independent of their parents, so each included file
+must begin with a section header.
 
 The krb5.conf file can specify that configuration should be obtained
 from a loadable module, rather than the file itself, using the

--- a/src/man/krb5.conf.man
+++ b/src/man/krb5.conf.man
@@ -111,9 +111,9 @@ includedir DIRNAME
 \fIFILENAME\fP or \fIDIRNAME\fP should be an absolute path. The named file or
 directory must exist and be readable.  Including a directory includes
 all files within the directory whose names consist solely of
-alphanumeric characters, dashes, or underscores.  Included profile
-files are syntactically independent of their parents, so each included
-file must begin with a section header.
+alphanumeric characters, dashes, or underscores, or any filename ending in
+\fI.conf\fP.  Included profile files are syntactically independent of their
+parents, so each included file must begin with a section header.
 .sp
 The krb5.conf file can specify that configuration should be obtained
 from a loadable module, rather than the file itself, using the

--- a/src/util/profile/prof_parse.c
+++ b/src/util/profile/prof_parse.c
@@ -221,11 +221,17 @@ static errcode_t parse_include_file(const char *filename,
     return retval;
 }
 
-/* Return non-zero if filename contains only alphanumeric characters, dashes,
- * and underscores. */
+/*
+ * Return non-zero if filename contains only alphanumeric characters, dashes,
+ * and underscores, or if the filename ends in ".conf".
+ */
 static int valid_name(const char *filename)
 {
     const char *p;
+    size_t len = strlen(filename);
+
+    if (len > 5 && !strcmp(filename + len - 5, ".conf"))
+        return 1;
 
     for (p = filename; *p != '\0'; p++) {
         if (!isalnum((unsigned char)*p) && *p != '-' && *p != '_')
@@ -235,9 +241,13 @@ static int valid_name(const char *filename)
 }
 
 /*
- * Include files within dirname.  Only files with names consisting entirely of
- * alphanumeric chracters, dashes, and underscores are included, in order to
- * avoid including editor backup files, .rpmsave files, and the like.
+ * Include files within dirname.  Only files with names consisting entirely
+ * of alphanumeric chracters, dashes, and underscores are included, in order
+ * to avoid including editor backup files, .rpmsave files, and the like, with
+ * the exception that any file name ending in ".conf" that's longer than 5
+ * characters is accepted, since that is the most obvious thing to naively
+ * name config files to be included by krb5.conf, and REALM.COM.conf is a
+ * pretty obvious first choice in many cases.
  */
 static errcode_t parse_include_dir(const char *dirname,
                                    struct profile_node *root_section)


### PR DESCRIPTION
Since the main config file is krb5.conf, the most obvious thing to name
a config file discovered through the "includedir" directive is
"REALM.COM.conf".

Once a user does that, they spend the next few minutes yanking their
hair out trying to figure out what syntax error they've got that causes
kinit not to find their realm.  Eventually, the user strace's kinit and
discovers it's ignoring the file altogether, but it's reading another
file next to it in the directory.  At this point a file renaming game
ensues, and the user discovers ".conf" is somehow not allowed at the end
of filenames.

If the user is unlucky, as I was, they named their config file
"redhat.conf" and not "redhat.com.conf", and so never figured out it's
just that all dots are banned until quite a bit of debugging later,
instead looking for something like an inverted strcmp() looking for
.conf itself.

This patch enables config files to have . in them if and only if they
end in ".conf" and are not unix "dotfiles".

Signed-off-by: Peter Jones <pjones@redhat.com>