### PR TITLE
Error on discarded qualifiers in gcc

### DIFF
--- a/src/aclocal.m4
+++ b/src/aclocal.m4
@@ -526,7 +526,7 @@ if test "$GCC" = yes ; then
     TRY_WARN_CC_FLAG(-Wno-format-zero-length)
     # Other flags here may not be supported on some versions of
     # gcc that people want to use.
-    for flag in overflow strict-overflow missing-format-attribute missing-prototypes return-type missing-braces parentheses switch unused-function unused-label unused-variable unused-value unknown-pragmas sign-compare newline-eof error=uninitialized error=pointer-arith error=int-conversion error=incompatible-pointer-types ; do
+    for flag in overflow strict-overflow missing-format-attribute missing-prototypes return-type missing-braces parentheses switch unused-function unused-label unused-variable unused-value unknown-pragmas sign-compare newline-eof error=uninitialized error=pointer-arith error=int-conversion error=incompatible-pointer-types error=discarded-qualifiers ; do
       TRY_WARN_CC_FLAG(-W$flag)
     done
     #  old-style-definition? generates many, many warnings


### PR DESCRIPTION
[Will Fiveash asked for this, but since it isn't a bug he reported, I didn't credit him in the commit message.]

If a function call passes a const pointer to a function accepting the
same pointer type without the const qualifier, that should be treated
as an erorr if possible.  In sufficiently recent gcc, pass
-Werror=discarded-qualifiers.  (In clang, this is already covered by
-Werror=incompatible-pointer-types which we recently added.)