### PR TITLE
Fix recent memory leak in locate_kdc.c

### DIFF
--- a/src/lib/krb5/os/locate_kdc.c
+++ b/src/lib/krb5/os/locate_kdc.c
@@ -240,7 +240,7 @@ locate_srv_conf_1(krb5_context context, const krb5_data *realm,
                  error_message(code));
         if (code == PROF_NO_SECTION || code == PROF_NO_RELATION)
             code = 0;
-        return code;
+        goto cleanup;
     }
 
     for (i=0; hostlist[i]; i++) {


### PR DESCRIPTION
Commit ce112dec844e4650b5ad174bd40f21c32aebe1d1 introduced a memory
leak in locate_srv_conf_1() by moving the free(realmstr) call to the
cleanup handler, because there was an early return after realmstr is
allocated.  Convert that early return to a goto.