### PR TITLE
Improve kadmin parsing of time intervals

### DIFF
--- a/doc/admin/admin_commands/kadmin_local.rst
+++ b/doc/admin/admin_commands/kadmin_local.rst
@@ -260,11 +260,12 @@ Options:
     (:ref:`getdate` string) The password expiration date.
 
 **-maxlife** *maxlife*
-    (:ref:`getdate` string) The maximum ticket life for the principal.
+    (:ref:`duration` or :ref:`getdate` string) The maximum ticket life
+    for the principal.
 
 **-maxrenewlife** *maxrenewlife*
-    (:ref:`getdate` string) The maximum renewable life of tickets for
-    the principal.
+    (:ref:`duration` or :ref:`getdate` string) The maximum renewable
+    life of tickets for the principal.
 
 **-kvno** *kvno*
     The initial key version number.
@@ -702,10 +703,12 @@ Alias: **addpol**
 The following options are available:
 
 **-maxlife** *time*
-    (:ref:`getdate` string) Sets the maximum lifetime of a password.
+    (:ref:`duration` or :ref:`getdate` string) Sets the maximum
+    lifetime of a password.
 
 **-minlife** *time*
-    (:ref:`getdate` string) Sets the minimum lifetime of a password.
+    (:ref:`duration` or :ref:`getdate` string) Sets the minimum
+    lifetime of a password.
 
 **-minlength** *length*
     Sets the minimum length of a password.
@@ -731,21 +734,21 @@ The following options are available:
 .. _policy_failurecountinterval:
 
 **-failurecountinterval** *failuretime*
-    (:ref:`getdate` string) Sets the allowable time between
-    authentication failures.  If an authentication failure happens
-    after *failuretime* has elapsed since the previous failure,
-    the number of authentication failures is reset to 1.  A
+    (:ref:`duration` or :ref:`getdate` string) Sets the allowable time
+    between authentication failures.  If an authentication failure
+    happens after *failuretime* has elapsed since the previous
+    failure, the number of authentication failures is reset to 1.  A
     *failuretime* value of 0 (the default) means forever.
 
 .. _policy_lockoutduration:
 
 **-lockoutduration** *lockouttime*
-    (:ref:`getdate` string) Sets the duration for which the principal
-    is locked from authenticating if too many authentication failures
-    occur without the specified failure count interval elapsing.
-    A duration of 0 (the default) means the principal remains locked
-    out until it is administratively unlocked with ``modprinc
-    -unlock``.
+    (:ref:`duration` or :ref:`getdate` string) Sets the duration for
+    which the principal is locked from authenticating if too many
+    authentication failures occur without the specified failure count
+    interval elapsing.  A duration of 0 (the default) means the
+    principal remains locked out until it is administratively unlocked
+    with ``modprinc -unlock``.
 
 **-allowedkeysalts**
     Specifies the key/salt tuples supported for long-term keys when

--- a/src/kadmin/cli/getdate.y
+++ b/src/kadmin/cli/getdate.y
@@ -863,10 +863,11 @@ difftm(struct tm *a, struct tm *b)
 #include <krb5.h>
 int yyparse(void);
 
+time_t get_date_rel(char *, time_t);
 time_t get_date(char *);
 
 time_t
