### PR TITLE
Allow zero cksumtype in krb5_k_verify_checksum()

### DIFF
--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -904,8 +904,10 @@ krb5_c_make_checksum(krb5_context context, krb5_cksumtype cksumtype,
  *
  * This function verifies that @a cksum is a valid checksum for @a data.  If
  * the checksum type of @a cksum is a keyed checksum, @a key is used to verify
- * the checksum.  The actual checksum key will be derived from @a key and @a
- * usage if key derivation is specified for the checksum type.
+ * the checksum.  If the checksum type in @a cksum is 0 and @a key is not NULL,
+ * the mandatory checksum type for @a key will be used.  The actual checksum
+ * key will be derived from @a key and @a usage if key derivation is specified
+ * for the checksum type.
  *
  * @note This function is similar to krb5_k_verify_checksum(), but operates
  * on keyblock @a key.
@@ -1470,8 +1472,10 @@ krb5_k_make_checksum_iov(krb5_context context, krb5_cksumtype cksumtype,
  *
  * This function verifies that @a cksum is a valid checksum for @a data.  If
  * the checksum type of @a cksum is a keyed checksum, @a key is used to verify
- * the checksum.  The actual checksum key will be derived from @a key and @a
- * usage if key derivation is specified for the checksum type.
+ * the checksum.  If the checksum type in @a cksum is 0 and @a key is not NULL,
+ * the mandatory checksum type for @a key will be used.  The actual checksum
+ * key will be derived from @a key and @a usage if key derivation is specified
+ * for the checksum type.
  *
  * @note This function is similar to krb5_c_verify_checksum(), but operates
  * on opaque @a key.

--- a/src/lib/crypto/crypto_tests/t_cf2.c
+++ b/src/lib/crypto/crypto_tests/t_cf2.c
@@ -47,6 +47,7 @@
 #include <string.h>
 
 int main () {
+    krb5_error_code ret;
     char pepper1[1025], pepper2[1025];
     krb5_keyblock *k1 = NULL, *k2 = NULL, *out = NULL;
     krb5_data s2k;
@@ -59,20 +60,24 @@ int main () {
             break;
         if (scanf("%1024s", &s[0]) == EOF)
             break;
-        assert (krb5_init_keyblock(0, enctype, 0, &k1) == 0);
+        ret = krb5_init_keyblock(0, enctype, 0, &k1);
+        assert(!ret);
         s2k.data = &s[0];
         s2k.length = strlen(s);
-        assert(krb5_c_string_to_key (0, enctype, &s2k, &s2k, k1) == 0);
+        ret = krb5_c_string_to_key (0, enctype, &s2k, &s2k, k1);
+        assert(!ret);
         if (scanf("%1024s", &s[0]) == EOF)
             break;
-        assert (krb5_init_keyblock(0, enctype, 0, &k2) == 0);
+        ret = krb5_init_keyblock(0, enctype, 0, &k2);
+        assert(!ret);
         s2k.data = &s[0];
         s2k.length = strlen(s);
-        assert(krb5_c_string_to_key (0, enctype, &s2k, &s2k, k2) == 0);
+        ret = krb5_c_string_to_key (0, enctype, &s2k, &s2k, k2);
+        assert(!ret);
         if (scanf("%1024s %1024s", pepper1, pepper2) == EOF)
             break;
-        assert(krb5_c_fx_cf2_simple(0, k1, pepper1,
-                                    k2, pepper2, &out) ==0);
+        ret = krb5_c_fx_cf2_simple(0, k1, pepper1, k2, pepper2, &out);
+        assert(!ret);
         i = out->length;
         for (; i > 0; i--) {
             printf ("%02x",

--- a/src/lib/crypto/crypto_tests/t_cksums.c
+++ b/src/lib/crypto/crypto_tests/t_cksums.c
@@ -167,6 +167,7 @@ printhex(const char *head, void *data, size_t len)
 int
 main(int argc, char **argv)
 {
+    krb5_error_code ret;
     krb5_context context = NULL;
     size_t i;
     struct test *test;
@@ -189,8 +190,9 @@ main(int argc, char **argv)
         } else
             kbp = NULL;
         plain = string2data(test->plaintext);
-        assert(krb5_c_make_checksum(context, test->sumtype, kbp, test->usage,
-                                    &plain, &cksum) == 0);
+        ret = krb5_c_make_checksum(context, test->sumtype, kbp, test->usage,
+                                   &plain, &cksum);
+        assert(!ret);
         if (verbose) {
             char buf[64];
             krb5_cksumtype_to_string(test->sumtype, buf, sizeof(buf));

--- a/src/lib/crypto/crypto_tests/t_cmac.c
+++ b/src/lib/crypto/crypto_tests/t_cmac.c
@@ -99,6 +99,7 @@ check_result(const char *name, const unsigned char *result,
 int
 main(int argc, char **argv)
 {
+    krb5_error_code ret;
     krb5_context context = NULL;
     krb5_keyblock keyblock;
     krb5_key key;
@@ -112,27 +113,32 @@ main(int argc, char **argv)
     keyblock.enctype = ENCTYPE_CAMELLIA128_CTS_CMAC;
     keyblock.length = 16;
     keyblock.contents = keybytes;
-    assert(krb5_k_create_key(context, &keyblock, &key) == 0);
+    ret = krb5_k_create_key(context, &keyblock, &key);
+    assert(!ret);
 
     /* Example 1. */
     iov.flags = KRB5_CRYPTO_TYPE_DATA;
     iov.data = make_data(input, 0);
-    assert(krb5int_cmac_checksum(enc, key, &iov, 1, &result) == 0);
+    ret = krb5int_cmac_checksum(enc, key, &iov, 1, &result);
+    assert(!ret);
     check_result("example 1", resultbuf, cmac1);
 
     /* Example 2. */
     iov.data.length = 16;
-    assert(krb5int_cmac_checksum(enc, key, &iov, 1, &result) == 0);
+    ret = krb5int_cmac_checksum(enc, key, &iov, 1, &result);
+    assert(!ret);
     check_result("example 2", resultbuf, cmac2);
 
     /* Example 3. */
     iov.data.length = 40;
-    assert(krb5int_cmac_checksum(enc, key, &iov, 1, &result) == 0);
+    ret = krb5int_cmac_checksum(enc, key, &iov, 1, &result);
+    assert(!ret);
     check_result("example 3", resultbuf, cmac3);
 
     /* Example 4. */
     iov.data.length = 64;
-    assert(krb5int_cmac_checksum(enc, key, &iov, 1, &result) == 0);
+    ret = krb5int_cmac_checksum(enc, key, &iov, 1, &result);
+    assert(!ret);
     check_result("example 4", resultbuf, cmac4);
 
     printf("All CMAC tests passed.\n");

--- a/src/lib/crypto/crypto_tests/t_decrypt.c
+++ b/src/lib/crypto/crypto_tests/t_decrypt.c
@@ -598,6 +598,7 @@ static char *plaintexts[] = {
 static int
 generate(krb5_context context)
 {
+    krb5_error_code ret;
     size_t i, j;
     krb5_keyblock kb;
     krb5_data plain, seed = string2data("seed");
@@ -605,15 +606,20 @@ generate(krb5_context context)
     size_t enclen;
     char buf[64];
 
-    assert(krb5_c_random_seed(context, &seed) == 0);
+    ret = krb5_c_random_seed(context, &seed);
+    assert(!ret);
     for (i = 0; i < sizeof(enctypes) / sizeof(*enctypes); i++) {
         for (j = 0; j < sizeof(plaintexts) / sizeof(*plaintexts); j++) {
-            assert(krb5_c_make_random_key(context, enctypes[i], &kb) == 0);
+            ret = krb5_c_make_random_key(context, enctypes[i], &kb);
+            assert(!ret);
             plain = string2data(plaintexts[j]);
-            assert(krb5_c_encrypt_length(context, enctypes[i], plain.length,
-                                         &enclen) == 0);
-            assert(alloc_data(&enc.ciphertext, enclen) == 0);
-            assert(krb5_c_encrypt(context, &kb, j, NULL, &plain, &enc) == 0);
+            ret = krb5_c_encrypt_length(context, enctypes[i], plain.length,
+                                        &enclen);
+            assert(!ret);
+            ret = alloc_data(&enc.ciphertext, enclen);
+            assert(!ret);
+            ret = krb5_c_encrypt(context, &kb, j, NULL, &plain, &enc);
+            assert(!ret);
             krb5_enctype_to_name(enctypes[i], FALSE, buf, sizeof(buf));
             printf("\nEnctype: %s\n", buf);
             printf("Plaintext: %s\n", plaintexts[j]);
@@ -629,6 +635,7 @@ generate(krb5_context context)
 int
 main(int argc, char **argv)
 {
+    krb5_error_code ret;
     krb5_context context = NULL;
     krb5_data plain;
     size_t i;
@@ -645,7 +652,8 @@ main(int argc, char **argv)
         kb.enctype = test->enctype;
         kb.length = test->keybits.length;
         kb.contents = (unsigned char *)test->keybits.data;
-        assert(alloc_data(&plain, test->ciphertext.length) == 0);
+        ret = alloc_data(&plain, test->ciphertext.length);
+        assert(!ret);
         enc.magic = KV5M_ENC_DATA;
         enc.enctype = test->enctype;
         enc.kvno = 0;

--- a/src/lib/crypto/crypto_tests/t_derive.c
+++ b/src/lib/crypto/crypto_tests/t_derive.c
@@ -238,6 +238,7 @@ get_enc_provider(krb5_enctype enctype)
 int
 main(int argc, char **argv)
 {
+    krb5_error_code ret;
     krb5_context context = NULL;
     size_t i;
     struct test *test;
@@ -255,10 +256,12 @@ main(int argc, char **argv)
         kb.enctype = test->enctype;
         kb.length = test->inkey.length;
         kb.contents = (unsigned char *)test->inkey.data;
-        assert(krb5_k_create_key(context, &kb, &inkey) == 0);
+        ret = krb5_k_create_key(context, &kb, &inkey);
+        assert(!ret);
         enc = get_enc_provider(test->enctype);
-        assert(krb5int_derive_key(enc, inkey, &outkey, &test->constant,
-                                  test->alg) == 0);
+        ret = krb5int_derive_key(enc, inkey, &outkey, &test->constant,
+                                 test->alg);
+        assert(!ret);
         if (verbose) {
             char buf[64];
             krb5_enctype_to_name(test->enctype, FALSE, buf, sizeof(buf));

--- a/src/lib/crypto/crypto_tests/t_fork.c
+++ b/src/lib/crypto/crypto_tests/t_fork.c
@@ -62,7 +62,7 @@ main()
     krb5_key key_aes, key_rc4;
     krb5_data state_rc4, plain = string2data("plain"), decrypted;
     krb5_enc_data out_aes, out_rc4;
-    pid_t pid;
+    pid_t pid, wpid;
     int status;
 
     /* Seed the PRNG instead of creating a context, so we don't need
@@ -98,7 +98,8 @@ main()
 
     /* If we're the parent, make sure the child succeeded. */
     if (pid != 0) {
-        assert(wait(&status) == pid);
+        wpid = wait(&status);
+        assert(wpid == pid);
         if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
             fprintf(stderr, "Child failed with status %d\n", status);
             return 1;

--- a/src/lib/crypto/crypto_tests/t_kperf.c
+++ b/src/lib/crypto/crypto_tests/t_kperf.c
@@ -45,6 +45,7 @@
 int
 main(int argc, char **argv)
 {
+    krb5_error_code ret;
     krb5_keyblock kblock;
     krb5_key key;
     krb5_enctype enctype;
@@ -63,7 +64,8 @@ main(int argc, char **argv)
     intf = argv[1][0];
     assert(intf == 'c' || intf =='k');
     op = argv[1][1];
-    assert(krb5_string_to_enctype(argv[2], &enctype) == 0);
+    ret = krb5_string_to_enctype(argv[2], &enctype);
+    assert(!ret);
     blocksize = atoi(argv[3]);
     num_blocks = atoi(argv[4]);
 

--- a/src/lib/crypto/crypto_tests/t_prf.c
+++ b/src/lib/crypto/crypto_tests/t_prf.c
@@ -39,6 +39,7 @@
 #include <assert.h>
 
 int main () {
+    krb5_error_code ret;
     krb5_data input, output;
     krb5_keyblock *key = NULL;
     unsigned int in_length;
@@ -53,26 +54,30 @@ int main () {
             break;
         if (scanf("%1024s", &s[0]) == EOF)
             break;
-        assert (krb5_init_keyblock(0, enctype, 0, &key) == 0);
+        ret = krb5_init_keyblock(0, enctype, 0, &key);
+        assert(!ret);
         input.data = &s[0];
         input.length = strlen(s);
-        assert(krb5_c_string_to_key (0, enctype, &input, &input, key) == 0);
+        ret = krb5_c_string_to_key (0, enctype, &input, &input, key);
+        assert(!ret);
 
         if (scanf("%u", &in_length) == EOF)
             break;
 
         if (in_length ) {
             unsigned int lc;
-            assert ((input.data = malloc(in_length)) != NULL);
+            ret = alloc_data(&input, in_length);
+            assert(!ret);
             for (lc = in_length; lc > 0; lc--) {
                 scanf ("%2x",  &i);
                 input.data[in_length-lc] = (unsigned) (i&0xff);
             }
-            input.length = in_length;
-            assert (krb5_c_prf_length(0, enctype, &prfsz) == 0);
-            assert (output.data = malloc(prfsz));
-            output.length = prfsz;
-            assert (krb5_c_prf(0, key, &input, &output) == 0);
+            ret = krb5_c_prf_length(0, enctype, &prfsz);
+            assert(!ret);
+            ret = alloc_data(&output, prfsz);
+            assert(!ret);
+            ret = krb5_c_prf(0, key, &input, &output);
+            assert(!ret);
 
             free (input.data);
             input.data = NULL;

--- a/src/lib/crypto/crypto_tests/t_prng.c
+++ b/src/lib/crypto/crypto_tests/t_prng.c
@@ -56,21 +56,22 @@ int main () {
             break;
         if (seed_length ) {
             unsigned int lc;
-            assert ((input.data = malloc(seed_length)) != NULL);
+            ret = alloc_data(&input, seed_length);
+            assert(!ret);
             for (lc = seed_length; lc > 0; lc--) {
                 scanf ("%2x",  &i);
                 input.data[seed_length-lc] = (unsigned) (i&0xff);
             }
-            input.length = seed_length;
-            assert (krb5_c_random_add_entropy (0, source_id, &input) == 0);
+            ret = krb5_c_random_add_entropy (0, source_id, &input);
+            assert(!ret);
             free (input.data);
             input.data = NULL;
         }
         if (scanf ("%u", &i) == EOF)
             break;
         if (i) {
-            assert ((output.data = malloc (i)) != NULL);
-            output.length = i;
+            ret = alloc_data(&output, i);
+            assert(!ret);
             ret = krb5_c_random_make_octets (0, &output);
             if (ret)
                 printf ("failed\n");

--- a/src/lib/crypto/crypto_tests/t_str2key.c
+++ b/src/lib/crypto/crypto_tests/t_str2key.c
@@ -726,7 +726,8 @@ main(int argc, char **argv)
         test = &test_cases[i];
         string = string2data(test->string);
         salt = string2data(test->salt);
-        assert(krb5_init_keyblock(context, test->enctype, 0, &keyblock) == 0);
+        ret = krb5_init_keyblock(context, test->enctype, 0, &keyblock);
+        assert(!ret);
         k5_allow_weak_pbkdf2iter = test->allow_weak;
         ret = krb5_c_string_to_key_with_params(context, test->enctype,
                                                &string, &salt, &test->params,


### PR DESCRIPTION
A checksum type of 0 means to use the mandatory checksum type in
krb5_k_make_checksum(), krb5_k_make_checksum_iov(), and
krb5_k_verify_checksum_iov().  Extend this meaning to
krb5_k_verify_checksum() for the checksum type in the krb5_checksum
argument.  This change also applies to krb5_c_verify_checksum().
    
Add code to t_cksums.c to test checksum verification, including with
checksum type 0 for applicable test cases.
