### PR TITLE
Fix unlikely leak in KDC AS-REQ error path

### DIFF
--- a/src/kdc/do_as_req.c
+++ b/src/kdc/do_as_req.c
@@ -859,7 +859,7 @@ prepare_error_as(struct kdc_request_state *rstate, krb5_kdc_req *request,
 
     retval = krb5_us_timeofday(kdc_context, &errpkt.stime, &errpkt.susec);
     if (retval)
-        return retval;
+        goto cleanup;
     errpkt.error = error;
     errpkt.server = request->server;
     errpkt.client = (error == KDC_ERR_WRONG_REALM) ? canon_client :


### PR DESCRIPTION
In prepare_error_as(), if krb5_us_timeofday() fails and error pa-data
was supplied, the FAST cookie and a shallow copy of the error padata
can be leaked.  Reported by Will Fiveash.
