### PR TITLE
net-server.c cleanups

### DIFF
--- a/src/include/socket-utils.h
+++ b/src/include/socket-utils.h
@@ -119,6 +119,17 @@ sa_is_inet(struct sockaddr *sa)
     return sa->sa_family == AF_INET || sa->sa_family == AF_INET6;
 }
 
+/* Return true if sa is an IPv4 or IPv6 wildcard address. */
+static inline int
+sa_is_wildcard(struct sockaddr *sa)
+{
+    if (sa->sa_family == AF_INET6)
+        return IN6_IS_ADDR_UNSPECIFIED(&sa2sin6(sa)->sin6_addr);
+    else if (sa->sa_family == AF_INET)
+        return sa2sin(sa)->sin_addr.s_addr == INADDR_ANY;
+    return 0;
+}
+
 /* Return the length of an IPv4 or IPv6 socket structure; abort if it is
  * neither. */
 static inline socklen_t

--- a/src/lib/apputils/net-server.c
+++ b/src/lib/apputils/net-server.c
@@ -105,17 +105,6 @@ paddr(struct sockaddr *sa)
     return buf;
 }
 
-/* Return true if sa is an IPv4 or IPv6 wildcard address. */
-static int
-is_wildcard(struct sockaddr *sa)
-{
-    if (sa->sa_family == AF_INET6)
-        return IN6_IS_ADDR_UNSPECIFIED(&sa2sin6(sa)->sin6_addr);
-    else if (sa->sa_family == AF_INET)
-        return sa2sin(sa)->sin_addr.s_addr == INADDR_ANY;
-    return 0;
-}
-
 /* KDC data.  */
 
 enum conn_type {
@@ -764,7 +753,7 @@ setup_socket(struct socksetup *data, struct bind_address *ba,
     }
 
     /* Try to turn on pktinfo for UDP wildcard sockets. */
-    if (ba->type == UDP && is_wildcard(sock_address)) {
+    if (ba->type == UDP && sa_is_wildcard(sock_address)) {
         krb5_klog_syslog(LOG_DEBUG, _("Setting pktinfo on socket %s"),
                          paddr(sock_address));
         ret = set_pktinfo(sock, sock_address->sa_family);

--- a/src/lib/apputils/udppktinfo.c
+++ b/src/lib/apputils/udppktinfo.c
@@ -141,19 +141,17 @@ is_socket_bound_to_wildcard(int sock)
 {
     struct sockaddr_storage bound_addr;
     socklen_t bound_addr_len = sizeof(bound_addr);
+    struct sockaddr *sa = ss2sa(&bound_addr);
 
-    if (getsockname(sock, ss2sa(&bound_addr), &bound_addr_len) < 0)
+    if (getsockname(sock, sa, &bound_addr_len) < 0)
         return -1;
 
-    switch (ss2sa(&bound_addr)->sa_family) {
-    case AF_INET:
-        return ss2sin(&bound_addr)->sin_addr.s_addr == INADDR_ANY;
-    case AF_INET6:
-        return IN6_IS_ADDR_UNSPECIFIED(&ss2sin6(&bound_addr)->sin6_addr);
-    default:
+    if (!sa_is_inet(sa)) {
         errno = EINVAL;
         return -1;
     }
+
+    return sa_is_wildcard(sa);
 }
 
 #ifdef HAVE_IP_PKTINFO


### PR DESCRIPTION
The first two commits are PR #587.  The next two commits remove some redundancy introduced by PR #587 by introducing the sa_is_wildcard() helper and using it.  The final two commits clean up some constructs made unnecessary when we removed the workaround for non-pktinfo platforms.
