### PR TITLE
Fix segfault on NULL key_data

### DIFF
--- a/src/lib/kdb/kdb_default.c
+++ b/src/lib/kdb/kdb_default.c
@@ -445,6 +445,11 @@ krb5_def_fetch_mkey_list(krb5_context        context,
     if (retval)
         return (retval);
 
+    if (master_entry->n_key_data == 0) {
+        retval = KRB5_KDB_NOMASTERKEY;
+        goto clean_n_exit;
+    }
+
     /*
      * Check if the input mkey is the latest key and if it isn't then find the
      * latest mkey.

--- a/src/tests/t_mkey.py
+++ b/src/tests/t_mkey.py
@@ -328,4 +328,11 @@ check_mkvno(realm.user_princ, 1)
 realm.run([kdb5_util, 'use_mkey', '2', 'now-1day'])
 check_mkey_list((2, defetype, True, True), (1, des3, True, False))
 
+# Regression test for PR#437. Purge the master key and verify that
+# a master key fetch does not segfault.
+realm.run([kadminl, 'purgekeys', '-all', 'K/M'])
+out = realm.run([kadminl, 'getprinc', realm.user_princ], expected_code=1)
+if 'Cannot find master key record in database' not in out:
+    fail('Unexpected output from failed master key fetch')
+
 success('Master key rollover tests')


### PR DESCRIPTION
Fail gracefully in case "krbprincipalkey" cannot be read from LDAP.