### PR TITLE
Cleaner handling of keyboard interrupts

### DIFF
--- a/src/lib/krb5/krb/gic_pwd.c
+++ b/src/lib/krb5/krb/gic_pwd.c
@@ -326,9 +326,8 @@ krb5_get_init_creds_password(krb5_context context,
     /* If all the kdc's are unavailable, or if the error was due to a
        user interrupt, fail */
 
-    if ((ret == KRB5_KDC_UNREACH) ||
-        (ret == KRB5_LIBOS_PWDINTR) ||
-        (ret == KRB5_REALM_CANT_RESOLVE))
+    if (ret == KRB5_KDC_UNREACH || ret == KRB5_REALM_CANT_RESOLVE ||
+        ret == KRB5_LIBOS_PWDINTR || ret == KRB5_LIBOS_CANTREADPWD)
         goto cleanup;
 
     /* if the reply did not come from the master kdc, try again with

--- a/src/util/k5test.py
+++ b/src/util/k5test.py
@@ -448,6 +448,14 @@ def _onexit():
         print '--stop-after=NUM to stop after a daemon is started in order to'
         print 'attach to it with a debugger.  Use --help to see other options.'
 
+
+def _onsigint(signum, frame):
+    # Exit without displaying a stack trace.  Suppress messages from _onexit.
+    global _success
+    _success = True
+    sys.exit(1)
+
+
 # Find the parent of dir which is at the root of a build or source directory.
 def _find_root(dir):
     while True:
@@ -1198,6 +1206,7 @@ _current_pass = None
 _daemons = []
 _parse_args()
 atexit.register(_onexit)
+signal.signal(signal.SIGINT, _onsigint)
 _outfile = open('testlog', 'w')
 _cmd_index = 1
 buildtop = _find_buildtop()


### PR DESCRIPTION
I think I've seen people complain about printing com_err messages on keyboard interrupts in the past, but we don't seem to have an existing ticket for it, so maybe it was out of band.  Anyway, it's been annoying me for years, so the first commit fixes that.  (I thought we also did fallback-to-master on keyboard interrupts, therefore attempting to read the password twice, but I can't reproduce this and we explicitly avoid fallback on KRB5_LIBOS_PWDINTR in gic_pwd.c, so I must be misremembering.)

The second commit also fixes a personal annoyance in the test suite.  Displaying stack traces on keyboard exit is a universal problem for Python scripts which don't explicitly avoid it.  Fortunately, we can solve this problem in k5test.py by installing a signal handler, and avoid having to wrap every Python test script in a try/except.