### PR TITLE
Fix SPNEGO imported cred initialization

### DIFF
--- a/src/lib/gssapi/spnego/spnego_mech.c
+++ b/src/lib/gssapi/spnego/spnego_mech.c
@@ -2993,14 +2993,11 @@ spnego_gss_import_cred(OM_uint32 *minor_status,
 	ret = gss_import_cred(minor_status, token, &mcred);
 	if (GSS_ERROR(ret))
 		return (ret);
-	spcred = malloc(sizeof(*spcred));
-	if (spcred == NULL) {
-		gss_release_cred(minor_status, &mcred);
-		*minor_status = ENOMEM;
-		return (GSS_S_FAILURE);
-	}
-	spcred->mcred = mcred;
-	spcred->neg_mechs = GSS_C_NULL_OID_SET;
+
+	ret = create_spnego_cred(minor_status, mcred, &spcred);
+	if (GSS_ERROR(ret))
+	    return (ret);
+
 	*cred_handle = (gss_cred_id_t)spcred;
 	return (ret);
 }


### PR DESCRIPTION
[I ran into this while running a test program under valgrind when looking into something else.]

In spnego_gss_import_cred(), use create_spnego_cred() to create the
SPNEGO credential structure.  Prior to this change, an imported SPNEGO
cred did not initialize the no_ask_integ field (added by commit
cf39ed349976908626cad3e05e17788f8334bce9, ticket #6938).
