### PR TITLE
Fix Makefile for paths containing '+' character

### DIFF
--- a/src/include/Makefile.in
+++ b/src/include/Makefile.in
@@ -57,19 +57,19 @@ SBINDIR = @sbindir@
 LIBDIR  = @libdir@
 SYSCONFCONF = @SYSCONFCONF@
 
-PROCESS_REPLACE = -e "s+@KRB5RCTMPDIR+$(KRB5RCTMPDIR)+" \
-		  -e "s+@PREFIX+$(INSTALL_PREFIX)+" \
-		  -e "s+@EXEC_PREFIX+$(INSTALL_EXEC_PREFIX)+" \
-		  -e "s+@BINDIR+$(BINDIR)+" \
-		  -e "s+@LIBDIR+$(LIBDIR)+" \
-		  -e "s+@SBINDIR+$(SBINDIR)+" \
-		  -e "s+@MODULEDIR+$(MODULE_DIR)+" \
-		  -e "s+@GSSMODULEDIR+$(GSS_MODULE_DIR)+" \
-		  -e 's+@LOCALSTATEDIR+$(LOCALSTATEDIR)+' \
-		  -e 's+@RUNSTATEDIR+$(RUNSTATEDIR)+' \
-		  -e 's+@SYSCONFDIR+$(SYSCONFDIR)+' \
-		  -e 's+@DYNOBJEXT+$(DYNOBJEXT)+' \
-		  -e 's+@SYSCONFCONF+$(SYSCONFCONF)+'
+PROCESS_REPLACE = -e "s\"@KRB5RCTMPDIR\"$(KRB5RCTMPDIR)\"" \
+		  -e "s\"@PREFIX\"$(INSTALL_PREFIX)\"" \
+		  -e "s\"@EXEC_PREFIX\"$(INSTALL_EXEC_PREFIX)\"" \
+		  -e "s\"@BINDIR\"$(BINDIR)\"" \
+		  -e "s\"@LIBDIR\"$(LIBDIR)\"" \
+		  -e "s\"@SBINDIR\"$(SBINDIR)\"" \
+		  -e "s\"@MODULEDIR\"$(MODULE_DIR)\"" \
+		  -e "s\"@GSSMODULEDIR\"$(GSS_MODULE_DIR)\"" \
+		  -e "s\"@LOCALSTATEDIR\"$(LOCALSTATEDIR)\"" \
+		  -e "s\"@RUNSTATEDIR\"$(RUNSTATEDIR)\"" \
+		  -e "s\"@SYSCONFDIR\"$(SYSCONFDIR)\"" \
+		  -e "s\"@DYNOBJEXT\"$(DYNOBJEXT)\"" \
+		  -e "s\"@SYSCONFCONF\"$(SYSCONFCONF)\""
 
 OSCONFSRC = $(srcdir)/osconf.hin
 


### PR DESCRIPTION
include/Makefile uses a regex to perform variable substitution with '+'
used for delimeter. The '+' is also a valid character in a unix path, so
the paths need to be escaped in regex context.

I've tried to replace the sed thing with substitution by means of autoconf,
but it didn't work out for me because paths would get substituted as
"${exec_prefix}/sbin" which is not appropriate for C header file. So this
time I'm only providing hacky fix.