### PR TITLE
Simplify LDAP module by relying on OpenLDAP 2.1

### DIFF
--- a/src/configure.in
+++ b/src/configure.in
@@ -1214,11 +1214,7 @@ ldap_plugin_dir=""
 ldap_lib=""
 if test -n "$OPENLDAP_PLUGIN"; then
   AC_CHECK_HEADERS(ldap.h lber.h, :, [AC_MSG_ERROR($ac_header not found)])
-  AC_CHECK_LIB(ldap, ldap_init, :, [AC_MSG_ERROR(libldap not found or missing ldap_init)])
-  old_LIBS="$LIBS"
-  LIBS="$LIBS -lldap"
-  AC_CHECK_FUNCS(ldap_initialize ldap_url_parse_nodn ldap_unbind_ext_s ldap_str2dn ldap_explode_dn)
-  LIBS="$old_LIBS"
+  AC_CHECK_LIB(ldap, ldap_str2dn, :, [AC_MSG_ERROR(libldap not found or missing ldap_str2dn)])
 
   BER_OKAY=0
   AC_CHECK_LIB(ldap, ber_init, [BER_OKAY=1])

--- a/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.h
@@ -300,15 +300,6 @@ krb5_ldap_lock( krb5_context, int );
 krb5_error_code
 krb5_ldap_unlock( krb5_context );
 
-#ifndef HAVE_LDAP_INITIALIZE
-int
-ldap_initialize(LDAP **, char *);
-#endif
-#ifndef HAVE_LDAP_UNBIND_EXT_S
-int
-ldap_unbind_ext_s(LDAP *, LDAPControl **, LDAPControl **);
-#endif
-
 /* lockout.c */
 krb5_error_code
 krb5_ldap_lockout_check_policy(krb5_context context,

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.c
@@ -1231,6 +1231,8 @@ krb5_ldap_policydn_to_name(krb5_context context, const char *policy_dn,
     kdb5_dal_handle *dal_handle;
     krb5_ldap_context *ldap_context;
     const char *realmdn;
+    char *rdn;
+    LDAPDN dn;
 
     *name_out = NULL;
     SETUP_CONTEXT();
@@ -1248,46 +1250,22 @@ krb5_ldap_policydn_to_name(krb5_context context, const char *policy_dn,
     if (policy_dn[plen] != ',' || strcmp(realmdn, policy_dn + plen + 1) != 0)
         return EINVAL;
 
-#if defined HAVE_LDAP_STR2DN
-    {
-        char *rdn;
-        LDAPDN dn;
-
-        rdn = k5memdup0(policy_dn, plen, &ret);
-        if (rdn == NULL)
-            return ret;
-        ret = ldap_str2dn(rdn, &dn, LDAP_DN_FORMAT_LDAPV3 | LDAP_DN_PEDANTIC);
-        free(rdn);
-        if (ret)
-            return EINVAL;
-        if (dn[0] == NULL || dn[1] != NULL ||
-            dn[0][0]->la_attr.bv_len != 2 ||
-            strncasecmp(dn[0][0]->la_attr.bv_val, "cn", 2) != 0) {
-            ret = EINVAL;
-        } else {
-            *name_out = k5memdup0(dn[0][0]->la_value.bv_val,
-                                  dn[0][0]->la_value.bv_len, &ret);
-        }
-        ldap_dnfree(dn);
+    rdn = k5memdup0(policy_dn, plen, &ret);
+    if (rdn == NULL)
         return ret;
+    ret = ldap_str2dn(rdn, &dn, LDAP_DN_FORMAT_LDAPV3 | LDAP_DN_PEDANTIC);
+    free(rdn);
+    if (ret)
+        return EINVAL;
+    if (dn[0] == NULL || dn[1] != NULL || dn[0][0]->la_attr.bv_len != 2 ||
+        strncasecmp(dn[0][0]->la_attr.bv_val, "cn", 2) != 0) {
+        ret = EINVAL;
+    } else {
+        *name_out = k5memdup0(dn[0][0]->la_value.bv_val,
+                              dn[0][0]->la_value.bv_len, &ret);
     }
-#elif defined HAVE_LDAP_EXPLODE_DN
-    {
-        char **parsed_dn;
-
-        /* 1 = return DN components without type prefix */
-        parsed_dn = ldap_explode_dn(policy_dn, 1);
-        if (parsed_dn == NULL)
-            return EINVAL;
-        *name_out = strdup(parsed_dn[0]);
-        if (*name_out == NULL)
-            return ENOMEM;
-        ldap_value_free(parsed_dn);
-        return 0;
-    }
-#else
-    return EINVAL;
-#endif
+    ldap_dnfree(dn);
+    return ret;
 }
 
 /* Compute the policy DN for the given policy name. */
@@ -1699,47 +1677,3 @@ cleanup:
     free_princ_ent_contents(&princ_ent);
     return ret;
 }
-
-/* Solaris libldap does not provide the following functions which are in
- * OpenLDAP. */
-#ifndef HAVE_LDAP_INITIALIZE
-int
-ldap_initialize(LDAP **ldp, char *url)
-{
-    int rc = 0;
-    LDAP *ld = NULL;
-    LDAPURLDesc *ludp = NULL;
-
-    /*
-     * For now, we don't use any DN that may be provided.  And on Solaris
-     * (based on Mozilla's LDAP client code), we need the _nodn form to parse
-     * "ldap://host" without a trailing slash.
-     *
-     * Also, this version won't handle an input string which contains multiple
-     * URLs, unlike the OpenLDAP ldap_initialize.  See
-     * https://bugzilla.mozilla.org/show_bug.cgi?id=353336#c1 .
-     */
-#ifdef HAVE_LDAP_URL_PARSE_NODN
-    rc = ldap_url_parse_nodn(url, &ludp);
-#else
-    rc = ldap_url_parse(url, &ludp);
-#endif
-    if (rc == 0) {
-        ld = ldap_init(ludp->lud_host, ludp->lud_port);
-        if (ld != NULL)
-            *ldp = ld;
-        else
-            rc = KRB5_KDB_ACCESS_ERROR;
-        ldap_free_urldesc(ludp);
-    }
-    return rc;
-}
-#endif /* HAVE_LDAP_INITIALIZE */
-
-#ifndef HAVE_LDAP_UNBIND_EXT_S
-int
-ldap_unbind_ext_s(LDAP *ld, LDAPControl **sctrls, LDAPControl **cctrls)
-{
-    return ldap_unbind_ext(ld, sctrls, cctrls);
-}
-#endif /* HAVE_LDAP_UNBIND_EXT_S */


### PR DESCRIPTION
Solaris 11 provides an OpenLDAP library (which we don't auto-detect,
but should) in addition to the old Mozilla LDAP library; this will
become the default LDAP library in the next release.  As there is no
longer a need to build against the Mozilla LDAP library, and as we
have unwittingly relied on some OpenLDAP-specific features since 1.13,
remove the compatibility code for the Mozilla LDAP library and just
require OpenLDAP 2.1 (which added ldap_str2dn).