### PR TITLE
Correctly initialize the out ccache in gss_krb5_copy_ccache()

### DIFF
--- a/src/lib/gssapi/krb5/copy_ccache.c
+++ b/src/lib/gssapi/krb5/copy_ccache.c
@@ -8,8 +8,6 @@ gss_krb5int_copy_ccache(OM_uint32 *minor_status,
                         const gss_buffer_t value)
 {
     krb5_gss_cred_id_t k5creds;
-    krb5_cc_cursor cursor;
-    krb5_creds creds;
     krb5_error_code code;
     krb5_context context;
     krb5_ccache out_ccache;
@@ -37,7 +35,7 @@ gss_krb5int_copy_ccache(OM_uint32 *minor_status,
         return GSS_S_FAILURE;
     }
 
-    code = krb5_cc_start_seq_get(context, k5creds->ccache, &cursor);
+    code = krb5_cc_copy_creds(context, k5creds->ccache, out_ccache);
     if (code) {
         k5_mutex_unlock(&k5creds->lock);
         *minor_status = code;
@@ -45,12 +43,6 @@ gss_krb5int_copy_ccache(OM_uint32 *minor_status,
         krb5_free_context(context);
         return(GSS_S_FAILURE);
     }
-    while (!code && !krb5_cc_next_cred(context, k5creds->ccache, &cursor,
-                                       &creds)) {
-        code = krb5_cc_store_cred(context, out_ccache, &creds);
-        krb5_free_cred_contents(context, &creds);
-    }
-    krb5_cc_end_seq_get(context, k5creds->ccache, &cursor);
     k5_mutex_unlock(&k5creds->lock);
     *minor_status = code;
     if (code)

--- a/src/lib/krb5/ccache/ccbase.c
+++ b/src/lib/krb5/ccache/ccbase.c
@@ -366,16 +366,6 @@ krb5_cc_move(krb5_context context, krb5_ccache src, krb5_ccache dst)
         return ret;
     }
 
-    ret = krb5_cc_get_principal(context, src, &princ);
-    if (!ret) {
-        ret = krb5_cc_initialize(context, dst, princ);
-    }
-    if (ret) {
-        krb5_cc_unlock(context, src);
-        krb5_cccol_unlock(context);
-        return ret;
-    }
-
     ret = krb5_cc_lock(context, dst);
     if (!ret) {
         ret = krb5_cc_copy_creds(context, src, dst);

--- a/src/lib/krb5/ccache/cccopy.c
+++ b/src/lib/krb5/ccache/cccopy.c
@@ -7,6 +7,18 @@ krb5_cc_copy_creds(krb5_context context, krb5_ccache incc, krb5_ccache outcc)
     krb5_error_code code;
     krb5_cc_cursor cur = 0;
     krb5_creds creds;
+    krb5_principal princ = NULL;
+
+    code = krb5_cc_get_principal(context, incc, &princ);
+    if (code != 0) {
+        goto cleanup;
+    }
+
+    code = krb5_cc_initialize(context, outcc, princ);
+    krb5_free_principal(context, princ);
+    if (code != 0) {
+        goto cleanup;
+    }
 
     if ((code = krb5_cc_start_seq_get(context, incc, &cur)))
         goto cleanup;

--- a/src/windows/ms2mit/ms2mit.c
+++ b/src/windows/ms2mit/ms2mit.c
@@ -157,21 +157,12 @@ main(int argc, char *argv[])
         goto cleanup;
     }
 
-    if (code = krb5_cc_get_principal(kcontext, mslsa_ccache, &princ)) {
-        com_err(argv[0], code, "while obtaining MS LSA principal");
-        goto cleanup;
-    }
-
     if (ccachestr)
         code = krb5_cc_resolve(kcontext, ccachestr, &ccache);
     else
         code = krb5_cc_resolve(kcontext, "API:", &ccache);
     if (code) {
         com_err(argv[0], code, "while getting default ccache");
-        goto cleanup;
-    }
-    if (code = krb5_cc_initialize(kcontext, ccache, princ)) {
-        com_err (argv[0], code, "when initializing ccache");
         goto cleanup;
     }
 
@@ -191,7 +182,6 @@ main(int argc, char *argv[])
     }
 
 cleanup:
-    krb5_free_principal(kcontext, princ);
     if (ccache != NULL)
         krb5_cc_close(kcontext, ccache);
     if (mslsa_ccache != NULL)


### PR DESCRIPTION
In Samba we call gss_krb5_copy_ccache() to copy a gssapi_cred to a new credential cache. This fails because the cache is not initialized. The code works with Heimdal Kerberos. I think we also should correctly initialize the cache because we are not able to do it outside of Kerberos because we do not have access to the principal.

I think the right spot is to do it in krb5_cc_copy_creds() and use that function.