### PR TITLE
Do not segfault if we can't check if the KDC is a master

### DIFF
--- a/src/lib/krb5/os/sendto_kdc.c
+++ b/src/lib/krb5/os/sendto_kdc.c
@@ -433,7 +433,7 @@ krb5_sendto_kdc(krb5_context context, const krb5_data *message,
 {
     krb5_error_code retval, err;
     struct serverlist servers;
-    int server_used;
+    int server_used = -1;
     k5_transport_strategy strategy;
     krb5_data reply = empty_data(), *hook_message = NULL, *hook_reply = NULL;
 
@@ -532,6 +532,10 @@ krb5_sendto_kdc(krb5_context context, const krb5_data *message,
     /* Set use_master to 1 if we ended up talking to a master when we didn't
      * explicitly request to. */
     if (*use_master == 0) {
+        if (server_used < 0 || server_used >= servers.nservers) {
+            retval = KDC_ERR_BADOPTION;
+            goto cleanup;
+        }
         *use_master = k5_kdc_is_master(context, realm,
                                        &servers.servers[server_used]);
         TRACE_SENDTO_KDC_MASTER(context, *use_master);


### PR DESCRIPTION
I've run into a segfault when the client tries to talk to the KDC which isn't running.

Look at server_used in frame 8, it is set to 22002. So have an out of bound array access and segfault dereferencing the content.

```
0x00007f7d5c2e00da in waitpid () from /lib64/libc.so.6
#0  0x00007f7d5c2e00da in waitpid () from /lib64/libc.so.6
No symbol table info available.
#1  0x00007f7d5c25b9ab in do_system () from /lib64/libc.so.6
No symbol table info available.
#2  0x00007f7d5e24aae3 in smb_panic_default (why=0x7f7d5e29b655 "internal error") at ../lib/util/fault.c:141
        result = 32637
        pidstr = "29720\000\000\000H\265)^}\177\000\000\325\000\000\001"
        cmdstring = "/home/asn/workspace/projects/samba/selftest/gdb_backtrace 29720\000[\000\000\000n", '\000' <repeats 11 times>, ">\266)^}\177\000\000X\267)^}\177\000\000\260\aL\201\362U\000\000t", '\000' <repeats 23 times>, "\365\252c\323\000\000\000\000\324\000\000\000\000\000\000\000`\247c\323\376\177\000\000\220\323*\201\362U\000\000\324\000\000\000\000\000\000\000\060\302A\201\362U\000\000\060\302A\201\362U\000\000\320\301A\201\362U\000\000`\247c\323\376\177\000"
        __FUNCTION__ = "smb_panic_default"
#3  0x00007f7d5e24ac6e in smb_panic (why=0x7f7d5e29b655 "internal error") at ../lib/util/fault.c:169
No locals.
#4  0x00007f7d5e24a936 in fault_report (sig=11) at ../lib/util/fault.c:83
        counter = 1
        __FUNCTION__ = "fault_report"
#5  0x00007f7d5e24a94b in sig_fault (sig=11) at ../lib/util/fault.c:94
No locals.
#6  <signal handler called>
No symbol table info available.
#7  k5_kdc_is_master (context=context@entry=0x55f2814932a0, realm=realm@entry=0x7ffed363aea0, server=0x55f281842380) at locate_kdc.c:685
        list = {servers = 0x6eda360500000000, nservers = 1859794437}
#8  0x00007f7d5d0d8e8c in krb5_sendto_kdc (context=context@entry=0x55f2814932a0, message=<optimized out>, message@entry=0x7ffed363ae80, realm=realm@entry=0x7ffed363aea0, reply_out=reply_out@entry=0x7ffed363ae90, use_master=use_master@entry=0x7ffed363ae7c, no_udp=no_udp@entry=0) at sendto_kdc.c:535
        retval = 0
        err = 0
        servers = {servers = 0x55f2814bbcb0, nservers = 1}
        server_used = 22002
        strategy = <optimized out>
        reply = {magic = -1760647422, length = 0, data = 0x0}
        hook_message = 0x0
        hook_reply = 0x0
#9  0x00007f7d5d0a5d1d in k5_init_creds_get (context=context@entry=0x55f2814932a0, ctx=0x55f281493620, use_master=use_master@entry=0x7ffed363b058) at get_in_tkt.c:542
        code = <optimized out>
        request = {magic = -1760647422, length = 175, data = 0x55f2814bba30 "j\201\254\060\201\251\241\003\002\001\005\242\003\002\001\n\243\016\060\f0\n\241\004\002\002"}
        reply = {magic = -1760647422, length = 0, data = 0x0}
        realm = {magic = -1760647422, length = 21, data = 0x55f2812ad390 "SAMBA2000.EXAMPLE.COM*"}
        flags = 1
        tcp_only = 0
        master = 0
#10 0x00007f7d5d0a5ea4 in k5_get_init_creds (context=context@entry=0x55f2814932a0, creds=creds@entry=0x7ffed363c380, client=client@entry=0x55f2812e7210, prompter=prompter@entry=0x0, prompter_data=prompter_data@entry=0x0, start_time=start_time@entry=0, in_tkt_service=0x0, options=0x0, gak_fct=0x7f7d5d0a7910 <krb5_get_as_key_password>, gak_data=0x7ffed363b0c0, use_master=0x7ffed363b058, as_reply=0x7ffed363b060) at get_in_tkt.c:1699
        code = <optimized out>
        ctx = 0x55f281493620
#11 0x00007f7d5d0a7ee7 in krb5_get_init_creds_password (context=0x55f2814932a0, creds=0x7ffed363c380, client=0x55f2812e7210, password=0x55f2812e7ba0 "machinelocDCpass5", prompter=0x0, data=0x0, start_time=0, in_tkt_service=0x0, options=0x0) at gic_pwd.c:317
        ret = <optimized out>
        use_master = 0
        as_reply = 0x0
        tries = <optimized out>
        chpw_creds = {magic = 0, client = 0x0, server = 0x0, keyblock = {magic = 0, enctype = 0, length = 0, contents = 0x0}, times = {authtime = 0, starttime = 0, endtime = 0, renew_till = 0}, is_skey = 0, ticket_flags = 0, addresses = 0x0, ticket = {magic = 0, length = 0, data = 0x0}, second_ticket = {magic = 0, length = 0, data = 0x0}, authdata = 0x0}
        chpw_opts = 0x0
        gakpw = {storage = {magic = 0, length = 0, data = 0x0}, password = 0x7ffed363b070}
        pw0 = {magic = -1760647422, length = 17, data = 0x55f2812e7ba0 "machinelocDCpass5"}
        pw1 = {magic = 0, length = 0, data = 0x7ffed363b130 ""}
        banner = "ؼc\323\376\177\000\000p\273c\323\376\177\000\000h\273c\323\376\177\000\000n;)\\}\177\000\000`\270c\323\376\177\000\000P\270c\323\376\177\000\000\330\063\257U}\177\000\000\370\271c\323\376\177\000\000\000\000\000\000\000\000\000\000a9&\\}\177\000\000Y\002\000\000\000\000\000\000ؼc\323\376\177\000\000*v|\356\252Ǐ\347`\334}\\}\177\000\000\241L\234,\001\200\377\377_\263c\323\376\177\000\000\t\000\000\000\000\000\000\000'\000\000\000\071\000\000\000\001", '\000' <repeats 15 times>, "\210\263c\323\376\177\000\000\020(\322^}\177\000\000\000\000\000\000\000\000\000\000n;)\\}\177\000\000\000\271c\323\376\177\000\000\360\270c"...
        pw0array = '\000' <repeats 12 times>, "}\177\000\000\060\267c\323\376\177\000\000\000\000\000\000\376\177\000\000\000\000\000\000}\177\000\000\025\000\000\000\376\177\000\000\000\000\000\000\000\000\000\000\032\000\000\000}\177\000\000kS\336^}\177\000\000\000\000\000\000\002\000\000\000\200\267c\323\376\177\000\000\000\000\000\000\000\000\000\000\377\377\377\377\377\377\377\377\000\000\000\000\002\000\000\000kS\336^}\177\000\000\070\276c\323\376\177\000\000\000\000\000\000\000\000\000\000\b@&\\}\177\000\000\000\000\000\000}\177\000\000 s.\201\362U\000\000\000\000\000\000\376\177\000\000\020\000\000\000\060\000\000\000p\302c\323\376\177\000\000\260\301c\323\376\177\000\000\000\000\000\000\376\177\000\000"...
        pw1array = "P\273c\323\376\177\000\000\000\000\000\000\362U\000\000\000\000\000\000\376\177\000\000`\273c\323\376\177\000\000\000\000\000\000\362U\000\000\020\000\000\000\060\000\000\000\360\305c\323\376\177\000\000\060\305c\323\376\177\000\000\000\000\000\000\376\177\000\000\000\000\000\000\362U\000\000p\273c\323\376\177\000\000\000\000\000\000}\177\000\000\000\000\000\000\000\000\000\000)\000\000\000\376\177\000\000\000\000\000\000\000\000\000\000)\000\000\000\362U\000\000\300\270\277\200\362U\000\000\000\000\000\000\001\000\000\000\300\273c\323\376\177\000\000\000\000\000\000\000\000\000\000\377\377\377\377\377\377\377\377\000\000\000\000\002\000\000\000Ѹ\277\200\362U\000\000@}0\201\362U\000\000\002\000\000\000\000\000\000\000\260"...
        prompt = {{prompt = 0x1 <error: Cannot access memory at address 0x1>, hidden = 1590789860, reply = 0x7ffed363b1e8}, {prompt = 0x7f7d5d77d53e "libsys-rw-samba4.so", hidden = 1568189200, reply = 0x7f7d5ed101d5 <_dl_map_object+117>}}
        prompt_types = {-748438368, 32766}
        errsave = {code = 0, msg = 0x0}
        message = 0x7ffed363b128 ""
```