### PR TITLE
Allow libev to use pthreads on old platforms

### DIFF
--- a/src/util/verto/ev.c
+++ b/src/util/verto/ev.c
@@ -1511,7 +1511,14 @@ ecb_binary32_to_binary16 (uint32_t x)
  * alternatively, you can remove this #error and link against libpthread,
  * which will then provide the memory fences.
  */
+/*
+ * krb5 change: per the comment below, we are allowing pthreads on platforms
+ * which are too old to have better memory thead support, as is the case on
+ * older Solaris versions.
+ */
+#if 0
 # error "memory fences not defined for your architecture, please report"
+#endif
 #endif
 
 #ifndef ECB_MEMORY_FENCE


### PR DESCRIPTION
The upgrade to libev 4.22 introduced the use of "memory fences" for
more reliable signal processing.  Memory fences are usually
implemented using assembly or compiler primitives, but may be
implemented using pthreads as a last resort.  The unmodified libev
errors out at compile time if pthreads is used, but notes that this
error can be removed if relying on pthreads is okay.  Because the
project's nightly build infrastructure includes an old Solaris machine
whose toolchain is too old for any of the non-pthreads memory fence
implementations, remove the error to allow the build to succeed.  (A
dependency on pthreads functions on Solaris does not require linking
with libpthread.)