### PR TITLE
Revisit inquire_attrs_for_mech on old mechs

### DIFF
--- a/src/lib/gssapi/mechglue/g_mechattr.c
+++ b/src/lib/gssapi/mechglue/g_mechattr.c
@@ -181,8 +181,12 @@ gss_inquire_attrs_for_mech(
     mech = gssint_get_mechanism(selected_mech);
     if (mech == NULL)
         return GSS_S_BAD_MECH;
-    else if (mech->gss_inquire_attrs_for_mech == NULL)
-        return GSS_S_UNAVAILABLE;
+
+    /* If the mech does not implement RFC 5587, return success with an empty
+     * mech_attrs and known_mech_attrs. */
+    if (mech->gss_inquire_attrs_for_mech == NULL)
+        return GSS_S_COMPLETE;
+
     public_mech = gssint_get_public_oid(selected_mech);
     status = mech->gss_inquire_attrs_for_mech(minor, public_mech, mech_attrs,
                                               known_mech_attrs);


### PR DESCRIPTION
[Tom: I'm putting this in ticket: 8358 along with the previous change to gss_inquire_attrs_for_mech(), since we haven't yet included ticket 8358 in any release.  Let me know if I should use a separate ticket instead.]

In gss_inquire_attrs_for_mech(), if the mech does not implement RFC
5587, return success with empty mech_attrs and known_mech_attrs sets
to indicate a lack of knowledge for all attributes.  The previous
behavior of returning an error caused gss_indicate_mechs_by_attr() to
fail out in the presence of an old mechanism, in turn causing
gss_acquire_cred() and SPNEGO to break.
