### PR TITLE
Krb5 1.10 dns_canonicalize_hostname flag support

### DIFF
--- a/doc/admin.texinfo
+++ b/doc/admin.texinfo
@@ -587,6 +587,13 @@ depends on configure-time options; if none were given, the default is to
 disable this option.  If the DNS support is not compiled in, this entry
 has no effect.
 
+@itemx dns_canonicalize_hostname
+Indicate whether name lookups will be used to canonicalize hostnames for
+use in service principal names. Setting this flag to false can improve 
+security by reducing reliance on DNS but means that short hostnames will
+not be canonicalized to fully-qualified hostnames. The default value is 
+false.
+
 @itemx dns_fallback
 General flag controlling the use of DNS for Kerberos information.  If
 both of the preceding options are specified, this option has no effect.

--- a/doc/rst_source/krb_admins/conf_files/krb5_conf.rst
+++ b/doc/rst_source/krb_admins/conf_files/krb5_conf.rst
@@ -101,6 +101,9 @@ The libdefaults section may contain any of the following relations:
 **default_tkt_enctypes**
     Identifies the supported list of session key encryption types that should be requested by the client. The format is the same as for default_tgs_enctypes. The default value for this tag is *aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 des3-cbc-sha1 arcfour-hmac-md5 des-cbc-crc des-cbc-md5 des-cbc-md4*. 
 
+**dns_canonicalize_hostname***
+    Indicate whether name lookups will be used to canonicalize hostnames for use in service principal names. Setting this flag to false can improve security by reducing reliance on DNS but means that short hostnames will not be canonicalized to fully-qualified hostnames. The default value is false.
+
 **dns_fallback**
     General flag controlling the use of DNS for Kerberos information. If both of the preceding options are specified, this option has no effect. 
 

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -207,6 +207,7 @@ typedef INT64_TYPE krb5_int64;
 #define KRB5_CONF_DISABLE                     "disable"
 #define KRB5_CONF_DISABLE_LAST_SUCCESS        "disable_last_success"
 #define KRB5_CONF_DISABLE_LOCKOUT             "disable_lockout"
+#define KRB5_CONF_DNS_CANONICALIZE_HOSTNAME   "dns_canonicalize_hostname"
 #define KRB5_CONF_DNS_LOOKUP_KDC              "dns_lookup_kdc"
 #define KRB5_CONF_DNS_LOOKUP_REALM            "dns_lookup_realm"
 #define KRB5_CONF_DNS_FALLBACK                "dns_fallback"
@@ -1480,6 +1481,7 @@ struct _krb5_context {
 
     krb5_boolean allow_weak_crypto;
     krb5_boolean ignore_acceptor_hostname;
+    krb5_boolean dns_canonicalize_hostname;
 
     krb5_trace_callback trace_callback;
     void *trace_callback_data;

--- a/src/lib/krb5/krb/init_ctx.c
+++ b/src/lib/krb5/krb/init_ctx.c
@@ -178,6 +178,14 @@ krb5_init_context_profile(profile_t profile, krb5_flags flags,
         goto cleanup;
     ctx->ignore_acceptor_hostname = tmp;
 
+    /* Disables canonicalizing hostnames for service principals. */
+    retval = profile_get_boolean(ctx->profile, KRB5_CONF_LIBDEFAULTS,
+				 KRB5_CONF_DNS_CANONICALIZE_HOSTNAME, NULL, 1,
+				 &tmp);
+    if (retval)
+     	goto cleanup;
+    ctx->dns_canonicalize_hostname = tmp;
+
     /* initialize the prng (not well, but passable) */
     if ((retval = krb5_c_random_os_entropy( ctx, 0, NULL)) !=0)
         goto cleanup;

--- a/src/lib/krb5/os/sn2princ.c
+++ b/src/lib/krb5/os/sn2princ.c
@@ -89,7 +89,7 @@ krb5_sname_to_principal(krb5_context context, const char *hostname, const char *
 
         /* copy the hostname into non-volatile storage */
 
-        if (type == KRB5_NT_SRV_HST) {
+        if (type == KRB5_NT_SRV_HST && context->dns_canonicalize_hostname) {
             struct addrinfo *ai = NULL, hints;
             int err;
             char hnamebuf[NI_MAXHOST];


### PR DESCRIPTION
This is a backport of the dns_canonicalize_hostname feature present in later versions.

I realize this is a stale branch; however, my company uses this version on CentOS 6.  A bug report was submitted to have a similar patch implemented: https://bugs.centos.org/view.php?id=10775, but I believe committing here is important, too.