### PR TITLE
Fix GSSRPC server credential memory leak

### DIFF
--- a/src/include/gssrpc/rename.h
+++ b/src/include/gssrpc/rename.h
@@ -257,8 +257,6 @@
 
 #define svc_debug_gss		gssrpc_svc_debug_gss
 
-#define svcauth_gss_creds	gssrpc_svc_auth_gss_creds
-
 /* svc_auth_gssapi.c */
 
 #define svc_debug_gssapi	gssrpc_svc_debug_gssapi

--- a/src/lib/rpc/libgssrpc.exports
+++ b/src/lib/rpc/libgssrpc.exports
@@ -43,7 +43,6 @@ gssrpc_pmap_set
 gssrpc_pmap_unset
 gssrpc_registerrpc
 gssrpc_rpc_createrr
-gssrpc_svc_auth_gss_creds
 gssrpc_svc_auth_gss_ops
 gssrpc_svc_auth_gssapi_ops
 gssrpc_svc_auth_none

--- a/src/lib/rpc/svc_auth_gss.c
+++ b/src/lib/rpc/svc_auth_gss.c
@@ -107,7 +107,6 @@ struct svc_rpc_gss_data {
 	(*(struct svc_rpc_gss_data **)&(auth)->svc_ah_private)
 
 /* Global server credentials. */
-gss_cred_id_t		svcauth_gss_creds;
 static gss_name_t	svcauth_gss_name = NULL;
 
 bool_t


### PR DESCRIPTION
In svc_auth_gss.c, stop using the global svcauth_gss_creds, and
instead keep a credential in struct svc_rpc_gss_data.  This change
ensures that the same credential is used for each accept_sec_context
call for a particular context, and ensures that the credential is
freed when the authentication data is destroyed.  Also, do not acquire
a credential when the default name is used (as it is in kadmind) as it
is not needed.

Leave the svcauth_gss_creds around for the backportable fix as it is
in the library export list.  It will be removed in a subsequent
commit.
