### PR TITLE
Clean t_sname_match in lib/krb5/krb

### DIFF
--- a/src/lib/krb5/krb/Makefile.in
+++ b/src/lib/krb5/krb/Makefile.in
@@ -503,7 +503,7 @@ clean::
 	$(OUTPRE)t_ad_fx_armor$(EXEEXT) $(OUTPRE)t_ad_fx_armor.$(OBJEXT) \
 	$(OUTPRE)t_vfy_increds$(EXEEXT) $(OUTPRE)t_vfy_increds.$(OBJEXT) \
 	$(OUTPRE)t_response_items$(EXEEXT) \
-	$(OUTPRE)t_response_items.$(OBJEXT) $(OUTPRE)t_sname_match(EXEEXT) \
+	$(OUTPRE)t_response_items.$(OBJEXT) $(OUTPRE)t_sname_match$(EXEEXT) \
 	$(OUTPRE)t_sname_match.$(OBJEXT)
 
 @libobj_frag@


### PR DESCRIPTION
Add a missing "$" to t_sname_match$(EXEEXT) in the clean rule in
lib/krb5/krb/Makefile.in.