### PR TITLE
Make krb5_kt_register and krb5_kt_kdb_ops public

### DIFF
--- a/src/clients/kinit/kinit_kdb.c
+++ b/src/clients/kinit/kinit_kdb.c
@@ -33,7 +33,7 @@
 
 #include <k5-int.h>
 #include <kadm5/admin.h>
-#include <kdb_kt.h>
+#include <kdb.h>
 #include "extern.h"
 
 /** Server handle */
@@ -66,7 +66,7 @@ kinit_kdb_init(krb5_context *pcontext, char *realm)
                         &server_handle);
     if (retval)
         return retval;
-    retval = krb5_kt_register(*pcontext, &krb5_kt_kdb_ops);
+    retval = krb5_db_register_keytab(*pcontext);
     return retval;
 }
 

--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -358,6 +358,22 @@ extern char *krb5_mkey_pwd_prompt2;
 #define KRB5_DB_LOCKMODE_PERMANENT    0x0008
 
 /* libkdb.spec */
+
+/**
+ * @brief Register the KDB key table.
+ *
+ * This allows 'KDB:' to be used as the the keytab name.
+ *
+ * @param[in]  context  The libary context
+ *
+ * @retval
+ * 0 Success
+ *
+ * @return
+ * Kerberos error codes
+ */
+krb5_error_code krb5_db_register_keytab(krb5_context context);
+
 krb5_error_code krb5_db_setup_lib_handle(krb5_context kcontext);
 krb5_error_code krb5_db_open( krb5_context kcontext, char **db_args, int mode );
 krb5_error_code krb5_db_init  ( krb5_context kcontext );

--- a/src/kadmin/server/ovsec_kadmd.c
+++ b/src/kadmin/server/ovsec_kadmd.c
@@ -187,7 +187,7 @@ setup_kdb_keytab()
     ret = krb5_ktkdb_set_context(context);
     if (ret)
         return ret;
-    ret = krb5_kt_register(context, &krb5_kt_kdb_ops);
+    ret = krb5_db_register_keytab(context);
     if (ret)
         return ret;
     return krb5_gss_register_acceptor_identity("KDB:");

--- a/src/lib/kdb/keytab.c
+++ b/src/lib/kdb/keytab.c
@@ -66,6 +66,12 @@ typedef struct krb5_ktkdb_data {
 } krb5_ktkdb_data;
 
 krb5_error_code
+krb5_db_register_keytab(krb5_context context)
+{
+	return krb5_kt_register(context, &krb5_kt_kdb_ops);
+}
+
+krb5_error_code
 krb5_ktkdb_resolve(context, name, id)
     krb5_context          context;
     const char          * name;

--- a/src/lib/kdb/libkdb5.exports
+++ b/src/lib/kdb/libkdb5.exports
@@ -87,6 +87,7 @@ krb5_db_delete_policy
 krb5_db_free_policy
 krb5_def_store_mkey_list
 krb5_db_promote
+krb5_db_register_keytab
 ulog_add_update
 ulog_init_header
 ulog_map


### PR DESCRIPTION
In Samba I've implemented a kpasswd service because we need to do ACL checking for incoming kpasswd requests. For the decryption of the packet I need the decryption key from the keytab. We have implemented a KDB module for samba. I'm able to load everything with kadm5_init() from kadm5srv_mit but then I need to register the KDB key table operations that I can use 'KDB:' as the keytable name. This way the samba KDB module for the realm which kadm5_init() set gets loaded.