### PR TITLE
Fix GSSAPI authind attribute name in docs

### DIFF
--- a/doc/admin/auth_indicator.rst
+++ b/doc/admin/auth_indicator.rst
@@ -53,5 +53,5 @@ but a user who authenticates with a password would not::
       host/high.value.server@KRBTEST.COM
 
 GSSAPI server applications can inspect authentication indicators
-through the :ref:`auth-indicator <gssapi_authind_attr>` name
+through the :ref:`auth-indicators <gssapi_authind_attr>` name
 attribute.

--- a/doc/appdev/gssapi.rst
+++ b/doc/appdev/gssapi.rst
@@ -182,7 +182,7 @@ the krb5 mechanism is used:
 
 .. _gssapi_authind_attr:
 
-* "auth-indicator" attribute:
+* "auth-indicators" attribute:
 
 This attribute will be included in the gss_inquire_name_ output if the
 ticket contains :ref:`authentication indicators <auth_indicator>`.


### PR DESCRIPTION
The correct attribute name is "auth-indicators".