### PR TITLE
Fix unlikely pointer error in get_in_tkt.c

### DIFF
--- a/src/lib/krb5/krb/get_in_tkt.c
+++ b/src/lib/krb5/krb/get_in_tkt.c
@@ -344,10 +344,11 @@ add_padata(krb5_pa_data ***padptr, krb5_preauthtype pa_type,
     if (pad)
         for (size=0; pad[size]; size++);
     pad = realloc(pad, sizeof(*pad)*(size+2));
-
     if (pad == NULL)
         return ENOMEM;
-    pad[size+1] = NULL;
+    *padptr = pad;
+    pad[size] = pad[size + 1] = NULL;
+
     pa = malloc(sizeof(krb5_pa_data));
     if (pa == NULL)
         return ENOMEM;
@@ -363,7 +364,6 @@ add_padata(krb5_pa_data ***padptr, krb5_preauthtype pa_type,
     }
     pa->pa_type = pa_type;
     pad[size] = pa;
-    *padptr = pad;
     return 0;
 }
 


### PR DESCRIPTION
In add_padata(), reset the caller's pointer as soon as realloc()
succeeds, to ensure that the old pointer isn't left behind if a later
allocation fails.

(Note to self: after merging this, make a note in the RT ticket about the 1.14/1.13 backport, since it won't be a trivial merge.)
