### PR TITLE
Fix use_dns_uri() type safety

### DIFF
--- a/src/lib/krb5/os/locate_kdc.c
+++ b/src/lib/krb5/os/locate_kdc.c
@@ -75,7 +75,7 @@ static krb5_boolean
 use_dns_uri(krb5_context ctx)
 {
     krb5_error_code ret;
-    krb5_boolean use;
+    int use;
 
     ret = profile_get_boolean(ctx->profile, KRB5_CONF_LIBDEFAULTS,
                               KRB5_CONF_DNS_URI_LOOKUP, NULL,


### PR DESCRIPTION
profile_get_boolean() outputs an int, not a krb5_boolean.  Adjust the
local variable "use" to match, or we get a warning.  Reported by Will
Fiveash.
