### PR TITLE
Clean up libdb2 warnings

### DIFF
--- a/src/plugins/kdb/db2/libdb2/btree/bt_delete.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_delete.c
@@ -152,7 +152,8 @@ __bt_stkacq(t, hp, c)
 	indx_t idx = 0;
 	db_pgno_t pgno;
 	recno_t nextpg, prevpg;
-	int exact, level;
+	int exact;
+	unsigned int level;
 
 	/*
 	 * Find the first occurrence of the key in the tree.  Toss the

--- a/src/plugins/kdb/db2/libdb2/btree/bt_put.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_put.c
@@ -208,7 +208,8 @@ delete:		if (__bt_dleaf(t, key, h, idx) == RET_ERROR) {
 	 * into the offset array, shift the pointers up.
 	 */
 	nbytes = NBLEAFDBT(key->size, data->size);
-	if (h->upper - h->lower < nbytes + sizeof(indx_t)) {
+	if ((u_int32_t)h->upper - (u_int32_t)h->lower
+	    < nbytes + sizeof(indx_t)) {
 		if ((status = __bt_split(t, h, key,
 		    data, dflags, nbytes, idx)) != RET_SUCCESS)
 			return (status);
@@ -292,7 +293,7 @@ bt_fast(t, key, data, exactp)
 	 * have to search to get split stack.
 	 */
 	nbytes = NBLEAFDBT(key->size, data->size);
-	if (h->upper - h->lower < nbytes + sizeof(indx_t))
+	if ((u_int32_t)h->upper - (u_int32_t)h->lower < nbytes + sizeof(indx_t))
 		goto miss;
 
 	if (t->bt_order == FORWARD) {

--- a/src/plugins/kdb/db2/libdb2/btree/bt_search.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_search.c
@@ -159,7 +159,7 @@ __bt_snext(t, h, key, exactp)
 	EPGNO *parent;
 	indx_t idx = 0;
 	db_pgno_t pgno;
-	int level;
+	unsigned int level;
 
 	/*
 	 * Get the next page.  The key is either an exact
@@ -239,7 +239,7 @@ __bt_sprev(t, h, key, exactp)
 	EPGNO *parent;
 	indx_t idx = 0;
 	db_pgno_t pgno;
-	int level;
+	unsigned int level;
 
 	/*
 	 * Get the previous page.  The key is either an exact

--- a/src/plugins/kdb/db2/libdb2/btree/bt_split.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_split.c
@@ -245,9 +245,12 @@ __bt_split(t, sp, key, data, flags, ilen, argskip)
 			WR_BINTERNAL(dest, nksize ? nksize : bl->ksize,
 			    rchild->pgno, bl->flags & P_BIGKEY);
 			memmove(dest, bl->bytes, nksize ? nksize : bl->ksize);
-			if (bl->flags & P_BIGKEY &&
-			    bt_preserve(t, *(db_pgno_t *)bl->bytes) == RET_ERROR)
-				goto err1;
+			if (bl->flags & P_BIGKEY) {
+				db_pgno_t pgno;
+				memcpy(&pgno, bl->bytes, sizeof(pgno));
+				if (bt_preserve(t, pgno) == RET_ERROR)
+					goto err1;
+			}
 			break;
 		case P_RINTERNAL:
 			/*
@@ -568,9 +571,12 @@ bt_broot(t, h, l, r)
 		 * If the key is on an overflow page, mark the overflow chain
 		 * so it isn't deleted when the leaf copy of the key is deleted.
 		 */
-		if (bl->flags & P_BIGKEY &&
-		    bt_preserve(t, *(db_pgno_t *)bl->bytes) == RET_ERROR)
-			return (RET_ERROR);
+		if (bl->flags & P_BIGKEY) {
+			db_pgno_t pgno;
+			memcpy(&pgno, bl->bytes, sizeof(pgno));
+			if (bt_preserve(t, pgno) == RET_ERROR)
+				return (RET_ERROR);
+		}
 		break;
 	case P_BINTERNAL:
 		bi = GETBINTERNAL(r, 0);

--- a/src/plugins/kdb/db2/libdb2/btree/bt_split.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_split.c
@@ -215,7 +215,8 @@ __bt_split(t, sp, key, data, flags, ilen, argskip)
 		}
 
 		/* Split the parent page if necessary or shift the indices. */
-		if (h->upper - h->lower < nbytes + sizeof(indx_t)) {
+		if ((u_int32_t)h->upper - (u_int32_t)h->lower
+		    < nbytes + sizeof(indx_t)) {
 			sp = h;
 			h = h->pgno == P_ROOT ?
 			    bt_root(t, h, &l, &r, &skip, nbytes) :
@@ -237,7 +238,7 @@ __bt_split(t, sp, key, data, flags, ilen, argskip)
 			h->linp[skip] = h->upper -= nbytes;
 			dest = (char *)h + h->linp[skip];
 			memmove(dest, bi, nbytes);
-			((BINTERNAL *)dest)->pgno = rchild->pgno;
+			((BINTERNAL *)(void *)dest)->pgno = rchild->pgno;
 			break;
 		case P_BLEAF:
 			h->linp[skip] = h->upper -= nbytes;
@@ -261,14 +262,14 @@ __bt_split(t, sp, key, data, flags, ilen, argskip)
 				dest = (char *)h + h->linp[skip - 1];
 			else
 				dest = (char *)l + l->linp[NEXTINDEX(l) - 1];
-			((RINTERNAL *)dest)->nrecs = rec_total(lchild);
-			((RINTERNAL *)dest)->pgno = lchild->pgno;
+			((RINTERNAL *)(void *)dest)->nrecs = rec_total(lchild);
+			((RINTERNAL *)(void *)dest)->pgno = lchild->pgno;
 
 			/* Update the right page count. */
 			h->linp[skip] = h->upper -= nbytes;
 			dest = (char *)h + h->linp[skip];
-			((RINTERNAL *)dest)->nrecs = rec_total(rchild);
-			((RINTERNAL *)dest)->pgno = rchild->pgno;
+			((RINTERNAL *)(void *)dest)->nrecs = rec_total(rchild);
+			((RINTERNAL *)(void *)dest)->pgno = rchild->pgno;
 			break;
 		case P_RLEAF:
 			/*
@@ -279,14 +280,14 @@ __bt_split(t, sp, key, data, flags, ilen, argskip)
 				dest = (char *)h + h->linp[skip - 1];
 			else
 				dest = (char *)l + l->linp[NEXTINDEX(l) - 1];
-			((RINTERNAL *)dest)->nrecs = NEXTINDEX(lchild);
-			((RINTERNAL *)dest)->pgno = lchild->pgno;
+			((RINTERNAL *)(void *)dest)->nrecs = NEXTINDEX(lchild);
+			((RINTERNAL *)(void *)dest)->pgno = lchild->pgno;
 
 			/* Update the right page count. */
 			h->linp[skip] = h->upper -= nbytes;
 			dest = (char *)h + h->linp[skip];
-			((RINTERNAL *)dest)->nrecs = NEXTINDEX(rchild);
-			((RINTERNAL *)dest)->pgno = rchild->pgno;
+			((RINTERNAL *)(void *)dest)->nrecs = NEXTINDEX(rchild);
+			((RINTERNAL *)(void *)dest)->pgno = rchild->pgno;
 			break;
 		default:
 			abort();
@@ -584,7 +585,7 @@ bt_broot(t, h, l, r)
 		h->linp[1] = h->upper -= nbytes;
 		dest = (char *)h + h->upper;
 		memmove(dest, bi, nbytes);
-		((BINTERNAL *)dest)->pgno = r->pgno;
+		((BINTERNAL *)(void *)dest)->pgno = r->pgno;
 		break;
 	default:
 		abort();

--- a/src/plugins/kdb/db2/libdb2/btree/btree.h
+++ b/src/plugins/kdb/db2/libdb2/btree/btree.h
@@ -128,7 +128,7 @@ typedef struct _binternal {
 
 /* Get the page's BINTERNAL structure at index indx. */
 #define	GETBINTERNAL(pg, indx)						\
-	((BINTERNAL *)((char *)(pg) + (pg)->linp[indx]))
+	((BINTERNAL *)(void *)((char *)(pg) + (pg)->linp[indx]))
 
 /* Get the number of bytes in the entry. */
 #define NBINTERNAL(len)							\
@@ -136,9 +136,9 @@ typedef struct _binternal {
 
 /* Copy a BINTERNAL entry to the page. */
 #define	WR_BINTERNAL(p, size, pgno, flags) {				\
-	*(u_int32_t *)p = size;						\
+	*(u_int32_t *)(void *)p = size;					\
 	p += sizeof(u_int32_t);						\
-	*(db_pgno_t *)p = pgno;						\
+	*(db_pgno_t *)(void *)p = pgno;					\
 	p += sizeof(db_pgno_t);						\
 	*(u_char *)p = flags;						\
 	p += sizeof(u_char);						\
@@ -155,7 +155,7 @@ typedef struct _rinternal {
 
 /* Get the page's RINTERNAL structure at index indx. */
 #define	GETRINTERNAL(pg, indx)						\
-	((RINTERNAL *)((char *)(pg) + (pg)->linp[indx]))
+	((RINTERNAL *)(void *)((char *)(void *)(pg) + (pg)->linp[indx]))
 
 /* Get the number of bytes in the entry. */
 #define NRINTERNAL							\
@@ -163,9 +163,9 @@ typedef struct _rinternal {
 
 /* Copy a RINTERAL entry to the page. */
 #define	WR_RINTERNAL(p, nrecs, pgno) {					\
-	*(recno_t *)p = nrecs;						\
+	*(recno_t *)(void *)p = nrecs;					\
 	p += sizeof(recno_t);						\
-	*(db_pgno_t *)p = pgno;						\
+	*(db_pgno_t *)(void *)p = pgno;					\
 }
 
 /* For the btree leaf pages, the item is a key and data pair. */
@@ -178,7 +178,7 @@ typedef struct _bleaf {
 
 /* Get the page's BLEAF structure at index indx. */
 #define	GETBLEAF(pg, indx)						\
-	((BLEAF *)((char *)(pg) + (pg)->linp[indx]))
+	((BLEAF *)(void *)((char *)(pg) + (pg)->linp[indx]))
 
 /* Get the number of bytes in the entry. */
 #define NBLEAF(p)	NBLEAFDBT((p)->ksize, (p)->dsize)
@@ -190,9 +190,9 @@ typedef struct _bleaf {
 
 /* Copy a BLEAF entry to the page. */
 #define	WR_BLEAF(p, key, data, flags) {					\
-	*(u_int32_t *)p = key->size;					\
+	*(u_int32_t *)(void *)p = key->size;				\
 	p += sizeof(u_int32_t);						\
-	*(u_int32_t *)p = data->size;					\
+	*(u_int32_t *)(void *)p = data->size;				\
 	p += sizeof(u_int32_t);						\
 	*(u_char *)p = flags;						\
 	p += sizeof(u_char);						\
@@ -210,7 +210,7 @@ typedef struct _rleaf {
 
 /* Get the page's RLEAF structure at index indx. */
 #define	GETRLEAF(pg, indx)						\
-	((RLEAF *)((char *)(pg) + (pg)->linp[indx]))
+	((RLEAF *)(void *)((char *)(pg) + (pg)->linp[indx]))
 
 /* Get the number of bytes in the entry. */
 #define NRLEAF(p)	NRLEAFDBT((p)->dsize)
@@ -221,7 +221,7 @@ typedef struct _rleaf {
 
 /* Copy a RLEAF entry to the page. */
 #define	WR_RLEAF(p, data, flags) {					\
-	*(u_int32_t *)p = data->size;					\
+	*(u_int32_t *)(void *)p = data->size;				\
 	p += sizeof(u_int32_t);						\
 	*(u_char *)p = flags;						\
 	p += sizeof(u_char);						\

--- a/src/plugins/kdb/db2/libdb2/hash/hash.c
+++ b/src/plugins/kdb/db2/libdb2/hash/hash.c
@@ -997,7 +997,7 @@ __call_hash(hashp, k, len)
 	int8_t *k;
 	int32_t len;
 {
-	int32_t n, bucket;
+	u_int32_t n, bucket;
 
 	n = hashp->hash(k, len);
 	bucket = n & hashp->hdr.high_mask;

--- a/src/plugins/kdb/db2/libdb2/hash/hash.h
+++ b/src/plugins/kdb/db2/libdb2/hash/hash.h
@@ -67,19 +67,19 @@ typedef struct hashhdr {	/* Disk resident portion */
 	int32_t	magic;		/* Magic NO for hash tables */
 	int32_t	version;	/* Version ID */
 	int32_t	lorder;		/* Byte Order */
-	int32_t	bsize;		/* Bucket/Page Size */
+	u_int32_t	bsize;	/* Bucket/Page Size */
 	int32_t	bshift;		/* Bucket shift */
 	int32_t	ovfl_point;	/* Where overflow pages are being allocated */
-	int32_t	last_freed;	/* Last overflow page freed */
-	int32_t	max_bucket;	/* ID of Maximum bucket in use */
-	int32_t	high_mask;	/* Mask to modulo into entire table */
-	int32_t	low_mask;	/* Mask to modulo into lower half of table */
-	int32_t	ffactor;	/* Fill factor */
+	u_int32_t	last_freed;	/* Last overflow page freed */
+	u_int32_t	max_bucket;	/* ID of Maximum bucket in use */
+	u_int32_t	high_mask;	/* Mask to modulo into entire table */
+	u_int32_t	low_mask;	/* Mask to modulo into lower half of table */
+	u_int32_t	ffactor;	/* Fill factor */
 	int32_t	nkeys;		/* Number of keys in hash table */
-	int32_t	hdrpages;	/* Size of table header */
-	int32_t	h_charkey;	/* value of hash(CHARKEY) */
+	u_int32_t	hdrpages;	/* Size of table header */
+	u_int32_t	h_charkey;	/* value of hash(CHARKEY) */
 #define NCACHED	32		/* number of bit maps and spare points */
-	int32_t	spares[NCACHED];/* spare pages for overflow */
+	u_int32_t	spares[NCACHED];/* spare pages for overflow */
 	u_int16_t	bitmaps[NCACHED];	/* address of overflow page bitmaps */
 } HASHHDR;
 
@@ -174,7 +174,7 @@ typedef struct item_info {
 	indx_t		ndx;
 	indx_t		pgndx;
 	u_int8_t	status;
-	int32_t		seek_size;
+	u_int32_t	seek_size;
 	db_pgno_t		seek_found_page;
 	indx_t		key_off;
 	indx_t		data_off;

--- a/src/plugins/kdb/db2/libdb2/hash/hash_page.c
+++ b/src/plugins/kdb/db2/libdb2/hash/hash_page.c
@@ -231,7 +231,7 @@ putpair(p, key, val)
 {
 	u_int16_t *pagep, n, off;
 
-	pagep = (PAGE16 *)p;
+	pagep = (PAGE16 *)(void *)p;
 
 	/* Items on the page are 0-indexed. */
 	n = NUM_ENT(pagep);
@@ -888,7 +888,7 @@ __pgin_routine(pg_cookie, pgno, page)
 	if (is_bitmap_pgno(hashp, pgno)) {
 		max = hashp->hdr.bsize >> 2;	/* divide by 4 bytes */
 		for (i = 0; i < max; i++)
-			M_32_SWAP(((int32_t *)pagep)[i]);
+			M_32_SWAP(((int32_t *)(void *)pagep)[i]);
 	} else
 		swap_page_header_in(pagep);
 }
@@ -919,7 +919,7 @@ __pgout_routine(pg_cookie, pgno, page)
 	if (is_bitmap_pgno(hashp, pgno)) {
 		max = hashp->hdr.bsize >> 2;	/* divide by 4 bytes */
 		for (i = 0; i < max; i++)
-			M_32_SWAP(((int32_t *)pagep)[i]);
+			M_32_SWAP(((int32_t *)(void *)pagep)[i]);
 	} else
 		swap_page_header_out(pagep);
 }
@@ -1037,7 +1037,7 @@ __ibitmap(hashp, pnum, nbits, ndx)
 	/* make a new bitmap page */
 	if (__new_page(hashp, pnum, A_BITMAP) != 0)
 		return (1);
-	if (!(ip = (u_int32_t *)__get_page(hashp, pnum, A_BITMAP)))
+	if (!(ip = (u_int32_t *)(void *)__get_page(hashp, pnum, A_BITMAP)))
 		return (1);
 	hashp->nmaps++;
 	clearints = ((nbits - 1) >> INT32_T_BYTE_SHIFT) + 1;
@@ -1074,8 +1074,8 @@ overflow_page(hashp)
 	HTAB *hashp;
 {
 	u_int32_t *freep;
-	int32_t bit, first_page, free_bit, free_page, i, in_use_bits, j;
-	int32_t max_free, offset, splitnum;
+	u_int32_t bit, first_page, free_bit, free_page, i, in_use_bits, j;
+	u_int32_t max_free, offset, splitnum;
 	u_int16_t addr;
 #ifdef DEBUG2
 	int32_t tmp1, tmp2;
@@ -1299,7 +1299,7 @@ __free_ovflpage(hashp, pagep)
 	PAGE16 *pagep;
 {
 	u_int32_t *freep;
-	int32_t bit_address, free_page, free_bit;
+	u_int32_t bit_address, free_page, free_bit;
 	u_int16_t addr, ndx;
 
 	addr = page_to_oaddr(hashp, ADDR(pagep));
@@ -1340,7 +1340,7 @@ fetch_bitmap(hashp, ndx)
 	if (ndx >= hashp->nmaps)
 		return (NULL);
 	if (!hashp->mapp[ndx])
-	    hashp->mapp[ndx] = (u_int32_t *)__get_page(hashp,
+	    hashp->mapp[ndx] = (u_int32_t *)(void *)__get_page(hashp,
 	        hashp->hdr.bitmaps[ndx], A_BITMAP);
 
 	return (hashp->mapp[ndx]);

--- a/src/plugins/kdb/db2/libdb2/hash/page.h
+++ b/src/plugins/kdb/db2/libdb2/hash/page.h
@@ -88,7 +88,7 @@
 #define PAIR_OVERHEAD	((sizeof(indx_t) << 1))
 
 /* Use this macro to extract a value of type T from page P at offset O. */
-#define REFERENCE(P, T, O)  (((T *)((u_int8_t *)(P) + O))[0])
+#define REFERENCE(P, T, O)  (((T *)(void *)((u_int8_t *)(void *)(P) + O))[0])
 
 /*
  * Use these macros to access fields on a page; P is a PAGE16 *.

--- a/src/plugins/kdb/db2/libdb2/mpool/mpool.c
+++ b/src/plugins/kdb/db2/libdb2/mpool/mpool.c
@@ -156,7 +156,7 @@ mpool_delete(mp, page)
 	struct _hqh *head;
 	BKT *bp;
 
-	bp = (BKT *)((char *)page - sizeof(BKT));
+	bp = (void *)((char *)page - sizeof(BKT));
 
 #ifdef DEBUG
 	if (!(bp->flags & MPOOL_PINNED)) {
@@ -237,7 +237,8 @@ mpool_get(mp, pgno, flags)
 	if (lseek(mp->fd, off, SEEK_SET) != off)
 		return (NULL);
 
-	if ((nr = read(mp->fd, bp->page, mp->pagesize)) != mp->pagesize) {
+	if ((nr = read(mp->fd, bp->page, mp->pagesize)) !=
+	    (ssize_t)mp->pagesize) {
 		if (nr > 0) {
 			/* A partial read is definitely bad. */
 			errno = EINVAL;
@@ -287,7 +288,7 @@ mpool_put(mp, page, flags)
 #ifdef STATISTICS
 	++mp->pageput;
 #endif
-	bp = (BKT *)((char *)page - sizeof(BKT));
+	bp = (void *)((char *)page - sizeof(BKT));
 #ifdef DEBUG
 	if (!(bp->flags & MPOOL_PINNED)) {
 		(void)fprintf(stderr,
@@ -429,7 +430,8 @@ mpool_write(mp, bp)
 	}
 	if (lseek(mp->fd, off, SEEK_SET) != off)
 		return (RET_ERROR);
-	if (write(mp->fd, bp->page, mp->pagesize) != mp->pagesize)
+	if (write(mp->fd, bp->page, mp->pagesize) !=
+	    (ssize_t)mp->pagesize)
 		return (RET_ERROR);
 
 	/*

--- a/src/plugins/kdb/db2/libdb2/recno/rec_close.c
+++ b/src/plugins/kdb/db2/libdb2/recno/rec_close.c
@@ -155,7 +155,8 @@ __rec_sync(dbp, flags)
 		 */
 		status = (dbp->seq)(dbp, &key, &data, R_FIRST);
 		while (status == RET_SUCCESS) {
-			if (write(t->bt_rfd, data.data, data.size) != data.size)
+			if (write(t->bt_rfd, data.data, data.size) !=
+			    (ssize_t)data.size)
 				return (RET_ERROR);
 			status = (dbp->seq)(dbp, &key, &data, R_NEXT);
 		}
@@ -167,7 +168,7 @@ __rec_sync(dbp, flags)
 		while (status == RET_SUCCESS) {
 			iov[0].iov_base = data.data;
 			iov[0].iov_len = data.size;
-			if (writev(t->bt_rfd, iov, 2) != data.size + 1)
+			if (writev(t->bt_rfd, iov, 2) != (ssize_t)data.size + 1)
 				return (RET_ERROR);
 			status = (dbp->seq)(dbp, &key, &data, R_NEXT);
 		}

--- a/src/plugins/kdb/db2/libdb2/recno/rec_put.c
+++ b/src/plugins/kdb/db2/libdb2/recno/rec_put.c
@@ -213,8 +213,8 @@ __rec_iput(t, nrec, data, flags)
 			return (RET_ERROR);
 		tdata.data = db;
 		tdata.size = NOVFLSIZE;
-		*(db_pgno_t *)db = pg;
-		*(u_int32_t *)(db + sizeof(db_pgno_t)) = data->size;
+		memcpy(db, &pg, sizeof(pg));
+		*(u_int32_t *)(void *)(db + sizeof(db_pgno_t)) = data->size;
 		dflags = P_BIGDATA;
 		data = &tdata;
 	} else
@@ -256,7 +256,8 @@ __rec_iput(t, nrec, data, flags)
 	 * the offset array, shift the pointers up.
 	 */
 	nbytes = NRLEAFDBT(data->size);
-	if (h->upper - h->lower < nbytes + sizeof(indx_t)) {
+	if ((u_int32_t)h->upper - (u_int32_t)h->lower
+	    < nbytes + sizeof(indx_t)) {
 		status = __bt_split(t, h, NULL, data, dflags, nbytes, idx);
 		if (status == RET_SUCCESS)
 			++t->bt_nrecs;

--- a/src/plugins/kdb/db2/libdb2/test/run.test
+++ b/src/plugins/kdb/db2/libdb2/test/run.test
@@ -36,7 +36,7 @@ main()
 	find $bindir -type f -exec test -r {} \; -print | head -100 > $BINFILES
 
 	if [ $# -eq 0 ]; then
-		for t in 1 2 3 4 5 6 7 8 9 10 11 12 13 20 40 41 50 60 61 62; do
+		for t in 1 2 3 4 5 6 7 8 9 10 11 12 13 20 40 41 50 60 61 62 63; do
 			test$t
 		done
 	else
@@ -47,7 +47,7 @@ main()
 			[0-9]*)
 				test$1;;
 			btree)
-				for t in 1 2 3 7 8 9 10 12 13 40 41 50 60 61 62; do
+				for t in 1 2 3 7 8 9 10 12 13 40 41 50 60 61 62 63; do
 					test$t
 				done;;
 			hash)
@@ -1007,6 +1007,28 @@ test62 () {
 			exit 1
 		fi
 	done
+}
+
+test63 () {
+	echo "Test 63: btree: big key, medium data, bt_split unaligned access"
+	# 488 = 512 - 20 (header) - 3 ("foo") - 1 (newline)
+	# 223 = 232 - 8 (key pointer)
+	# 232 = bt_ovflsize = (512 - 20 (header)) / 2 (DEFMINKEYPAGE)
+	#	- (2 (indx_t) + 12 (NBLEAFDBT(0,0)))
+	awk 'BEGIN {
+		s = "";
+		for (i = 0; i < 488; i++) {
+			s = s "x";
+		}
+		d = "";
+		for (i = 0; i < 223; i++) {
+			d = d "x";
+		}
+		for (i = 0; i < 128; i++) {
+			printf("p\nk%s%03d\nd%s\n", s, i, d);
+		}
+	}' /dev/null > $TMP2
+	$PROG -o $TMP3 -i psize=512 btree $TMP2
 }
 
 main $*


### PR DESCRIPTION
Clean up many pointer alignment warnings by casting through (void *).

Clean up many signed-unsigned comparison warnings by casting to
unsigned types as appropriate.