### PR TITLE
Update LDAP docs for password lockout

### DIFF
--- a/doc/admin/conf_ldap.rst
+++ b/doc/admin/conf_ldap.rst
@@ -47,7 +47,10 @@ Configuring Kerberos with OpenLDAP back-end
     container.
 
  5. Configure the LDAP server ACLs to enable the KDC and kadmin server
-    DNs to read and write the Kerberos data.
+    DNs to read and write the Kerberos data.  If
+    **disable_last_success** and **disable_lockout** are both set to
+    true in the :ref:`dbmodules` subsection for the realm, then the
+    KDC DN only requires read access to the Kerberos data.
 
     Sample access control information::
 
@@ -67,13 +70,13 @@ Configuring Kerberos with OpenLDAP back-end
 
        # Providing access to realm container
        access to dn.subtree= "cn=EXAMPLE.COM,cn=krbcontainer,dc=example,dc=com"
-           by dn.exact="cn=kdc-service,dc=example,dc=com" read
+           by dn.exact="cn=kdc-service,dc=example,dc=com" write
            by dn.exact="cn=adm-service,dc=example,dc=com" write
            by * none
 
        # Providing access to principals, if not underneath realm container
        access to dn.subtree= "ou=users,dc=example,dc=com"
-           by dn.exact="cn=kdc-service,dc=example,dc=com" read
+           by dn.exact="cn=kdc-service,dc=example,dc=com" write
            by dn.exact="cn=adm-service,dc=example,dc=com" write
            by * none
 

--- a/doc/admin/lockout.rst
+++ b/doc/admin/lockout.rst
@@ -138,3 +138,13 @@ have the largest positive impact on performance, and will still allow
 account lockout policies to operate.  However, it will make it
 impossible to observe the last successful authentication time with
 kadmin.
+
+
+KDC setup and account lockout
+-----------------------------
+
+To update the account lockout state on principals, the KDC must be
+able to write to the principal database.  For the DB2 module, no
+special setup is required.  For the LDAP module, the KDC DN must be
+granted write access to the principal objects.  If the KDC DN has only
+read access, account lockout will not function.


### PR DESCRIPTION
The KDC now needs write access to the LDAP KDB, unless password
lockout and tracking of the last successful authentication time are
disabled.  Update the example LDAP access control text in
conf_ldap.rst to reflect this.  Reported by Will Fiveash.
