### PR TITLE
Improve bad password inference in kinit

### DIFF
--- a/src/lib/krb5/krb/preauth_otp.c
+++ b/src/lib/krb5/krb/preauth_otp.c
@@ -31,6 +31,7 @@
 #include "k5-int.h"
 #include "k5-json.h"
 #include "int-proto.h"
+#include "os-proto.h"
 
 #include <krb5/clpreauth_plugin.h>
 #include <ctype.h>
@@ -475,6 +476,7 @@ doprompt(krb5_context context, krb5_prompter_fct prompter, void *prompter_data,
     krb5_prompt prompt;
     krb5_data prompt_reply;
     krb5_error_code retval;
+    krb5_prompt_type prompt_type = KRB5_PROMPT_TYPE_PREAUTH;
 
     if (prompttxt == NULL || out == NULL)
         return EINVAL;
@@ -486,7 +488,10 @@ doprompt(krb5_context context, krb5_prompter_fct prompter, void *prompter_data,
     prompt.prompt = (char *)prompttxt;
     prompt.hidden = 1;
 
+    /* PROMPTER_INVOCATION */
+    k5_set_prompt_types(context, &prompt_type);
     retval = (*prompter)(context, prompter_data, NULL, banner, 1, &prompt);
+    k5_set_prompt_types(context, NULL);
     if (retval != 0)
         return retval;
 


### PR DESCRIPTION
The first commit on this branch sets prompt types in OTP client preauth.  I noticed this omission while testing an earlier version of the second commit.  I also noticed that clpreauth modules can invoke the prompter but currently have no way of setting prompt types, so I think code which calls krb5_get_prompt_types() needs to expect a possible NULL result.

The second commit implements a change we talked about on last Tuesday's dev call, which is to display "Password incorrect" in kinit if we get a preauth-failed error from the KDC and witnessed a password prompt.  I didn't expand this change to other programs which perform AS requests; I think it's not as big of a deal to see a "Preauthentication failed" error from another utility like kadmin or kpasswd.