-get_date(char *p)
+get_date_rel(char *p, time_t nowtime)
 {
     struct my_timeb	*now = NULL;
     struct tm		*tm, gmt;
@@ -880,7 +881,7 @@ get_date(char *p)
     if (now == NULL) {
         now = &ftz;
 
-	ftz.time = time((time_t *) 0);
+	ftz.time = nowtime;
 
 	if (! (tm = gmtime (&ftz.time)))
 	    return -1;
@@ -1014,6 +1015,13 @@ get_date(char *p)
     /* Have to do *something* with a legitimate -1 so it's distinguishable
      * from the error return value.  (Alternately could set errno on error.) */
     return Start == -1 ? 0 : Start;
+}
+
+
+time_t
+get_date(char *p)
+{
+    return get_date_rel(p, time(NULL));
 }
 
 

--- a/src/kadmin/cli/kadmin.c
+++ b/src/kadmin/cli/kadmin.c
@@ -154,11 +154,11 @@ strdate(krb5_timestamp when)
 /* Parse a date string using getdate.y.  On failure, output an error message
  * and return (time_t)-1. */
 static time_t
-parse_date(char *str)
+parse_date(char *str, time_t now)
 {
     time_t date;
 
-    date = get_date(str);
+    date = get_date_rel(str, now);
     if (date == (time_t)-1)
         error(_("Invalid date specification \"%s\".\n"), str);
     return date;
@@ -178,7 +178,7 @@ parse_interval(char *str, time_t now)
     if (krb5_string_to_deltat(str, &delta) == 0)
         return delta;
 
-    date = parse_date(str);
+    date = parse_date(str, now);
     if (date == (time_t)-1)
         return date;
 
@@ -1020,7 +1020,7 @@ kadmin_parse_princ_args(int argc, char *argv[], kadm5_principal_ent_t oprinc,
         if (!strcmp("-expire", argv[i])) {
             if (++i > argc - 2)
                 return -1;
-            date = parse_date(argv[i]);
+            date = parse_date(argv[i], now);
             if (date == (time_t)-1)
                 return -1;
             oprinc->princ_expire_time = date;
@@ -1030,7 +1030,7 @@ kadmin_parse_princ_args(int argc, char *argv[], kadm5_principal_ent_t oprinc,
         if (!strcmp("-pwexpire", argv[i])) {
             if (++i > argc - 2)
                 return -1;
-            date = parse_date(argv[i]);
+            date = parse_date(argv[i], now);
             if (date == (time_t)-1)
                 return -1;
             oprinc->pw_expiration = date;

--- a/src/kadmin/cli/kadmin.c
+++ b/src/kadmin/cli/kadmin.c
@@ -1431,7 +1431,7 @@ kadmin_getprinc(int argc, char *argv[])
                strdate(dprinc.last_pwd_change) : _("[never]"));
         printf(_("Password expiration date: %s\n"),
                dprinc.pw_expiration ?
-               strdate(dprinc.pw_expiration) : _("[none]"));
+               strdate(dprinc.pw_expiration) : _("[never]"));
         printf(_("Maximum ticket life: %s\n"), strdur(dprinc.max_life));
         printf(_("Maximum renewable life: %s\n"),
                strdur(dprinc.max_renewable_life));
@@ -1732,8 +1732,8 @@ kadmin_getpol(int argc, char *argv[])
     }
     if (argc == 2) {
         printf(_("Policy: %s\n"), policy.policy);
-        printf(_("Maximum password life: %ld\n"), policy.pw_max_life);
-        printf(_("Minimum password life: %ld\n"), policy.pw_min_life);
+        printf(_("Maximum password life: %s\n"), strdur(policy.pw_max_life));
+        printf(_("Minimum password life: %s\n"), strdur(policy.pw_min_life));
         printf(_("Minimum password length: %ld\n"), policy.pw_min_length);
         printf(_("Minimum number of password character classes: %ld\n"),
                policy.pw_min_classes);

--- a/src/kadmin/cli/kadmin.c
+++ b/src/kadmin/cli/kadmin.c
@@ -151,6 +151,50 @@ strdate(krb5_timestamp when)
     return out;
 }
 
+/* Parse a date string using getdate.y.  On failure, output an error message
+ * and return (time_t)-1. */
+static time_t
+parse_date(char *str)
+{
+    time_t date;
+
+    date = get_date(str);
+    if (date == (time_t)-1)
+        error(_("Invalid date specification \"%s\".\n"), str);
+    return date;
+}
+
+/*
+ * Parse a time interval.  Use krb5_string_to_deltat() if it works; otherwise
+ * use getdate.y and subtract now, with sanity checks.  On failure, output an
+ * error message and return (time_t)-1.
+ */
+static time_t
+parse_interval(char *str, time_t now)
+{
+    time_t date;
+    krb5_deltat delta;
+
+    if (krb5_string_to_deltat(str, &delta) == 0)
+        return delta;
+
+    date = parse_date(str);
+    if (date == (time_t)-1)
+        return date;
+
+    /* Interpret an absolute time of 0 (e.g. "never") as an interval of 0. */
+    if (date == 0)
+        return 0;
+
+    /* Don't return a negative interval if the date is in the past. */
+    if (date < now) {
+        error(_("Interval specification \"%s\" is in the past.\n"), str);
+        return (time_t)-1;
+    }
+
+    return date - now;
+}
+
 /* this is a wrapper to go around krb5_parse_principal so we can set
    the default realm up properly */
 static krb5_error_code
@@ -952,8 +996,7 @@ kadmin_parse_princ_args(int argc, char *argv[], kadm5_principal_ent_t oprinc,
                         int *n_ks_tuple, char *caller)
 {
     int i;
-    time_t date;
-    time_t now;
+    time_t now, date, interval;
     krb5_error_code retval;
 
     *mask = 0;
@@ -977,11 +1020,9 @@ kadmin_parse_princ_args(int argc, char *argv[], kadm5_principal_ent_t oprinc,
         if (!strcmp("-expire", argv[i])) {
             if (++i > argc - 2)
                 return -1;
-            date = get_date(argv[i]);
-            if (date == (time_t)-1) {
-                error(_("Invalid date specification \"%s\".\n"), argv[i]);
+            date = parse_date(argv[i]);
+            if (date == (time_t)-1)
                 return -1;
-            }
             oprinc->princ_expire_time = date;
             *mask |= KADM5_PRINC_EXPIRE_TIME;
             continue;
@@ -989,11 +1030,9 @@ kadmin_parse_princ_args(int argc, char *argv[], kadm5_principal_ent_t oprinc,
         if (!strcmp("-pwexpire", argv[i])) {
             if (++i > argc - 2)
                 return -1;
-            date = get_date(argv[i]);
-            if (date == (time_t)-1) {
-                error(_("Invalid date specification \"%s\".\n"), argv[i]);
+            date = parse_date(argv[i]);
+            if (date == (time_t)-1)
                 return -1;
-            }
             oprinc->pw_expiration = date;
             *mask |= KADM5_PW_EXPIRATION;
             continue;
@@ -1001,24 +1040,20 @@ kadmin_parse_princ_args(int argc, char *argv[], kadm5_principal_ent_t oprinc,
         if (!strcmp("-maxlife", argv[i])) {
             if (++i > argc - 2)
                 return -1;
-            date = get_date(argv[i]);
-            if (date == (time_t)-1) {
-                error(_("Invalid date specification \"%s\".\n"), argv[i]);
+            interval = parse_interval(argv[i], now);
+            if (interval == (time_t)-1)
                 return -1;
-            }
-            oprinc->max_life = date - now;
+            oprinc->max_life = interval;
             *mask |= KADM5_MAX_LIFE;
             continue;
         }
         if (!strcmp("-maxrenewlife", argv[i])) {
             if (++i > argc - 2)
                 return -1;
-            date = get_date(argv[i]);
-            if (date == (time_t)-1) {
-                error(_("Invalid date specification \"%s\".\n"), argv[i]);
+            interval = parse_interval(argv[i], now);
+            if (interval == (time_t)-1)
                 return -1;
-            }
-            oprinc->max_renewable_life = date - now;
+            oprinc->max_renewable_life = interval;
             *mask |= KADM5_MAX_RLIFE;
             continue;
         }
@@ -1502,7 +1537,7 @@ kadmin_parse_policy_args(int argc, char *argv[], kadm5_policy_ent_t policy,
 {
     krb5_error_code retval;
     int i;
-    time_t now, date;
+    time_t now, interval;
 
     time(&now);
     *mask = 0;
@@ -1510,23 +1545,19 @@ kadmin_parse_policy_args(int argc, char *argv[], kadm5_policy_ent_t policy,
         if (!strcmp(argv[i], "-maxlife")) {
             if (++i > argc -2)
                 return -1;
-            date = get_date(argv[i]);
-            if (date == (time_t)-1) {
-                error(_("Invalid date specification \"%s\".\n"), argv[i]);
+            interval = parse_interval(argv[i], now);
+            if (interval == (time_t)-1)
                 return -1;
-            }
-            policy->pw_max_life = date - now;
+            policy->pw_max_life = interval;
             *mask |= KADM5_PW_MAX_LIFE;
             continue;
         } else if (!strcmp(argv[i], "-minlife")) {
             if (++i > argc - 2)
                 return -1;
-            date = get_date(argv[i]);
-            if (date == (time_t)-1) {
-                error(_("Invalid date specification \"%s\".\n"), argv[i]);
+            interval = parse_interval(argv[i], now);
+            if (interval == (time_t)-1)
                 return -1;
-            }
-            policy->pw_min_life = date - now;
+            policy->pw_min_life = interval;
             *mask |= KADM5_PW_MIN_LIFE;
             continue;
         } else if (!strcmp(argv[i], "-minlength")) {
@@ -1558,32 +1589,20 @@ kadmin_parse_policy_args(int argc, char *argv[], kadm5_policy_ent_t policy,
                    !strcmp(argv[i], "-failurecountinterval")) {
             if (++i > argc - 2)
                 return -1;
-            /* Allow bare numbers for compatibility with 1.8-1.9. */
-            date = get_date(argv[i]);
-            if (date != (time_t)-1)
-                policy->pw_failcnt_interval = date - now;
-            else if (isdigit(*argv[i]))
-                policy->pw_failcnt_interval = atoi(argv[i]);
-            else {
-                error(_("Invalid date specification \"%s\".\n"), argv[i]);
+            interval = parse_interval(argv[i], now);
+            if (interval == (time_t)-1)
                 return -1;
-            }
+            policy->pw_failcnt_interval = interval;
             *mask |= KADM5_PW_FAILURE_COUNT_INTERVAL;
             continue;
         } else if (strlen(argv[i]) == 16 &&
                    !strcmp(argv[i], "-lockoutduration")) {
             if (++i > argc - 2)
                 return -1;
-            /* Allow bare numbers for compatibility with 1.8-1.9. */
-            date = get_date(argv[i]);
-            if (date != (time_t)-1)
-                policy->pw_lockout_duration = date - now;
-            else if (isdigit(*argv[i]))
-                policy->pw_lockout_duration = atoi(argv[i]);
-            else {
-                error(_("Invalid date specification \"%s\".\n"), argv[i]);
+            interval = parse_interval(argv[i], now);
+            if (interval == (time_t)-1)
                 return -1;
-            }
+            policy->pw_lockout_duration = interval;
             *mask |= KADM5_PW_LOCKOUT_DURATION;
             continue;
         } else if (!strcmp(argv[i], "-allowedkeysalts")) {

--- a/src/kadmin/cli/kadmin.h
+++ b/src/kadmin/cli/kadmin.h
@@ -78,7 +78,7 @@ randkey_princ(void *lhandle, krb5_principal princ, krb5_boolean keepold,
 #endif
 #endif
 
-extern time_t get_date(char *);
+extern time_t get_date_rel(char *, time_t);
 
 /* Yucky global variables */
 extern krb5_context context;

--- a/src/tests/Makefile.in
+++ b/src/tests/Makefile.in
@@ -137,6 +137,7 @@ check-pytests:: plugorder rdreq responder s2p s4u2proxy unlockiter
 	$(RUNPYTEST) $(srcdir)/t_skew.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_keytab.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_kadmin_acl.py $(PYTESTFLAGS)
+	$(RUNPYTEST) $(srcdir)/t_kadmin_parsing.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_kdb.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_keydata.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_mkey.py $(PYTESTFLAGS)

--- a/src/tests/t_kadmin_parsing.py
+++ b/src/tests/t_kadmin_parsing.py
@@ -1,0 +1,89 @@
+#!/usr/bin/python
+from k5test import *
+
+# This file contains tests for kadmin command parsing.  Principal
+# flags (which can also be used in kadm5.acl or krb5.conf) are tested
+# in t_princflags.py.
+
+# kadmin recognizes time intervals using either the
+# krb5_string_to_deltat() formats or the relative getdate.y formats.
+# (Absolute getdate.y formats also work with the current time
+# subtracted; this isn't very useful and we won't test it here.)
+intervals = (
+    # krb5_string_to_deltat() formats.  Whitespace ( \t\n) is allowed
+    # before or between most elements or at the end, but not after
+    # 's'.  Negative or oversized numbers are allowed in most places,
+    # but not after the first number in an HH:MM:SS form.
+    ('28s', '0 days 00:00:28'),
+    ('7m ', '0 days 00:07:00'),
+    ('6m 9s', '0 days 00:06:09'),
+    ('2h', '0 days 02:00:00'),
+    ('2h-5s', '0 days 01:59:55'),
+    ('2h3m', '0 days 02:03:00'),
+    ('2h3m5s', '0 days 02:03:05'),
+    ('5d ', '5 days 00:00:00'),
+    ('5d-48s', '4 days 23:59:12'),
+    ('5d18m', '5 days 00:18:00'),
+    ('5d -6m56s', '4 days 23:54:56'),
+    ('5d4h', '5 days 04:00:00'),
+    ('5d4h 1s', '5 days 04:00:01'),
+    ('5d4h3m', '5 days 04:03:00'),
+    (' \t 15d \n 4h  3m  2s', '15 days 04:03:02'),
+    ('10-8:45:0', '10 days 08:45:00'),
+    ('1000:67:99', '41 days 17:08:39'),
+    ('999:11', '41 days 15:11:00'),
+    ('382512', '4 days 10:15:12'),
+
+    # getdate.y relative formats (and "never", which is handled
+    # specially as a zero interval).  Any number of relative forms can
+    # be specified in any order.  Whitespace is ignored before or
+    # after any token.  "month" and "year" are allowed as units but
+    # depend on the current time, so we won't test them.  Plural unit
+    # names are treated identically to singular unit names.  Numbers
+    # before unit names are optional and may be signed; there are also
+    # aliases for some numbers.  "ago" inverts the interval up to the
+    # point where it appears.
+    ('never', '0 days 00:00:00'),
+    ('fortnight', '14 days 00:00:00'),
+    ('3 day ago 4 weeks 8 hours', '25 days 08:00:00'),
+    ('8 second -3 secs 5 minute ago 63 min', '0 days 00:57:55'),
+    ('min mins min mins min', '0 days 00:05:00'),
+    ('tomorrow tomorrow today yesterday now last minute', '0 days 23:59:00'),
+    ('this second next minute first hour third fortnight fourth day '
+     'fifth weeks sixth sec seventh secs eighth second ninth mins tenth '
+     'day eleventh min twelfth sec', '91 days 01:22:34'))
+
+realm = K5Realm(create_host=False, get_creds=False)
+realm.run([kadminl, 'addpol', 'pol'])
+for instr, outstr in intervals:
+    realm.run([kadminl, 'modprinc', '-maxlife', instr, realm.user_princ])
+    out = realm.run([kadminl, 'getprinc', realm.user_princ])
+    if 'Maximum ticket life: ' + outstr + '\n' not in out:
+        fail('princ maxlife: ' + instr)
+
+    realm.run([kadminl, 'modprinc', '-maxrenewlife', instr, realm.user_princ])
+    out = realm.run([kadminl, 'getprinc', realm.user_princ])
+    if 'Maximum renewable life: ' + outstr + '\n' not in out:
+        fail('princ maxrenewlife: ' + instr)
+
+    realm.run([kadminl, 'modpol', '-maxlife', instr, 'pol'])
+    out = realm.run([kadminl, 'getpol', 'pol'])
+    if 'Maximum password life: ' + outstr + '\n' not in out:
+        fail('pol maxlife: ' + instr)
+
+    realm.run([kadminl, 'modpol', '-minlife', instr, 'pol'])
+    out = realm.run([kadminl, 'getpol', 'pol'])
+    if 'Minimum password life: ' + outstr + '\n' not in out:
+        fail('pol maxlife: ' + instr)
+
+    realm.run([kadminl, 'modpol', '-failurecountinterval', instr, 'pol'])
+    out = realm.run([kadminl, 'getpol', 'pol'])
+    if 'Password failure count reset interval: ' + outstr + '\n' not in out:
+        fail('pol maxlife: ' + instr)
+
+    realm.run([kadminl, 'modpol', '-lockoutduration', instr, 'pol'])
+    out = realm.run([kadminl, 'getpol', 'pol'])
+    if 'Password lockout duration: ' + outstr + '\n' not in out:
+        fail('pol maxlife: ' + instr)
+
+success('kadmin command parsing tests')


### PR DESCRIPTION
When parsing time intervals in kadmin commands, try
krb5_string_to_deltat() first, then fall back to subtracting the
current time from get_date().  If we do fall back, treat "never" as a
zero interval, and error out rather than yield a huge interval if
get_date() returns a time in the past.

Notable behavior differences: bare numbers of seconds and suffixed
numbers (e.g. "5m" or "6h") are now supported for all intervals;
HH:MM:SS and HH:MM are now treated as intervals rather than absolute
times with the current time subtracted.
