### PR TITLE
Remove instances of "XXX" in error descriptors

### DIFF
--- a/src/lib/krb5/error_tables/krb5_err.et
+++ b/src/lib/krb5/error_tables/krb5_err.et
@@ -258,7 +258,7 @@ error_code KRB5_BAD_MSIZE,		"Message size is incompatible with encryption type"
 error_code KRB5_CC_TYPE_EXISTS,		"Credentials cache type is already registered."
 error_code KRB5_KT_TYPE_EXISTS,		"Key table type is already registered."
 
-error_code KRB5_CC_IO,			"Credentials cache I/O operation failed XXX"
+error_code KRB5_CC_IO,			"Credentials cache I/O operation failed"
 error_code KRB5_FCC_PERM,		"Credentials cache permissions incorrect"
 error_code KRB5_FCC_NOFILE,		"No credentials cache found"
 error_code KRB5_FCC_INTERNAL,		"Internal credentials cache error"


### PR DESCRIPTION
These are confusing to end users who may encounter them and serve no clear purpose.

This also makes the strings for `KRB5_RC_IO` consistent.