### PR TITLE
Fix memory leak in LDAP rename

### DIFF
--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.c
@@ -554,6 +554,7 @@ cleanup:
     free(dn);
     free(suser);
     free(tuser);
+    free_berdata(bersecretkey);
     krb5_db_free_principal(context, entry);
     ldap_mods_free(mods, 1);
     krb5_ldap_put_handle_to_pool(ldap_context, ldap_server_handle);

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.h
@@ -140,6 +140,9 @@ krb5_error_code
 krb5_decode_krbsecretkey(krb5_context, krb5_db_entry *, struct berval **,
                          krb5_kvno *);
 
+void
+free_berdata(struct berval **array);
+
 krb5_error_code
 berval2tl_data(struct berval *in, krb5_tl_data **out);
 

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
@@ -429,7 +429,7 @@ asn1_decode_sequence_of_keys(krb5_data *in, ldap_seqof_key_data *out)
  * Free a NULL-terminated struct berval *array[] and all its contents.
  * Does not set array to NULL after freeing it.
  */
-static void
+void
 free_berdata(struct berval **array)
 {
     int i;


### PR DESCRIPTION
krb5_ldap_rename_principal() must free bersecretkey.
