### PR TITLE
Add a krb5_rd_req() function returing the decryption key

### DIFF
--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -2179,7 +2179,8 @@ void KRB5_CALLCONV krb5_free_config_files(char **filenames);
 
 krb5_error_code krb5_rd_req_decoded(krb5_context, krb5_auth_context *,
                                     const krb5_ap_req *, krb5_const_principal,
-                                    krb5_keytab, krb5_flags *, krb5_ticket **);
+                                    krb5_keytab, krb5_flags *, krb5_ticket **,
+                                    krb5_keyblock **);
 
 krb5_error_code krb5_rd_req_decoded_anyflag(krb5_context, krb5_auth_context *,
                                             const krb5_ap_req *,

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -2185,7 +2185,8 @@ krb5_error_code krb5_rd_req_decoded(krb5_context, krb5_auth_context *,
 krb5_error_code krb5_rd_req_decoded_anyflag(krb5_context, krb5_auth_context *,
                                             const krb5_ap_req *,
                                             krb5_const_principal, krb5_keytab,
-                                            krb5_flags *, krb5_ticket **);
+                                            krb5_flags *, krb5_ticket **,
+                                            krb5_keyblock **);
 
 krb5_error_code KRB5_CALLCONV
 krb5_cc_register(krb5_context, const krb5_cc_ops *, krb5_boolean );

--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -5224,6 +5224,71 @@ krb5_get_in_tkt_with_keytab(krb5_context context, krb5_flags options,
  * @param [in]     keytab         Key table, or NULL to use the default
  * @param [out]    ap_req_options If non-null, the AP-REQ flags on output
  * @param [out]    ticket         If non-null, ticket from the AP-REQ message
+ * @param [out]    keyblock       If non-null, the key used to decrypt the
+ *                                ticket
+ *
+ * This function parses, decrypts and verifies a AP-REQ message from @a inbuf
+ * and stores the authenticator in @a auth_context.
+ *
+ * If a keyblock was specified in @a auth_context using
+ * krb5_auth_con_setuseruserkey(), that key is used to decrypt the ticket in
+ * AP-REQ message and @a keytab is ignored.  In this case, @a server should be
+ * specified as a complete principal name to allow for proper transited-path
+ * checking and replay cache selection.
+ *
+ * Otherwise, the decryption key is obtained from @a keytab, or from the
+ * default keytab if it is NULL.  In this case, @a server may be a complete
+ * principal name, a matching principal (see krb5_sname_match()), or NULL to
+ * match any principal name.  The keys tried against the encrypted part of the
+ * ticket are determined as follows:
+ *
+ * - If @a server is a complete principal name, then its entry in @a keytab is
+ *   tried.
+ * - Otherwise, if @a keytab is iterable, then all entries in @a keytab which
+ *   match @a server are tried.
+ * - Otherwise, the server principal in the ticket must match @a server, and
+ *   its entry in @a keytab is tried.
+ *
+ * The client specified in the decrypted authenticator must match the client
+ * specified in the decrypted ticket.
+ *
+ * If the @a remote_addr field of @a auth_context is set, the request must come
+ * from that address.
+ *
+ * If a replay cache handle is provided in the @a auth_context, the
+ * authenticator and ticket are verified against it.  If no conflict is found,
+ * the new authenticator is then stored in the replay cache of @a auth_context.
+ *
+ * Various other checks are performed on the decoded data, including
+ * cross-realm policy, clockskew, and ticket validation times.
+ *
+ * On success the authenticator, subkey, and remote sequence number of the
+ * request are stored in @a auth_context. If the #AP_OPTS_MUTUAL_REQUIRED
+ * bit is set, the local sequence number is XORed with the remote sequence
+ * number in the request.
+ *
+ * Use krb5_free_ticket() to free @a ticket when it is no longer needed.
+ * Use krb5_free_keyblock() to free @a keyblock when it is no longer needed.
+ *
+ * @retval 0 Success; otherwise - Kerberos error codes
+ */
+krb5_error_code KRB5_CALLCONV
+krb5_rd_req_key(krb5_context context, krb5_auth_context *auth_context,
+                const krb5_data *inbuf, krb5_const_principal server,
+                krb5_keytab keytab, krb5_flags *ap_req_options,
+                krb5_ticket **ticket, krb5_keyblock **keyblock);
+
+/**
+ * Parse and decrypt a @c KRB_AP_REQ message.
+ *
+ * @param [in]     context        Library context
+ * @param [in,out] auth_context   Pre-existing or newly created auth context
+ * @param [in]     inbuf          AP-REQ message to be parsed
+ * @param [in]     server         Matching principal for server, or NULL to
+ *                                allow any principal in keytab
+ * @param [in]     keytab         Key table, or NULL to use the default
+ * @param [out]    ap_req_options If non-null, the AP-REQ flags on output
+ * @param [out]    ticket         If non-null, ticket from the AP-REQ message
  *
  * This function parses, decrypts and verifies a AP-REQ message from @a inbuf
  * and stores the authenticator in @a auth_context.

--- a/src/kdc/kdc_util.c
+++ b/src/kdc/kdc_util.c
@@ -420,7 +420,7 @@ kdc_rd_ap_req(kdc_realm_t *kdc_active_realm,
         retval = krb5_rd_req_decoded_anyflag(kdc_context, &auth_context, apreq,
                                              apreq->ticket->server,
                                              kdc_active_realm->realm_keytab,
-                                             NULL, NULL);
+                                             NULL, NULL, NULL);
 
         /* If the ticket was decrypted, don't try any more keys. */
         if (apreq->ticket->enc_part2 != NULL)

--- a/src/lib/gssapi/krb5/accept_sec_context.c
+++ b/src/lib/gssapi/krb5/accept_sec_context.c
@@ -640,7 +640,7 @@ kg_accept_krb5(minor_status, context_handle,
     }
 
     code = krb5_rd_req_decoded(context, &auth_context, request, accprinc,
-                               cred->keytab, &ap_req_options, NULL);
+                               cred->keytab, &ap_req_options, NULL, NULL);
 
     krb5_free_principal(context, accprinc);
     if (code) {

--- a/src/lib/krb5/krb/rd_req.c
+++ b/src/lib/krb5/krb/rd_req.c
@@ -36,10 +36,10 @@
  */
 
 krb5_error_code KRB5_CALLCONV
-krb5_rd_req(krb5_context context, krb5_auth_context *auth_context,
-            const krb5_data *inbuf, krb5_const_principal server,
-            krb5_keytab keytab, krb5_flags *ap_req_options,
-            krb5_ticket **ticket)
+krb5_rd_req_key(krb5_context context, krb5_auth_context *auth_context,
+                const krb5_data *inbuf, krb5_const_principal server,
+                krb5_keytab keytab, krb5_flags *ap_req_options,
+                krb5_ticket **ticket, krb5_keyblock **keyblock)
 {
     krb5_error_code       retval;
     krb5_ap_req         * request;
@@ -78,7 +78,7 @@ krb5_rd_req(krb5_context context, krb5_auth_context *auth_context,
 #endif /* LEAN_CLIENT */
 
     retval = krb5_rd_req_decoded(context, auth_context, request, server,
-                                 keytab, ap_req_options, NULL, NULL);
+                                 keytab, ap_req_options, NULL, keyblock);
     if (!retval && ticket != NULL) {
         /* Steal the ticket pointer for the caller. */
         *ticket = request->ticket;
@@ -99,4 +99,14 @@ cleanup_auth_context:
 cleanup_request:
     krb5_free_ap_req(context, request);
     return retval;
+}
+
+krb5_error_code KRB5_CALLCONV
+krb5_rd_req(krb5_context context, krb5_auth_context *auth_context,
+            const krb5_data *inbuf, krb5_const_principal server,
+            krb5_keytab keytab, krb5_flags *ap_req_options,
+            krb5_ticket **ticket)
+{
+    return krb5_rd_req_key(context, auth_context, inbuf, server,
+                           keytab, ap_req_options, ticket, NULL);
 }

--- a/src/lib/krb5/krb/rd_req.c
+++ b/src/lib/krb5/krb/rd_req.c
@@ -32,13 +32,6 @@
  *
  *  server specifies the expected server's name for the ticket.
  *
- *  keyproc specifies a procedure to generate a decryption key for the
- *  ticket.  If keyproc is non-NULL, keyprocarg is passed to it, and the result
- *  used as a decryption key. If keyproc is NULL, then fetchfrom is checked;
- *  if it is non-NULL, it specifies a parameter name from which to retrieve the
- *  decryption key.  If fetchfrom is NULL, then the default key store is
- *  consulted.
- *
  *  returns system errors, encryption errors, replay errors
  */
 

--- a/src/lib/krb5/krb/rd_req.c
+++ b/src/lib/krb5/krb/rd_req.c
@@ -78,7 +78,7 @@ krb5_rd_req(krb5_context context, krb5_auth_context *auth_context,
 #endif /* LEAN_CLIENT */
 
     retval = krb5_rd_req_decoded(context, auth_context, request, server,
-                                 keytab, ap_req_options, NULL);
+                                 keytab, ap_req_options, NULL, NULL);
     if (!retval && ticket != NULL) {
         /* Steal the ticket pointer for the caller. */
         *ticket = request->ticket;

--- a/src/lib/krb5/krb/rd_req_dec.c
+++ b/src/lib/krb5/krb/rd_req_dec.c
@@ -55,13 +55,6 @@
  *  rcache specifies a replay detection cache used to store authenticators and
  *  server names
  *
- *  keyproc specifies a procedure to generate a decryption key for the
- *  ticket.  If keyproc is non-NULL, keyprocarg is passed to it, and the result
- *  used as a decryption key. If keyproc is NULL, then fetchfrom is checked;
- *  if it is non-NULL, it specifies a parameter name from which to retrieve the
- *  decryption key.  If fetchfrom is NULL, then the default key store is
- *  consulted.
- *
  *  authdat is set to point at allocated storage structures; the caller
  *  should free them when finished.
  *

--- a/src/lib/krb5/krb/rd_req_dec.c
+++ b/src/lib/krb5/krb/rd_req_dec.c
@@ -820,14 +820,15 @@ krb5_rd_req_decoded_anyflag(krb5_context context,
                             krb5_auth_context *auth_context,
                             const krb5_ap_req *req,
                             krb5_const_principal server, krb5_keytab keytab,
-                            krb5_flags *ap_req_options, krb5_ticket **ticket)
+                            krb5_flags *ap_req_options, krb5_ticket **ticket,
+                            krb5_keyblock **keyblock)
 {
     krb5_error_code retval;
     retval = rd_req_decoded_opt(context, auth_context,
                                 req, server, keytab,
                                 ap_req_options, ticket,
                                 0, /* don't check_valid_flag */
-                                NULL); /* keyblock */
+                                keyblock); /* keyblock */
     return retval;
 }
 

--- a/src/lib/krb5/krb/rd_req_dec.c
+++ b/src/lib/krb5/krb/rd_req_dec.c
@@ -469,7 +469,8 @@ static krb5_error_code
 rd_req_decoded_opt(krb5_context context, krb5_auth_context *auth_context,
                    const krb5_ap_req *req, krb5_const_principal server,
                    krb5_keytab keytab, krb5_flags *ap_req_options,
-                   krb5_ticket **ticket, int check_valid_flag)
+                   krb5_ticket **ticket, int check_valid_flag,
+                   krb5_keyblock **keyblock)
 {
     krb5_error_code       retval = 0;
     krb5_enctype         *desired_etypes = NULL;
@@ -775,6 +776,14 @@ rd_req_decoded_opt(krb5_context context, krb5_auth_context *auth_context,
     if (ticket)
         if ((retval = krb5_copy_ticket(context, req->ticket, ticket)))
             goto cleanup;
+    if (keyblock != NULL) {
+        retval = krb5_copy_keyblock(context,
+                                    &decrypt_key,
+                                    keyblock);
+        if (retval != 0) {
+            goto cleanup;
+        }
+    }
     if (ap_req_options) {
         *ap_req_options = req->ap_options & AP_OPTS_WIRE_MASK;
         if (rfc4537_etypes_len != 0)
@@ -808,7 +817,8 @@ krb5_rd_req_decoded(krb5_context context, krb5_auth_context *auth_context,
     retval = rd_req_decoded_opt(context, auth_context,
                                 req, server, keytab,
                                 ap_req_options, ticket,
-                                1); /* check_valid_flag */
+                                1, /* check_valid_flag */
+                                NULL); /* keyblock */
     return retval;
 }
 
@@ -823,7 +833,8 @@ krb5_rd_req_decoded_anyflag(krb5_context context,
     retval = rd_req_decoded_opt(context, auth_context,
                                 req, server, keytab,
                                 ap_req_options, ticket,
-                                0); /* don't check_valid_flag */
+                                0, /* don't check_valid_flag */
+                                NULL); /* keyblock */
     return retval;
 }
 

--- a/src/lib/krb5/krb/rd_req_dec.c
+++ b/src/lib/krb5/krb/rd_req_dec.c
@@ -804,14 +804,14 @@ krb5_error_code
 krb5_rd_req_decoded(krb5_context context, krb5_auth_context *auth_context,
                     const krb5_ap_req *req, krb5_const_principal server,
                     krb5_keytab keytab, krb5_flags *ap_req_options,
-                    krb5_ticket **ticket)
+                    krb5_ticket **ticket, krb5_keyblock **keyblock)
 {
     krb5_error_code retval;
     retval = rd_req_decoded_opt(context, auth_context,
                                 req, server, keytab,
                                 ap_req_options, ticket,
                                 1, /* check_valid_flag */
-                                NULL); /* keyblock */
+                                keyblock); /* keyblock */
     return retval;
 }
 

--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -537,6 +537,7 @@ krb5_rd_priv
 krb5_rd_rep
 krb5_rd_rep_dce
 krb5_rd_req
+krb5_rd_req_key
 krb5_rd_req_decoded
 krb5_rd_req_decoded_anyflag
 krb5_rd_safe

--- a/src/lib/krb5_32.def
+++ b/src/lib/krb5_32.def
@@ -470,3 +470,4 @@ EXPORTS
 	krb5_get_init_creds_opt_set_pac_request		@435
 	krb5int_trace					@436 ; PRIVATE GSSAPI
 	krb5_expand_hostname				@437
+	krb5_rd_req_key					@438


### PR DESCRIPTION
I've implemented a kpasswd service in Samba. The reason is that we need ACL checking against Samba database (DSDB).

For this we have an krb5 implementation to decrypt the tickets. To get the authenticated session info, we get the ticket parse the PAC and verify the PAC signature. For the validation of the PAC signature I need the key we used to decrypt the ticket. So I added a new function called krb5_rd_req_key() which adds an out pointer to store the allocated keyblock.

As I'm still a total KRB5 newbie, I'm not sure if this is the right way to get it, but it was the only I found.