### PR TITLE
Fix unaligned accesses in bt_split.c

### DIFF
--- a/src/plugins/kdb/db2/libdb2/btree/bt_split.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_split.c
@@ -245,9 +245,12 @@ __bt_split(t, sp, key, data, flags, ilen, argskip)
 			WR_BINTERNAL(dest, nksize ? nksize : bl->ksize,
 			    rchild->pgno, bl->flags & P_BIGKEY);
 			memmove(dest, bl->bytes, nksize ? nksize : bl->ksize);
-			if (bl->flags & P_BIGKEY &&
-			    bt_preserve(t, *(db_pgno_t *)bl->bytes) == RET_ERROR)
-				goto err1;
+			if (bl->flags & P_BIGKEY) {
+				db_pgno_t pgno;
+				memcpy(&pgno, bl->bytes, sizeof(pgno));
+				if (bt_preserve(t, pgno) == RET_ERROR)
+					goto err1;
+			}
 			break;
 		case P_RINTERNAL:
 			/*
@@ -568,9 +571,12 @@ bt_broot(t, h, l, r)
 		 * If the key is on an overflow page, mark the overflow chain
 		 * so it isn't deleted when the leaf copy of the key is deleted.
 		 */
-		if (bl->flags & P_BIGKEY &&
-		    bt_preserve(t, *(db_pgno_t *)bl->bytes) == RET_ERROR)
-			return (RET_ERROR);
+		if (bl->flags & P_BIGKEY) {
+			db_pgno_t pgno;
+			memcpy(&pgno, bl->bytes, sizeof(pgno));
+			if (bt_preserve(t, pgno) == RET_ERROR)
+				return (RET_ERROR);
+		}
 		break;
 	case P_BINTERNAL:
 		bi = GETBINTERNAL(r, 0);

--- a/src/plugins/kdb/db2/libdb2/test/run.test
+++ b/src/plugins/kdb/db2/libdb2/test/run.test
@@ -36,7 +36,7 @@ main()
 	find $bindir -type f -exec test -r {} \; -print | head -100 > $BINFILES
 
 	if [ $# -eq 0 ]; then
-		for t in 1 2 3 4 5 6 7 8 9 10 11 12 13 20 40 41 50 60 61 62; do
+		for t in 1 2 3 4 5 6 7 8 9 10 11 12 13 20 40 41 50 60 61 62 63; do
 			test$t
 		done
 	else
@@ -47,7 +47,7 @@ main()
 			[0-9]*)
 				test$1;;
 			btree)
-				for t in 1 2 3 7 8 9 10 12 13 40 41 50 60 61 62; do
+				for t in 1 2 3 7 8 9 10 12 13 40 41 50 60 61 62 63; do
 					test$t
 				done;;
 			hash)
@@ -1007,6 +1007,28 @@ test62 () {
 			exit 1
 		fi
 	done
+}
+
+test63 () {
+	echo "Test 63: btree: big key, medium data, bt_split unaligned access"
+	# 488 = 512 - 20 (header) - 3 ("foo") - 1 (newline)
+	# 223 = 232 - 8 (key pointer)
+	# 232 = bt_ovflsize = (512 - 20 (header)) / 2 (DEFMINKEYPAGE)
+	#	- (2 (indx_t) + 12 (NBLEAFDBT(0,0)))
+	awk 'BEGIN {
+		s = "";
+		for (i = 0; i < 488; i++) {
+			s = s "x";
+		}
+		d = "";
+		for (i = 0; i < 223; i++) {
+			d = d "x";
+		}
+		for (i = 0; i < 128; i++) {
+			printf("p\nk%s%03d\nd%s\n", s, i, d);
+		}
+	}' /dev/null > $TMP2
+	$PROG -o $TMP3 -i psize=512 btree $TMP2
 }
 
 main $*


### PR DESCRIPTION
In the libdb2 btree back end, splitting a page at an overflow key
could result in an unaligned access, causing a crash (and data
corruption) on platforms with strict alignment.  This probably occurs
only rarely in practice.

Also includes regression test and debugging improvements.