### PR TITLE
Fix kadmin test scripts buildsystem on FreeBSD

### DIFF
--- a/src/build-tools/Makefile.in
+++ b/src/build-tools/Makefile.in
@@ -14,7 +14,7 @@ PKGCONFIG_FILES = \
 all-unix: krb5-config $(PKGCONFIG_FILES)
 
 krb5-config $(PKGCONFIG_FILES): $(BUILDTOP)/config.status
-	cd $(BUILDTOP) && $(SHELL) config.status $(mydir)/$@
+	(cd $(BUILDTOP) && $(SHELL) config.status $(mydir)/$@)
 krb5-config: $(srcdir)/krb5-config.in
 kadm-client.pc: $(srcdir)/kadm-client.pc.in
 kadm-server.pc: $(srcdir)/kadm-server.pc.in

--- a/src/doc/Makefile.in
+++ b/src/doc/Makefile.in
@@ -93,8 +93,8 @@ pdf: $(PDFDIR)
 composite: Doxyfile $(docsrc)/version.py
 	rm -rf doxy rst_apiref rst_composite
 	$(DOXYGEN)
-	cwd=`pwd`; cd $(docsrc)/tools && \
-		$(PYTHON) doxy.py -i $$cwd/doxy/xml -o $$cwd/rst_apiref
+	(cwd=`pwd`; cd $(docsrc)/tools && \
+		$(PYTHON) doxy.py -i $$cwd/doxy/xml -o $$cwd/rst_apiref)
 	mkdir -p rst_composite
 	do_subdirs="$(RST_SOURCES)" ; \
 	for i in $$do_subdirs; do \

--- a/src/include/Makefile.in
+++ b/src/include/Makefile.in
@@ -34,7 +34,7 @@ all-unix: @MAINT@ verify-calling-conventions-krb5
 
 $(srcdir)/autoconf.h.in: @MAINT@ $(srcdir)/autoconf.stmp
 $(srcdir)/autoconf.stmp: $(top_srcdir)/configure.in $(top_srcdir)/aclocal.m4
-	cd $(top_srcdir) && $(AUTOHEADER) --include=$(CONFIG_RELTOPDIR) $(AUTOHEADERFLAGS)
+	(cd $(top_srcdir) && $(AUTOHEADER) --include=$(CONFIG_RELTOPDIR) $(AUTOHEADERFLAGS))
 	touch $(srcdir)/autoconf.stmp
 
 ##DOS##autoconf.h: win-mac.h

--- a/src/kadmin/testing/scripts/Makefile.in
+++ b/src/kadmin/testing/scripts/Makefile.in
@@ -14,9 +14,9 @@ all: env-setup.sh $(GEN_SCRIPTS)
 env-setup.sh: env-setup.stamp
 env-setup.stamp: $(srcdir)/env-setup.shin $(BUILDTOP)/config.status \
 		Makefile 
-	cd $(BUILDTOP) && \
+	(cd $(BUILDTOP) && \
 		CONFIG_FILES=$(mydir)/env-setup.sh:$(mydir)/env-setup.shin $(SHELL) \
-		config.status
+		config.status)
 	chmod +x env-setup.sh
 	touch env-setup.stamp
 

--- a/src/lib/rpc/Makefile.in
+++ b/src/lib/rpc/Makefile.in
@@ -221,7 +221,7 @@ do-dyn-lclint:
 
 $(BUILDTOP)/include/gssrpc/types.h: types.stamp
 types.stamp: $(top_srcdir)/include/gssrpc/types.hin $(BUILDTOP)/config.status
-	cd $(BUILDTOP) && $(SHELL) config.status include/gssrpc/types.h
+	(cd $(BUILDTOP) && $(SHELL) config.status include/gssrpc/types.h)
 	touch types.stamp
 
 clean-unix::


### PR DESCRIPTION
We depend on the behavior of having a separate subshell for each line,
so force it where make (on FreeBSD 10.3) does not create one.