### PR TITLE
Relax t_sn2princ.py reverse resolution test

### DIFF
--- a/src/tests/t_sn2princ.py
+++ b/src/tests/t_sn2princ.py
@@ -69,7 +69,6 @@ if offline:
 # and reverse resolving to these names.
 oname = 'ptr-mismatch.kerberos.org'
 fname = 'www.kerberos.org'
-rname = 'kerberos-org.mit.edu'
 
 # Verify forward resolution before testing for it.
 try:
@@ -91,9 +90,11 @@ try:
     names = socket.getnameinfo(sockaddr, socket.NI_NAMEREQD)
 except socket.gaierror:
     skip_rest('reverse sn2princ tests', 'cannot reverse resolve %s' % oname)
-if names[0].lower() != rname:
+rname = names[0].lower()
+if rname == fname:
     skip_rest('reverse sn2princ tests',
-              '%s reverse resolves to %s, not %s' % (oname, names[0], rname))
+              '%s reverse resolves to %s '
+              'which should be different from %s' % (oname, rname, fname))
 
 # Test default canonicalization (forward and reverse lookup).
 test(oname, rname, 'R3')


### PR DESCRIPTION
Relax t_sn2princ.py check of the reverse resolution of the test
hostname.  The new requirement is that it be different from the
forward resolved hostname.  (There is also an existing implicit
requirement that it be in the mit.edu domain.)  This makes
t_sn2princ.py more robust against changes in the reverse resolution of
the test hostname.

ticket: 8422 (new)
tags: pullup
target_version: 1.14-next
target_version: 1.13-next