### PR TITLE
Memory scrubbing improvements

### DIFF
--- a/src/aclocal.m4
+++ b/src/aclocal.m4
@@ -53,6 +53,8 @@ AC_SUBST(EXTRA_FILES)
 dnl Consider using AC_USE_SYSTEM_EXTENSIONS when we require autoconf
 dnl 2.59c or later, but be sure to test on Solaris first.
 AC_DEFINE([_GNU_SOURCE], 1, [Define to enable extensions in glibc])
+AC_DEFINE([__STDC_WANT_LIB_EXT1__], 1, [Define to enable C11 extensions])
+
 WITH_CC dnl
 AC_REQUIRE_CPP
 if test -z "$LD" ; then LD=$CC; fi

--- a/src/kadmin/dbutil/kdb5_create.c
+++ b/src/kadmin/dbutil/kdb5_create.c
@@ -348,10 +348,7 @@ void kdb5_create(argc, argv)
         printf(_("Warning: couldn't stash master key.\n"));
     }
     /* clean up */
-    if (pw_str) {
-        memset(pw_str, 0, pw_size);
-        free(pw_str);
-    }
+    zapfree(pw_str, pw_size);
     free(master_salt.data);
 
     if (kadm5_create(&global_params)) {

--- a/src/kdc/main.c
+++ b/src/kdc/main.c
@@ -170,8 +170,7 @@ finish_realm(kdc_realm_t *rdp)
             krb5_free_principal(rdp->realm_context, rdp->realm_tgsprinc);
         krb5_free_context(rdp->realm_context);
     }
-    memset(rdp, 0, sizeof(*rdp));
-    free(rdp);
+    zapfree(rdp, sizeof(*rdp));
 }
 
 /* Set *val_out to an allocated string containing val1 and/or val2, separated

--- a/src/lib/crypto/builtin/enc_provider/rc4.c
+++ b/src/lib/crypto/builtin/enc_provider/rc4.c
@@ -144,10 +144,8 @@ k5_arcfour_docrypt(krb5_key key, const krb5_data *state, krb5_crypto_iov *data,
                              (const unsigned char *)iov->data.data, iov->data.length);
     }
 
-    if (state == NULL) {
-        memset(arcfour_ctx, 0, sizeof(ArcfourContext));
-        free(arcfour_ctx);
-    }
+    if (state == NULL)
+        zapfree(arcfour_ctx, sizeof(ArcfourContext));
 
     return 0;
 }

--- a/src/lib/gssapi/krb5/delete_sec_context.c
+++ b/src/lib/gssapi/krb5/delete_sec_context.c
@@ -87,7 +87,7 @@ krb5_gss_delete_sec_context(minor_status, context_handle, output_token)
         krb5_free_context(ctx->k5_context);
 
     /* Zero out context */
-    memset(ctx, 0, sizeof(*ctx));
+    zap(ctx, sizeof(*ctx));
     xfree(ctx);
 
     /* zero the handle itself */

--- a/src/lib/gssapi/krb5/export_sec_context.c
+++ b/src/lib/gssapi/krb5/export_sec_context.c
@@ -91,7 +91,7 @@ error_out:
         if (kret != 0 && context != 0)
             save_error_info((OM_uint32)kret, context);
     if (obuffer && bufsize) {
-        memset(obuffer, 0, bufsize);
+        zap(obuffer, bufsize);
         xfree(obuffer);
     }
     if (*minor_status == 0)

