### PR TITLE
Fix thread support for Solaris and simplify

### DIFF
--- a/src/include/k5-thread.h
+++ b/src/include/k5-thread.h
@@ -243,14 +243,10 @@ typedef k5_os_nothread_mutex k5_os_mutex;
    symbol tables of the current process.  */
 
 #if defined(HAVE_PRAGMA_WEAK_REF) && !defined(NO_WEAK_PTHREADS)
-# pragma weak pthread_once
-# pragma weak pthread_mutex_lock
-# pragma weak pthread_mutex_unlock
-# pragma weak pthread_mutex_destroy
-# pragma weak pthread_mutex_init
-# pragma weak pthread_self
-# pragma weak pthread_equal
-# define USE_PTHREAD_LOCK_ONLY_IF_LOADED
+# define USE_CONDITIONAL_PTHREADS
+#endif
+
+#ifdef USE_CONDITIONAL_PTHREADS
 
 /* Can't rely on useful stubs -- see above regarding Solaris.  */
 typedef struct {
@@ -284,9 +280,8 @@ typedef pthread_mutex_t k5_os_mutex;
 # define K5_OS_MUTEX_PARTIAL_INITIALIZER        \
     PTHREAD_MUTEX_INITIALIZER
 
-#ifdef USE_PTHREAD_LOCK_ONLY_IF_LOADED
+#ifdef USE_CONDITIONAL_PTHREADS
 
-# define USE_PTHREAD_LOADED_MUTEX_FUNCTIONS
 # define k5_os_mutex_finish_init(M)             (0)
 int k5_os_mutex_init(k5_os_mutex *m);
 int k5_os_mutex_destroy(k5_os_mutex *m);


### PR DESCRIPTION
threads.c failed to build on Solaris afer commit
17932091cc0d5981c5a78d389ffa4a5c7b532bd6 because k5-thread.h did not
define the conditional k5_once_t structure (because NO_WEAK_PTHREADS
is defined) but threads.c tried to build the conditional k5_once()
function.

Use a single preprocessor symbol, USE_CONDITIONAL_PTHREADS, to
determine whether to use and define pthreads functions which
conditionalize on whether pthreads is loaded.  In threads.c, move the
new k5_once() definitions into the USE_CONDITIONAL_PTHREADS block,
defining a stub function if other code will not refer to it.

Also move #pragma weak declarations from k5-threads.h into threads.c,
as we should no longer be conditionally referring to those symbols
outside of threads.c.

Also eliminate some missing-prototype warnings where we define
functions for linker-visibility but don't have corresponding
prototypes in k5-threads.h.