### PR TITLE
Fix KDC to drop repeated in-progress requests

### DIFF
--- a/src/kdc/replay.c
+++ b/src/kdc/replay.c
@@ -177,6 +177,10 @@ kdc_check_lookaside(krb5_context kcontext, krb5_data *req_packet,
 
     e->num_hits++;
     hits++;
+
+    if (e->reply_packet.length == 0)
+        return TRUE;
+
     return (krb5_copy_data(kcontext, &e->reply_packet,
                            reply_packet_out) == 0);
 }


### PR DESCRIPTION
The KDC's behavior when it receives a repeated request while the
original request is still processing is supposed to be to drop the
request.  A bug was causing the KDC to instead replay an empty
reply.  Setting kdc_check_lookaside in replay.c to return a NULL
reply_packet when the request hasn't finished returns the KDC back
to the expected behavior.