### PR TITLE
Remove redeclaration of ttyname.

### DIFF
--- a/src/clients/ksu/main.c
+++ b/src/clients/ksu/main.c
@@ -932,7 +932,7 @@ int standard_shell(sh)
 
 static char * ontty()
 {
-    char *p, *ttyname();
+    char *p;
     static char buf[MAXPATHLEN + 5];
     int result;
 


### PR DESCRIPTION
The original declaration is in unistd.h with a different
signature.

This caused an issue building with clang fortify on Chrome OS.

Caused the following error;

main.c:858:15: error: redeclaration of 'ttyname' must have the 'overloadable' attribute
    char *p, *ttyname();
              ^
/build/samus/usr/include/unistd.h:784:14: note: previous overload of function is here
extern char *ttyname (int __fd) __THROW __CLANG_NO_MANGLE (ttyname);
