### PR TITLE
k5_parse_host_string()

### DIFF
--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -1747,6 +1747,10 @@ krb5_encode_kdc_rep(krb5_context, krb5_msgtype, const krb5_enc_kdc_rep_part *,
                     int using_subkey, const krb5_keyblock *, krb5_kdc_rep *,
                     krb5_data ** );
 
+krb5_error_code
+k5_parse_host_string(const char *address, int default_port, char **host_out,
+                     int *port_out);
+
 /*
  * [De]Serialization Handle and operations.
  */

--- a/src/lib/krb5/krb/Makefile.in
+++ b/src/lib/krb5/krb/Makefile.in
@@ -75,6 +75,7 @@ STLIBOBJS= \
 	pac.o		\
 	pac_sign.o	\
 	parse.o		\
+	parse_host_string.o	\
 	plugin.o	\
 	pr_to_salt.o	\
 	preauth2.o	\
@@ -184,6 +185,7 @@ OBJS=	$(OUTPRE)addr_comp.$(OBJEXT)	\
 	$(OUTPRE)pac.$(OBJEXT)		\
 	$(OUTPRE)pac_sign.$(OBJEXT)	\
 	$(OUTPRE)parse.$(OBJEXT)	\
+	$(OUTPRE)parse_host_string.$(OBJEXT)	\
 	$(OUTPRE)plugin.$(OBJEXT)	\
 	$(OUTPRE)pr_to_salt.$(OBJEXT)	\
 	$(OUTPRE)preauth2.$(OBJEXT)	\
@@ -293,6 +295,7 @@ SRCS=	$(srcdir)/addr_comp.c	\
 	$(srcdir)/pac.c		\
 	$(srcdir)/pac_sign.c	\
 	$(srcdir)/parse.c	\
+	$(srcdir)/parse_host_string.c	\
 	$(srcdir)/plugin.c	\
 	$(srcdir)/pr_to_salt.c	\
 	$(srcdir)/preauth2.c	\

--- a/src/lib/krb5/krb/parse_host_string.c
+++ b/src/lib/krb5/krb/parse_host_string.c
@@ -1,0 +1,124 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* lib/krb5/krb/parse_host_string.c - Parse host strings into host and port */
+/*
+ * Copyright (C) 2016 by the Massachusetts Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "k5-int.h"
+#include <ctype.h>
+
+/* Return true if s is composed solely of digits. */
+static krb5_boolean
+is_string_numeric(const char *s)
+{
+    if (*s == '\0')
+        return FALSE;
+
+    for (; *s != '\0'; s++) {
+        if (!isdigit(*s))
+            return FALSE;
+    }
+
+    return TRUE;
+}
+
+/*
+ * Parse a string containing a host specifier. The expected format for the
+ * string is:
+ *
+ * host[:port] or port
+ *
+ * host and port are optional, though one must be present.  host may have
+ * brackets around it for IPv6 addresses.
+ *
+ * Arguments:
+ * address - The address string that should be parsed.
+ * default_port - The default port to use if no port is found.
+ * host_out - An output pointer for the parsed host, or NULL if no host was
+ * specified or an error occured.  Must be freed.
+ * port_out - An output pointer for the parsed port.  Will be 0 on error.
+ *
+ * Returns 0 on success, otherwise an error.
+ */
+krb5_error_code
+k5_parse_host_string(const char *address, int default_port, char **host_out,
+                     int *port_out)
+{
+    krb5_error_code ret;
+    int port_num;
+    const char *p, *host = NULL, *port = NULL;
+    char *endptr, *hostname = NULL;
+    size_t hostlen = 0;
+    unsigned long l;
+
+    *host_out = NULL;
+    *port_out = 0;
+
+    if (address == NULL || *address == '\0')
+        return EINVAL;
+    if (default_port < 0 || default_port > 65535)
+        return EINVAL;
+
+    /* Find the bounds of the host string and the start of the port string. */
+    if (is_string_numeric(address)) {
+        port = address;
+    } else if (*address == '[' && (p = strchr(address, ']')) != NULL) {
+        host = address + 1;
+        hostlen = p - host;
+        if (*(p + 1) == ':')
+            port = p + 2;
+    } else {
+        host = address;
+        hostlen = strcspn(host, " \t:");
+        if (host[hostlen] == ':')
+            port = host + hostlen + 1;
+    }
+
+    /* Parse the port number, or use the default port. */
+    if (port != NULL) {
+        errno = 0;
+        l = strtoul(port, &endptr, 10);
+        if (errno || endptr == port || *endptr != '\0' || l > 65535)
+            return EINVAL;
+        port_num = l;
+    } else {
+        port_num = default_port;
+    }
+
+    /* Copy the host if it was specified. */
+    if (host != NULL) {
+        hostname = k5memdup0(host, hostlen, &ret);
+        if (hostname == NULL)
+            return ENOMEM;
+    }
+
+    *host_out = hostname;
+    *port_out = port_num;
+    return 0;
+}

