### PR TITLE
Add KRB5_TRACE calls for DNS lookups

### DIFF
--- a/src/include/k5-trace.h
+++ b/src/include/k5-trace.h
@@ -155,6 +155,20 @@ void krb5int_trace(krb5_context context, const char *fmt, ...);
     TRACE(c, "ccselect choosing default cache {ccache} for server " \
           "principal {princ}", cache, server)
 
+#define TRACE_DNS_SRV_ANS(c, host, port, prio, weight)                \
+    TRACE(c, "SRV answer: {int} {int} {int} \"{str}\"", prio, weight, \
+          port, host)
+#define TRACE_DNS_SRV_NOTFOUND(c)               \
+    TRACE(c, "No SRV records found")
+#define TRACE_DNS_SRV_SEND(c, domain)                   \
+    TRACE(c, "Sending DNS SRV query for {str}", domain)
+#define TRACE_DNS_URI_ANS(c, uri, prio, weight)                         \
+    TRACE(c, "URI answer: {int} {int} \"{str}\"", prio, weight, uri)
+#define TRACE_DNS_URI_NOTFOUND(c)               \
+    TRACE(c, "No URI records found")
+#define TRACE_DNS_URI_SEND(c, domain)                   \
+    TRACE(c, "Sending DNS URI query for {str}", domain)
+
 #define TRACE_FAST_ARMOR_CCACHE(c, ccache_name)         \
     TRACE(c, "FAST armor ccache: {str}", ccache_name)
 #define TRACE_FAST_ARMOR_CCACHE_KEY(c, keyblock)                \

--- a/src/lib/krb5/os/dnsglue.h
+++ b/src/lib/krb5/os/dnsglue.h
@@ -167,15 +167,16 @@ struct srv_dns_entry {
     char *host;
 };
 
-krb5_error_code krb5int_make_srv_query_realm(const krb5_data *realm,
-                                             const char *service,
-                                             const char *protocol,
-                                             struct srv_dns_entry **answers);
+krb5_error_code
+krb5int_make_srv_query_realm(krb5_context context, const krb5_data *realm,
+                             const char *service, const char *protocol,
+                             struct srv_dns_entry **answers);
+
 void krb5int_free_srv_dns_data(struct srv_dns_entry *);
 
 krb5_error_code
-k5_make_uri_query(const krb5_data *realm, const char *service,
-                  struct srv_dns_entry **answers);
+k5_make_uri_query(krb5_context context, const krb5_data *realm,
+                  const char *service, struct srv_dns_entry **answers);
 
 #endif /* KRB5_DNS_LOOKUP */
 #endif /* !defined(KRB5_DNSGLUE_H) */

--- a/src/lib/krb5/os/t_locate_kdc.c
+++ b/src/lib/krb5/os/t_locate_kdc.c
@@ -127,7 +127,7 @@ main (int argc, char *argv[])
         break;
 
     case LOOKUP_DNS:
-        err = locate_srv_dns_1(&realm, "_kerberos", "_udp", &sl);
+        err = locate_srv_dns_1(ctx, &realm, "_kerberos", "_udp", &sl);
         break;
 
     case LOOKUP_WHATEVER:


### PR DESCRIPTION
To help admins troubleshoot DNS records without resorting to strace/gdb.