### PR TITLE
Remove all makefiles in make distclean

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -20,9 +20,12 @@ SUBDIRS=util include lib \
 	plugins/kdb/db2 \
 	@ldap_plugin_dir@ \
 	plugins/kdb/test \
+	plugins/locate/python \
+	plugins/preauth/cksum_body \
 	plugins/preauth/otp \
 	plugins/preauth/pkinit \
 	plugins/preauth/test \
+	plugins/preauth/wpse \
 	plugins/tls/k5tls \
 	kdc kadmin slave clients appl tests \
 	config-files build-tools man doc @po@

--- a/src/configure.in
+++ b/src/configure.in
@@ -1210,6 +1210,7 @@ old_CFLAGS=$CFLAGS
 CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
 AC_CHECK_LIB(aceclnt, sd_init, [
 	     AC_MSG_NOTICE([Enabling RSA securID support])
+	     K5_GEN_MAKEFILE(plugins/preauth/securid_sam2)
 	     sam2_plugin=plugins/preauth/securid_sam2
 	     ])
 AC_SUBST(sam2_plugin)
@@ -1428,7 +1429,6 @@ dnl	ccapi ccapi/lib ccapi/lib/unix ccapi/server ccapi/server/unix ccapi/test
 	plugins/kdb/test
 	plugins/preauth/cksum_body
 	plugins/preauth/otp
-	plugins/preauth/securid_sam2
 	plugins/preauth/test
 	plugins/preauth/wpse
 	plugins/authdata/greet_client

--- a/src/plugins/locate/python/Makefile.in
+++ b/src/plugins/locate/python/Makefile.in
@@ -1,3 +1,6 @@
+# The python locate module is not built by default.  To build it
+# manally, run "make all-liblinks".
+
 mydir=plugins$(S)locate$(S)python
 BUILDTOP=$(REL)..$(S)..$(S)..
 
@@ -14,8 +17,6 @@ SRCS= \
 	$(srcdir)/py-locate.c
 STLIBOBJS= py-locate.o
 
-all-unix: all-liblinks
-install-unix: install-libs
 clean-unix:: clean-liblinks clean-libs clean-libobjs
 
 @libnover_frag@

--- a/src/plugins/preauth/cksum_body/Makefile.in
+++ b/src/plugins/preauth/cksum_body/Makefile.in
@@ -1,3 +1,6 @@
+# The cksum_body preauth module is not built by default.  To build it
+# manually, run "make all-libs".
+
 mydir=plugins$(S)preauth$(S)cksum_body
 BUILDTOP=$(REL)..$(S)..$(S)..
 MODULE_INSTALL_DIR = $(KRB5_PA_MODULE_DIR)
@@ -16,8 +19,6 @@ STLIBOBJS=cksum_body_main.o
 
 SRCS= $(srcdir)/cksum_body_main.c
 
-all-unix: $(LIBBASE)$(SO_EXT)
-install-unix: install-libs
 clean-unix:: clean-libs clean-libobjs
 
 @libnover_frag@

--- a/src/plugins/preauth/wpse/Makefile.in
+++ b/src/plugins/preauth/wpse/Makefile.in
@@ -1,3 +1,6 @@
+# The Worst Preauthentication Scheme Ever is not built by default.  To
+# build it manually, run "make all-libs".
+
 mydir=plugins$(S)preauth$(S)wpse
 BUILDTOP=$(REL)..$(S)..$(S)..
 MODULE_INSTALL_DIR = $(KRB5_PA_MODULE_DIR)
@@ -16,8 +19,6 @@ STLIBOBJS=wpse_main.o
 
 SRCS=wpse_main.c
 
-all-unix: all-libs
-install-unix: install-libs
 clean-unix:: clean-libs clean-libobjs
 
 @libnover_frag@

--- a/src/tests/Makefile.in
+++ b/src/tests/Makefile.in
@@ -1,7 +1,7 @@
 mydir=tests
 BUILDTOP=$(REL)..
 SUBDIRS = resolve asn.1 create hammer verify gssapi dejagnu shlib \
-	gss-threads misc
+	gss-threads misc threads
 
 RUN_DB_TEST = $(RUN_SETUP) KRB5_KDC_PROFILE=kdc.conf KRB5_CONFIG=krb5.conf \
 	LC_ALL=C $(VALGRIND)

--- a/src/tests/threads/Makefile.in
+++ b/src/tests/threads/Makefile.in
@@ -1,3 +1,8 @@
+# The test programs here are not built or run by default.  You can
+# build a specific test program with "make gss-perf" or similar.
+# "make run-t_rcache" will run the replay cache test program in the
+# proper environment.
+
 mydir=tests$(S)threads
 BUILDTOP=$(REL)..$(S)..
 
@@ -28,8 +33,6 @@ init_ctx: init_ctx.o $(KRB5_BASE_DEPLIBS)
 
 profread: profread.o $(KRB5_BASE_DEPLIBS)
 	$(CC_LINK) $(PTHREAD_CFLAGS) -o profread profread.o $(KRB5_BASE_LIBS) $(THREAD_LINKOPTS)
-
-check-unix: run-t_rcache
 
 install:
 

--- a/src/util/Makefile.in
+++ b/src/util/Makefile.in
@@ -4,7 +4,8 @@ mydir=util
 # configure scripts, so hide this.
 ##WIN32##!if 0
 SUBDIRS=support $(MAYBE_ET_@COM_ERR_VERSION@) $(MAYBE_SS_@SS_VERSION@) \
-	profile gss-kernel-lib $(MAYBE_VERTO_@VERTO_VERSION@)
+	profile gss-kernel-lib collected-client-lib \
+	$(MAYBE_VERTO_@VERTO_VERSION@)
 ##WIN32##!endif
 WINSUBDIRS=windows support et profile wshelper
 BUILDTOP=$(REL)..

--- a/src/util/collected-client-lib/Makefile.in
+++ b/src/util/collected-client-lib/Makefile.in
@@ -1,3 +1,6 @@
+# The collected client library is not built by default.  To build it
+# manually, run "make all-libs".
+
 mydir=util$(S)collected-client-lib
 BUILDTOP=$(REL)..$(S)..
 RELDIR=../util/collected-client-lib
@@ -65,9 +68,6 @@ LIBS_UTILS=-lresolv
 SHLIB_EXPLIBS= $(LIBS) $(DL_LIB) $(LIBS_UTILS)
 
 DEPLIBS=
-
-#
-all-unix: lib$(LIBBASE)$(SHLIBVEXT)
 
 clean-unix:: clean-libs
 


### PR DESCRIPTION
In PR #498 we noted that "make distclean" still leaves behind nine files, three of which distclean is supposed to leave alone and six of which are Makefiles generated by configure and not visited by recursive make.  We discussed possible solutions to the six Makefiles but didn't implement them in that PR.

Of the six orphaned Makefiles, one is for the securid_sam2 preauth plugin and the other five are for sort of questionable directories which we could maybe do without.  We clearly can't remove the securid_sam2 directory (at least until SPAKE is implemented and deployed at MIT, which is many years away), so I figured it would act as a model for the other five.  However, it turns out that securid_sam2 should be handled by conditionally generating the Makefile, as we do for PKINIT, LDAP, and other conditionally built directories.

The commit I've attached here conditionally generates the securid_sam2 Makefile and implements Tom's suggested solution for the other five directories.  But we might consider deleting the other five directories instead, or at least some of them.
