### PR TITLE
Fix authdata framework CAMMAC extraction function

### DIFF
--- a/src/lib/krb5/krb/authdata.c
+++ b/src/lib/krb5/krb/authdata.c
@@ -561,13 +561,13 @@ extract_cammacs(krb5_context kcontext, krb5_authdata **cammacs,
 
         /* Add the verified elements to list and free the container array. */
         for (n_elements = 0; elements[n_elements] != NULL; n_elements++);
-        new_list = realloc(list, (count + n_elements + 1) * sizeof(list));
+        new_list = realloc(list, (count + n_elements + 1) * sizeof(*list));
         if (new_list == NULL) {
             ret = ENOMEM;
             goto cleanup;
         }
         list = new_list;
-        memcpy(list + count, elements, n_elements * sizeof(list));
+        memcpy(list + count, elements, n_elements * sizeof(*list));
         count += n_elements;
         list[count] = NULL;
         free(elements);


### PR DESCRIPTION
[Discovered by Coverity scan.]

Commit f4f619e7905d762204695dd66450e586c183c9fd used the wrong
sizeof() expressions for reallocating and copying into the list.  No
misbehavior manifested in tests because sizeof(list) == sizeof(*list)
on typical platforms.  Use the correct sizeof expressions.
