### PR TITLE
Unconstify some krb5 GSS OIDs

### DIFF
--- a/src/lib/gssapi/krb5/gssapiP_krb5.h
+++ b/src/lib/gssapi/krb5/gssapiP_krb5.h
@@ -90,7 +90,7 @@
 #define GSS_MECH_IAKERB_OID_LENGTH 6
 #define GSS_MECH_IAKERB_OID "\053\006\001\005\002\005"
 
-extern const gss_OID_set_desc * const kg_all_mechs;
+extern const gss_OID_set kg_all_mechs;
 
 #define CKSUMTYPE_KG_CB         0x8003
 

--- a/src/lib/gssapi/krb5/gssapi_krb5.c
+++ b/src/lib/gssapi/krb5/gssapi_krb5.c
@@ -151,29 +151,33 @@ const gss_OID_desc krb5_gss_oid_array[] = {
     { 0, 0 }
 };
 
-const gss_OID_desc * const gss_mech_krb5              = krb5_gss_oid_array+0;
-const gss_OID_desc * const gss_mech_krb5_old          = krb5_gss_oid_array+1;
-const gss_OID_desc * const gss_mech_krb5_wrong        = krb5_gss_oid_array+2;
-const gss_OID_desc * const gss_mech_iakerb            = krb5_gss_oid_array+3;
+#define kg_oids ((gss_OID)krb5_gss_oid_array)
+
+const gss_OID gss_mech_krb5             = &kg_oids[0];
+const gss_OID gss_mech_krb5_old         = &kg_oids[1];
+const gss_OID gss_mech_krb5_wrong       = &kg_oids[2];
+const gss_OID gss_mech_iakerb           = &kg_oids[3];
 
 
-const gss_OID_desc * const gss_nt_krb5_name           = krb5_gss_oid_array+5;
-const gss_OID_desc * const gss_nt_krb5_principal      = krb5_gss_oid_array+6;
-const gss_OID_desc * const GSS_KRB5_NT_PRINCIPAL_NAME = krb5_gss_oid_array+5;
+const gss_OID gss_nt_krb5_name                  = &kg_oids[5];
+const gss_OID gss_nt_krb5_principal             = &kg_oids[6];
+const gss_OID GSS_KRB5_NT_PRINCIPAL_NAME        = &kg_oids[5];
 
-const gss_OID_desc * const GSS_KRB5_CRED_NO_CI_FLAGS_X = krb5_gss_oid_array+7;
+const gss_OID GSS_KRB5_CRED_NO_CI_FLAGS_X       = &kg_oids[7];
 
 static const gss_OID_set_desc oidsets[] = {
-    {1, (gss_OID) krb5_gss_oid_array+0}, /* RFC OID */
-    {1, (gss_OID) krb5_gss_oid_array+1}, /* pre-RFC OID */
-    {3, (gss_OID) krb5_gss_oid_array+0}, /* all names for krb5 mech */
-    {4, (gss_OID) krb5_gss_oid_array+0}, /* all krb5 names and IAKERB */
+    {1, &kg_oids[0]}, /* RFC OID */
+    {1, &kg_oids[1]}, /* pre-RFC OID */
+    {3, &kg_oids[0]}, /* all names for krb5 mech */
+    {4, &kg_oids[0]}, /* all krb5 names and IAKERB */
 };
 
-const gss_OID_set_desc * const gss_mech_set_krb5 = oidsets+0;
-const gss_OID_set_desc * const gss_mech_set_krb5_old = oidsets+1;
-const gss_OID_set_desc * const gss_mech_set_krb5_both = oidsets+2;
-const gss_OID_set_desc * const kg_all_mechs = oidsets+3;
+#define kg_oidsets ((gss_OID_set)oidsets)
+
+const gss_OID_set gss_mech_set_krb5             = &kg_oidsets[0];
+const gss_OID_set gss_mech_set_krb5_old         = &kg_oidsets[1];
+const gss_OID_set gss_mech_set_krb5_both        = &kg_oidsets[2];
+const gss_OID_set kg_all_mechs                  = &kg_oidsets[3];
 
 g_set kg_vdb = G_SET_INIT;
 