--- a/src/lib/gssapi/krb5/lucid_context.c
+++ b/src/lib/gssapi/krb5/lucid_context.c
@@ -266,9 +266,9 @@ free_lucid_key_data(
 {
     if (key) {
         if (key->data && key->length) {
-            memset(key->data, 0, key->length);
+            zap(key->data, key->length);
             xfree(key->data);
-            memset(key, 0, sizeof(gss_krb5_lucid_key_t));
+            zap(key, sizeof(gss_krb5_lucid_key_t));
         }
     }
 }

--- a/src/lib/gssapi/mechglue/g_initialize.c
+++ b/src/lib/gssapi/mechglue/g_initialize.c
@@ -560,10 +560,8 @@ releaseMechInfo(gss_mech_info *pCf)
 	if (cf->mech_type != GSS_C_NO_OID &&
 	    cf->mech_type != &cf->mech->mech_type)
 		generic_gss_release_oid(&minor_status, &cf->mech_type);
-	if (cf->mech != NULL && cf->freeMech) {
-		memset(cf->mech, 0, sizeof(*cf->mech));
-		free(cf->mech);
-	}
+	if (cf->freeMech)
+		zapfree(cf->mech, sizeof(*cf->mech));
 	if (cf->dl_handle != NULL)
 		krb5int_close_plugin(cf->dl_handle);
 	if (cf->int_mech_type != GSS_C_NO_OID)

--- a/src/lib/kadm5/srv/svr_principal.c
+++ b/src/lib/kadm5/srv/svr_principal.c
@@ -48,13 +48,8 @@ kadm5_ret_t krb5_copy_key_data_contents(context, from, to)
         if ( from->key_data_length[i] ) {
             to->key_data_contents[i] = malloc(from->key_data_length[i]);
             if (to->key_data_contents[i] == NULL) {
-                for (i = 0; i < idx; i++) {
-                    if (to->key_data_contents[i]) {
-                        memset(to->key_data_contents[i], 0,
-                               to->key_data_length[i]);
-                        free(to->key_data_contents[i]);
-                    }
-                }
+                for (i = 0; i < idx; i++)
+                    zapfree(to->key_data_contents[i], to->key_data_length[i]);
                 return ENOMEM;
             }
             memcpy(to->key_data_contents[i], from->key_data_contents[i],

--- a/src/lib/krb5/krb/authdata.c
+++ b/src/lib/krb5/krb/authdata.c
@@ -480,8 +480,7 @@ krb5_authdata_context_free(krb5_context kcontext,
         context->modules = NULL;
     }
     krb5int_close_plugin_dirs(&context->plugins);
-    memset(context, 0, sizeof(*context));
-    free(context);
+    zapfree(context, sizeof(*context));
 }
 
 krb5_error_code KRB5_CALLCONV

--- a/src/lib/krb5/krb/pac.c
+++ b/src/lib/krb5/krb/pac.c
@@ -125,14 +125,9 @@ krb5_pac_free(krb5_context context,
               krb5_pac pac)
 {
     if (pac != NULL) {
-        if (pac->data.data != NULL) {
-            memset(pac->data.data, 0, pac->data.length);
-            free(pac->data.data);
-        }
-        if (pac->pac != NULL)
-            free(pac->pac);
-        memset(pac, 0, sizeof(*pac));
-        free(pac);
+        zapfree(pac->data.data, pac->data.length);
+        free(pac->pac);
+        zapfree(pac, sizeof(*pac));
     }
 }
 

--- a/src/util/support/zap.c
+++ b/src/util/support/zap.c
@@ -34,5 +34,8 @@
 
 void krb5int_zap(void *ptr, size_t len)
 {
-    memset(ptr, 0, len);
+    volatile char *p = ptr;
+
+    while (len--)
+        *p++ = '\0';
 }


### PR DESCRIPTION
The first commit here improves the reliability of zap() with current and (we hope) future compilers, in particular by using memset_s() when we can.  There's a potential technique not used here, which is to make a call to memset through a volatile function pointer, but I don't know that it's any more likely to work than a shared library call to a function using a volatile char *.

The second commit uses zap() in places where we currently use memset().

I tried creating an automated test for zap() by creating a core file and looking through it for a sentinel string, but so far I haven't been able to get the test to fail with gcc 5.4.0-6ubuntu1~16.04.2 or clang 3.8.0-2ubuntu4, even using just free() with no zap or memset.