### PR TITLE
Add code to properly handle plugins for dlclose()

### DIFF
--- a/src/lib/gssapi/mechglue/mglueP.h
+++ b/src/lib/gssapi/mechglue/mglueP.h
@@ -717,6 +717,7 @@ typedef struct gss_mech_config {
 	char *mechNameStr;		/* mechanism string name */
 	char *optionStr;		/* optional mech parameters */
 	void *dl_handle;		/* RTLD object handle for the mech */
+	int dl_handle_no_close;		/* whether to close on exit */
 	gss_OID mech_type;		/* mechanism oid */
 	gss_mechanism mech;		/* mechanism initialization struct */
  	int priority;			/* mechanism preference order */


### PR DESCRIPTION
In Fedora 25 we started experiencing issues with the way libgssapi_krb5 calls dlclose() in some situations, various reports have been coalesced in this bugzilla:
https://bugzilla.redhat.com/show_bug.cgi?id=1398370

This patch implements a possible way to avoid calling dlclose() on plugins multiple times on a program exit() (once by the dynamic linker and then again by the gss librray destructor). It does require plugins to implement a destructor too, but it can cope with older plugins that don't.

Comments appreciated.