### PR TITLE
Properly escape quotes for otp set_string example

### DIFF
--- a/doc/admin/admin_commands/kadmin_local.rst
+++ b/doc/admin/admin_commands/kadmin_local.rst
@@ -668,7 +668,7 @@ Alias: **setstr**
 Example::
 
     set_string host/foo.mit.edu session_enctypes aes128-cts
-    set_string user@FOO.COM otp [{"type":"hotp","username":"custom"}]
+    set_string user@FOO.COM otp "[{""type"":""hotp"",""username"":""al""}]"
 
 .. _set_string_end:
 


### PR DESCRIPTION
The user from debian bug 828976 noted that the documentation has an example that does not escape the quotes.

Maybe this should get an RT ticket for pullup...