### PR TITLE
Fix leak in krb5_server_decrypt_ticket_keytab()

### DIFF
--- a/src/lib/krb5/krb/srv_dec_tkt.c
+++ b/src/lib/krb5/krb/srv_dec_tkt.c
@@ -99,8 +99,10 @@ krb5_server_decrypt_ticket_keytab(krb5_context context,
         retval = KRB5_KT_NOTFOUND;
         while ((code = krb5_kt_next_entry(context, keytab,
                                           &ktent, &cursor)) == 0) {
-            if (ktent.key.enctype != ticket->enc_part.enctype)
+            if (ktent.key.enctype != ticket->enc_part.enctype) {
+                (void) krb5_free_keytab_entry_contents(context, &ktent);
                 continue;
+            }
 
             retval = decrypt_ticket_keyblock(context, &ktent.key, ticket);
             if (retval == 0) {


### PR DESCRIPTION
[From RT ticket 8482.  This bug has been present since 1.7, but krb5_server_decrypt_ticket_keytab() isn't used much.]

When we skip a keytab entry because it is of the wrong enctype, free
it before continuing.
