### PR TITLE
Fix leak in test_check_allowed_to_delegate()

### DIFF
--- a/src/plugins/kdb/test/kdb_test.c
+++ b/src/plugins/kdb/test/kdb_test.c
@@ -497,6 +497,8 @@ test_check_allowed_to_delegate(krb5_context context,
             break;
         }
     }
+    krb5_free_unparsed_name(context, sprinc);
+    krb5_free_unparsed_name(context, tprinc);
     profile_free_list(values);
     return found ? 0 : KRB5KDC_ERR_POLICY;
 }


### PR DESCRIPTION
sprinc and tprinc must be freed.  Reported by Will Fiveash.
