### PR TITLE
Skip password prompt when running ksu as root

### DIFF
--- a/src/clients/ksu/main.c
+++ b/src/clients/ksu/main.c
@@ -119,6 +119,7 @@ main (argc, argv)
     krb5_boolean stored = FALSE, cc_reused = FALSE;
     krb5_boolean zero_password;
     krb5_boolean restrict_creds;
+    krb5_boolean given_princ = FALSE;
     krb5_deltat lifetime, rlife;
 
     params = (char **) xcalloc (2, sizeof (char *));
@@ -238,6 +239,7 @@ main (argc, argv)
                 com_err(prog_name, retval, _("when parsing name %s"), optarg);
                 errflg++;
             }
+            given_princ = TRUE;
             break;
 #ifdef DEBUG
         case 'D':
@@ -462,7 +464,7 @@ main (argc, argv)
 
     if ((source_uid == 0) || (target_uid == source_uid)){
 #ifdef GET_TGT_VIA_PASSWD
-        if ((!all_rest_copy) && client != NULL && (stored == FALSE)){
+        if (!all_rest_copy && given_princ && client != NULL && !stored) {
             fprintf(stderr, _("WARNING: Your password may be exposed if you "
                               "enter it here and are logged\n"));
             fprintf(stderr, _("         in remotely using an unsecure "


### PR DESCRIPTION
A change introduced in 5fd5a67 resulted in root always being prompted for
the target user password when running ksu.  Restore the previous behavior
which is to only prompt if the principal is provided with -n.