### PR TITLE
Add a kprop-port option to kadmind

### DIFF
--- a/doc/admin/admin_commands/kadmind.rst
+++ b/doc/admin/admin_commands/kadmind.rst
@@ -16,6 +16,7 @@ SYNOPSIS
 [**-P** *pid_file*]
 [**-p** *kdb5_util_path*]
 [**-K** *kprop_path*]
+[**-k** *kprop_port*]
 [**-F** *dump_file*]
 
 DESCRIPTION
@@ -100,6 +101,11 @@ OPTIONS
 **-K** *kprop_path*
     specifies the path to the kprop command to use to send full dumps
     to slaves in response to full resync requests.
+
+**-k** *kprop_port*
+    specifies the port by which the kprop process that is spawned by kadmind
+    connects to the slave kpropd, in order to transfer the dump file during
+    a full resync request.
 
 **-F** *dump_file*
     specifies the file path to be used for dumping the KDB in response

--- a/src/kadmin/server/ipropd_svc.c
+++ b/src/kadmin/server/ipropd_svc.c
@@ -36,6 +36,7 @@ extern short l_port;
 extern char *kdb5_util;
 extern char *kprop;
 extern char *dump_file;
+extern char *kprop_port;
 
 static char *reply_ok_str	= "UPDATE_OK";
 static char *reply_err_str	= "UPDATE_ERROR";
@@ -392,10 +393,9 @@ ipropx_resync(uint32_t vers, struct svc_req *rqstp)
 
 	DPRINT("%s: exec `kprop -r %s -f %s %s' ...\n",
 	       whoami, handle->params.realm, dump_file, clhost);
-	/* XXX Yuck!  */
-	if (getenv("KPROP_PORT")) {
+	if (kprop_port != NULL) {
 	    pret = execl(kprop, "kprop", "-r", handle->params.realm, "-f",
-			 dump_file, "-P", getenv("KPROP_PORT"), clhost, NULL);
+			 dump_file, "-P", kprop_port, clhost, NULL);
 	} else {
 	    pret = execl(kprop, "kprop", "-r", handle->params.realm, "-f",
 			 dump_file, clhost, NULL);

--- a/src/kadmin/server/ovsec_kadmd.c
+++ b/src/kadmin/server/ovsec_kadmd.c
@@ -72,6 +72,7 @@ int nofork = 0;
 char *kdb5_util = KPROPD_DEFAULT_KDB5_UTIL;
 char *kprop = KPROPD_DEFAULT_KPROP;
 char *dump_file = KPROP_DEFAULT_FILE;
+char *kprop_port = NULL;
 
 static krb5_context context;
 static char *progname;
@@ -86,7 +87,7 @@ usage()
     fprintf(stderr, _("Usage: kadmind [-x db_args]* [-r realm] [-m] [-nofork] "
                       "[-port port-number]\n"
                       "\t\t[-proponly] [-p path-to-kdb5_util] [-F dump-file]\n"
-                      "\t\t[-K path-to-kprop] [-P pid_file]\n"
+                      "\t\t[-K path-to-kprop] [-k kprop-port] [-P pid_file]\n"
                       "\nwhere,\n\t[-x db_args]* - any number of database "
                       "specific arguments.\n"
                       "\t\t\tLook at each database documentation for "
@@ -431,6 +432,11 @@ main(int argc, char *argv[])
             if (!argc)
                 usage();
             kprop = *argv;
+        } else if (strcmp(*argv, "-k") == 0) {
+            argc--, argv++;
+            if (!argc)
+                usage();
+            kprop_port = *argv;
         } else {
             break;
         }
@@ -526,6 +532,9 @@ main(int argc, char *argv[])
                     progname, KRB5_IPROP_PROG, KRB5_IPROP_VERS);
         }
     }
+
+    if (kprop_port == NULL)
+        kprop_port = getenv("KPROP_PORT");
 
     krb5_klog_syslog(LOG_INFO, _("starting"));
     if (nofork)

--- a/src/tests/t_iprop.py
+++ b/src/tests/t_iprop.py
@@ -223,10 +223,9 @@ if 'Attributes: DISALLOW_ALL_TIX' not in out:
 slave1_out_dump_path = os.path.join(realm.testdir, 'dump.slave1.out')
 slave2_in_dump_path = os.path.join(realm.testdir, 'dump.slave2.in')
 slave2_kprop_port = str(realm.portbase + 9)
-slave1m['KPROP_PORT'] = slave2_kprop_port
 realm.start_server([kadmind, '-r', realm.realm, '-nofork', '-proponly', '-W',
-                    '-p', kdb5_util, '-K', kprop, '-F', slave1_out_dump_path],
-                   'starting...', slave1m)
+                    '-p', kdb5_util, '-K', kprop, '-k', slave2_kprop_port,
+                    '-F', slave1_out_dump_path], 'starting...', slave1m)
 
 # Test similar default_realm and domain_realm map settings with -r realm.
 slave3_in_dump_path = os.path.join(realm.testdir, 'dump.slave3.in')


### PR DESCRIPTION
This adds '-k' to kadmind for setting the port that kprop is spawned with during full resyncs, and preserves the use of KPROP_PORT if the option is not used.