### PR TITLE
Link correct VS2015 C libraries for debug builds

### DIFF
--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -53,7 +53,11 @@ clean-windows::
 
 ##WIN32##!if defined(VISUALSTUDIOVERSION)
 ##WIN32##!if $(VISUALSTUDIOVERSION:.=) >= 140
+##WIN32##!ifdef NODEBUG
 ##WIN32##WINCRTEXTRA = ucrt.lib vcruntime.lib
+##WIN32##!else
+##WIN32##WINCRTEXTRA = ucrtd.lib vcruntimed.lib
+##WIN32##!endif
 ##WIN32##!endif
 ##WIN32##!endif
 ##WIN32##WINLIBS = kernel32.lib ws2_32.lib user32.lib shell32.lib oldnames.lib \

--- a/src/windows/kfwlogon/Makefile.in
+++ b/src/windows/kfwlogon/Makefile.in
@@ -9,7 +9,11 @@ PROG_LIBPATH=-L$(TOPLIBD) -L$(KRB5_LIBDIR)
 
 !if defined(VISUALSTUDIOVERSION)
 !if $(VISUALSTUDIOVERSION:.=) >= 140
+!ifdef NODEBUG
 WINCRTEXTRA = ucrt.lib vcruntime.lib
+!else
+WINCRTEXTRA = ucrtd.lib vcruntimed.lib
+!endif
 !endif
 !endif
 SYSLIBS = kernel32.lib user32.lib advapi32.lib wsock32.lib secur32.lib userenv.lib $(WINCRTEXTRA)


### PR DESCRIPTION
When building with VS2015 and NODEBUG is not set, link with the
debugging versions of ucrt.lib and vcruntime.lib.  Based on work by
Chris Kingsley.
