### PR TITLE
Implement principal renaming in LDAP

### DIFF
--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -602,6 +602,13 @@ krb5_dbe_compute_salt(krb5_context context, const krb5_key_data *key,
                       krb5_const_principal princ, krb5_int16 *salttype_out,
                       krb5_data **salt_out);
 
+/*
+ * Modify the key data of entry to explicitly store salt values using the
+ * KRB5_KDB_SALTTYPE_SPECIAL salt type.
+ */
+krb5_error_code
+krb5_dbe_specialize_salt(krb5_context context, krb5_db_entry *entry);
+
 krb5_error_code
 krb5_dbe_cpw( krb5_context        kcontext,
               krb5_keyblock       * master_key,

--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -379,6 +379,9 @@ krb5_error_code krb5_db_put_principal ( krb5_context kcontext,
                                         krb5_db_entry *entry );
 krb5_error_code krb5_db_delete_principal ( krb5_context kcontext,
                                            krb5_principal search_for );
+krb5_error_code
+krb5_db_rename_principal(krb5_context kcontext, krb5_principal source,
+                         krb5_principal target);
 
 /*
  * Iterate over principals in the KDB.  If the callback may write to the DB,
@@ -766,6 +769,11 @@ krb5_dbe_def_encrypt_key_data( krb5_context             context,
                                krb5_key_data          * key_data);
 
 krb5_error_code
+krb5_db_def_rename_principal(krb5_context kcontext,
+                             krb5_const_principal source,
+                             krb5_const_principal target);
+
+krb5_error_code
 krb5_db_create_policy( krb5_context kcontext,
                        osa_policy_ent_t policy);
 
@@ -841,7 +849,7 @@ krb5_dbe_free_string(krb5_context, char *);
  * This number indicates the date of the last incompatible change to the DAL.
  * The maj_ver field of the module's vtable structure must match this version.
  */
-#define KRB5_KDB_DAL_MAJOR_VERSION 5
+#define KRB5_KDB_DAL_MAJOR_VERSION 6
 
 /*
  * A krb5_context can hold one database object.  Modules should use
@@ -1034,6 +1042,18 @@ typedef struct _kdb_vftabl {
      */
     krb5_error_code (*delete_principal)(krb5_context kcontext,
                                         krb5_const_principal search_for);
+
+    /*
+     * Optional:  Rename a principal.  If the source principal does not exist,
+     * return KRB5_KDB_NOENTRY.  If the target exists, return an error.
+     *
+     * NOTE: If the module chooses to implement a custom function for renaming
+     * a principal instead of using krb5_db_def_rename_principal, then the
+     * rename will fail if iprop logging is enabled.
+     */
+    krb5_error_code (*rename_principal)(krb5_context kcontext,
+                                        krb5_const_principal source,
+                                        krb5_const_principal target);
 
     /*
      * Optional: For each principal entry in the database, invoke func with the

--- a/src/lib/kdb/kdb5.c
+++ b/src/lib/kdb/kdb5.c
@@ -2260,6 +2260,48 @@ krb5_dbe_compute_salt(krb5_context context, const krb5_key_data *key,
     return 0;
 }
 
+krb5_error_code
+krb5_dbe_specialize_salt(krb5_context context, krb5_db_entry *entry)
+{
+    krb5_int16 stype, i;
+    krb5_data *salt = NULL;
+    krb5_error_code ret = 0;
+    uint8_t *data;
+
+    if (context == NULL || entry == NULL)
+        return EINVAL;
+
+    /*
+     * Store salt values explicitly so that they don't depend on the principal
+     * name.
+     */
+    for (i = 0; i < entry->n_key_data; i++) {
+        ret = krb5_dbe_compute_salt(context, &entry->key_data[i], entry->princ,
+                                    &stype, &salt);
+        if (ret)
+            goto cleanup;
+
+        data = krb5_db_alloc(context, NULL, salt->length);
+        if (data == NULL) {
+            ret = ENOMEM;
+            goto cleanup;
+        }
+        memcpy(data, salt->data, salt->length);
+
+        entry->key_data[i].key_data_type[1] = KRB5_KDB_SALTTYPE_SPECIAL;
+        krb5_db_free(context, entry->key_data[i].key_data_contents[1]);
+        entry->key_data[i].key_data_contents[1] = data;
+        entry->key_data[i].key_data_length[1] = salt->length;
+        entry->key_data[i].key_data_ver = 2;
+        krb5_free_data(context, salt);
+        salt = NULL;
+    }
+
+cleanup:
+    krb5_free_data(context, salt);
+    return ret;
+}
+
 /* change password functions */
 krb5_error_code
 krb5_dbe_cpw(krb5_context kcontext, krb5_keyblock *master_key,

--- a/src/lib/kdb/kdb_default.c
+++ b/src/lib/kdb/kdb_default.c
@@ -538,3 +538,47 @@ clean_n_exit:
         krb5_dbe_free_key_list(context, mkey_list_head);
     return retval;
 }
