### PR TITLE
Fix cstyle-file.py when emacs is not installed

### DIFF
--- a/src/util/cstyle-file.py
+++ b/src/util/cstyle-file.py
@@ -76,7 +76,12 @@ def emacs_reindent(lines):
         args = ['emacs', '-q', '-batch', '-l', cstyle_el, '-l', reindent_el,
                 f.name]
         with open(os.devnull, 'w') as devnull:
-            if call(args, stdin=devnull, stdout=devnull, stderr=devnull) != 0:
+            try:
+                st = call(args, stdin=devnull, stdout=devnull, stderr=devnull)
+                if st != 0:
+                    return None
+            except OSError:
+                # Fail gracefully if emacs isn't installed.
                 return None
         f.seek(0)
         ilines = f.readlines()


### PR DESCRIPTION
emacs_reindent() is intended to fail gracefully when emacs is not
installed, but instead subprocess.call() throws an OSError.  Check for
this error and return normally.