### PR TITLE
Add getrandom() support

### DIFF
--- a/src/lib/crypto/krb/crypto_int.h
+++ b/src/lib/crypto/krb/crypto_int.h
@@ -510,6 +510,7 @@ void krb5int_crypto_impl_cleanup(void);
  * PRNG modules must implement the following APIs from krb5.h:
  *   krb5_c_random_add_entropy
  *   krb5_c_random_make_octets
+ *   krb5_c_random_os_entropy
  *
  * PRNG modules should implement these functions.  They are called from the
  * crypto library init and cleanup functions, and can be used to setup and tear
@@ -519,7 +520,7 @@ int k5_prng_init(void);
 void k5_prng_cleanup(void);
 
 /* Used by PRNG modules to gather OS entropy.  Returns true on success. */
-krb5_boolean k5_get_os_entropy(unsigned char *buf, size_t len);
+krb5_boolean k5_get_os_entropy(unsigned char *buf, size_t len, int strong);
 
 /*** Inline helper functions ***/
 

--- a/src/lib/crypto/krb/prng.c
+++ b/src/lib/crypto/krb/prng.c
@@ -36,10 +36,12 @@ krb5_c_random_seed(krb5_context context, krb5_data *data)
 #if defined(_WIN32)
 
 krb5_boolean
-k5_get_os_entropy(unsigned char *buf, size_t len)
+k5_get_os_entropy(unsigned char *buf, size_t len, int strong)
 {
     krb5_boolean result;
     HCRYPTPROV provider;
+
+    /* CryptGenRandom is always considered strong. */
 
     if (!CryptAcquireContext(&provider, NULL, NULL, PROV_RSA_FULL,
                              CRYPT_VERIFYCONTEXT))
@@ -47,22 +49,6 @@ k5_get_os_entropy(unsigned char *buf, size_t len)
     result = CryptGenRandom(provider, len, buf);
     (void)CryptReleaseContext(provider, 0);
     return result;
-}
-
-krb5_error_code KRB5_CALLCONV
-krb5_c_random_os_entropy(krb5_context context, int strong, int *success)
-{
-    int oursuccess = 0;
-    char buf[1024];
-    krb5_data data = make_data(buf, sizeof(buf));
-
-    if (k5_get_os_entropy(buf, sizeof(buf)) &&
-        krb5_c_random_add_entropy(context, KRB5_C_RANDSOURCE_OSRAND,
-                                  &data) == 0)
-        oursuccess = 1;
-    if (success != NULL)
-        *success = oursuccess;
-    return 0;
 }
 
 #else /* not Windows */
@@ -107,44 +93,11 @@ cleanup:
 }
 
 krb5_boolean
-k5_get_os_entropy(unsigned char *buf, size_t len)
+k5_get_os_entropy(unsigned char *buf, size_t len, int strong)
 {
+    if (strong != 0)
+        return read_entropy_from_device("/dev/random", buf, len);
     return read_entropy_from_device("/dev/urandom", buf, len);
-}
-
-/* Read entropy from device and contribute it to the PRNG.  Returns true on
- * success. */
-static krb5_boolean
-add_entropy_from_device(krb5_context context, const char *device)
-{
-    krb5_data data;
-    unsigned char buf[64];
-
-    if (!read_entropy_from_device(device, buf, sizeof(buf)))
-        return FALSE;
-    data = make_data(buf, sizeof(buf));
-    return (krb5_c_random_add_entropy(context, KRB5_C_RANDSOURCE_OSRAND,
-                                      &data) == 0);
-}
-
-krb5_error_code KRB5_CALLCONV
-krb5_c_random_os_entropy(krb5_context context, int strong, int *success)
-{
-    int unused;
-    int *oursuccess = (success != NULL) ? success : &unused;
-
-    *oursuccess = 0;
-    /* If we are getting strong data then try that first.  We are
-       guaranteed to cause a reseed of some kind if strong is true and
-       we have both /dev/random and /dev/urandom.  We want the strong
-       data included in the reseed so we get it first.*/
-    if (strong) {
-        if (add_entropy_from_device(context, "/dev/random"))
-            *oursuccess = 1;
-    }
-    if (add_entropy_from_device(context, "/dev/urandom"))
-        *oursuccess = 1;
-    return 0;
 }
 
 #endif /* not Windows */

--- a/src/lib/crypto/krb/prng_device.c
+++ b/src/lib/crypto/krb/prng_device.c
@@ -1,5 +1,5 @@
 /* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
-/* lib/crypto/krb/prng_os.c - OS-native PRNG implementation */
+/* lib/crypto/krb/prng_device.c - OS device-based PRNG implementation */
 /*
  * Copyright (C) 2011 by the Massachusetts Institute of Technology.
  * All rights reserved.

--- a/src/lib/crypto/krb/prng_os.c
+++ b/src/lib/crypto/krb/prng_os.c
@@ -91,3 +91,9 @@ krb5_c_random_make_octets(krb5_context context, krb5_data *outdata)
     }
     return 0;
 }
+
+krb5_error_code KRB5_CALLCONV
+krb5_c_random_os_entropy(krb5_context context, int strong, int *success)
+{
+    return 0;
+}

--- a/src/lib/crypto/krb/prng_os.c
+++ b/src/lib/crypto/krb/prng_os.c
@@ -1,0 +1,73 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* lib/crypto/krb/prng_os.c - OS PRNG implementation */
+/*
+ * Copyright (C) 2016 by the Massachusetts Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file implements a PRNG module which relies on the system's PRNG.  An
+ * OS packager can select this module given sufficient confidence in the
+ * operating system's native PRNG quality.
+ */
+
+#include "crypto_int.h"
+
+int
+k5_prng_init(void)
+{
+    return 0;
+}
+
+void
+k5_prng_cleanup(void)
+{
+}
+
+krb5_error_code KRB5_CALLCONV
+krb5_c_random_add_entropy(krb5_context context, unsigned int randsource,
+                          const krb5_data *indata)
+{
+    return 0;
+}
+
+krb5_error_code KRB5_CALLCONV
+krb5_c_random_make_octets(krb5_context context, krb5_data *outdata)
+{
+    krb5_boolean res;
+
+    res = k5_get_os_entropy((unsigned char *)outdata->data,
+                            (size_t)outdata->length, 0);
+    return (res == FALSE) ? KRB5_CRYPTO_INTERNAL : 0;
+}
+
+krb5_error_code KRB5_CALLCONV
+krb5_c_random_os_entropy(krb5_context context, int strong, int *success)
+{
+    return 0;
+}


### PR DESCRIPTION
- First commit eliminates a codepath where we can Ouroboros urandom.
- Second commit adds support for getrandom() to both OS and Fortuna PRNGs.

One thing I did not do here (but could) is move the urandom socket reuse code from prng_os.c to prng.c so that Fortuna could take advantage of it.  I don't know how much of an advantage this will be in practice.  (Reuse of the /dev/random socket seems over-aggressive.)

I plan to backport this to 1.14, but as it adds features it is probably inappropriate for upstream 1.14-next.