### PR TITLE
Add doxygen comments for RFC 8009, RFC 4757

### DIFF
--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -426,10 +426,10 @@ typedef struct _krb5_crypto_iov {
 #define ENCTYPE_DES3_CBC_SHA1               0x0010
 #define ENCTYPE_AES128_CTS_HMAC_SHA1_96     0x0011 /**< RFC 3962 */
 #define ENCTYPE_AES256_CTS_HMAC_SHA1_96     0x0012 /**< RFC 3962 */
-#define ENCTYPE_AES128_CTS_HMAC_SHA256_128  0x0013
-#define ENCTYPE_AES256_CTS_HMAC_SHA384_192  0x0014
-#define ENCTYPE_ARCFOUR_HMAC                0x0017
-#define ENCTYPE_ARCFOUR_HMAC_EXP            0x0018
+#define ENCTYPE_AES128_CTS_HMAC_SHA256_128  0x0013 /**< RFC 8009 */
+#define ENCTYPE_AES256_CTS_HMAC_SHA384_192  0x0014 /**< RFC 8009 */
+#define ENCTYPE_ARCFOUR_HMAC                0x0017 /**< RFC 4757 */
+#define ENCTYPE_ARCFOUR_HMAC_EXP            0x0018 /**< RFC 4757 */
 #define ENCTYPE_CAMELLIA128_CTS_CMAC        0x0019 /**< RFC 6803 */
 #define ENCTYPE_CAMELLIA256_CTS_CMAC        0x001a /**< RFC 6803 */
 #define ENCTYPE_UNKNOWN                     0x01ff
@@ -448,12 +448,12 @@ typedef struct _krb5_crypto_iov {
                                                 ENCTYPE_AES128_CTS_HMAC_SHA1_96 */
 #define CKSUMTYPE_HMAC_SHA1_96_AES256 0x0010 /**< RFC 3962. Used with
                                                 ENCTYPE_AES256_CTS_HMAC_SHA1_96 */
-#define CKSUMTYPE_HMAC_SHA256_128_AES128 0x0013
-#define CKSUMTYPE_HMAC_SHA384_192_AES256 0x0014
+#define CKSUMTYPE_HMAC_SHA256_128_AES128 0x0013 /**< RFC 8009 */
+#define CKSUMTYPE_HMAC_SHA384_192_AES256 0x0014 /**< RFC 8009 */
 #define CKSUMTYPE_CMAC_CAMELLIA128 0x0011 /**< RFC 6803 */
 #define CKSUMTYPE_CMAC_CAMELLIA256 0x0012 /**< RFC 6803 */
-#define CKSUMTYPE_MD5_HMAC_ARCFOUR -137 /*Microsoft netlogon cksumtype*/
-#define CKSUMTYPE_HMAC_MD5_ARCFOUR -138 /*Microsoft md5 hmac cksumtype*/
+#define CKSUMTYPE_MD5_HMAC_ARCFOUR -137 /* Microsoft netlogon */
+#define CKSUMTYPE_HMAC_MD5_ARCFOUR -138 /**< RFC 4757 */
 
 /*
  * The following are entropy source designations. Whenever


### PR DESCRIPTION
The aes-sha2 specification has been published as RFC 8009.  Add
Doxygen comments to the #defines for its enctype and checksum type
comments.  Also add comments for the RC4 enctype and checksum type
constants referring to RFC 4757.
