### PR TITLE
Add another AD-SIGNTICKET corner case test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -379,6 +379,7 @@ local.properties
 /src/tests/adata
 /src/tests/au.log
 /src/tests/etinfo
+/src/tests/forward
 /src/tests/gcred
 /src/tests/hist
 /src/tests/hooks

--- a/src/tests/Makefile.in
+++ b/src/tests/Makefile.in
@@ -6,11 +6,11 @@ SUBDIRS = resolve asn.1 create hammer verify gssapi dejagnu shlib \
 RUN_DB_TEST = $(RUN_SETUP) KRB5_KDC_PROFILE=kdc.conf KRB5_CONFIG=krb5.conf \
 	LC_ALL=C $(VALGRIND)
 
-OBJS= adata.o etinfo.o gcred.o hist.o hooks.o hrealm.o icred.o kdbtest.o \
-	localauth.o plugorder.o rdreq.o responder.o s2p.o s4u2proxy.o \
-	unlockiter.o
-EXTRADEPSRCS= adata.c etinfo.c gcred.c hist.c hooks.c hrealm.c icred.c \
-	kdbtest.c localauth.c plugorder.c rdreq.o responder.c s2p.c \
+OBJS= adata.o etinfo.o forward.o gcred.o hist.o hooks.o hrealm.o icred.o \
+	kdbtest.o localauth.o plugorder.o rdreq.o responder.o s2p.o \
+	s4u2proxy.o unlockiter.o
+EXTRADEPSRCS= adata.c etinfo.c forward.c gcred.c hist.c hooks.c hrealm.c \
+	icred.c kdbtest.c localauth.c plugorder.c rdreq.o responder.c s2p.c \
 	s4u2proxy.c unlockiter.c
 
 TEST_DB = ./testdb
@@ -28,6 +28,9 @@ adata: adata.o $(KRB5_BASE_DEPLIBS)
 
 etinfo: etinfo.o $(KRB5_BASE_DEPLIBS)
 	$(CC_LINK) -o $@ etinfo.o $(KRB5_BASE_LIBS)
+
+forward: forward.o $(KRB5_BASE_DEPLIBS)
+	$(CC_LINK) -o $@ forward.o $(KRB5_BASE_LIBS)
 
 gcred: gcred.o $(KRB5_BASE_DEPLIBS)
 	$(CC_LINK) -o $@ gcred.o $(KRB5_BASE_LIBS)
@@ -112,8 +115,8 @@ kdb_check: kdc.conf krb5.conf
 	$(RUN_DB_TEST) ../kadmin/dbutil/kdb5_util $(KADMIN_OPTS) destroy -f
 	$(RM) $(TEST_DB)* stash_file
 
-check-pytests: adata etinfo gcred hist hooks hrealm icred kdbtest localauth
-check-pytests: plugorder rdreq responder s2p s4u2proxy unlockiter
+check-pytests: adata etinfo forward gcred hist hooks hrealm icred kdbtest
+check-pytests: localauth plugorder rdreq responder s2p s4u2proxy unlockiter
 	$(RUNPYTEST) $(srcdir)/t_general.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_hooks.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_dump.py $(PYTESTFLAGS)
@@ -166,8 +169,8 @@ check-pytests: plugorder rdreq responder s2p s4u2proxy unlockiter
 	$(RUNPYTEST) $(srcdir)/t_tabdump.py $(PYTESTFLAGS)
 
 clean:
-	$(RM) adata etinfo gcred hist hooks hrealm icred kdbtest localauth
-	$(RM) plugorder rdreq responder s2p s4u2proxy unlockiter
+	$(RM) adata etinfo forward gcred hist hooks hrealm icred kdbtest
+	$(RM) localauth plugorder rdreq responder s2p s4u2proxy unlockiter
 	$(RM) krb5.conf kdc.conf
 	$(RM) -rf kdc_realm/sandbox ldap
 	$(RM) au.log

--- a/src/tests/forward.c
+++ b/src/tests/forward.c
@@ -1,0 +1,93 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* tests/forward.c - test harness for getting forwarded creds */
+/*
+ * Copyright (C) 2016 by the Massachusetts Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* This test program overwrites the default credential cache with a forwarded
+ * TGT obtained using the TGT presently in the cache. */
+
+#include "k5-int.h"
+
+static krb5_context ctx;
+
+static void
+check(krb5_error_code code)
+{
+    const char *errmsg;
+
+    if (code) {
+        errmsg = krb5_get_error_message(ctx, code);
+        fprintf(stderr, "%s\n", errmsg);
+        krb5_free_error_message(ctx, errmsg);
+        exit(1);
+    }
+}
+
+int
+main()
+{
+    krb5_ccache cc;
+    krb5_creds mcred, tgt, *fcred;
+    krb5_principal client, tgtprinc;
+    krb5_flags options;
+
+    /* Open the default ccache and get the client and TGT principal names. */
+    check(krb5_init_context(&ctx));
+    check(krb5_cc_default(ctx, &cc));
+    check(krb5_cc_get_principal(ctx, cc, &client));
+    check(krb5_build_principal_ext(ctx, &tgtprinc, client->realm.length,
+                                   client->realm.data, KRB5_TGS_NAME_SIZE,
+                                   KRB5_TGS_NAME, client->realm.length,
+                                   client->realm.data, 0));
+
+    /* Fetch the TGT credential. */
+    memset(&mcred, 0, sizeof(mcred));
+    mcred.client = client;
+    mcred.server = tgtprinc;
+    check(krb5_cc_retrieve_cred(ctx, cc, 0, &mcred, &tgt));
+
+    /* Get a forwarded TGT. */
+    mcred.times = tgt.times;
+    mcred.times.starttime = 0;
+    options = (tgt.ticket_flags & KDC_TKT_COMMON_MASK) | KDC_OPT_FORWARDED;
+    check(krb5_get_cred_via_tkt(ctx, &tgt, options, NULL, &mcred, &fcred));
+
+    /* Reinitialize the default ccache with the forwarded TGT. */
+    check(krb5_cc_initialize(ctx, cc, client));
+    check(krb5_cc_store_cred(ctx, cc, fcred));
+
+    krb5_free_creds(ctx, fcred);
+    krb5_free_cred_contents(ctx, &tgt);
+    krb5_free_principal(ctx, tgtprinc);
+    krb5_free_principal(ctx, client);
+    krb5_cc_close(ctx, cc);
+    krb5_free_context(ctx);
+    return 0;
+}

--- a/src/tests/t_authdata.py
+++ b/src/tests/t_authdata.py
@@ -169,6 +169,15 @@ realm.run([kvno, 'restricted'], expected_code=1)
 realm.run([kadminl, 'setstr', 'restricted', 'require_auth', 'a b c ind2'])
 realm.run([kvno, 'restricted'])
 
+# Regression test for one manifestation of #8139: ensure that
+# forwarded TGTs obtained across a TGT re-key still work when the
+# preferred krbtgt enctype changes.
+realm.kinit(realm.user_princ, password('user'), ['-f'])
+realm.run([kadminl, 'cpw', '-randkey', '-keepold', '-e', 'des3-cbc-sha1',
+           realm.krbtgt_princ])
+realm.run(['./forward'])
+realm.run([kvno, realm.host_princ])
+
 realm.stop()
 realm2.stop()
 


### PR DESCRIPTION
Prior to the fix for #8139, forwarded TGTs obtained across a krbtgt
re-key could fail if the preferred krbtgt enctype changed, because
krb5_c_verify_checksum() returns an bad-enctype error due to the
mismatched checksum.  Add a test case for this scenario, using a new
test harness program which obtains a forwarded TGT.