### PR TITLE
Fix build with -O3 on ppc64el

### DIFF
--- a/src/lib/krb5/os/sendto_kdc.c
+++ b/src/lib/krb5/os/sendto_kdc.c
@@ -173,6 +173,8 @@ get_curtime_ms(time_ms *time_out)
 {
     struct timeval tv;
 
+    *time_out = 0;
+
     if (gettimeofday(&tv, 0))
         return errno;
     *time_out = (time_ms)tv.tv_sec * 1000 + tv.tv_usec / 1000;

--- a/src/tests/asn.1/trval.c
+++ b/src/tests/asn.1/trval.c
@@ -180,6 +180,7 @@ int trval2(fp, enc, len, lev, rlen)
     int rlen_ext = 0;
 
     r = OK;
+    *rlen = -1;
 
     if (len < 2) {
         fprintf(fp, "missing id and length octets (%d)\n", len);


### PR DESCRIPTION
Ubuntu runs ppc64el builds with -O3, which elicited a few warnings
from gcc that were not generated elsewhere, as documented at
https://bugs.launchpad.net/ubuntu/+source/krb5/+bug/1592841 .

Initialize the output variable at the top of a couple helper functions
to silence the uninitialized-variable warnings.