### PR TITLE
Warn about dump -recurse nonfunctionality

### DIFF
--- a/doc/admin/admin_commands/kdb5_util.rst
+++ b/doc/admin/admin_commands/kdb5_util.rst
@@ -182,6 +182,12 @@ load_dump version 7".  If filename is not specified, or is the string
     corruption, this option will probably retrieve more principals
     than the **-rev** option will.
 
+    .. note::
+        The **-recurse** option currently doesn't modify the dump
+        functionality as described above; it does a normal dump.
+
+    .. deprecated:: 1.5
+
 .. _kdb5_util_dump_end:
 
 load

--- a/src/kadmin/dbutil/dump.c
+++ b/src/kadmin/dbutil/dump.c
@@ -1303,6 +1303,9 @@ dump_db(int argc, char **argv)
         } else if (!strcmp(argv[aindex], "-recurse")) {
             /* Accept this for compatibility, but do nothing since
              * krb5_db_iterate doesn't support it. */
+            fprintf(stderr,
+                    _("%s: WARNING: the -recurse option is currently "
+                      "unimplemented\n"), progname);
         } else {
             break;
         }


### PR DESCRIPTION
kdb5_util dump -recurse hasn't behaved as documented since krb5-1.5,
when the DAL was integrated.  Restoring it is a nontrivial amount of
work, so just document it for now.

ticket: 8470 (new)
target_version: 1.14-next
target_version: 1.13-next
tags: pullup