+
+krb5_error_code
+krb5_db_def_rename_principal(krb5_context kcontext,
+                             krb5_const_principal source,
+                             krb5_const_principal target)
+{
+    krb5_db_entry *kdb = NULL;
+    krb5_principal old;
+
+    krb5_error_code ret;
+
+    if (source == NULL || target == NULL)
+        return EINVAL;
+
+    ret = krb5_db_get_principal(kcontext, source,
+                                KRB5_KDB_FLAG_ALIAS_OK, &kdb);
+    if (ret)
+        goto cleanup;
+
+    /*
+     * Store salt values explicitly so that they don't depend on the principal
+     * name.
+     */
+    ret = krb5_dbe_specialize_salt(kcontext, kdb);
+    if (ret)
+        goto cleanup;
+
+    old = kdb->princ;
+    kdb->princ = (krb5_principal) target;
+
+    ret = krb5_db_put_principal(kcontext, kdb);
+
+    kdb->princ = old;
+
+    if (ret)
+        goto cleanup;
+
+    ret = krb5_db_delete_principal(kcontext, (krb5_principal)source);
+
+
+cleanup:
+    krb5_db_free_principal(kcontext, kdb);
+    return ret;
+}

--- a/src/lib/kdb/libkdb5.exports
+++ b/src/lib/kdb/libkdb5.exports
@@ -58,6 +58,7 @@ krb5_dbe_lookup_mod_princ_data
 krb5_dbe_lookup_tl_data
 krb5_dbe_search_enctype
 krb5_dbe_set_string
+krb5_dbe_specialize_salt
 krb5_dbe_update_actkvno
 krb5_dbe_update_last_admin_unlock
 krb5_dbe_update_last_pwd_change

--- a/src/lib/kdb/libkdb5.exports
+++ b/src/lib/kdb/libkdb5.exports
@@ -24,6 +24,7 @@ krb5_db_lock
 krb5_db_mkey_list_alias
 krb5_db_put_principal
 krb5_db_refresh_config
+krb5_db_rename_principal
 krb5_db_set_context
 krb5_db_setup_mkey_name
 krb5_db_sign_authdata

