### PR TITLE
Default to LSA when TGT in LSA is inaccessible [KRB-13]

### DIFF
--- a/src/lib/krb5/os/sendto_kdc.c
+++ b/src/lib/krb5/os/sendto_kdc.c
@@ -399,7 +399,7 @@ check_for_svc_unavailable (krb5_context context,
     return 1;
 }
 
-void
+void KRB5_CALLCONV
 krb5_set_kdc_send_hook(krb5_context context, krb5_pre_send_fn send_hook,
                        void *data)
 {
@@ -407,7 +407,7 @@ krb5_set_kdc_send_hook(krb5_context context, krb5_pre_send_fn send_hook,
     context->kdc_send_hook_data = data;
 }
 
-void
+void KRB5_CALLCONV
 krb5_set_kdc_recv_hook(krb5_context context, krb5_post_recv_fn recv_hook,
                        void *data)
 {

--- a/src/windows/ms2mit/ms2mit.c
+++ b/src/windows/ms2mit/ms2mit.c
@@ -39,19 +39,16 @@ xusage(void)
     exit(1);
 }
 
-void
-main(
-    int argc,
-    char *argv[]
-    )
+int
+main(int argc, char *argv[])
 {
-    krb5_context kcontext;
+    krb5_context kcontext = NULL;
     krb5_error_code code;
     krb5_ccache ccache=NULL;
     krb5_ccache mslsa_ccache=NULL;
     krb5_cc_cursor cursor;
     krb5_creds creds;
-    krb5_principal princ;
+    krb5_principal princ = NULL;
     int initial_ticket = 0;
     int option;
     char * ccachestr = 0;
@@ -73,28 +70,23 @@ main(
 
     if (code = krb5_init_context(&kcontext)) {
         com_err(argv[0], code, "while initializing kerberos library");
-        exit(1);
+        goto cleanup;
     }
 
     if (code = krb5_cc_resolve(kcontext, "MSLSA:", &mslsa_ccache)) {
         com_err(argv[0], code, "while opening MS LSA ccache");
-        krb5_free_context(kcontext);
-        exit(1);
+        goto cleanup;
     }
 
     if (code = krb5_cc_set_flags(kcontext, mslsa_ccache, KRB5_TC_NOTICKET)) {
         com_err(argv[0], code, "while setting KRB5_TC_NOTICKET flag");
-        krb5_cc_close(kcontext, mslsa_ccache);
-        krb5_free_context(kcontext);
-        exit(1);
+        goto cleanup;
     }
 
     /* Enumerate tickets from cache looking for an initial ticket */
     if ((code = krb5_cc_start_seq_get(kcontext, mslsa_ccache, &cursor))) {
         com_err(argv[0], code, "while initiating the cred sequence of MS LSA ccache");
-        krb5_cc_close(kcontext, mslsa_ccache);
-        krb5_free_context(kcontext);
-        exit(1);
+        goto cleanup;
     }
 
     while (!(code = krb5_cc_next_cred(kcontext, mslsa_ccache, &cursor, &creds)))
@@ -110,24 +102,18 @@ main(
 
     if (code = krb5_cc_set_flags(kcontext, mslsa_ccache, 0)) {
         com_err(argv[0], code, "while clearing flags");
-        krb5_cc_close(kcontext, mslsa_ccache);
-        krb5_free_context(kcontext);
-        exit(1);
+        goto cleanup;
     }
 
     if ( !initial_ticket ) {
         fprintf(stderr, "%s: Initial Ticket Getting Tickets are not available from the MS LSA\n",
                 argv[0]);
-        krb5_cc_close(kcontext, mslsa_ccache);
-        krb5_free_context(kcontext);
-        exit(1);
+        goto cleanup;
     }
 
     if (code = krb5_cc_get_principal(kcontext, mslsa_ccache, &princ)) {
         com_err(argv[0], code, "while obtaining MS LSA principal");
-        krb5_cc_close(kcontext, mslsa_ccache);
-        krb5_free_context(kcontext);
-        exit(1);
+        goto cleanup;
     }
 
     if (ccachestr)
@@ -136,32 +122,24 @@ main(
         code = krb5_cc_default(kcontext, &ccache);
     if (code) {
         com_err(argv[0], code, "while getting default ccache");
-        krb5_free_principal(kcontext, princ);
-        krb5_cc_close(kcontext, mslsa_ccache);
-        krb5_free_context(kcontext);
-        exit(1);
+        goto cleanup;
     }
     if (code = krb5_cc_initialize(kcontext, ccache, princ)) {
         com_err (argv[0], code, "when initializing ccache");
-        krb5_free_principal(kcontext, princ);
-        krb5_cc_close(kcontext, mslsa_ccache);
-        krb5_cc_close(kcontext, ccache);
-        krb5_free_context(kcontext);
-        exit(1);
+        goto cleanup;
     }
 
     if (code = krb5_cc_copy_creds(kcontext, mslsa_ccache, ccache)) {
         com_err (argv[0], code, "while copying MS LSA ccache to default ccache");
-        krb5_free_principal(kcontext, princ);
-        krb5_cc_close(kcontext, ccache);
-        krb5_cc_close(kcontext, mslsa_ccache);
-        krb5_free_context(kcontext);
-        exit(1);
+        goto cleanup;
     }
 
+cleanup:
     krb5_free_principal(kcontext, princ);
-    krb5_cc_close(kcontext, ccache);
-    krb5_cc_close(kcontext, mslsa_ccache);
+    if (ccache != NULL)
+        krb5_cc_close(kcontext, ccache);
+    if (mslsa_ccache != NULL)
+        krb5_cc_close(kcontext, mslsa_ccache);
     krb5_free_context(kcontext);
-    return(0);
+    return code ? 1 : 0;
 }


### PR DESCRIPTION
When UAC is enabled and a domain user with Administrator privileges logs
in the TGT is inaccessible.  This is because if the TGT is accessible it
may be possible for a non-elevated user session to get a ticket with an
unfiltered PAC and bypass the UAC.  This causes a bug where the current
tickets in the LSA cache are all copied to the ccache except the TGT,
which prevents a user session from getting new tickets.  In this case,
ms2mit will now set the LSA cache to the default cache to workaround
this issue.