### PR TITLE
Fix documented kcpreauth minor version

### DIFF
--- a/src/include/krb5/kdcpreauth_plugin.h
+++ b/src/include/krb5/kdcpreauth_plugin.h
@@ -34,7 +34,7 @@
  * Declarations for kdcpreauth plugin module implementors.
  *
  * The kdcpreauth interface has a single supported major version, which is 1.
- * Major version 1 has a current minor version of 3.  kdcpreauth modules should
+ * Major version 1 has a current minor version of 2.  kdcpreauth modules should
  * define a function named kdcpreauth_<modulename>_initvt, matching the
  * signature:
  *


### PR DESCRIPTION
Commit 7b12eb4757f8dd05b79c9b49d4289f0caf1f6eec erroneously changed
the documented kdcpreauth minor version from 2 to 3.  Only the
callback version changed in that commit; the interface minor version
remains at 2 (from commit 83b4ecd20e50ad330cd761977d5dadefe30a785b
which added the loop method).