### PR TITLE
Add test case for PKINIT DH renegotiation

### DIFF
--- a/src/tests/t_pkinit.py
+++ b/src/tests/t_pkinit.py
@@ -174,6 +174,24 @@ realm.kinit(realm.user_princ,
                    '-X', 'flag_RSA_PROTOCOL=yes'])
 realm.klist(realm.user_princ)
 
+# Test a DH parameter renegotiation by temporarily setting a 4096-bit
+# minimum on the KDC.
+tracefile = os.path.join(realm.testdir, 'trace')
+minbits_kdc_conf = {'realms': {'$realm': {'pkinit_dh_min_bits': '4096'}}}
+minbits_env = realm.special_env('restrict', True, kdc_conf=minbits_kdc_conf)
+realm.stop_kdc()
+realm.start_kdc(env=minbits_env)
+realm.run(['env', 'KRB5_TRACE=' + tracefile, kinit, '-X',
+           'X509_user_identity=' + file_identity, realm.user_princ])
+with open(tracefile, 'r') as f:
+    trace = f.read()
+if ('Key parameters not accepted' not in trace or
+    'Preauth tryagain input types' not in trace or
+    'trying again with KDC-provided parameters' not in trace):
+    fail('DH renegotiation steps not found in kinit trace log')
+realm.stop_kdc()
+realm.start_kdc()
+
 # Run the basic test - PKINIT with FILE: identity, with a password on the key,
 # supplied by the prompter.
 # Expect failure if the responder does nothing, and we have no prompter.


### PR DESCRIPTION
In t_pkinit.py, add a PKINIT test case where the KDC sends
KDC_ERR_DH_KEY_PARAMETERS_NOT_ACCEPTED and the client retries with the
KDC's TD_DH_PARAMETERS value, using the clpreauth tryagain method.
Use the trace log to verify that the renegotiation actually takes
place.

[I don't think k5_preauth_tryagain() was covered by the test suite before this test case, and I want to make sure I don't break it while improving continue-after-preauth-failure behavior.]