### PR TITLE
python-ldap-27::modify() function errors when parsing kerberos.ldif

### DIFF
--- a/src/plugins/kdb/ldap/libkdb_ldap/kerberos.ldif
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kerberos.ldif
@@ -46,7 +46,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.1.1
                 NAME 'krbPrincipalName'
                 EQUALITY caseExactIA5Match
                 SUBSTR caseExactSubstringsMatch
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.26)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
 
 ##### If there are multiple krbPrincipalName values for an entry, this
@@ -62,7 +62,7 @@ attributetypes: ( 1.2.840.113554.1.4.1.6.1
                 EQUALITY caseExactIA5Match
                 SUBSTR caseExactSubstringsMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 ##### This specifies the type of the principal, the types could be any of
 ##### the types mentioned in section 6.2 of RFC 4120
@@ -74,7 +74,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.3.1
                 NAME 'krbPrincipalType'
                 EQUALITY integerMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### This flag is used to find whether directory User Password has to be used
@@ -89,7 +89,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.5.1
                 NAME 'krbUPEnabled'
                 DESC 'Boolean'
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.7
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### The time at which the principal expires
@@ -101,7 +101,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.6.1
                 NAME 'krbPrincipalExpiration'
                 EQUALITY generalizedTimeMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### The krbTicketFlags attribute holds information about the kerberos flags for a principal
@@ -129,7 +129,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.8.1
                 NAME 'krbTicketFlags'
                 EQUALITY integerMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### The maximum ticket lifetime for a principal in seconds
@@ -141,7 +141,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.9.1
                 NAME 'krbMaxTicketLife'
                 EQUALITY integerMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### Maximum renewable lifetime for a principal's ticket in seconds
@@ -153,7 +153,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.10.1
                 NAME 'krbMaxRenewableAge'
                 EQUALITY integerMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### Forward reference to the Realm object.
@@ -166,7 +166,7 @@ add: attributetypes
 attributetypes: ( 2.16.840.1.113719.1.301.4.14.1
                 NAME 'krbRealmReferences'
                 EQUALITY distinguishedNameMatch
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
 
 
 ##### List of LDAP servers that kerberos servers can contact.
@@ -182,7 +182,7 @@ add: attributetypes
 attributetypes: ( 2.16.840.1.113719.1.301.4.15.1
                 NAME 'krbLdapServers'
                 EQUALITY caseIgnoreMatch
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.15)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
 
 ##### A set of forward references to the KDC Service objects.
@@ -195,7 +195,7 @@ add: attributetypes
 attributetypes: ( 2.16.840.1.113719.1.301.4.17.1
                 NAME 'krbKdcServers'
                 EQUALITY distinguishedNameMatch
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
 
 
 ##### A set of forward references to the Password Service objects.
@@ -208,7 +208,7 @@ add: attributetypes
 attributetypes: ( 2.16.840.1.113719.1.301.4.18.1
                 NAME 'krbPwdServers'
                 EQUALITY distinguishedNameMatch
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
 
 
 ##### This attribute holds the Host Name or the ip address, 
@@ -222,7 +222,7 @@ add: attributetypes
 attributetypes: ( 2.16.840.1.113719.1.301.4.24.1
                 NAME 'krbHostServer'
                 EQUALITY caseExactIA5Match
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.26)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
 
 ##### This attribute holds the scope for searching the principals
@@ -236,7 +236,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.25.1
                 NAME 'krbSearchScope'
                 EQUALITY integerMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### FDNs pointing to Kerberos principals
@@ -247,7 +247,7 @@ add: attributetypes
 attributetypes: ( 2.16.840.1.113719.1.301.4.26.1
                 NAME 'krbPrincipalReferences'
                 EQUALITY distinguishedNameMatch
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
 
 
 ##### This attribute specifies which attribute of the user objects  
@@ -261,7 +261,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.28.1
                 NAME 'krbPrincNamingAttr'
                 EQUALITY caseIgnoreMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### A set of forward references to the Administration Service objects.
@@ -274,7 +274,7 @@ add: attributetypes
 attributetypes: ( 2.16.840.1.113719.1.301.4.29.1
                 NAME 'krbAdmServers'
                 EQUALITY distinguishedNameMatch
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
 
 
 ##### Maximum lifetime of a principal's password
@@ -286,7 +286,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.30.1
                 NAME 'krbMaxPwdLife'
                 EQUALITY integerMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### Minimum lifetime of a principal's password
@@ -298,7 +298,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.31.1
                 NAME 'krbMinPwdLife'
                 EQUALITY integerMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### Minimum number of character clases allowed in a password
@@ -310,7 +310,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.32.1
                 NAME 'krbPwdMinDiffChars' 
                 EQUALITY integerMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### Minimum length of the password
@@ -322,7 +322,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.33.1
                 NAME 'krbPwdMinLength' 
                 EQUALITY integerMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### Number of previous versions of passwords that are stored
@@ -334,7 +334,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.34.1
                 NAME 'krbPwdHistoryLength' 
                 EQUALITY integerMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### Number of consecutive pre-authentication failures before lockout
@@ -346,7 +346,7 @@ attributetypes: ( 1.3.6.1.4.1.5322.21.2.1
                 NAME 'krbPwdMaxFailure' 
                 EQUALITY integerMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### Period after which bad preauthentication count will be reset
@@ -358,7 +358,7 @@ attributetypes: ( 1.3.6.1.4.1.5322.21.2.2
                 NAME 'krbPwdFailureCountInterval' 
                 EQUALITY integerMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### Period in which lockout is enforced
@@ -370,7 +370,7 @@ attributetypes: ( 1.3.6.1.4.1.5322.21.2.3
                 NAME 'krbPwdLockoutDuration' 
                 EQUALITY integerMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### Policy attribute flags
@@ -382,7 +382,7 @@ attributetypes: ( 1.2.840.113554.1.4.1.6.2
                 NAME 'krbPwdAttributes'
                 EQUALITY integerMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### Policy maximum ticket lifetime
@@ -394,7 +394,7 @@ attributetypes: ( 1.2.840.113554.1.4.1.6.3
                 NAME 'krbPwdMaxLife'
                 EQUALITY integerMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### Policy maximum ticket renewable lifetime
@@ -406,7 +406,7 @@ attributetypes: ( 1.2.840.113554.1.4.1.6.4
                 NAME 'krbPwdMaxRenewableLife'
                 EQUALITY integerMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.27
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### Allowed enctype:salttype combinations for key changes
@@ -418,7 +418,7 @@ attributetypes: ( 1.2.840.113554.1.4.1.6.5
                 NAME 'krbPwdAllowedKeysalts'
                 EQUALITY caseIgnoreIA5Match
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.26
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### FDN pointing to a Kerberos Password Policy object
@@ -430,7 +430,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.36.1
                 NAME 'krbPwdPolicyReference'
                 EQUALITY distinguishedNameMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### The time at which the principal's password expires
@@ -442,7 +442,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.37.1
                 NAME 'krbPasswordExpiration'
                 EQUALITY generalizedTimeMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### This attribute holds the principal's key (krbPrincipalKey) that is encrypted with
@@ -482,7 +482,7 @@ add: attributetypes
 attributetypes: ( 2.16.840.1.113719.1.301.4.39.1
                 NAME 'krbPrincipalKey'
                 EQUALITY octetStringMatch
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.40)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 )
 
 
 ##### FDN pointing to a Kerberos Ticket Policy object.
@@ -494,7 +494,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.40.1
                 NAME 'krbTicketPolicyReference'
                 EQUALITY distinguishedNameMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.12
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### Forward reference to an entry that starts sub-trees
@@ -507,7 +507,7 @@ add: attributetypes
 attributetypes: ( 2.16.840.1.113719.1.301.4.41.1
                 NAME 'krbSubTrees'
                 EQUALITY distinguishedNameMatch
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
 
 
 ##### Holds the default encryption/salt type combinations of principals for
@@ -520,7 +520,7 @@ add: attributetypes
 attributetypes: ( 2.16.840.1.113719.1.301.4.42.1
                 NAME 'krbDefaultEncSaltTypes'
                 EQUALITY caseIgnoreMatch
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.15)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
 
 ##### Holds the Supported encryption/salt type combinations of principals for
@@ -544,7 +544,7 @@ add: attributetypes
 attributetypes: ( 2.16.840.1.113719.1.301.4.43.1
                 NAME 'krbSupportedEncSaltTypes'
                 EQUALITY caseIgnoreMatch
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.15)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )
 
 
 ##### This attribute holds the principal's old keys (krbPwdHistory) that is encrypted with
@@ -584,7 +584,7 @@ add: attributetypes
 attributetypes: ( 2.16.840.1.113719.1.301.4.44.1
                 NAME 'krbPwdHistory'
                 EQUALITY octetStringMatch
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.40)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 )
 
 
 ##### The time at which the principal's password last password change happened.
@@ -596,7 +596,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.45.1
                 NAME 'krbLastPwdChange'
                 EQUALITY generalizedTimeMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 ##### The time at which the principal was last administratively unlocked.
 
@@ -607,7 +607,7 @@ attributetypes: ( 1.3.6.1.4.1.5322.21.2.5
                 NAME 'krbLastAdminUnlock'
                 EQUALITY generalizedTimeMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 ##### This attribute holds the kerberos master key.
 ##### This can be used to encrypt principal keys. 
@@ -632,7 +632,7 @@ add: attributetypes
 attributetypes: ( 2.16.840.1.113719.1.301.4.46.1
                 NAME 'krbMKey'
                 EQUALITY octetStringMatch
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.40)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 )
 
 
 ##### This stores the alternate principal names for the principal in the RFC 1961 specified format
@@ -643,7 +643,7 @@ add: attributetypes
 attributetypes: ( 2.16.840.1.113719.1.301.4.47.1
                 NAME 'krbPrincipalAliases'
                 EQUALITY caseExactIA5Match
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.26)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
 
 ##### The time at which the principal's last successful authentication happened.
@@ -655,7 +655,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.48.1
                 NAME 'krbLastSuccessfulAuth'
                 EQUALITY generalizedTimeMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### The time at which the principal's last failed authentication happened.
@@ -667,7 +667,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.49.1
                 NAME 'krbLastFailedAuth'
                 EQUALITY generalizedTimeMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.24
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 ##### This attribute stores the number of failed authentication attempts
@@ -680,7 +680,7 @@ attributetypes: ( 2.16.840.1.113719.1.301.4.50.1
                 NAME 'krbLoginFailedCount' 
                 EQUALITY integerMatch
                 SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 
-                SINGLE-VALUE)
+                SINGLE-VALUE )
 
 
 
@@ -692,7 +692,7 @@ add: attributetypes
 attributetypes: ( 2.16.840.1.113719.1.301.4.51.1
                 NAME 'krbExtraData'
                 EQUALITY octetStringMatch
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.40)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.40 )
 
 
 ##### This attributes holds references to the set of directory objects.
@@ -705,7 +705,7 @@ add: attributetypes
 attributetypes: ( 2.16.840.1.113719.1.301.4.52.1
                 NAME 'krbObjectReferences'
                 EQUALITY distinguishedNameMatch
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
 
 
 ##### This attribute holds references to a Container object where 
@@ -718,7 +718,7 @@ add: attributetypes
 attributetypes: ( 2.16.840.1.113719.1.301.4.53.1
                 NAME 'krbPrincContainerRef'
                 EQUALITY distinguishedNameMatch
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.12 )
 
 
 ##### A list of authentication indicator strings, one of which must be satisfied
@@ -743,7 +743,7 @@ attributetypes: ( 1.3.6.1.4.1.5322.21.2.4
                 NAME 'krbAllowedToDelegateTo'
                 EQUALITY caseExactIA5Match
                 SUBSTR caseExactSubstringsMatch
-                SYNTAX 1.3.6.1.4.1.1466.115.121.1.26)
+                SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )
 
 ########################################################################
 ########################################################################


### PR DESCRIPTION
When using the python-ldap-27::modify() function, an error message is generated:

("{'info': 'olcAttributeTypes: Missing closing parenthesis before end of input', 'desc': 'Other (e.g., implementation specific) error'}", 1)

parsing the kerberos.ldif file.  Most related RFCs, such as 2307, do specify class declarations with a space in between the closing right parenthesis.  Adding a space allows the python library to complete successfully.  The updated LDIF file has been tested with OpenLDAP 2.4.44.