### PR TITLE
Use k5_bcmp in krb5_k_verify_checksum()

### DIFF
--- a/src/lib/crypto/krb/verify_checksum.c
+++ b/src/lib/crypto/krb/verify_checksum.c
@@ -63,8 +63,8 @@ krb5_k_verify_checksum(krb5_context context, krb5_key key,
     if (ret)
         return ret;
 
-    *valid = (memcmp(computed.contents, cksum->contents,
-                     ctp->output_size) == 0);
+    *valid = (k5_bcmp(computed.contents, cksum->contents,
+                      ctp->output_size) == 0);
 
     free(computed.contents);
     return 0;


### PR DESCRIPTION
Not sure how I missed this in 07d68eec2788bfe80686608813f644838707c168.
