### PR TITLE
Move CFLAGS and CPP_FLAGS after local includes

### DIFF
--- a/src/util/gss-kernel-lib/Makefile.in
+++ b/src/util/gss-kernel-lib/Makefile.in
@@ -2,7 +2,7 @@ mydir=util/gss-kernel-lib
 BUILDTOP=$(REL)..$(S)..
 
 DEFINES=-DKRB5_KERNEL
-ALL_CFLAGS=$(CPPFLAGS) $(CFLAGS) $(WARN_CFLAGS) $(DEFS) $(DEFINES) -I. -Igssapi
+ALL_CFLAGS=$(WARN_CFLAGS) $(DEFS) $(DEFINES) -I. -Igssapi $(CPPFLAGS) $(CFLAGS)
 
 SHLIB_EXPDEPS = \
 	$(TOPLIBD)/libk5crypto$(SHLIBEXT) \


### PR DESCRIPTION
The gss-kernel-lib Makefile overrides ALL_CFLAGS.  It was setting
the CFLAGS and CPPFLAGS to occure before local includes, which
causes some compilers to include system header files before the
local header files.  Moving the CPPFLAGS and CFLAGS to the end of
ALL_CFLAGS corrects this behavior.