### PR TITLE
Improve cleanup in krb5_rc_io_fetch()

### DIFF
--- a/src/lib/krb5/rcache/rc_dfl.c
+++ b/src/lib/krb5/rcache/rc_dfl.c
@@ -517,7 +517,7 @@ errout:
         free(rep->server);
     if (rep->msghash)
         free(rep->msghash);
-    rep->client = rep->server = 0;
+    rep->client = rep->server = rep->msghash = NULL;
     return retval;
 }
 


### PR DESCRIPTION
[No ticket, as this is not a bug.]

In the error cleanup for krb5_rc_io_fetch(), null out rep->msghash
after freeing it, like we do with rep->client and rep->server.  This
omission is currently harmless because krb5_rc_io_fetch() never sets
rep->msghash before failing, but it could result in a double-free or
use after free if the code changes.