### PR TITLE
Integrate with appveyor for Windows CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+build_script:
+  - call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86
+  - mkdir C:\kfw
+  - set KRB_INSTALL_DIR=C:\kfw
+  - set CPU=i386
+  - set NO_LEASH=1
+  - set
+  - cd C:\Projects\krb5\src
+  - nmake -f Makefile.in prep-windows
+  - nmake
+  - nmake install
+  - set CPU=AMD64
+  - setenv /x64
+  - nmake clean
+  - nmake
+  - nmake install

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -504,9 +504,12 @@ install-windows::
 	copy windows\leashdll\$(OUTPRE)*.lib "$(KRB_INSTALL_DIR)\lib\."
 	copy windows\leashdll\$(OUTPRE)*.dll "$(KRB_INSTALL_DIR)\bin\."
 	$(INSTALLDBGSYMS) windows\leashdll\$(OUTPRE)*.pdb "$(KRB_INSTALL_DIR)\bin\."
+##DOS##!ifndef NO_LEASH
 	copy windows\leash\$(OUTPRE)*.exe "$(KRB_INSTALL_DIR)\bin\."
 	$(INSTALLDBGSYMS) windows\leash\$(OUTPRE)*.pdb "$(KRB_INSTALL_DIR)\bin\."
 	copy windows\leash\$(OUTPRE)*.chm "$(KRB_INSTALL_DIR)\bin\."
+	copy windows\leash\htmlhelp\*.chm "$(KRB_INSTALL_DIR)\bin\."
+##DOS##!endif
 	copy windows\kfwlogon\$(OUTPRE)*.lib "$(KRB_INSTALL_DIR)\lib\."
 	copy windows\kfwlogon\$(OUTPRE)*.exe "$(KRB_INSTALL_DIR)\bin\."
 	copy windows\kfwlogon\$(OUTPRE)*.dll "$(KRB_INSTALL_DIR)\bin\."
@@ -535,7 +538,6 @@ install-windows::
 	$(INSTALLDBGSYMS) clients\kdeltkt\$(OUTPRE)kdeltkt.pdb "$(KRB_INSTALL_DIR)\bin\."
 	$(INSTALLDBGSYMS) clients\kpasswd\$(OUTPRE)kpasswd.pdb "$(KRB_INSTALL_DIR)\bin\."
 	$(INSTALLDBGSYMS) clients\kswitch\$(OUTPRE)kswitch.pdb "$(KRB_INSTALL_DIR)\bin\."
-	copy windows\leash\htmlhelp\*.chm "$(KRB_INSTALL_DIR)\bin\."
 
 check-prerecurse: runenv.py
 	$(RM) $(SKIPTESTS)

--- a/src/util/wshelper/resource.rc
+++ b/src/util/wshelper/resource.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include <afxres.h>
+#include <windows.h>
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/src/windows/Makefile.in
+++ b/src/windows/Makefile.in
@@ -1,3 +1,6 @@
 BUILDTOP=..
 NO_OUTPRE=1
-SUBDIRS= lib leashdll leash cns ms2mit kfwlogon
+!ifndef NO_LEASH
+LEASH=leash
+!endif
+SUBDIRS= lib leashdll $(LEASH) cns ms2mit kfwlogon


### PR DESCRIPTION
appveyor.com is a hosted continuous integration service for Windows.
Add an appveyor.yml file containing build instructions.  The appveyor
virtual machines do not include the MFC libraries, so change
util/wshelper/resource.rc to avoid including <afxres.h> (which it does
not need) and add a build conditional for leash.

Right now we do not build the installers; the appveyor VMs do not
appear to have the version of the WiX toolkit we need, and we would
also have problems with the missing leash executable.