### PR TITLE
Fix kadmin min_life check with nonexistent policy

### DIFF
--- a/src/kadmin/server/misc.c
+++ b/src/kadmin/server/misc.c
@@ -177,10 +177,12 @@ check_min_life(void *server_handle, krb5_principal principal,
     if(ret)
         return ret;
     if(princ.aux_attributes & KADM5_POLICY) {
+        /* Look up the policy.  If it doesn't exist, treat this principal as if
+         * it had no policy. */
         if((ret=kadm5_get_policy(handle->lhandle,
                                  princ.policy, &pol)) != KADM5_OK) {
             (void) kadm5_free_principal_ent(handle->lhandle, &princ);
-            return ret;
+            return (ret == KADM5_UNK_POLICY) ? 0 : ret;
         }
         if((now - princ.last_pwd_change) < pol.pw_min_life &&
            !(princ.attributes & KRB5_KDB_REQUIRES_PWCHANGE)) {

--- a/src/tests/t_policy.py
+++ b/src/tests/t_policy.py
@@ -2,7 +2,7 @@
 from k5test import *
 import re
 
-realm = K5Realm(create_host=False)
+realm = K5Realm(create_host=False, start_kadmind=True)
 
 # Test password quality enforcement.
 realm.run([kadminl, 'addpol', '-minlength', '6', '-minclasses', '2', 'pwpol'])
@@ -39,6 +39,9 @@ if 'Policy: newpol [does not exist]\n' not in out:
 realm.run([kadminl, 'modprinc', '-policy', 'newpol', 'pwuser'])
 # pwuser should allow reuse of the current password since newpol doesn't exist.
 realm.run([kadminl, 'cpw', '-pw', '3rdpassword', 'pwuser'])
+# Regression test for #8427 (min_life check with nonexistent policy).
+realm.run([kadmin, '-p', 'pwuser', '-w', '3rdpassword', 'cpw', '-pw',
+           '3rdpassword', 'pwuser'])
 
 # Create newpol and verify that it is enforced.
 realm.run([kadminl, 'addpol', '-minlength', '3', 'newpol'])


### PR DESCRIPTION
In kadmind, self-service key changes require a check against the
policy's min_life field.  If the policy does not exist, this check
should succeed according to the semantics introduced by ticket #7385.
Fix check_min_life() to return 0 if kadm5_get_policy() returns
KADM5_UNK_POLICY.  Reported by John Devitofranceschi.
