### PR TITLE
Fix check-pytests-no

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -498,6 +498,7 @@ check-unix:
 
 check-pytests-no: check-postrecurse
 	@echo 'Skipped python test scripts: python 2.5 or later required' >> \
+		$(SKIPTESTS)
 
 check-cmocka-no: check-postrecurse
 	@echo 'Skipped cmocka tests due to missing library or header file' >> \


### PR DESCRIPTION
Commit 0db097ba8b605ea7a6e0364ad786da6528868179 accidentally removed
the $(SKIPTESTS) line from check-pytests-no, causing a syntax error
when running "make check" when python is missing or not sufficiently
new.