### PR TITLE
Stop generating doc/CHANGES

### DIFF
--- a/src/util/mkrel
+++ b/src/util/mkrel
@@ -136,9 +136,6 @@ if test $newstyle = t; then
 		sed -e '/#[a-z 	]*KRB5_RELDATE/c\
 #define KRB5_RELDATE "'"$reldate"'"' patchlevel.h > patchlevel.h.new && \
 		mv patchlevel.h.new patchlevel.h)
-	if test $checkout = t; then
-		(cd $reldir && git log --stat $reltag > doc/CHANGES)
-	fi
 else
 
 	(cd $reldir/src/lib/krb5/krb && \


### PR DESCRIPTION
Shipping a 10MB+ doc/CHANGES file in the release tarball doesn't make
much sense in a modern context where historical information is readily
available in a distributed version control system.

ticket: 8488 (new)