### PR TITLE
Fix keytab file format description

### DIFF
--- a/doc/formats/keytab_file_format.rst
+++ b/doc/formats/keytab_file_format.rst
@@ -29,12 +29,12 @@ the key entry.  Key entries use the following informal grammar::
         timestamp (32 bits)
         key version (8 bits)
         enctype (16 bits)
-        key length (32 bits)
+        key length (16 bits)
         key contents
         key version (32 bits) [in release 1.14 and later]
 
     principal ::=
-        count of components (32 bits) [includes realm in version 1]
+        count of components (16 bits) [includes realm in version 1]
         realm (data)
         component1 (data)
         component2 (data)

--- a/src/lib/krb5/keytab/kt_file.c
+++ b/src/lib/krb5/keytab/kt_file.c
@@ -1001,7 +1001,7 @@ const krb5_kt_ops krb5_kt_dfl_ops = {
  * sizeof(krb5_int32) bytes for the timestamp
  * sizeof(krb5_octet) bytes for the key version number
  * sizeof(krb5_int16) bytes for the enctype
- * sizeof(krb5_int32) bytes for the key length, followed by the key
+ * sizeof(krb5_int16) bytes for the key length, followed by the key
  */
 
 #ifndef SEEK_SET


### PR DESCRIPTION
The key length and count of principal components are 16-bit fields.
