### PR TITLE
Use APPVEYOR_BUILD_FOLDER

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ build_script:
   - set CPU=i386
   - set NO_LEASH=1
   - set
-  - cd C:\Projects\krb5\src
+  - cd %APPVEYOR_BUILD_FOLDER%\src
   - nmake -f Makefile.in prep-windows
   - nmake
   - nmake install


### PR DESCRIPTION
The directory that AppVeyor does checkouts into can vary.  Use the
documented APPVEYOR_BUILD_FOLDER environment variable instead of
hardcoding a value.