### PR TITLE
Check princ length in krb5_sname_match()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -320,6 +320,7 @@ local.properties
 /src/lib/krb5/krb/t_vfy_increds
 /src/lib/krb5/krb/t_walk_rtree
 /src/lib/krb5/krb/t_response_items
+/src/lib/krb5/krb/t_sname_match
 
 /src/lib/krb5/os/t_expand_path
 /src/lib/krb5/os/t_locate_kdc

--- a/src/lib/krb5/krb/Makefile.in
+++ b/src/lib/krb5/krb/Makefile.in
@@ -353,6 +353,7 @@ SRCS=	$(srcdir)/addr_comp.c	\
 	$(srcdir)/t_copy_context.c \
 	$(srcdir)/t_in_ccache.c	\
 	$(srcdir)/t_response_items.c \
+	$(srcdir)/t_sname_match.c \
 	$(srcdir)/t_vfy_increds.c
 
 # Someday, when we have a "maintainer mode", do this right:
@@ -437,9 +438,12 @@ t_copy_context: t_copy_context.o $(KRB5_BASE_DEPLIBS)
 t_response_items: t_response_items.o response_items.o $(KRB5_BASE_DEPLIBS)
 	$(CC_LINK) -o $@ t_response_items.o response_items.o $(KRB5_BASE_LIBS)
 
+t_sname_match: t_sname_match.o sname_match.o $(KRB5_BASE_DEPLIBS)
+	$(CC_LINK) -o $@ t_sname_match.o sname_match.o $(KRB5_BASE_LIBS)
+
 TEST_PROGS= t_walk_rtree t_kerb t_ser t_deltat t_expand t_authdata t_pac \
 	t_in_ccache t_cc_config t_copy_context \
-	t_princ t_etypes t_vfy_increds t_response_items
+	t_princ t_etypes t_vfy_increds t_response_items t_sname_match
 
 check-unix:: $(TEST_PROGS)
 	$(RUN_TEST_LOCAL_CONF) ./t_kerb \
@@ -475,6 +479,7 @@ check-unix:: $(TEST_PROGS)
 	$(RUN_TEST) ./t_etypes
 	$(RUN_TEST) ./t_response_items
 	$(RUN_TEST) ./t_copy_context
+	$(RUN_TEST) ./t_sname_match
 
 check-pytests:: t_expire_warn t_vfy_increds
 	$(RUNPYTEST) $(srcdir)/t_expire_warn.py $(PYTESTFLAGS)
@@ -497,7 +502,9 @@ clean::
 	$(OUTPRE)t_in_ccache$(EXEEXT) $(OUTPRE)t_in_ccache.$(OBJEXT)	\
 	$(OUTPRE)t_ad_fx_armor$(EXEEXT) $(OUTPRE)t_ad_fx_armor.$(OBJEXT) \
 	$(OUTPRE)t_vfy_increds$(EXEEXT) $(OUTPRE)t_vfy_increds.$(OBJEXT) \
-	$(OUTPRE)t_response_items$(EXEEXT) $(OUTPRE)t_response_items.$(OBJEXT)
+	$(OUTPRE)t_response_items$(EXEEXT) \
+	$(OUTPRE)t_response_items.$(OBJEXT) $(OUTPRE)t_sname_match(EXEEXT) \
+	$(OUTPRE)t_sname_match.$(OBJEXT)
 
 @libobj_frag@
 

