### PR TITLE
cc_file: always truncate, instead of relying on O_EXCL to guarantee creation

### DIFF
--- a/src/lib/krb5/ccache/cc_file.c
+++ b/src/lib/krb5/ccache/cc_file.c
@@ -456,7 +456,7 @@ fcc_initialize(krb5_context context, krb5_ccache id, krb5_principal princ)
     k5_cc_mutex_lock(context, &data->lock);
 
     unlink(data->filename);
-    flags = O_CREAT | O_EXCL | O_RDWR | O_BINARY | O_CLOEXEC;
+    flags = O_CREAT | O_RDWR | O_BINARY | O_CLOEXEC;
     fd = open(data->filename, flags, 0600);
     if (fd == -1) {
         ret = interpret_errno(context, errno);
@@ -480,6 +480,12 @@ fcc_initialize(krb5_context context, krb5_ccache id, krb5_principal princ)
     if (ret)
         goto cleanup;
     file_locked = TRUE;
+
+    st = ftruncate(fd, 0);
+    if (st == -1) {
+        ret = interpret_errno(context, errno);
+        goto cleanup;
+    }
 
     /* Prepare the header and principal in buf. */
     k5_buf_init_dynamic(&buf);


### PR DESCRIPTION
The problem with unlink() followed by open() with O_CREAT|O_EXCL is that
there is a race window where another process initializing the same
ccache filename could have already re-created the file by the time we
reach open(). In that case open() will return EEXIST, which
fcc_initialize() makes no attempt to recover from and just returns
KRB5_FCC_INTERNAL.

We can instead drop O_EXCL, meaning that the file might already exist at
the time of the open() call, but then call ftruncate() on it *after*
acquiring the write lock, ensuring that the file is written safely even
when multiple concurrent processes are initializing the ccache.