### PR TITLE
Modify shlib.conf to cross compile for Chrome OS.

### DIFF
--- a/src/config/shlib.conf
+++ b/src/config/shlib.conf
@@ -442,6 +442,11 @@ mips-*-netbsd*)
 	RUN_ENV='LD_LIBRARY_PATH=`echo $(PROG_LIBPATH) | sed -e "s/-L//g" -e "s/ /:/g"`'
 	RUN_VARS='LD_LIBRARY_PATH'
 
+	if [[ $krb5_cv_host == *-cros-linux-gnu ]]; then
+		use_linker_init_option=yes
+		use_linker_fini_option=yes
+	fi
+
 	## old version:
 	# Linux libc does weird stuff at shlib link time, must be
 	# explicitly listed here.  This also makes it get used even


### PR DESCRIPTION
Sets use_linker_init_option and use_linker_fini_option to yes
when compiling for Chrome OS.