--- a/src/plugins/kdb/db2/db2_exp.c
+++ b/src/plugins/kdb/db2/db2_exp.c
@@ -218,6 +218,7 @@ kdb_vftabl PLUGIN_SYMBOL_NAME(krb5_db2, kdb_function_table) = {
     /* free_principal */                wrap_krb5_db2_free_principal,
     /* put_principal */                 wrap_krb5_db2_put_principal,
     /* delete_principal */              wrap_krb5_db2_delete_principal,
+    /* rename_principal */              NULL,
     /* iterate */                       wrap_krb5_db2_iterate,
     /* create_policy */                 wrap_krb5_db2_create_policy,
     /* get_policy */                    wrap_krb5_db2_get_policy,

--- a/src/plugins/kdb/ldap/ldap_exp.c
+++ b/src/plugins/kdb/ldap/ldap_exp.c
@@ -61,7 +61,7 @@ kdb_vftabl PLUGIN_SYMBOL_NAME(krb5_ldap, kdb_function_table) = {
     /* free_principal */                    krb5_ldap_free_principal,
     /* put_principal */                     krb5_ldap_put_principal,
     /* delete_principal */                  krb5_ldap_delete_principal,
-    /* rename_principal */                  NULL,
+    /* rename_principal */                  krb5_ldap_rename_principal,
     /* iterate */                           krb5_ldap_iterate,
     /* create_policy */                     krb5_ldap_create_password_policy,
     /* get_policy */                        krb5_ldap_get_password_policy,

--- a/src/plugins/kdb/ldap/ldap_exp.c
+++ b/src/plugins/kdb/ldap/ldap_exp.c
@@ -61,6 +61,7 @@ kdb_vftabl PLUGIN_SYMBOL_NAME(krb5_ldap, kdb_function_table) = {
     /* free_principal */                    krb5_ldap_free_principal,
     /* put_principal */                     krb5_ldap_put_principal,
     /* delete_principal */                  krb5_ldap_delete_principal,
+    /* rename_principal */                  NULL,
     /* iterate */                           krb5_ldap_iterate,
     /* create_policy */                     krb5_ldap_create_password_policy,
     /* get_policy */                        krb5_ldap_get_password_policy,

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.h
@@ -60,6 +60,10 @@ krb5_error_code
 krb5_get_userdn(krb5_context, krb5_db_entry *, char **);
 
 krb5_error_code
+replace_rdn(krb5_context context, const char *dn, const char *newrdn,
+            char **newdn);
+
+krb5_error_code
 store_tl_data(krb5_tl_data *, int, void *);
 
 krb5_error_code
@@ -91,6 +95,10 @@ krb5_add_ber_mem_ldap_mod(LDAPMod  ***, char *, int, struct berval **);
 
 krb5_error_code
 krb5_add_int_mem_ldap_mod(LDAPMod  ***, char *, int , int);
+
+krb5_error_code
+krb5_ldap_modify_ext(krb5_context context, LDAP *ld, const char *dn,
+                     LDAPMod **mods, int op);
 
 krb5_error_code
 krb5_ldap_free_mod_array(LDAPMod **);

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.c
@@ -352,6 +352,241 @@ cleanup:
     return st;
 }
 
+/*
+ * Check if a principal is a standalone principal. *res will be 1 if it is,
+ * 0 if it isn't, and undefined if an error occurs.
+ */
+static inline krb5_error_code
+is_standalone_principal(krb5_context kcontext, krb5_db_entry *entry, int *res)
+{
+    krb5_error_code code;
+
+    code = krb5_get_princ_type(kcontext, entry, res);
+    if (!code)
+        *res = *res == KDB_STANDALONE_PRINCIPAL_OBJECT ? 1 : 0;
+
+    return code;
+}
+
+/*
+ * Unparse a principal name from a krb5_principal, and store it in the user
+ * argument.
+ */
+static krb5_error_code
+unparse_principal_name(krb5_context context, krb5_const_principal princ,
+                       char **user)
+{
+    krb5_error_code res;
+    char *luser = NULL;
+
+    *user = NULL;
+    res = krb5_unparse_name(context, princ, &luser);
+    if (res)
+        goto cleanup;
+
+    res = krb5_ldap_unparse_principal_name(luser);
+    if (res)
+        goto cleanup;
+
+    *user = luser;
+    luser = NULL;
+
+cleanup:
+    free(luser);
+    return res;
+}
+
+/*
+ * Rename a principal's rdn.
+ *
+ * NOTE: Not every LDAP ds supports deleting the old rdn. If that is desired,
+ * it will have to be deleted afterwards.
+ */
+static krb5_error_code
+rename_principal_rdn(krb5_context context, LDAP *ld, const char *dn,
+                    const char *newprinc, char **newdn)
+{
+    int ret;
+    char *newrdn = NULL;
+    char *newdn_out = NULL;
+
+    *newdn = NULL;
+
+    ret = asprintf(&newrdn, "krbprincipalname=%s", newprinc);
+    if (ret < 0) {
+        newrdn = NULL;
+        return ENOMEM;
+    }
+
+    /*
+     * ldap_rename_s takes an integer to delete the old rdn when the new one is
+     * created, but this fails on at least one LDAP directory (389ds). Instead,
+     * it will have to be renamed and deleted at a later point in time.
+     */
+    ret = ldap_rename_s(ld, dn, newrdn, NULL, 0, NULL, NULL);
+    if (ret == -1) {
+        ldap_get_option(ld, LDAP_OPT_ERROR_NUMBER, &ret);
+        ret = set_ldap_error(context, ret, OP_MOD);
+        goto cleanup;
+    }
+
+    ret = replace_rdn(context, dn, newrdn, &newdn_out);
+    if (ret)
+        goto cleanup;
+
+    *newdn = newdn_out;
+    newdn_out = NULL;
+
+cleanup:
+    free(newrdn);
+    free(newdn_out);
+    return ret;
+}
+
+/*
+ * Rename a principal.
+ */
+krb5_error_code
+krb5_ldap_rename_principal(krb5_context context, krb5_const_principal source,
+                           krb5_const_principal target)
+{
+    int is_standalone;
+    krb5_error_code st;
+    char *suser = NULL, *tuser = NULL, *strval[2], *dn = NULL;
+    char *newdn = NULL;
+    krb5_db_entry *entry = NULL;
+    krb5_kvno mkvno;
+    struct berval **bersecretkey = NULL;
+    kdb5_dal_handle *dal_handle = NULL;
+    krb5_ldap_context *ldap_context = NULL;
+    krb5_ldap_server_handle *ldap_server_handle = NULL;
+    LDAP *ld = NULL;
+    LDAPMod **mods = NULL;
+
+    /* Clear the global error string */
+    krb5_clear_error_message(context);
+
+    SETUP_CONTEXT();
+    if (ldap_context->lrparams == NULL || ldap_context->container_dn == NULL)
+        return EINVAL;
+
+    /* get ldap handle */
+    GET_HANDLE();
+
+    /*
+     * Pass no flags. This means principal aliases won't be returned, which is
+     * a good thing since we don't support renaming aliases.
+     */
+    st = krb5_ldap_get_principal(context, source, 0, &entry);
+    if (st)
+        goto cleanup;
+
+    st = is_standalone_principal(context, entry, &is_standalone);
+    if (st)
+        goto cleanup;
+
+    st = krb5_get_userdn(context, entry, &dn);
+    if (st)
+        goto cleanup;
+    if (dn == NULL) {
+        st = EINVAL;
+        k5_setmsg(context, st, _("dn information missing"));
+        goto cleanup;
+    }
+
+    st = unparse_principal_name(context, source, &suser);
+    if (st)
+        goto cleanup;
+    st = unparse_principal_name(context, target, &tuser);
+    if (st)
+        goto cleanup;
+
+    /*
+     * Specialize the salt and store it first so that in case of an error the
+     * correct salt will still be used.
+     */
+    /* Transform salts as necessary. */
+    st = krb5_dbe_specialize_salt(context, entry);
+    if (st)
+        goto cleanup;
+
+    /* Store the new key */
+    st = krb5_dbe_lookup_mkvno(context, entry, &mkvno);
+    if (st)
+        goto cleanup;
+
+    bersecretkey = krb5_encode_krbsecretkey(entry->key_data, entry->n_key_data,
+                                            mkvno);
+    if (bersecretkey == NULL) {
+        st = ENOMEM;
+        goto cleanup;
+    }
+
+    st = krb5_add_ber_mem_ldap_mod(&mods, "krbPrincipalKey",
+                                   LDAP_MOD_REPLACE | LDAP_MOD_BVALUES,
+                                   bersecretkey);
+    if (st != 0)
+        goto cleanup;
+
+    /* Update the principal. */
+    st = krb5_ldap_modify_ext(context, ld, dn, mods, OP_MOD);
+    if (st)
+        goto cleanup;
+    ldap_mods_free(mods, 1);
+    mods = NULL;
+
+    /*
+     * If it's a standalone principal we want to rename the dn. If not, modify
+     * it in place.
+     */
+    if (is_standalone) {
+        st = rename_principal_rdn(context, ld, dn, tuser, &newdn);
+        if (st)
+            goto cleanup;
+        free(dn);
+        dn = newdn;
+        newdn = NULL;
+    }
+
+    memset(strval, 0, sizeof(strval));
+    strval[0] = suser;
+    st = krb5_add_str_mem_ldap_mod(&mods, "krbPrincipalName",
+                                   LDAP_MOD_DELETE, strval);
+    if (st)
+        goto cleanup;
+
+    memset(strval, 0, sizeof(strval));
+    strval[0] = tuser;
+    /*
+     * There can be more than one krbPrincipalName, so we have to delete
+     * the old one and add the new one.
+     */
+    if (!is_standalone) {
+        st = krb5_add_str_mem_ldap_mod(&mods, "krbPrincipalName", LDAP_MOD_ADD,
+                                       strval);
+        if (st)
+            goto cleanup;
+    }
+
+    st = krb5_add_str_mem_ldap_mod(&mods, "krbCanonicalName", LDAP_MOD_REPLACE,
+                                   strval);
+    if (st)
+        goto cleanup;
+
+    /* Update the principal. */
+    st = krb5_ldap_modify_ext(context, ld, dn, mods, OP_MOD);
+    if (st)
+        goto cleanup;
+
+cleanup:
+    free(dn);
+    free(suser);
+    free(tuser);
+    krb5_ldap_free_principal(context, entry);
+    ldap_mods_free(mods, 1);
+    krb5_ldap_put_handle_to_pool(ldap_context, ldap_server_handle);
+    return st;
+}
 
 /*
  * Function: krb5_ldap_unparse_principal_name

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.h
@@ -105,6 +105,9 @@ krb5_ldap_get_principal(krb5_context , krb5_const_principal ,
 krb5_error_code
 krb5_ldap_delete_principal(krb5_context, krb5_const_principal);
 
+krb5_error_code
+krb5_ldap_rename_principal(krb5_context context, krb5_const_principal source,
+                           krb5_const_principal target);
 void
 krb5_ldap_free_principal(krb5_context, krb5_db_entry *);
 
@@ -127,6 +130,10 @@ krb5_ldap_unparse_principal_name(char *);
 
 krb5_error_code
 krb5_ldap_parse_principal_name(char *, char **);
+
+struct berval**
+krb5_encode_krbsecretkey(krb5_key_data *key_data, int n_key_data,
+                         krb5_kvno mkvno);
 
 krb5_error_code
 krb5_decode_histkey(krb5_context, struct berval **, osa_princ_ent_rec *);

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
@@ -503,7 +503,7 @@ cleanup:
 }
 
 /* Decoding ASN.1 encoded key */
-static struct berval **
+struct berval **
 krb5_encode_krbsecretkey(krb5_key_data *key_data, int n_key_data,
                          krb5_kvno mkvno)
 {

--- a/src/plugins/kdb/ldap/libkdb_ldap/libkdb_ldap.exports
+++ b/src/plugins/kdb/ldap/libkdb_ldap/libkdb_ldap.exports
@@ -9,6 +9,7 @@ krb5_ldap_read_server_params
 krb5_ldap_put_principal
 krb5_ldap_get_principal
 krb5_ldap_delete_principal
+krb5_ldap_rename_principal
 krb5_ldap_free_principal
 krb5_ldap_iterate
 krb5_ldap_read_krbcontainer_dn

--- a/src/plugins/kdb/test/kdb_test.c
+++ b/src/plugins/kdb/test/kdb_test.c
@@ -559,6 +559,7 @@ kdb_vftabl PLUGIN_SYMBOL_NAME(krb5_test, kdb_function_table) = {
     test_free_principal,
     NULL, /* put_principal */
     NULL, /* delete_principal */
+    NULL, /* rename_principal */
     NULL, /* iterate */
     NULL, /* create_policy */
     NULL, /* get_policy */

--- a/src/tests/t_kdb.py
+++ b/src/tests/t_kdb.py
@@ -384,6 +384,18 @@ def test_pwhist(nhist):
 for n in (1, 2, 3, 4, 5):
     test_pwhist(n)
 
+# Test principal renaming and make sure last modified is changed
+def get_princ(princ):
+    out = realm.run([kadminl, 'getprinc', princ])
+    return dict(map(str.strip, x.split(":", 1)) for x in out.splitlines())
+
+realm.addprinc("rename", password('rename'))
+renameprinc = get_princ("rename")
+realm.run([kadminl, '-p', 'fake@KRBTEST.COM', 'renprinc', 'rename', 'renamed'])
+renamedprinc = get_princ("renamed")
+if renameprinc['Last modified'] == renamedprinc['Last modified']:
+    fail('Last modified data not updated when principal was renamed')
+
 # Regression test for #7980 (fencepost when dividing keys up by kvno).
 realm.run([kadminl, 'addprinc', '-randkey', '-e', 'aes256-cts,aes128-cts',
            'kvnoprinc'])


### PR DESCRIPTION
The previous way of renaming principals by adding a new entry and deleting the old one did not work in LDAP due to issues such as requiring renaming the DN in standalone principals, and modifying the DN in place for non-standalone principals. A new DAL function for renaming principals is added so that the plugins can properly rename the principal for their particular database. A function is also added to libkdb_ldap that implements the DAL rename_principal function that properly renames the DN and attributes when necessary.

[ticket: 8065](https://krbdev.mit.edu/rt/Ticket/Display.html?id=8065)