### PR TITLE
Error on declarations without type specification

### DIFF
--- a/src/aclocal.m4
+++ b/src/aclocal.m4
@@ -528,7 +528,7 @@ if test "$GCC" = yes ; then
     TRY_WARN_CC_FLAG(-Wno-format-zero-length)
     # Other flags here may not be supported on some versions of
     # gcc that people want to use.
-    for flag in overflow strict-overflow missing-format-attribute missing-prototypes return-type missing-braces parentheses switch unused-function unused-label unused-variable unused-value unknown-pragmas sign-compare newline-eof error=uninitialized error=pointer-arith error=int-conversion error=incompatible-pointer-types error=discarded-qualifiers ; do
+    for flag in overflow strict-overflow missing-format-attribute missing-prototypes return-type missing-braces parentheses switch unused-function unused-label unused-variable unused-value unknown-pragmas sign-compare newline-eof error=uninitialized error=pointer-arith error=int-conversion error=incompatible-pointer-types error=discarded-qualifiers error=implicit-int ; do
       TRY_WARN_CC_FLAG(-W$flag)
     done
     #  old-style-definition? generates many, many warnings

--- a/src/lib/crypto/builtin/sha1/t_shs3.c
+++ b/src/lib/crypto/builtin/sha1/t_shs3.c
@@ -56,6 +56,7 @@ int Dflag;
 
 int
 main(argc,argv)
+    int argc;
     char **argv;
 {
     char *argp;


### PR DESCRIPTION
Adds (conditional) build support for -Werror-implicit-int and fixes where this broke my build.

I would appreciate the first commit landing in 1.15, but I'm carrying it as a patch already so it's not hugely important.