### PR TITLE
Three minor fixes for KCM collection handling

### DIFF
--- a/src/lib/krb5/ccache/cc_kcm.c
+++ b/src/lib/krb5/ccache/cc_kcm.c
@@ -604,7 +604,7 @@ kcm_resolve(krb5_context context, krb5_ccache *cache_out, const char *residual)
     if (ret)
         goto cleanup;
 
-    if (*residual == '\0') {
+    if (*residual == '\0' || strchr(residual, ':') == NULL) {
         kcmreq_init(&req, KCM_OP_GET_DEFAULT_CACHE, NULL);
         ret = kcmio_call(context, io, &req);
         if (ret)

--- a/src/lib/krb5/ccache/cc_kcm.c
+++ b/src/lib/krb5/ccache/cc_kcm.c
@@ -885,7 +885,8 @@ kcm_ptcursor_new(krb5_context context, krb5_cc_ptcursor *cursor_out)
         return ret;
 
     /* If defname is a subsidiary cache, return a singleton cursor. */
-    if (strlen(defname) > 4)
+    /* subsidiary is denoted as KCM:UID:SUBSIDIARY_ID */
+    if (strlen(defname) > 4 && (strchr(defname+4, ':') != NULL))
         return make_ptcursor(defname + 4, NULL, io, cursor_out);
 
     kcmreq_init(&req, KCM_OP_GET_CACHE_UUID_LIST, NULL);


### PR DESCRIPTION
Hi,

I was working on a KCM deamon for SSSD and I noticed some strange issues around cache collections. To make sure these are not bugs in my KCM implementation, I also reproduced them with a setup running MIT client libraries and Heimdal KCM server (I used a Frankenstein setup where I bind-mounted the KCM socket from a container running Debian to a Fedora container, but I think that hardly matters..). None of the issues happen with Heimdal client.

I admit I don't know the Kerberos codebase well,so perhaps the patches are totally off, but hopefully we can use them at least to start a discussion.

The first issue is that when a new cache is generated, the ccache name points to the collection, not a subsidiary, for example:

```
[root@19dae3adc9b0 /]# kinit admin
Password for admin@IPA.TEST: 
[root@19dae3adc9b0 /]# klist 
Ticket cache: KCM:0
Default principal: admin@IPA.TEST
```

I would expect a subsidiary cache, as I see using a Heimdal client directly:

```
root@kdc:~# kinit admin
admin@IPA.TEST's Password: 
root@kdc:~# klist
Credentials cache: KCM:0:1
        Principal: admin@IPA.TEST
```

Looking at the code, the first issue is that when no cache exists and kinit generates one for the user, the library calls eventually calls `kcm_resolve`:

```
(gdb) bt
#0  kcm_resolve (context=0x6090d0, cache_out=0x7fffffffe3c0, residual=0x609494 "0") at /krb5/src/lib/krb5/ccache/cc_kcm.c:613
#1  0x00007ffff723496e in krb5_cc_resolve (context=0x6090d0, name=0x609490 "KCM:0", cache=0x7fffffffe3c0) at /krb5/src/lib/krb5/ccache/ccbase.c:239
#2  0x00007ffff7236044 in krb5_cc_default (context=0x6090d0, ccache=0x7fffffffe3c0) at /krb5/src/lib/krb5/ccache/ccdefault.c:56
#3  0x000000000040372b in k5_begin (opts=0x7fffffffe470, k5=0x7fffffffe440) at /krb5/src/clients/kinit/kinit.c:483
#4  0x0000000000405197 in main (argc=2, argv=0x7fffffffe5e8) at /krb5/src/clients/kinit/kinit.c:947
```

Note that residual is "0", which I think is OK, because we want to resolve the cache collection for UID 0 (yeah, I was running these tests as root..). And `kcm_resolve` only calls the KCM operation `KCM_OP_GET_DEFAULT_CACHE` which, in case no prior default cache exists, just returns the default collection as well, so the library gets "0" back. But I think that the collection should be resolved to a subsidiary at this point. To that end, I check if the default name returned in reply to `KCM_OP_GET_DEFAULT_CACHE,` is a subsidiary and if not, explicitly call `KCM_OP_GEN_NEW`. Looking at other collection caches, both `krcc_resolve` and `dir_resolve` do something similar. This is what the patch `KCM: Explicitly generate a new subsidiary if default ccache points to collection` does.

Looking at this area of code, I was not sure if maybe implementing the resolve operation in the KCM server (currently it's not implemented even in Heimdal..but we could detect that on the client side and fall back) might be a cleaner way.  Also, in a separate patch `KCM: Get default cache for residuals pointing to the collection` I also call the whole block that calls `get_default_cache` or `gen_new` not only for an empty residual as before but also for a cache collection.

Another issue was that switching collection caches was not working:

```
[root@19dae3adc9b0 /]# kinit admin
Password for admin@IPA.TEST: 
[root@19dae3adc9b0 /]# klist 
Ticket cache: KCM:0
Default principal: admin@IPA.TEST

Valid starting     Expires            Service principal
10/18/16 19:52:40  10/19/16 19:52:38  krbtgt/IPA.TEST@IPA.TEST
    renew until 10/25/16 19:52:38
[root@19dae3adc9b0 /]# kinit tuser
Password for tuser@IPA.TEST: 
[root@19dae3adc9b0 /]# klist -A
Ticket cache: KCM:0
Default principal: admin@IPA.TEST

Valid starting     Expires            Service principal
10/18/16 19:52:40  10/19/16 19:52:38  krbtgt/IPA.TEST@IPA.TEST
    renew until 10/25/16 19:52:38
```

Only admin is displayed, I would expect also tuser.

In the code, the issue seems to be in the `kcm_ptcursor_new` function. There is a condition at the top that checks if the first four characters are `KCM`:

```
     if (defname == NULL || strncmp(defname, "KCM:", 4) != 0)                                                                                                                                                  
         return make_ptcursor(NULL, NULL, NULL, cursor_out);  
```

But immediately after, any `defname` longer than 4 characters would be just used as a subsidiary. I think that's incorrect, KCM subsidiaries are normally formed as `KCM:UID:ID`, so I added a check for another colon in the defname string.

After the patches are applied, MIT libraries produce the same result as Heimdal does:

```
[root@19dae3adc9b0 /]# klist 
klist: No credentials cache found
[root@19dae3adc9b0 /]# kinit admin
Password for admin@IPA.TEST: 
[root@19dae3adc9b0 /]# klist 
Ticket cache: KCM:0:2
Default principal: admin@IPA.TEST

Valid starting     Expires            Service principal
10/18/16 20:35:34  10/19/16 20:35:32  krbtgt/IPA.TEST@IPA.TEST
    renew until 10/25/16 20:35:32
[root@19dae3adc9b0 /]# kinit tuser
Password for tuser@IPA.TEST: 
[root@19dae3adc9b0 /]# klist 
Ticket cache: KCM:0:3
Default principal: tuser@IPA.TEST

Valid starting     Expires            Service principal
10/18/16 20:35:41  10/19/16 20:35:39  krbtgt/IPA.TEST@IPA.TEST
    renew until 10/25/16 20:35:39
[root@19dae3adc9b0 /]# klist -A
Ticket cache: KCM:0:3
Default principal: tuser@IPA.TEST

Valid starting     Expires            Service principal
10/18/16 20:35:41  10/19/16 20:35:39  krbtgt/IPA.TEST@IPA.TEST
    renew until 10/25/16 20:35:39

Ticket cache: KCM:0:2
Default principal: admin@IPA.TEST

Valid starting     Expires            Service principal
10/18/16 20:35:34  10/19/16 20:35:32  krbtgt/IPA.TEST@IPA.TEST
    renew until 10/25/16 20:35:32
```
