### PR TITLE
kerberos.ldif: Add missing krbPwdPolicy attributes

### DIFF
--- a/src/plugins/kdb/ldap/libkdb_ldap/kerberos.ldif
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kerberos.ldif
@@ -878,7 +878,7 @@ objectClasses: ( 2.16.840.1.113719.1.301.6.14.1
                 NAME 'krbPwdPolicy' 
                 SUP top
                 MUST ( cn )
-                MAY ( krbMaxPwdLife $ krbMinPwdLife $ krbPwdMinDiffChars $ krbPwdMinLength $ krbPwdHistoryLength $ krbPwdMaxFailure $ krbPwdFailureCountInterval $ krbPwdLockoutDuration ) )
+                MAY ( krbMaxPwdLife $ krbMinPwdLife $ krbPwdMinDiffChars $ krbPwdMinLength $ krbPwdHistoryLength $ krbPwdMaxFailure $ krbPwdFailureCountInterval $ krbPwdLockoutDuration $ krbPwdAttributes $ krbPwdMaxLife $ krbPwdMaxRenewableLife $ krbPwdAllowedKeysalts ) )
 
 
 ##### The krbTicketPolicyAux holds Kerberos ticket policy attributes.


### PR DESCRIPTION
When LDAP backend support for policy extensions was added by 5edafa0532,
kerberos.ldif update was incomplete.

When kerberos.ldif is used to setup LDAP schema, this breaks policy:

root@servera:~# kadmin -p tomas/admin -w aaaa -q 'addpol -history 4 pol1'
Authenticating as principal tomas/admin with password.
add_policy: Database store error while creating policy "pol1".

slapd debug output:
58358d7e Entry (cn=pol1,cn=EXAMPLE.COM,cn=krbcontainer,dc=example,dc=com),
attribute 'krbPwdAttributes' not allowed
58358d7e mdb_add: entry failed schema check: attribute 'krbPwdAttributes' not
allowed (65)
58358d7e send_ldap_result: conn=1001 op=3 p=3
58358d7e send_ldap_result: err=65 matched="" text="attribute
'krbPwdAttributes' not allowed" 