### PR TITLE
Clean up krb5_db2_free_policy()

### DIFF
--- a/src/plugins/kdb/db2/kdb_db2.c
+++ b/src/plugins/kdb/db2/kdb_db2.c
@@ -1314,13 +1314,6 @@ krb5_db2_delete_policy(krb5_context context, char *policy)
     return osa_adb_destroy_policy(dbc->policy_db, policy);
 }
 
-void
-krb5_db2_free_policy(krb5_context context, osa_policy_ent_t entry)
-{
-    osa_free_policy_ent(entry);
-}
-
-
 /*
  * Merge non-replicated attributes from src into dst, setting
  * changed to non-zero if dst was changed.


### PR DESCRIPTION
Commit 03d34fcfa329fbc2f686a0b34e2731e37f483a34 (ticket 8414) removed
the prototype and all uses of krb5_db2_free_policy(), but neglected to
remove the function definition, resulting in a warning.  Remove the
definition now.