### PR TITLE
Fix error handling in k5_expand_path()

### DIFF
--- a/src/lib/krb5/os/expand_path.c
+++ b/src/lib/krb5/os/expand_path.c
@@ -537,5 +537,5 @@ k5_expand_path_tokens_extra(krb5_context context, const char *path_in,
 cleanup:
     k5_buf_free(&buf);
     free_extra_tokens(extra_tokens);
-    return 0;
+    return ret;
 }


### PR DESCRIPTION
In k5_expand_path_tokens_extra(), don't throw away non-zero return
statuses in the cleanup handler.