--- a/src/lib/gssapi/krb5/gssapi_krb5.h
+++ b/src/lib/gssapi/krb5/gssapi_krb5.h
@@ -37,7 +37,7 @@ extern "C" {
 /* Reserved static storage for GSS_oids.  See rfc 1964 for more details. */
 
 /* 2.1.1. Kerberos Principal Name Form: */
-GSS_DLLIMP extern const gss_OID_desc * const GSS_KRB5_NT_PRINCIPAL_NAME;
+GSS_DLLIMP extern const gss_OID GSS_KRB5_NT_PRINCIPAL_NAME;
 /* This name form shall be represented by the Object Identifier {iso(1)
  * member-body(2) United States(840) mit(113554) infosys(1) gssapi(2)
  * krb5(2) krb5_name(1)}.  The recommended symbolic name for this type
@@ -73,16 +73,16 @@ GSS_DLLIMP extern const gss_OID_desc * const GSS_KRB5_NT_PRINCIPAL_NAME;
  * generic(1) string_uid_name(3)}.  The recommended symbolic name for
  * this type is "GSS_KRB5_NT_STRING_UID_NAME". */
 
-GSS_DLLIMP extern const gss_OID_desc * const gss_mech_krb5;
-GSS_DLLIMP extern const gss_OID_desc * const gss_mech_krb5_old;
-GSS_DLLIMP extern const gss_OID_desc * const gss_mech_krb5_wrong;
-GSS_DLLIMP extern const gss_OID_desc * const gss_mech_iakerb;
-GSS_DLLIMP extern const gss_OID_set_desc * const gss_mech_set_krb5;
-GSS_DLLIMP extern const gss_OID_set_desc * const gss_mech_set_krb5_old;
-GSS_DLLIMP extern const gss_OID_set_desc * const gss_mech_set_krb5_both;
+GSS_DLLIMP extern const gss_OID gss_mech_krb5;
+GSS_DLLIMP extern const gss_OID gss_mech_krb5_old;
+GSS_DLLIMP extern const gss_OID gss_mech_krb5_wrong;
+GSS_DLLIMP extern const gss_OID gss_mech_iakerb;
+GSS_DLLIMP extern const gss_OID_set gss_mech_set_krb5;
+GSS_DLLIMP extern const gss_OID_set gss_mech_set_krb5_old;
+GSS_DLLIMP extern const gss_OID_set gss_mech_set_krb5_both;
 
-GSS_DLLIMP extern const gss_OID_desc * const gss_nt_krb5_name;
-GSS_DLLIMP extern const gss_OID_desc * const gss_nt_krb5_principal;
+GSS_DLLIMP extern const gss_OID gss_nt_krb5_name;
+GSS_DLLIMP extern const gss_OID gss_nt_krb5_principal;
 
 GSS_DLLIMP extern const gss_OID_desc krb5_gss_oid_array[];
 
@@ -94,7 +94,7 @@ GSS_DLLIMP extern const gss_OID_desc krb5_gss_oid_array[];
  * iso(1) member-body(2) Sweden(752) Stockholm University(43) Heimdal GSS-API
  * Extensions(13) no_ci_flags(29)
  */
-GSS_DLLIMP extern const gss_OID_desc * const GSS_KRB5_CRED_NO_CI_FLAGS_X;
+GSS_DLLIMP extern const gss_OID GSS_KRB5_CRED_NO_CI_FLAGS_X;
 
 #define gss_krb5_nt_general_name        gss_nt_krb5_name
 #define gss_krb5_nt_principal           gss_nt_krb5_principal

--- a/src/util/gss-kernel-lib/kernel_gss.c
+++ b/src/util/gss-kernel-lib/kernel_gss.c
@@ -37,8 +37,9 @@ static const gss_OID_desc oid_array[] = {
     {GSS_MECH_KRB5_OID_LENGTH, GSS_MECH_KRB5_OID},
     {GSS_MECH_KRB5_OLD_OID_LENGTH, GSS_MECH_KRB5_OLD_OID}
 };
-const gss_OID_desc *const gss_mech_krb5     = oid_array+0;
-const gss_OID_desc *const gss_mech_krb5_old = oid_array+1;
+#define oids ((gss_OID)oid_array)
+const gss_OID gss_mech_krb5     = &oids[0];
+const gss_OID gss_mech_krb5_old = &oids[1];
 
 /* Create a key from key data in a lucid context. */
 static krb5_error_code


### PR DESCRIPTION
gssapi_krb5.h declared some well-known OID constants as pointers to
const gss_OID_desc, which can't be assigned to application-declared
gss_OID variables or passed to GSSAPI functions without causing
warnings.

Declare these OID constants without the const qualifier on
gss_OID_desc, at the expense of some type safety.  (Fixing this
"correctly" probably requires some standards revision.)

ticket: 8399 (new)