### PR TITLE
Configuration option to increase the TCP/RPC connection limit

### DIFF
--- a/doc/admin/conf_files/kdc_conf.rst
+++ b/doc/admin/conf_files/kdc_conf.rst
@@ -43,7 +43,7 @@ The kdc.conf file may contain the following sections:
 [kdcdefaults]
 ~~~~~~~~~~~~~
 
-With one exception, relations in the [kdcdefaults] section specify
+With two exceptions, relations in the [kdcdefaults] section specify
 default values for realm variables, to be used if the [realms]
 subsection does not contain a relation for the tag.  See the
 :ref:`kdc_realms` section for the definitions of these relations.
@@ -60,6 +60,10 @@ subsection does not contain a relation for the tag.  See the
     Specifies the maximum packet size that can be sent over UDP.  The
     default value is 4096 bytes.
 
+**kdc_tcp_listen_backlog**
+    (Integer.)  Set the size of the listen() queue length for the KDC
+    daemon.  The value may be limited by OS settings.  The default value
+    is 5.
 
 .. _kdc_realms:
 

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -239,6 +239,7 @@ typedef unsigned char   u_char;
 #define KRB5_CONF_KDC_REQ_CHECKSUM_TYPE        "kdc_req_checksum_type"
 #define KRB5_CONF_KDC_TCP_PORTS                "kdc_tcp_ports"
 #define KRB5_CONF_KDC_TCP_LISTEN               "kdc_tcp_listen"
+#define KRB5_CONF_KDC_TCP_LISTEN_BACKLOG       "kdc_tcp_listen_backlog"
 #define KRB5_CONF_KDC_TIMESYNC                 "kdc_timesync"
 #define KRB5_CONF_KEY_STASH_FILE               "key_stash_file"
 #define KRB5_CONF_KPASSWD_LISTEN               "kpasswd_listen"

--- a/src/include/net-server.h
+++ b/src/include/net-server.h
@@ -67,7 +67,8 @@ krb5_error_code loop_add_rpc_service(int default_port, const char *addresses,
                                      void (*dispatchfn)());
 
 krb5_error_code loop_setup_network(verto_ctx *ctx, void *handle,
-                                   const char *progname);
+                                   const char *progname,
+                                   int tcp_listen_backlog);
 krb5_error_code loop_setup_signals(verto_ctx *ctx, void *handle,
                                    void (*reset)());
 void loop_free(verto_ctx *ctx);

--- a/src/include/osconf.hin
+++ b/src/include/osconf.hin
@@ -87,6 +87,7 @@
 
 #define DEFAULT_KDC_UDP_PORTLIST "88"
 #define DEFAULT_KDC_TCP_PORTLIST "88"
+#define DEFAULT_TCP_LISTEN_BACKLOG 5
 
 /*
  * Defaults for the KADM5 admin system.

--- a/src/kadmin/server/ovsec_kadmd.c
+++ b/src/kadmin/server/ovsec_kadmd.c
@@ -175,7 +175,8 @@ setup_loop(int proponly, verto_ctx **ctx_out)
             return ret;
     }
 #endif
-    return loop_setup_network(ctx, global_server_handle, progname);
+    return loop_setup_network(ctx, global_server_handle, progname,
+                              DEFAULT_TCP_LISTEN_BACKLOG);
 }
 
 /* Point GSSAPI at the KDB keytab so we don't need an actual file keytab. */


### PR DESCRIPTION
This adds "kdc_tcp_max_conn" to the kdcdefaults section, and bumps the default limit (which is arbitrary like the original value) .