### PR TITLE
Set alg param correctly for PKCS1

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -1319,8 +1319,7 @@ cms_signeddata_create(krb5_context context,
             alg = X509_ALGOR_new();
             if (alg == NULL)
                 goto cleanup2;
-            alg->algorithm = OBJ_nid2obj(NID_sha1);
-            alg->parameter = NULL;
+            X509_ALGOR_set0(alg, OBJ_nid2obj(NID_sha1), V_ASN1_NULL, NULL);
             alg_len = i2d_X509_ALGOR(alg, NULL);
             alg_buf = malloc(alg_len);
             if (alg_buf == NULL)


### PR DESCRIPTION
When using a smart card and constructing a DigestInfo to pass to the
CKM_RSA_PKCS mechanism, make sure to set the AlgorithmIdentifier
parameters correctly.  This is typically an ASN.1 NULL value.

Reported to Ubuntu in Launchpad #1629370.

ticket: 8506
target_version: 1.14-next
target_version: 1.13-next
tags: pullup