### PR TITLE
Remove meaningless checks decoding DB2 principals

### DIFF
--- a/src/plugins/kdb/db2/kdb_xdr.c
+++ b/src/plugins/kdb/db2/kdb_xdr.c
@@ -364,8 +364,7 @@ krb5_decode_princ_entry(krb5_context context, krb5_data *content,
         krb5_kdb_decode_int16(nextloc, (*tl_data)->tl_data_length);
         nextloc += 2;
 
-        if ((*tl_data)->tl_data_length < 0 ||
-            (*tl_data)->tl_data_length > sizeleft) {
+        if ((*tl_data)->tl_data_length > sizeleft) {
             retval = KRB5_KDB_TRUNCATED_RECORD;
             goto error_out;
         }
@@ -414,8 +413,7 @@ krb5_decode_princ_entry(krb5_context context, krb5_data *content,
                 krb5_kdb_decode_int16(nextloc, key_data->key_data_length[j]);
                 nextloc += 2;
 
-                if (key_data->key_data_length[j] < 0 ||
-                    key_data->key_data_length[j] > sizeleft) {
+                if (key_data->key_data_length[j] > sizeleft) {
                     retval = KRB5_KDB_TRUNCATED_RECORD;
                     goto error_out;
                 }


### PR DESCRIPTION
Commit e3d9f03a658e247dbb43cb345aa93a28782fd995 (ticket 8481) added
several checks for negative length values when decoding DB2 principal
entries, including two unnecessary checks on unsigned values.  Remove
those checks as they can generate warnings.
