### PR TITLE
Use library allocator, not module allocator, for principal/policy entries

### DIFF
--- a/src/kadmin/dbutil/dump.c
+++ b/src/kadmin/dbutil/dump.c
@@ -712,10 +712,9 @@ process_k5beta7_princ(krb5_context context, const char *fname, FILE *filep,
     krb5_tl_data *tl;
     krb5_error_code ret;
 
-    dbentry = krb5_db_alloc(context, NULL, sizeof(*dbentry));
+    dbentry = calloc(1, sizeof(*dbentry));
     if (dbentry == NULL)
         return 1;
-    memset(dbentry, 0, sizeof(*dbentry));
     (*linenop)++;
     nread = fscanf(filep, "%u\t%u\t%u\t%u\t%u\t", &u1, &u2, &u3, &u4, &u5);
     if (nread == EOF) {

--- a/src/kadmin/dbutil/kdb5_create.c
+++ b/src/kadmin/dbutil/kdb5_create.c
@@ -423,10 +423,9 @@ add_principal(context, princ, op, pblock)
     struct iterate_args   iargs;
     krb5_actkvno_node     actkvno;
 
-    entry = krb5_db_alloc(context, NULL, sizeof(*entry));
+    entry = calloc(1, sizeof(*entry));
     if (entry == NULL)
         return ENOMEM;
-    memset(entry, 0, sizeof(*entry));
 
     entry->len = KRB5_KDB_V1_BASE_LENGTH;
     entry->attributes = pblock->flags;

--- a/src/lib/kadm5/srv/svr_policy.c
+++ b/src/lib/kadm5/srv/svr_policy.c
@@ -249,7 +249,6 @@ kadm5_modify_policy(void *server_handle, kadm5_policy_ent_t entry, long mask)
     krb5_tl_data            *tl;
     osa_policy_ent_t         p;
     int                      ret;
-    size_t                   len;
 
     CHECK_HANDLE(server_handle);
 
@@ -329,17 +328,14 @@ kadm5_modify_policy(void *server_handle, kadm5_policy_ent_t entry, long mask)
         if ((mask & KADM5_POLICY_MAX_RLIFE))
             p->max_renewable_life = entry->max_renewable_life;
         if ((mask & KADM5_POLICY_ALLOWED_KEYSALTS)) {
-            krb5_db_free(handle->context, p->allowed_keysalts);
+            free(p->allowed_keysalts);
             p->allowed_keysalts = NULL;
             if (entry->allowed_keysalts != NULL) {
-                len = strlen(entry->allowed_keysalts) + 1;
-                p->allowed_keysalts = krb5_db_alloc(handle->context, NULL,
-                                                    len);
+                p->allowed_keysalts = strdup(entry->allowed_keysalts);
                 if (p->allowed_keysalts == NULL) {
                     ret = ENOMEM;
                     goto cleanup;
                 }
-                memcpy(p->allowed_keysalts, entry->allowed_keysalts, len);
             }
         }
         if ((mask & KADM5_POLICY_TL_DATA)) {

--- a/src/lib/kdb/encrypt_key.c
+++ b/src/lib/kdb/encrypt_key.c
@@ -74,7 +74,7 @@ krb5_dbe_def_encrypt_key_data( krb5_context             context,
     krb5_enc_data                 cipher;
 
     for (i = 0; i < key_data->key_data_ver; i++) {
-        krb5_db_free(context, key_data->key_data_contents[i]);
+        free(key_data->key_data_contents[i]);
         key_data->key_data_contents[i] = NULL;
     }
 
@@ -89,7 +89,7 @@ krb5_dbe_def_encrypt_key_data( krb5_context             context,
                                         &len)))
         return(retval);
 
-    ptr = krb5_db_alloc(context, NULL, 2 + len);
+    ptr = malloc(2 + len);
     if (ptr == NULL)
         return(ENOMEM);
 
@@ -108,7 +108,7 @@ krb5_dbe_def_encrypt_key_data( krb5_context             context,
 
     if ((retval = krb5_c_encrypt(context, mkey, /* XXX */ 0, 0,
                                  &plain, &cipher))) {
-        krb5_db_free(context, key_data->key_data_contents[0]);
+        free(key_data->key_data_contents[0]);
         return retval;
     }
 
@@ -118,10 +118,9 @@ krb5_dbe_def_encrypt_key_data( krb5_context             context,
             key_data->key_data_ver++;
             key_data->key_data_type[1] = keysalt->type;
             if ((key_data->key_data_length[1] = keysalt->data.length) != 0) {
-                key_data->key_data_contents[1] =
-                    krb5_db_alloc(context, NULL, keysalt->data.length);
+                key_data->key_data_contents[1] = malloc(keysalt->data.length);
                 if (key_data->key_data_contents[1] == NULL) {
-                    krb5_db_free(context, key_data->key_data_contents[0]);
+                    free(key_data->key_data_contents[0]);
                     return ENOMEM;
                 }
                 memcpy(key_data->key_data_contents[1], keysalt->data.data,

--- a/src/lib/kdb/kdb_convert.c
+++ b/src/lib/kdb/kdb_convert.c
@@ -623,10 +623,9 @@ ulog_conv_2dbentry(krb5_context context, krb5_db_entry **entry,
      * Set ent->n_tl_data = 0 initially, if this is an ADD update
      */
     if (is_add) {
-        ent = krb5_db_alloc(context, NULL, sizeof(*ent));
+        ent = calloc(1, sizeof(*ent));
         if (ent == NULL)
             return (ENOMEM);
-        memset(ent, 0, sizeof(*ent));
         ent->n_tl_data = 0;
     }
 

--- a/src/lib/kdb/t_stringattr.c
+++ b/src/lib/kdb/t_stringattr.c
@@ -49,12 +49,11 @@ main()
     assert(krb5int_init_context_kdc(&context) == 0);
 
     /* Start with an empty entry. */
-    ent = krb5_db_alloc(context, NULL, sizeof(*ent));
+    ent = calloc(1, sizeof(*ent));
     if (ent == NULL) {
         fprintf(stderr, "Can't allocate memory for entry.\n");
         return 1;
     }
-    memset(ent, 0, sizeof(*ent));
 
     /* Check that the entry has no strings to start. */
     assert(krb5_dbe_get_strings(context, ent, &strings, &count) == 0);

--- a/src/plugins/kdb/db2/db2_exp.c
+++ b/src/plugins/kdb/db2/db2_exp.c
@@ -117,10 +117,6 @@ WRAP_K (krb5_db2_get_principal,
          unsigned int f,
          krb5_db_entry **d),
         (ctx, p, f, d));
-WRAP_VOID (krb5_db2_free_principal,
-           (krb5_context ctx,
-            krb5_db_entry *d),
-           (ctx, d));
 WRAP_K (krb5_db2_put_principal,
         (krb5_context ctx,
          krb5_db_entry *d,
@@ -158,9 +154,6 @@ WRAP_K (krb5_db2_iter_policy,
 WRAP_K (krb5_db2_delete_policy,
         ( krb5_context kcontext, char *policy ),
         (kcontext, policy));
-WRAP_VOID (krb5_db2_free_policy,
-           ( krb5_context kcontext, osa_policy_ent_t entry ),
-           (kcontext, entry));
 
 WRAP_K (krb5_db2_promote_db,
         ( krb5_context kcontext, char *conf_section, char **db_args ),
@@ -215,7 +208,6 @@ kdb_vftabl PLUGIN_SYMBOL_NAME(krb5_db2, kdb_function_table) = {
     /* lock */                          wrap_krb5_db2_lock,
     /* unlock */                        wrap_krb5_db2_unlock,
     /* get_principal */                 wrap_krb5_db2_get_principal,
-    /* free_principal */                wrap_krb5_db2_free_principal,
     /* put_principal */                 wrap_krb5_db2_put_principal,
     /* delete_principal */              wrap_krb5_db2_delete_principal,
     /* rename_principal */              NULL,
@@ -225,9 +217,6 @@ kdb_vftabl PLUGIN_SYMBOL_NAME(krb5_db2, kdb_function_table) = {
     /* put_policy */                    wrap_krb5_db2_put_policy,
     /* iter_policy */                   wrap_krb5_db2_iter_policy,
     /* delete_policy */                 wrap_krb5_db2_delete_policy,
-    /* free_policy */                   wrap_krb5_db2_free_policy,
-    /* alloc */                         krb5_db2_alloc,
-    /* free */                          krb5_db2_free,
     /* blah blah blah */ 0,0,0,0,0,
     /* promote_db */                    wrap_krb5_db2_promote_db,
     0, 0, 0, 0,

--- a/src/plugins/kdb/db2/kdb_db2.c
+++ b/src/plugins/kdb/db2/kdb_db2.c
@@ -802,13 +802,6 @@ cleanup:
     return retval;
 }
 
-/* Free an entry returned by krb5_db2_get_principal. */
-void
-krb5_db2_free_principal(krb5_context context, krb5_db_entry *entry)
-{
-    krb5_dbe_free(context, entry);
-}
-
 krb5_error_code
 krb5_db2_put_principal(krb5_context context, krb5_db_entry *entry,
                        char **db_args)
@@ -912,7 +905,7 @@ krb5_db2_delete_principal(krb5_context context, krb5_const_principal searchfor)
     }
 
     retval = krb5_encode_princ_entry(context, &contdata, entry);
-    krb5_dbe_free(context, entry);
+    krb5_db_free_principal(context, entry);
     if (retval)
         goto cleankey;
 
@@ -1074,7 +1067,7 @@ curs_run_cb(iter_curs *curs, ctx_iterate_cb func, krb5_pointer func_arg)
 
     k5_mutex_unlock(krb5_db2_mutex);
     retval = (*func)(func_arg, entry);
-    krb5_dbe_free(ctx, entry);
+    krb5_db_free_principal(ctx, entry);
     k5_mutex_lock(krb5_db2_mutex);
     if (dbc->unlockiter) {
         lockerr = curs_lock(curs);
@@ -1254,18 +1247,6 @@ cleanup:
     free(polname);
     free(plockname);
     return status;
-}
-
-void   *
-krb5_db2_alloc(krb5_context context, void *ptr, size_t size)
-{
-    return realloc(ptr, size);
-}
-
-void
-krb5_db2_free(krb5_context context, void *ptr)
-{
-    free(ptr);
 }
 
 /* policy functions */

--- a/src/plugins/kdb/db2/kdb_db2.h
+++ b/src/plugins/kdb/db2/kdb_db2.h
@@ -55,7 +55,6 @@ krb5_error_code krb5_db2_fini(krb5_context);
 krb5_error_code krb5_db2_get_age(krb5_context, char *, time_t *);
 krb5_error_code krb5_db2_get_principal(krb5_context, krb5_const_principal,
                                        unsigned int, krb5_db_entry **);
-void krb5_db2_free_principal(krb5_context, krb5_db_entry *);
 krb5_error_code krb5_db2_put_principal(krb5_context, krb5_db_entry *,
                                        char **db_args);
 krb5_error_code krb5_db2_iterate(krb5_context, char *,
@@ -93,8 +92,6 @@ krb5_error_code krb5_db2_destroy(krb5_context kcontext, char *conf_section,
                                  char **db_args);
 
 const char *krb5_db2_err2str(krb5_context kcontext, long err_code);
-void *krb5_db2_alloc(krb5_context kcontext, void *ptr, size_t size);
-void krb5_db2_free(krb5_context kcontext, void *ptr);
 
 
 /* policy management functions */
@@ -113,7 +110,6 @@ krb5_error_code krb5_db2_iter_policy(krb5_context kcontext, char *match_entry,
 
 krb5_error_code krb5_db2_delete_policy(krb5_context kcontext, char *policy);
 
-void krb5_db2_free_policy(krb5_context kcontext, osa_policy_ent_t entry);
 
 /* Thread-safety wrapper slapped on top of original implementation.  */
 extern k5_mutex_t *krb5_db2_mutex;

--- a/src/plugins/kdb/db2/kdb_xdr.c
+++ b/src/plugins/kdb/db2/kdb_xdr.c
@@ -427,39 +427,6 @@ krb5_decode_princ_entry(krb5_context context, krb5_data *content,
     return 0;
 
 error_out:
-    krb5_dbe_free(context, entry);
+    krb5_db_free_principal(context, entry);
     return retval;
-}
-
-void
-krb5_dbe_free(krb5_context context, krb5_db_entry *entry)
-{
-    krb5_tl_data        * tl_data_next;
-    krb5_tl_data        * tl_data;
-    int i, j;
-
-    if (entry == NULL)
-        return;
-    free(entry->e_data);
-    krb5_free_principal(context, entry->princ);
-    for (tl_data = entry->tl_data; tl_data; tl_data = tl_data_next) {
-        tl_data_next = tl_data->tl_data_next;
-        free(tl_data->tl_data_contents);
-        free(tl_data);
-    }
-    if (entry->key_data) {
-        for (i = 0; i < entry->n_key_data; i++) {
-            for (j = 0; j < entry->key_data[i].key_data_ver; j++) {
-                if (entry->key_data[i].key_data_length[j]) {
-                    zapfree(entry->key_data[i].key_data_contents[j],
-                            entry->key_data[i].key_data_length[j]);
-                }
-                entry->key_data[i].key_data_contents[j] = NULL;
-                entry->key_data[i].key_data_length[j] = 0;
-                entry->key_data[i].key_data_type[j] = 0;
-            }
-        }
-        free(entry->key_data);
-    }
-    free(entry);
 }

--- a/src/plugins/kdb/db2/lockout.c
+++ b/src/plugins/kdb/db2/lockout.c
@@ -75,7 +75,7 @@ lookup_lockout_policy(krb5_context context,
             *pw_max_fail = policy->pw_max_fail;
             *pw_failcnt_interval = policy->pw_failcnt_interval;
             *pw_lockout_duration = policy->pw_lockout_duration;
-            krb5_db2_free_policy(context, policy);
+            krb5_db_free_policy(context, policy);
         }
     }
 

--- a/src/plugins/kdb/ldap/ldap_exp.c
+++ b/src/plugins/kdb/ldap/ldap_exp.c
@@ -58,7 +58,6 @@ kdb_vftabl PLUGIN_SYMBOL_NAME(krb5_ldap, kdb_function_table) = {
     /* lock */                              krb5_ldap_lock,
     /* unlock */                            krb5_ldap_unlock,
     /* get_principal */                     krb5_ldap_get_principal,
-    /* free_principal */                    krb5_ldap_free_principal,
     /* put_principal */                     krb5_ldap_put_principal,
     /* delete_principal */                  krb5_ldap_delete_principal,
     /* rename_principal */                  krb5_ldap_rename_principal,
@@ -68,9 +67,6 @@ kdb_vftabl PLUGIN_SYMBOL_NAME(krb5_ldap, kdb_function_table) = {
     /* put_policy */                        krb5_ldap_put_password_policy,
     /* iter_policy */                       krb5_ldap_iterate_password_policy,
     /* delete_policy */                     krb5_ldap_delete_password_policy,
-    /* free_policy */                       krb5_ldap_free_password_policy,
-    /* alloc */                             krb5_ldap_alloc,
-    /* free */                              krb5_ldap_free,
     /* optional functions */
     /* fetch_master_key */                  NULL /* krb5_ldap_fetch_mkey */,
     /* fetch_master_key_list */             NULL,

--- a/src/plugins/kdb/ldap/ldap_util/kdb5_ldap_realm.c
+++ b/src/plugins/kdb/ldap/ldap_util/kdb5_ldap_realm.c
@@ -1129,11 +1129,6 @@ krb5_dbe_update_tl_data_new(krb5_context context, krb5_db_entry *entry,
 
     /* copy the new data first, so we can fail cleanly if malloc()
      * fails */
-/*
-  if ((tmp =
-  (krb5_octet *) krb5_db_alloc(context, NULL,
-  new_tl_data->tl_data_length)) == NULL)
-*/
     if ((tmp = (krb5_octet *) malloc (new_tl_data->tl_data_length)) == NULL)
         return (ENOMEM);
 
@@ -1150,12 +1145,6 @@ krb5_dbe_update_tl_data_new(krb5_context context, krb5_db_entry *entry,
     /* if necessary, chain a new record in the beginning and point at it */
 
     if (!tl_data) {
-/*
-  if ((tl_data =
-  (krb5_tl_data *) krb5_db_alloc(context, NULL,
-  sizeof(krb5_tl_data)))
-  == NULL) {
-*/
         if ((tl_data = (krb5_tl_data *) malloc (sizeof(krb5_tl_data))) == NULL) {
             free(tmp);
             return (ENOMEM);
@@ -1168,8 +1157,7 @@ krb5_dbe_update_tl_data_new(krb5_context context, krb5_db_entry *entry,
 
     /* fill in the record */
 
-    if (tl_data->tl_data_contents)
-        krb5_db_free(context, tl_data->tl_data_contents);
+    free(tl_data->tl_data_contents);
 
     tl_data->tl_data_type = new_tl_data->tl_data_type;
     tl_data->tl_data_length = new_tl_data->tl_data_length;

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.c
@@ -128,15 +128,6 @@ krb5_dbe_free_contents(krb5_context context, krb5_db_entry *entry)
 }
 
 
-void
-krb5_ldap_free_principal(krb5_context kcontext, krb5_db_entry *entry)
-{
-    if (entry == NULL)
-        return;
-    krb5_dbe_free_contents(kcontext, entry);
-    free(entry);
-}
-
 krb5_error_code
 krb5_ldap_iterate(krb5_context context, char *match_expr,
                   krb5_error_code (*func)(krb5_pointer, krb5_db_entry *),
@@ -345,7 +336,7 @@ cleanup:
     if (DN)
         free (DN);
 
-    krb5_ldap_free_principal(context, entry);
+    krb5_db_free_principal(context, entry);
 
     ldap_mods_free(mods, 1);
     krb5_ldap_put_handle_to_pool(ldap_context, ldap_server_handle);
@@ -563,7 +554,7 @@ cleanup:
     free(dn);
     free(suser);
     free(tuser);
-    krb5_ldap_free_principal(context, entry);
+    krb5_db_free_principal(context, entry);
     ldap_mods_free(mods, 1);
     krb5_ldap_put_handle_to_pool(ldap_context, ldap_server_handle);
     return st;

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.h
@@ -108,8 +108,6 @@ krb5_ldap_delete_principal(krb5_context, krb5_const_principal);
 krb5_error_code
 krb5_ldap_rename_principal(krb5_context context, krb5_const_principal source,
                            krb5_const_principal target);
-void
-krb5_ldap_free_principal(krb5_context, krb5_db_entry *);
 
 krb5_error_code
 krb5_ldap_iterate(krb5_context, char *,

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
@@ -224,7 +224,7 @@ krb5_ldap_get_principal(krb5_context context, krb5_const_principal searchfor,
 
 cleanup:
     ldap_msgfree(result);
-    krb5_ldap_free_principal(context, entry);
+    krb5_db_free_principal(context, entry);
 
     if (filter)
         free (filter);

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_pwd_policy.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_pwd_policy.c
@@ -324,7 +324,7 @@ cleanup:
     ldap_msgfree(result);
     if (st != 0) {
         if (*policy != NULL) {
-            krb5_ldap_free_password_policy(context, *policy);
+            krb5_db_free_policy(context, *policy);
             *policy = NULL;
         }
     }
@@ -453,7 +453,7 @@ krb5_ldap_iterate_password_policy(krb5_context context, char *match_expr,
             goto cleanup;
 
         (*func)(func_arg, entry);
-        krb5_ldap_free_password_policy(context, entry);
+        krb5_db_free_policy(context, entry);
         entry = NULL;
 
         free(policy);
@@ -466,17 +466,4 @@ cleanup:
     ldap_msgfree(result);
     krb5_ldap_put_handle_to_pool(ldap_context, ldap_server_handle);
     return st;
-}
-
-void
-krb5_ldap_free_password_policy (context, entry)
-    krb5_context                context;
-    osa_policy_ent_t            entry;
-{
-    if (entry) {
-        free(entry->name);
-        free(entry->allowed_keysalts);
-        free(entry);
-    }
-    return;
 }

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_pwd_policy.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_pwd_policy.h
@@ -48,7 +48,4 @@ krb5_ldap_iterate_password_policy(krb5_context, char *,
                                   void (*)(krb5_pointer, osa_policy_ent_t),
                                   krb5_pointer);
 
-void
-krb5_ldap_free_password_policy(krb5_context kcontext, osa_policy_ent_t entry);
-
 #endif

--- a/src/plugins/kdb/ldap/libkdb_ldap/libkdb_ldap.exports
+++ b/src/plugins/kdb/ldap/libkdb_ldap/libkdb_ldap.exports
@@ -10,7 +10,6 @@ krb5_ldap_put_principal
 krb5_ldap_get_principal
 krb5_ldap_delete_principal
 krb5_ldap_rename_principal
-krb5_ldap_free_principal
 krb5_ldap_iterate
 krb5_ldap_read_krbcontainer_dn
 krb5_ldap_list_realm
@@ -30,13 +29,10 @@ krb5_ldap_create_password_policy
 krb5_ldap_put_password_policy
 krb5_ldap_get_password_policy
 krb5_ldap_delete_password_policy
-krb5_ldap_free_password_policy
 krb5_ldap_iterate_password_policy
 krb5_dbe_free_contents
 krb5_ldap_free_server_params
 krb5_ldap_free_server_context_params
-krb5_ldap_alloc
-krb5_ldap_free
 krb5_ldap_delete_realm_1
 krb5_ldap_lock
 krb5_ldap_unlock

--- a/src/plugins/kdb/ldap/libkdb_ldap/lockout.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/lockout.c
@@ -71,7 +71,7 @@ lookup_lockout_policy(krb5_context context,
             *pw_failcnt_interval = policy->pw_failcnt_interval;
             *pw_lockout_duration = policy->pw_lockout_duration;
         }
-        krb5_ldap_free_password_policy(context, policy);
+        krb5_db_free_policy(context, policy);
     }
 
     xdrmem_create(&xdrs, NULL, 0, XDR_FREE);

--- a/src/plugins/kdb/test/kdb_test.c
+++ b/src/plugins/kdb/test/kdb_test.c
@@ -393,48 +393,6 @@ cleanup:
     return ret;
 }
 
-static void
-test_free_principal(krb5_context context, krb5_db_entry *entry)
-{
-    krb5_tl_data *tl, *next;
-    int i, j;
-
-    if (entry == NULL)
-        return;
-    free(entry->e_data);
-    krb5_free_principal(context, entry->princ);
-    for (tl = entry->tl_data; tl != NULL; tl = next) {
-        next = tl->tl_data_next;
-        free(tl->tl_data_contents);
-        free(tl);
-    }
-    for (i = 0; i < entry->n_key_data; i++) {
-        for (j = 0; j < entry->key_data[i].key_data_ver; j++) {
-            if (entry->key_data[i].key_data_length[j]) {
-                zapfree(entry->key_data[i].key_data_contents[j],
-                        entry->key_data[i].key_data_length[j]);
-            }
-            entry->key_data[i].key_data_contents[j] = NULL;
-            entry->key_data[i].key_data_length[j] = 0;
-            entry->key_data[i].key_data_type[j] = 0;
-        }
-    }
-    free(entry->key_data);
-    free(entry);
-}
-
-static void *
-test_alloc(krb5_context context, void *ptr, size_t size)
-{
-    return realloc(ptr, size);
-}
-
-static void
-test_free(krb5_context context, void *ptr)
-{
-    free(ptr);
-}
-
 static krb5_error_code
 test_fetch_master_key(krb5_context context, krb5_principal mname,
                       krb5_keyblock *key_out, krb5_kvno *kvno_out,
@@ -556,7 +514,6 @@ kdb_vftabl PLUGIN_SYMBOL_NAME(krb5_test, kdb_function_table) = {
     NULL, /* lock */
     NULL, /* unlock */
     test_get_principal,
-    test_free_principal,
     NULL, /* put_principal */
     NULL, /* delete_principal */
     NULL, /* rename_principal */
@@ -566,9 +523,6 @@ kdb_vftabl PLUGIN_SYMBOL_NAME(krb5_test, kdb_function_table) = {
     NULL, /* put_policy */
     NULL, /* iter_policy */
     NULL, /* delete_policy */
-    NULL, /* free_policy */
-    test_alloc,
-    test_free,
     test_fetch_master_key,
     test_fetch_master_key_list,
     NULL, /* store_master_key_list */

--- a/src/tests/create/kdb5_mkdums.c
+++ b/src/tests/create/kdb5_mkdums.c
@@ -218,12 +218,11 @@ add_princ(context, str_newprinc)
     krb5_db_entry         *newentry;
     char                  princ_name[4096];
 
-    newentry = krb5_db_alloc(context, NULL, sizeof(*newentry));
+    newentry = calloc(1, sizeof(*newentry));
     if (newentry == NULL) {
         com_err(progname, ENOMEM, "while allocating DB entry");
         return;
     }
-    memset(newentry, 0, sizeof(*newentry));
     snprintf(princ_name, sizeof(princ_name), "%s@%s", str_newprinc, cur_realm);
     if ((retval = krb5_parse_name(context, princ_name, &newprinc))) {
         com_err(progname, retval, "while parsing '%s'", princ_name);


### PR DESCRIPTION
See http://mailman.mit.edu/pipermail/krbdev/2016-May/012583.html

This will have some conflicts with PR #446, so whichever one is merged first, the other will need adjusting.
