### PR TITLE
Fix recent change to kdcdefaults processing

### DIFF
--- a/src/kdc/main.c
+++ b/src/kdc/main.c
@@ -648,7 +648,7 @@ initialize_realms(krb5_context kcontext, int argc, char **argv)
         hierarchy[1] = KRB5_CONF_KDC_TCP_LISTEN;
         if (krb5_aprof_get_string(aprof, hierarchy, TRUE, &def_tcp_listen)) {
             hierarchy[1] = KRB5_CONF_KDC_TCP_PORTS;
-            if (krb5_aprof_get_string(aprof, hierarchy, TRUE, &def_udp_listen))
+            if (krb5_aprof_get_string(aprof, hierarchy, TRUE, &def_tcp_listen))
                 def_tcp_listen = NULL;
         }
         hierarchy[1] = KRB5_CONF_KDC_MAX_DGRAM_REPLY_SIZE;


### PR DESCRIPTION
When I integrated PR #380, I made a change to the last commit to ensure sure that kdc_ports and kdc_tcp_ports would still work inside [kdcdefaults].  Through a fascinating COPY_PASTE_ERROR heuristic, Coverity detected a bug in that change.  This commit fixes the bug.
