### PR TITLE
Consolidate sn2princ_realm() in kprop and kpropd

### DIFF
--- a/src/slave/Makefile.in
+++ b/src/slave/Makefile.in
@@ -3,11 +3,11 @@ BUILDTOP=$(REL)..
 
 all:	kprop kpropd kproplog
 
-CLIENTSRCS= $(srcdir)/kprop.c $(srcdir)/kprop_sock.c
-CLIENTOBJS= kprop.o kprop_sock.o
+CLIENTSRCS= $(srcdir)/kprop.c $(srcdir)/kprop_util.c
+CLIENTOBJS= kprop.o kprop_util.o
 
-SERVERSRCS= $(srcdir)/kpropd.c $(srcdir)/kpropd_rpc.c $(srcdir)/kprop_sock.c
-SERVEROBJS= kpropd.o kpropd_rpc.o kprop_sock.o
+SERVERSRCS= $(srcdir)/kpropd.c $(srcdir)/kpropd_rpc.c $(srcdir)/kprop_util.c
+SERVEROBJS= kpropd.o kpropd_rpc.o kprop_util.o
 
 LOGSRCS= $(srcdir)/kproplog.c
 LOGOBJS= kproplog.o

--- a/src/slave/deps
+++ b/src/slave/deps
@@ -12,7 +12,7 @@ $(OUTPRE)kprop.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
   $(top_srcdir)/include/krb5/authdata_plugin.h $(top_srcdir)/include/krb5/plugin.h \
   $(top_srcdir)/include/port-sockets.h $(top_srcdir)/include/socket-utils.h \
   kprop.c kprop.h
-$(OUTPRE)kprop_sock.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
+$(OUTPRE)kprop_util.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
   $(BUILDTOP)/include/krb5/krb5.h $(BUILDTOP)/include/osconf.h \
   $(BUILDTOP)/include/profile.h $(COM_ERR_DEPS) $(top_srcdir)/include/k5-buf.h \
   $(top_srcdir)/include/k5-err.h $(top_srcdir)/include/k5-gmt_mktime.h \
@@ -21,7 +21,7 @@ $(OUTPRE)kprop_sock.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
   $(top_srcdir)/include/k5-thread.h $(top_srcdir)/include/k5-trace.h \
   $(top_srcdir)/include/krb5.h $(top_srcdir)/include/krb5/authdata_plugin.h \
   $(top_srcdir)/include/krb5/plugin.h $(top_srcdir)/include/port-sockets.h \
-  $(top_srcdir)/include/socket-utils.h kprop.h kprop_sock.c
+  $(top_srcdir)/include/socket-utils.h kprop.h kprop_util.c
 $(OUTPRE)kpropd.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
   $(BUILDTOP)/include/gssapi/gssapi.h $(BUILDTOP)/include/kadm5/admin.h \
   $(BUILDTOP)/include/kadm5/chpass_util_strings.h $(BUILDTOP)/include/kadm5/kadm_err.h \

--- a/src/slave/kprop.h
+++ b/src/slave/kprop.h
@@ -37,3 +37,7 @@
 
 int sockaddr2krbaddr(krb5_context context, int family, struct sockaddr *sa,
                      krb5_address **dest);
+
+krb5_error_code
+sn2princ_realm(krb5_context context, const char *hostname, const char *sname,
+               const char *realm, krb5_principal *princ_out);

--- a/src/slave/kprop_util.c
+++ b/src/slave/kprop_util.c
@@ -1,5 +1,5 @@
 /* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
-/* slave/kprop_sock.c */
+/* slave/kprop_util.c */
 /*
  * Copyright (C) 2010 by the Massachusetts Institute of Technology.
  * All rights reserved.


### PR DESCRIPTION
In kprop and kpropd, factor out the duplicated implementation of
sn2princ_with_realm() into kprop_util.c.  Rename it to
sn2princ_realm(), remove the type parameter, and require the sname
parameter to be specified.  Rewrite the function to use
krb5_expand_hostname(), avoiding an unnecessary hostrealm lookup.

[There is also a prior commit to rename kprop_sock.c to kprop_util.c.]
