### PR TITLE
Fix S4U2Self KDC crash when anon is restricted

### DIFF
--- a/src/kdc/kdc_util.c
+++ b/src/kdc/kdc_util.c
@@ -739,7 +739,7 @@ validate_as_request(kdc_realm_t *kdc_active_realm,
         return(KDC_ERR_MUST_USE_USER2USER);
     }
 
-    if (check_anon(kdc_active_realm, request->client, request->server) != 0) {
+    if (check_anon(kdc_active_realm, client.princ, request->server) != 0) {
         *status = "ANONYMOUS NOT ALLOWED";
         return(KDC_ERR_POLICY);
     }

--- a/src/lib/krb5/krb/preauth2.c
+++ b/src/lib/krb5/krb/preauth2.c
@@ -638,8 +638,12 @@ process_pa_data(krb5_context context, krb5_init_creds_context ctx,
 
     if (must_preauth) {
         /* No real preauth types succeeded and we needed to preauthenticate. */
-        ret = (save.code != 0) ? k5_restore_ctx_error(context, &save) :
-            KRB5_PREAUTH_FAILED;
+        if (save.code != 0) {
+            ret = k5_restore_ctx_error(context, &save);
+            k5_wrapmsg(context, ret, KRB5_PREAUTH_FAILED,
+                       _("Pre-authentication failed"));
+        }
+        ret = KRB5_PREAUTH_FAILED;
     }
 
 cleanup:

--- a/src/tests/t_pkinit.py
+++ b/src/tests/t_pkinit.py
@@ -93,6 +93,11 @@ out = realm.run([kvno, realm.host_princ], expected_code=1)
 if 'KDC policy rejects request' not in out:
     fail('Wrong error for restricted anonymous PKINIT')
 
+# Regression test for #8458: S4U2Self requests crash the KDC if
+# anonymous is restricted.
+realm.kinit(realm.host_princ, flags=['-k'])
+realm.run([kvno, '-U', 'user', realm.host_princ])
+
 # Go back to a normal KDC and disable anonymous PKINIT.
 realm.stop_kdc()
 realm.start_kdc()


### PR DESCRIPTION
The first commit fixes a bug where S4U2Proxy can fail on the client side when the KDC is configured to support PKINIT.

The second commit fixes a KDC crash when restrict_anonymous_to_tgt is set and an S4U2Self request is received.  The test case added in the second commit relies on the first commit; if the first commit is not present, it will fail on the client side (causing the test script to fail) before exercising the KDC fix.