--- a/src/lib/krb5/krb/sname_match.c
+++ b/src/lib/krb5/krb/sname_match.c
@@ -36,6 +36,9 @@ krb5_sname_match(krb5_context context, krb5_const_principal matching,
     if (matching->type != KRB5_NT_SRV_HST || matching->length != 2)
         return krb5_principal_compare(context, matching, princ);
 
+    if (princ->length != 2)
+        return FALSE;
+
     /* Check the realm if present in matching. */
     if (matching->realm.length != 0 && !data_eq(matching->realm, princ->realm))
         return FALSE;

--- a/src/lib/krb5/krb/t_sname_match.c
+++ b/src/lib/krb5/krb/t_sname_match.c
@@ -1,0 +1,117 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* lib/krb5/krb/t_sname_match.c - Unit tests for krb5_sname_match() */
+/*
+ * Copyright (C) 2016 by the Massachusetts Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "k5-int.h"
+
+struct test {
+    const char *matchstr;
+    const char *princstr;
+    krb5_boolean result;
+    krb5_boolean ignore_acceptor_hostname;
+    krb5_boolean non_host_nametype;
+} tests[] = {
+    /* If matching is NULL, the result is true for any princ. */
+    { NULL, "a/b@R", TRUE },
+
+    /* If matching does not have two components or does not have name type
+     * KRB5_NT_SRV_HOST, the result is a direct comparison. */
+    { "a@R", "a@R", TRUE },
+    { "a@R", "b@R", FALSE },
+    { "a/@R", "a/@R", TRUE, FALSE, TRUE },
+    { "a/@R", "a/b@R", FALSE, FALSE, TRUE },
+    { "a/b@", "a/b@", TRUE, FALSE, TRUE },
+    { "a/b@", "a/b@R", FALSE, FALSE, TRUE },
+    { "a/b/@R", "a/b/@R", TRUE },
+    { "a/b/@R", "a/b/c@R", FALSE },
+
+    /* The number of components must match. */
+    { "a/b@R", "a@R", FALSE },
+    { "a/b@R", "a/b/@R", FALSE },
+    { "a/b@R", "a/b/c@R", FALSE },
+
+    /* If matching's realm is empty, any realm in princ is permitted. */
+    { "a/b@", "a/b@", TRUE },
+    { "a/b@", "a/b@R", TRUE },
+    { "a/b@R", "a/b@R", TRUE },
+    { "a/b@R", "a/b@S", FALSE },
+
+    /* matching's first component must match princ's (even if empty). */
+    { "/b@R", "/b@R", TRUE },
+    { "/b@R", "a/b@R", FALSE },
+
+    /* If matching's second component is empty, any second component in princ
+     * is permitted. */
+    { "a/@R", "a/@R", TRUE },
+    { "a/@R", "a/b@R", TRUE },
+
+    /* If ignore_acceptor_hostname is set, any second component in princ is
+     * permitted, even if there is a different second component in matching. */
+    { "a/b@R", "a/c@R", TRUE, TRUE },
+    { "a/b@R", "c/b@R", FALSE, TRUE },
+};
+
+int
+main()
+{
+    size_t i;
+    struct test *t;
+    krb5_principal matching, princ;
+    krb5_context ctx;
+
+    if (krb5_init_context(&ctx) != 0)
+        abort();
+    for (i = 0; i < sizeof(tests) / sizeof(*tests); i++) {
+        t = &tests[i];
+
+        if (t->matchstr != NULL) {
+            if (krb5_parse_name(ctx, t->matchstr, &matching) != 0)
+                abort();
+            if (t->non_host_nametype)
+                matching->type = KRB5_NT_PRINCIPAL;
+            else
+                matching->type = KRB5_NT_SRV_HST;
+        } else {
+            matching = NULL;
+        }
+        if (krb5_parse_name(ctx, t->princstr, &princ) != 0)
+            abort();
+
+        ctx->ignore_acceptor_hostname = t->ignore_acceptor_hostname;
+        if (krb5_sname_match(ctx, matching, princ) != t->result)
+            abort();
+
+        krb5_free_principal(ctx, matching);
+        krb5_free_principal(ctx, princ);
+    }
+    krb5_free_context(ctx);
+    return 0;
+}


### PR DESCRIPTION
krb5_sname_match() can read past the end of princ's component array in
some circumstances (typically when a keytab contains both "x" and
"x/y" principals).  Add a length check.  Reported by Spencer Jackson.

There is also a second commit to add unit tests.
