### PR TITLE
Fix and simplify locate_kdc.c port byte order

### DIFF
--- a/src/lib/krb5/os/changepw.c
+++ b/src/lib/krb5/os/changepw.c
@@ -75,15 +75,15 @@ locate_kpasswd(krb5_context context, const krb5_data *realm,
             size_t i;
             for (i = 0; i < serverlist->nservers; i++) {
                 struct server_entry *s = &serverlist->servers[i];
-                krb5_ui_2 kpasswd_port = htons(DEFAULT_KPASSWD_PORT);
+
                 if (!no_udp && s->transport == TCP)
                     s->transport = TCP_OR_UDP;
                 if (s->hostname != NULL)
-                    s->port = kpasswd_port;
+                    s->port = DEFAULT_KPASSWD_PORT;
                 else if (s->family == AF_INET)
-                    ss2sin(&s->addr)->sin_port = kpasswd_port;
+                    ss2sin(&s->addr)->sin_port = htons(DEFAULT_KPASSWD_PORT);
                 else if (s->family == AF_INET6)
-                    ss2sin6(&s->addr)->sin6_port = kpasswd_port;
+                    ss2sin6(&s->addr)->sin6_port = htons(DEFAULT_KPASSWD_PORT);
             }
         }
     }

--- a/src/lib/krb5/os/locate_kdc.c
+++ b/src/lib/krb5/os/locate_kdc.c
@@ -224,7 +224,7 @@ locate_srv_conf_1(krb5_context context, const krb5_data *realm,
     int i, default_port;
 
     Tprintf ("looking in krb5.conf for realm %s entry %s; ports %d,%d\n",
-             realm->data, name, ntohs(udpport));
+             realm->data, name, udpport);
 
     realmstr = k5memdup0(realm->data, realm->length, &code);
     if (realmstr == NULL)
@@ -253,15 +253,15 @@ locate_srv_conf_1(krb5_context context, const krb5_data *realm,
 
         parse_uri_if_https(hostspec, &this_transport, &hostspec, &uri_path);
 
-        default_port = (this_transport == HTTPS) ? htons(443) : udpport;
+        default_port = (this_transport == HTTPS) ? 443 : udpport;
         code = k5_parse_host_string(hostspec, default_port, &host, &port_num);
         if (code == 0 && host == NULL)
             code = EINVAL;
         if (code)
             goto cleanup;
 
-        code = add_host_to_list(serverlist, host, htons(port_num),
-                                this_transport, AF_UNSPEC, uri_path);
+        code = add_host_to_list(serverlist, host, port_num, this_transport,
+                                AF_UNSPEC, uri_path);
         if (code)
             goto cleanup;
 
@@ -316,7 +316,7 @@ locate_srv_dns_1(const krb5_data *realm, const char *service,
 
     for (entry = head; entry != NULL; entry = entry->next) {
         transport = (strcmp(protocol, "_tcp") == 0) ? TCP : UDP;
-        code = add_host_to_list(serverlist, entry->host, htons(entry->port),
+        code = add_host_to_list(serverlist, entry->host, entry->port,
                                 transport, AF_UNSPEC, NULL);
         if (code)
             goto cleanup;
@@ -479,23 +479,23 @@ prof_locate_server(krb5_context context, const krb5_data *realm,
            have old, crufty, wrong settings that this is probably
            better.  */
     kdc_ports:
-        dflport = htons(KRB5_DEFAULT_PORT);
+        dflport = KRB5_DEFAULT_PORT;
         break;
     case locate_service_master_kdc:
         profname = KRB5_CONF_MASTER_KDC;
         goto kdc_ports;
     case locate_service_kadmin:
         profname = KRB5_CONF_ADMIN_SERVER;
-        dflport = htons(DEFAULT_KADM5_PORT);
+        dflport = DEFAULT_KADM5_PORT;
         break;
     case locate_service_krb524:
         profname = KRB5_CONF_KRB524_SERVER;
         serv = getservbyname("krb524", "udp");
-        dflport = serv ? serv->s_port : htons(4444);
+        dflport = serv ? serv->s_port : 4444;
         break;
     case locate_service_kpasswd:
         profname = KRB5_CONF_KPASSWD_SERVER;
-        dflport = htons(DEFAULT_KPASSWD_PORT);
+        dflport = DEFAULT_KPASSWD_PORT;
         break;
     default:
         return EBUSY;           /* XXX */

--- a/src/lib/krb5/os/sendto_kdc.c
+++ b/src/lib/krb5/os/sendto_kdc.c
@@ -814,7 +814,7 @@ resolve_server(krb5_context context, const krb5_data *realm,
 #ifdef AI_NUMERICSERV
     hint.ai_flags |= AI_NUMERICSERV;
 #endif
-    result = snprintf(portbuf, sizeof(portbuf), "%d", ntohs(entry->port));
+    result = snprintf(portbuf, sizeof(portbuf), "%d", entry->port);
     if (SNPRINTF_OVERFLOW(result, sizeof(portbuf)))
         return EINVAL;
     TRACE_SENDTO_KDC_RESOLVING(context, entry->hostname);

--- a/src/lib/krb5/os/t_locate_kdc.c
+++ b/src/lib/krb5/os/t_locate_kdc.c
@@ -59,7 +59,7 @@ print_addrs (void)
 
         if (entry->hostname != NULL) {
             printf("%2d: host %s\t%s\tport %d\n", (int)i, entry->hostname,
-                   ttypename(entry->transport), ntohs(entry->port));
+                   ttypename(entry->transport), entry->port);
             continue;
         }
         err = getnameinfo((struct sockaddr *)&entry->addr, entry->addrlen,

--- a/src/lib/krb5/os/t_std_conf.c
+++ b/src/lib/krb5/os/t_std_conf.c
@@ -91,7 +91,7 @@ test_locate_kdc(krb5_context ctx, char *realm)
     for (i = 0; i < servers.nservers; i++) {
         struct server_entry *entry = &servers.servers[i];
         if (entry->hostname) {
-            printf(" host:%s/%d", entry->hostname, ntohs(entry->port));
+            printf(" host:%s/%d", entry->hostname, entry->port);
             continue;
         }
         switch (entry->family) {


### PR DESCRIPTION
[This PR is intended to supersede #505.]

Commit c89587b4476139f05f34aa2323bd7c7db348c44c introduced a bug in
the handling of KDC specifications using the default port, by passing
it to k5_parse_host_string() in network byte order.  Fix this by
removing all of the port byte order transformations in locate_kdc.c,
and storing the struct serverlist port field in host byte order.
Adjust other consumers of struct serverlist to expect the port to be
in host field to be in host byte order.

Reported by Isaac Boukris.