### PR TITLE
Set default_port to host byte order before calling k5_parse_host_string

### DIFF
--- a/src/lib/krb5/os/locate_kdc.c
+++ b/src/lib/krb5/os/locate_kdc.c
@@ -254,7 +254,7 @@ locate_srv_conf_1(krb5_context context, const krb5_data *realm,
         parse_uri_if_https(hostspec, &this_transport, &hostspec, &uri_path);
 
         default_port = (this_transport == HTTPS) ? htons(443) : udpport;
-        code = k5_parse_host_string(hostspec, default_port, &host, &port_num);
+        code = k5_parse_host_string(hostspec, ntohs(default_port), &host, &port_num);
         if (code == 0 && host == NULL)
             code = EINVAL;
         if (code)


### PR DESCRIPTION
In last refactoring of locate_srv_conf_1() the port number is converted
to network order when passed to add_host_to_list(htons(port_num)).
However, the default_port is already in network order so this caused
my configuration (kdc = 10.0.0.200) to fail (it tried port 22528).

At first, I thought to remove the above htons() call but then it fails
when I specify the port (10.0.0.200:88) because k5_parse_host_string()
doesn't call htons(), so instead I call ntohs(default_port) when
calling k5_parse_host_string() (also, this way the sanity check of
default_port in k5_parse_host_string() makes more sense).