--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -137,6 +137,7 @@ k5_marshal_cred
 k5_marshal_princ
 k5_os_free_context
 k5_os_init_context
+k5_parse_host_string
 k5_plugin_free_modules
 k5_plugin_load
 k5_plugin_load_all

--- a/src/lib/krb5/os/locate_kdc.c
+++ b/src/lib/krb5/os/locate_kdc.c
@@ -219,9 +219,9 @@ locate_srv_conf_1(krb5_context context, const krb5_data *realm,
                   k5_transport transport, int udpport)
 {
     const char  *realm_srv_names[4];
-    char **hostlist, *host, *port, *cp;
+    char **hostlist, *host = NULL;
     krb5_error_code code;
-    int i;
+    int i, default_port;
 
     Tprintf ("looking in krb5.conf for realm %s entry %s; ports %d,%d\n",
              realm->data, name, ntohs(udpport));
@@ -259,43 +259,25 @@ locate_srv_conf_1(krb5_context context, const krb5_data *realm,
 
         parse_uri_if_https(host, &this_transport, &host, &uri_path);
 
-        /* Find port number, and strip off any excess characters. */
-        if (*host == '[' && (cp = strchr(host, ']')))
-            cp = cp + 1;
-        else
-            cp = host + strcspn(host, " \t:");
-        port = (*cp == ':') ? cp + 1 : NULL;
-        *cp = '\0';
-
-        if (port) {
-            unsigned long l;
-            char *endptr;
-            l = strtoul (port, &endptr, 10);
-            if (endptr == NULL || *endptr != 0)
-                return EINVAL;
-            /* L is unsigned, don't need to check <0.  */
-            if (l > 65535)
-                return EINVAL;
-            port_num = htons(l);
-        } else if (this_transport == HTTPS) {
-            port_num = htons(443);
-        } else {
-            port_num = udpport;
-        }
-
-        /* If the hostname was in brackets, strip those off now. */
-        if (*host == '[' && (cp = strchr(host, ']'))) {
-            host++;
-            *cp = '\0';
-        }
-
-        code = add_host_to_list(serverlist, host, port_num, this_transport,
-                                AF_UNSPEC, uri_path);
+        default_port = (this_transport == HTTPS) ? htons(443) : udpport;
+        code = k5_parse_host_string(hostlist[i], default_port, &host,
+                                    &port_num);
+        if (code == 0 && host == NULL)
+            code = EINVAL;
         if (code)
             goto cleanup;
+
+        code = add_host_to_list(serverlist, host, htons(port_num),
+                                this_transport, AF_UNSPEC, uri_path);
+        if (code)
+            goto cleanup;
+
+        free(host);
+        host = NULL;
     }
 
 cleanup:
+    free(host);
     profile_free_list(hostlist);
     return code;
 }


### PR DESCRIPTION
Matt Rogers is working on an implementation of http://k5wiki.kerberos.org/wiki/Projects/KDC_Discovery and will need k5_parse_host_string() from PR #380.  I took the first commit from PR #380, made changes to the parsing code, and split it into two commits in case someone needs k5_parse_host_string() for a backport.

The commit in PR #380 made k5_is_string_numeric() visible in k5-int.h, but it wasn't used anywhere else in the PR.  Following the YAGNI principle, I changed it to a static helper.
