### PR TITLE
Add support for new openssl-1.1.0 APIs

### DIFF
--- a/src/configure.in
+++ b/src/configure.in
@@ -244,6 +244,10 @@ builtin)
   ;;
 openssl)
   AC_CHECK_LIB(crypto, PKCS7_get_signer_info)
+  AC_CHECK_TYPES([HMAC_CTX, EVP_MD_CTX], [], [], [[
+#include <openssl/hmac.h>
+#include <openssl/evp.h>
+  ]])
   ;;
 *)
   AC_MSG_ERROR([Unknown crypto implementation $withval])
@@ -280,6 +284,10 @@ builtin|openssl)
   AC_CHECK_LIB(crypto, CMS_get0_content,
                [AC_DEFINE([HAVE_OPENSSL_CMS], 1,
                           [Define if OpenSSL supports cms.])])
+  AC_CHECK_TYPES([HMAC_CTX, EVP_MD_CTX], [], [], [[
+#include <openssl/hmac.h>
+#include <openssl/evp.h>
+  ]])
   ;;
 nss)
   if test "${PKINIT_CRYPTO_IMPL_CFLAGS+set}" != set; then

--- a/src/include/k5-platform.h
+++ b/src/include/k5-platform.h
@@ -1099,4 +1099,17 @@ extern int k5_getopt_long(int nargc, char **nargv, char *options,
 #define getopt_long k5_getopt_long
 #endif /* HAVE_GETOPT_LONG */
 
+/*
+ * Compatibility for changed APIs in openssl-1.1.0.
+ * Pre openssl-1.1.0 will have these defined.
+ */
+#if HAVE_HMAC_CTX
+# define HMAC_CTX_free HMAC_CTX_cleanup
+#endif /* HAVE_HMAC_CTX */
+
+#if HAVE_EVP_MD_CTX
+# define EVP_MD_CTX_new() EVP_MD_CTX_create()
+# define EVP_MD_CTX_free(x) EVP_MD_CTX_destroy(x)
+#endif /* HAVE_EVP_MD_CTX */
+
 #endif /* K5_PLATFORM_H */

--- a/src/lib/crypto/openssl/enc_provider/aes.c
+++ b/src/lib/crypto/openssl/enc_provider/aes.c
@@ -65,22 +65,27 @@ cbc_enc(krb5_key key, const krb5_data *ivec, krb5_crypto_iov *data,
 {
     int             ret, olen = BLOCK_SIZE;
     unsigned char   iblock[BLOCK_SIZE], oblock[BLOCK_SIZE];
-    EVP_CIPHER_CTX  ciph_ctx;
+    EVP_CIPHER_CTX  *ciph_ctx;
     struct iov_cursor cursor;
 
-    EVP_CIPHER_CTX_init(&ciph_ctx);
-    ret = EVP_EncryptInit_ex(&ciph_ctx, map_mode(key->keyblock.length),
-                             NULL, key->keyblock.contents, (ivec) ? (unsigned char*)ivec->data : NULL);
-    if (ret == 0)
+    ciph_ctx = EVP_CIPHER_CTX_new();
+    if (!ciph_ctx)
         return KRB5_CRYPTO_INTERNAL;
+
+    ret = EVP_EncryptInit_ex(ciph_ctx, map_mode(key->keyblock.length),
+                             NULL, key->keyblock.contents, (ivec) ? (unsigned char*)ivec->data : NULL);
+    if (ret == 0) {
+        EVP_CIPHER_CTX_free(ciph_ctx);
+        return KRB5_CRYPTO_INTERNAL;
+    }
 
     k5_iov_cursor_init(&cursor, data, num_data, BLOCK_SIZE, FALSE);
     k5_iov_cursor_get(&cursor, iblock);
-    EVP_CIPHER_CTX_set_padding(&ciph_ctx,0);
-    ret = EVP_EncryptUpdate(&ciph_ctx, oblock, &olen, iblock, BLOCK_SIZE);
+    EVP_CIPHER_CTX_set_padding(ciph_ctx,0);
+    ret = EVP_EncryptUpdate(ciph_ctx, oblock, &olen, iblock, BLOCK_SIZE);
     if (ret == 1)
         k5_iov_cursor_put(&cursor, oblock);
-    EVP_CIPHER_CTX_cleanup(&ciph_ctx);
+    EVP_CIPHER_CTX_free(ciph_ctx);
 
     zap(iblock, BLOCK_SIZE);
     zap(oblock, BLOCK_SIZE);
@@ -94,22 +99,27 @@ cbc_decr(krb5_key key, const krb5_data *ivec, krb5_crypto_iov *data,
 {
     int              ret = 0, olen = BLOCK_SIZE;
     unsigned char    iblock[BLOCK_SIZE], oblock[BLOCK_SIZE];
-    EVP_CIPHER_CTX   ciph_ctx;
+    EVP_CIPHER_CTX   *ciph_ctx;
     struct iov_cursor cursor;
 
-    EVP_CIPHER_CTX_init(&ciph_ctx);
-    ret = EVP_DecryptInit_ex(&ciph_ctx, map_mode(key->keyblock.length),
-                             NULL, key->keyblock.contents, (ivec) ? (unsigned char*)ivec->data : NULL);
-    if (ret == 0)
+    ciph_ctx = EVP_CIPHER_CTX_new();
+    if (!ciph_ctx)
         return KRB5_CRYPTO_INTERNAL;
+
+    ret = EVP_DecryptInit_ex(ciph_ctx, map_mode(key->keyblock.length),
+                             NULL, key->keyblock.contents, (ivec) ? (unsigned char*)ivec->data : NULL);
+    if (ret == 0) {
+        EVP_CIPHER_CTX_free(ciph_ctx);
+        return KRB5_CRYPTO_INTERNAL;
+    }
 
     k5_iov_cursor_init(&cursor, data, num_data, BLOCK_SIZE, FALSE);
     k5_iov_cursor_get(&cursor, iblock);
-    EVP_CIPHER_CTX_set_padding(&ciph_ctx,0);
-    ret = EVP_DecryptUpdate(&ciph_ctx, oblock, &olen, iblock, BLOCK_SIZE);
+    EVP_CIPHER_CTX_set_padding(ciph_ctx,0);
+    ret = EVP_DecryptUpdate(ciph_ctx, oblock, &olen, iblock, BLOCK_SIZE);
     if (ret == 1)
         k5_iov_cursor_put(&cursor, oblock);
-    EVP_CIPHER_CTX_cleanup(&ciph_ctx);
+    EVP_CIPHER_CTX_free(ciph_ctx);
 
     zap(iblock, BLOCK_SIZE);
     zap(oblock, BLOCK_SIZE);

--- a/src/lib/crypto/openssl/enc_provider/camellia.c
+++ b/src/lib/crypto/openssl/enc_provider/camellia.c
@@ -89,22 +89,27 @@ cbc_enc(krb5_key key, const krb5_data *ivec, krb5_crypto_iov *data,
 {
     int             ret, olen = BLOCK_SIZE;
     unsigned char   iblock[BLOCK_SIZE], oblock[BLOCK_SIZE];
-    EVP_CIPHER_CTX  ciph_ctx;
     struct iov_cursor cursor;
+    EVP_CIPHER_CTX *ciph_ctx;
 
-    EVP_CIPHER_CTX_init(&ciph_ctx);
-    ret = EVP_EncryptInit_ex(&ciph_ctx, map_mode(key->keyblock.length),
-                             NULL, key->keyblock.contents, (ivec) ? (unsigned char*)ivec->data : NULL);
-    if (ret == 0)
+    ciph_ctx = EVP_CIPHER_CTX_new();
+    if (!ciph_ctx)
         return KRB5_CRYPTO_INTERNAL;
+
+    ret = EVP_EncryptInit_ex(ciph_ctx, map_mode(key->keyblock.length),
+                             NULL, key->keyblock.contents, (ivec) ? (unsigned char*)ivec->data : NULL);
+    if (ret == 0) {
+        EVP_CIPHER_CTX_free(ciph_ctx);
+        return KRB5_CRYPTO_INTERNAL;
+    }
 
     k5_iov_cursor_init(&cursor, data, num_data, BLOCK_SIZE, FALSE);
     k5_iov_cursor_get(&cursor, iblock);
-    EVP_CIPHER_CTX_set_padding(&ciph_ctx,0);
-    ret = EVP_EncryptUpdate(&ciph_ctx, oblock, &olen, iblock, BLOCK_SIZE);
+    EVP_CIPHER_CTX_set_padding(ciph_ctx,0);
+    ret = EVP_EncryptUpdate(ciph_ctx, oblock, &olen, iblock, BLOCK_SIZE);
     if (ret == 1)
         k5_iov_cursor_put(&cursor, oblock);
-    EVP_CIPHER_CTX_cleanup(&ciph_ctx);
+    EVP_CIPHER_CTX_free(ciph_ctx);
 
     zap(iblock, BLOCK_SIZE);
     zap(oblock, BLOCK_SIZE);
@@ -118,22 +123,27 @@ cbc_decr(krb5_key key, const krb5_data *ivec, krb5_crypto_iov *data,
 {
     int              ret = 0, olen = BLOCK_SIZE;
     unsigned char    iblock[BLOCK_SIZE], oblock[BLOCK_SIZE];
-    EVP_CIPHER_CTX   ciph_ctx;
     struct iov_cursor cursor;
+    EVP_CIPHER_CTX *ciph_ctx;
 
-    EVP_CIPHER_CTX_init(&ciph_ctx);
-    ret = EVP_DecryptInit_ex(&ciph_ctx, map_mode(key->keyblock.length),
-                             NULL, key->keyblock.contents, (ivec) ? (unsigned char*)ivec->data : NULL);
-    if (ret == 0)
+    ciph_ctx = EVP_CIPHER_CTX_new();
+    if (!ciph_ctx)
         return KRB5_CRYPTO_INTERNAL;
+
+    ret = EVP_DecryptInit_ex(ciph_ctx, map_mode(key->keyblock.length),
+                             NULL, key->keyblock.contents, (ivec) ? (unsigned char*)ivec->data : NULL);
+    if (ret == 0) {
+        EVP_CIPHER_CTX_free(ciph_ctx);
+        return KRB5_CRYPTO_INTERNAL;
+    }
 
     k5_iov_cursor_init(&cursor, data, num_data, BLOCK_SIZE, FALSE);
     k5_iov_cursor_get(&cursor, iblock);
-    EVP_CIPHER_CTX_set_padding(&ciph_ctx,0);
-    ret = EVP_DecryptUpdate(&ciph_ctx, oblock, &olen, iblock, BLOCK_SIZE);
+    EVP_CIPHER_CTX_set_padding(ciph_ctx,0);
+    ret = EVP_DecryptUpdate(ciph_ctx, oblock, &olen, iblock, BLOCK_SIZE);
     if (ret == 1)
         k5_iov_cursor_put(&cursor, oblock);
-    EVP_CIPHER_CTX_cleanup(&ciph_ctx);
+    EVP_CIPHER_CTX_free(ciph_ctx);
 
     zap(iblock, BLOCK_SIZE);
     zap(oblock, BLOCK_SIZE);

--- a/src/lib/crypto/openssl/enc_provider/des.c
+++ b/src/lib/crypto/openssl/enc_provider/des.c
@@ -82,25 +82,29 @@ k5_des_encrypt(krb5_key key, const krb5_data *ivec, krb5_crypto_iov *data,
     int ret, olen = DES_BLOCK_SIZE;
     unsigned char iblock[DES_BLOCK_SIZE], oblock[DES_BLOCK_SIZE];
     struct iov_cursor cursor;
-    EVP_CIPHER_CTX ciph_ctx;
     krb5_boolean empty;
+    EVP_CIPHER_CTX *ciph_ctx;
 
     ret = validate(key, ivec, data, num_data, &empty);
     if (ret != 0 || empty)
         return ret;
 
-    EVP_CIPHER_CTX_init(&ciph_ctx);
-
-    ret = EVP_EncryptInit_ex(&ciph_ctx, EVP_des_cbc(), NULL,
-                             key->keyblock.contents, (ivec && ivec->data) ? (unsigned char*)ivec->data : NULL);
-    if (!ret)
+    ciph_ctx = EVP_CIPHER_CTX_new();
+    if (!ciph_ctx)
         return KRB5_CRYPTO_INTERNAL;
 
-    EVP_CIPHER_CTX_set_padding(&ciph_ctx,0);
+    ret = EVP_EncryptInit_ex(ciph_ctx, EVP_des_cbc(), NULL,
+                             key->keyblock.contents, (ivec && ivec->data) ? (unsigned char*)ivec->data : NULL);
+    if (!ret) {
+        EVP_CIPHER_CTX_free(ciph_ctx);
+        return KRB5_CRYPTO_INTERNAL;
+    }
+
+    EVP_CIPHER_CTX_set_padding(ciph_ctx,0);
 
     k5_iov_cursor_init(&cursor, data, num_data, DES_BLOCK_SIZE, FALSE);
     while (k5_iov_cursor_get(&cursor, iblock)) {
-        ret = EVP_EncryptUpdate(&ciph_ctx, oblock, &olen,
+        ret = EVP_EncryptUpdate(ciph_ctx, oblock, &olen,
                                 (unsigned char *)iblock, DES_BLOCK_SIZE);
         if (!ret)
             break;
@@ -110,7 +114,7 @@ k5_des_encrypt(krb5_key key, const krb5_data *ivec, krb5_crypto_iov *data,
     if (ivec != NULL)
         memcpy(ivec->data, oblock, DES_BLOCK_SIZE);
 
-    EVP_CIPHER_CTX_cleanup(&ciph_ctx);
+    EVP_CIPHER_CTX_free(ciph_ctx);
 
     zap(iblock, sizeof(iblock));
     zap(oblock, sizeof(oblock));
@@ -127,26 +131,30 @@ k5_des_decrypt(krb5_key key, const krb5_data *ivec, krb5_crypto_iov *data,
     int ret, olen = DES_BLOCK_SIZE;
     unsigned char iblock[DES_BLOCK_SIZE], oblock[DES_BLOCK_SIZE];
     struct iov_cursor cursor;
-    EVP_CIPHER_CTX ciph_ctx;
     krb5_boolean empty;
+    EVP_CIPHER_CTX *ciph_ctx;
 
     ret = validate(key, ivec, data, num_data, &empty);
     if (ret != 0 || empty)
         return ret;
 
-    EVP_CIPHER_CTX_init(&ciph_ctx);
-
-    ret = EVP_DecryptInit_ex(&ciph_ctx, EVP_des_cbc(), NULL,
-                             key->keyblock.contents,
-                             (ivec) ? (unsigned char*)ivec->data : NULL);
-    if (!ret)
+    ciph_ctx = EVP_CIPHER_CTX_new();
+    if (!ciph_ctx)
         return KRB5_CRYPTO_INTERNAL;
 
-    EVP_CIPHER_CTX_set_padding(&ciph_ctx,0);
+    ret = EVP_DecryptInit_ex(ciph_ctx, EVP_des_cbc(), NULL,
+                             key->keyblock.contents,
+                             (ivec) ? (unsigned char*)ivec->data : NULL);
+    if (!ret) {
+        EVP_CIPHER_CTX_free(ciph_ctx);
+        return KRB5_CRYPTO_INTERNAL;
+    }
+
+    EVP_CIPHER_CTX_set_padding(ciph_ctx,0);
 
     k5_iov_cursor_init(&cursor, data, num_data, DES_BLOCK_SIZE, FALSE);
     while (k5_iov_cursor_get(&cursor, iblock)) {
-        ret = EVP_DecryptUpdate(&ciph_ctx, oblock, &olen,
+        ret = EVP_DecryptUpdate(ciph_ctx, oblock, &olen,
                                 iblock, DES_BLOCK_SIZE);
         if (!ret)
             break;
@@ -156,7 +164,7 @@ k5_des_decrypt(krb5_key key, const krb5_data *ivec, krb5_crypto_iov *data,
     if (ivec != NULL)
         memcpy(ivec->data, iblock, DES_BLOCK_SIZE);
 
-    EVP_CIPHER_CTX_cleanup(&ciph_ctx);
+    EVP_CIPHER_CTX_free(ciph_ctx);
 
     zap(iblock, sizeof(iblock));
     zap(oblock, sizeof(oblock));

--- a/src/lib/crypto/openssl/hash_provider/hash_md4.c
+++ b/src/lib/crypto/openssl/hash_provider/hash_md4.c
@@ -32,21 +32,24 @@
 static krb5_error_code
 k5_md4_hash(const krb5_crypto_iov *data, size_t num_data, krb5_data *output)
 {
-    EVP_MD_CTX ctx;
     unsigned int i;
+    EVP_MD_CTX *ctx;
 
     if (output->length != MD4_DIGEST_LENGTH)
         return KRB5_CRYPTO_INTERNAL;
 
-    EVP_MD_CTX_init(&ctx);
-    EVP_DigestInit_ex(&ctx, EVP_md4(), NULL);
+    ctx = EVP_MD_CTX_new();
+    if (!ctx)
+        return KRB5_CRYPTO_INTERNAL;
+
+    EVP_DigestInit_ex(ctx, EVP_md4(), NULL);
     for (i = 0; i < num_data; i++) {
         const krb5_data *d = &data[i].data;
         if (SIGN_IOV(&data[i]))
-            EVP_DigestUpdate(&ctx, (unsigned char *)d->data, d->length);
+            EVP_DigestUpdate(ctx, (unsigned char *)d->data, d->length);
     }
-    EVP_DigestFinal_ex(&ctx, (unsigned char *)output->data, NULL);
-    EVP_MD_CTX_cleanup(&ctx);
+    EVP_DigestFinal_ex(ctx, (unsigned char *)output->data, NULL);
+    EVP_MD_CTX_free(ctx);
     return 0;
 }
 

--- a/src/lib/crypto/openssl/hash_provider/hash_md5.c
+++ b/src/lib/crypto/openssl/hash_provider/hash_md5.c
@@ -32,21 +32,24 @@
 static krb5_error_code
 k5_md5_hash(const krb5_crypto_iov *data, size_t num_data, krb5_data *output)
 {
-    EVP_MD_CTX ctx;
     unsigned int i;
+    EVP_MD_CTX *ctx;
 
     if (output->length != MD5_DIGEST_LENGTH)
         return KRB5_CRYPTO_INTERNAL;
 
-    EVP_MD_CTX_init(&ctx);
-    EVP_DigestInit_ex(&ctx, EVP_md5(), NULL);
+    ctx = EVP_MD_CTX_new();
+    if (!ctx)
+        return KRB5_CRYPTO_INTERNAL;
+
+    EVP_DigestInit_ex(ctx, EVP_md5(), NULL);
     for (i = 0; i < num_data; i++) {
         const krb5_data *d = &data[i].data;
         if (SIGN_IOV(&data[i]))
-            EVP_DigestUpdate(&ctx, (unsigned char *)d->data, d->length);
+            EVP_DigestUpdate(ctx, (unsigned char *)d->data, d->length);
     }
-    EVP_DigestFinal_ex(&ctx, (unsigned char *)output->data, NULL);
-    EVP_MD_CTX_cleanup(&ctx);
+    EVP_DigestFinal_ex(ctx, (unsigned char *)output->data, NULL);
+    EVP_MD_CTX_free(ctx);
     return 0;
 }
 

--- a/src/lib/crypto/openssl/hash_provider/hash_sha1.c
+++ b/src/lib/crypto/openssl/hash_provider/hash_sha1.c
@@ -33,21 +33,24 @@
 static krb5_error_code
 k5_sha1_hash(const krb5_crypto_iov *data, size_t num_data, krb5_data *output)
 {
-    EVP_MD_CTX ctx;
     unsigned int i;
+    EVP_MD_CTX *ctx;
 
     if (output->length != SHA_DIGEST_LENGTH)
         return KRB5_CRYPTO_INTERNAL;
 
-    EVP_MD_CTX_init(&ctx);
-    EVP_DigestInit_ex(&ctx, EVP_sha1(), NULL);
+    ctx = EVP_MD_CTX_new();
+    if (!ctx)
+        return KRB5_CRYPTO_INTERNAL;
+
+    EVP_DigestInit_ex(ctx, EVP_sha1(), NULL);
     for (i = 0; i < num_data; i++) {
         const krb5_data *d = &data[i].data;
         if (SIGN_IOV(&data[i]))
-            EVP_DigestUpdate(&ctx, (unsigned char *)d->data, d->length);
+            EVP_DigestUpdate(ctx, (unsigned char *)d->data, d->length);
     }
-    EVP_DigestFinal_ex(&ctx, (unsigned char *)output->data, NULL);
-    EVP_MD_CTX_cleanup(&ctx);
+    EVP_DigestFinal_ex(ctx, (unsigned char *)output->data, NULL);
+    EVP_MD_CTX_free(ctx);
     return 0;
 }
 

--- a/src/lib/crypto/openssl/sha256.c
+++ b/src/lib/crypto/openssl/sha256.c
@@ -36,13 +36,16 @@
 krb5_error_code
 k5_sha256(const krb5_data *in, uint8_t out[K5_SHA256_HASHLEN])
 {
-    EVP_MD_CTX ctx;
+    EVP_MD_CTX *ctx;
     int ok;
 
-    EVP_MD_CTX_init(&ctx);
-    ok = EVP_DigestInit_ex(&ctx, EVP_sha256(), NULL);
-    ok = ok && EVP_DigestUpdate(&ctx, in->data, in->length);
-    ok = ok && EVP_DigestFinal_ex(&ctx, out, NULL);
-    EVP_MD_CTX_cleanup(&ctx);
+    ctx = EVP_MD_CTX_new();
+    if (!ctx)
+        return ENOMEM;
+
+    ok = EVP_DigestInit_ex(ctx, EVP_sha256(), NULL);
+    ok = ok && EVP_DigestUpdate(ctx, in->data, in->length);
+    ok = ok && EVP_DigestFinal_ex(ctx, out, NULL);
+    EVP_MD_CTX_free(ctx);
     return ok ? 0 : ENOMEM;
 }


### PR DESCRIPTION
openssl-1.1.0 made HMAC_CTX, EVP_MD_CTX, and EVP_CIPHER_CTX
opaque types, therefore adjust how we use these interfaces accordingly,
while also being backwards compatible with the older interfaces.
Note EVP_CIPHER_CTX_{new,free} have been available since openssl-0.9.8
and since krb5 already enforces that version or later we just
use those new interfaces unconditionally.