### PR TITLE
Fix detection of libaceclnt for securid_sam2

### DIFF
--- a/src/configure.in
+++ b/src/configure.in
@@ -1255,7 +1255,7 @@ AC_SUBST(LDAP)
 sam2_plugin=""
 old_CFLAGS=$CFLAGS
 CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
-AC_CHECK_LIB(aceclnt, sd_init, [
+AC_CHECK_LIB(aceclnt, SD_Init, [
 	     AC_MSG_NOTICE([Enabling RSA securID support])
 	     K5_GEN_MAKEFILE(plugins/preauth/securid_sam2)
 	     sam2_plugin=plugins/preauth/securid_sam2


### PR DESCRIPTION
The symbol we need is SD_Init(), not sd_init().
