### PR TITLE
Add a free_e_data function pointer to krb5_db_entry

### DIFF
--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -1382,6 +1382,17 @@ typedef struct _kdb_vftabl {
                                                  krb5_const_principal client,
                                                  const krb5_db_entry *server,
                                                  krb5_const_principal proxy);
+
+    /* End of minor version 0. */
+
+    /*
+     * Optional: Free the e_data pointer of a database entry.  If this method
+     * is not implemented, the e_data pointer in principal entries will be
+     * freed with free() as seen by libkdb5.
+     */
+    void (*free_principal_e_data)(krb5_context kcontext, krb5_octet *e_data);
+
+    /* End of minor version 1 for major version 6. */
 } kdb_vftabl;
 
 #endif /* !defined(_WIN32) */

--- a/src/lib/kdb/kdb5.c
+++ b/src/lib/kdb/kdb5.c
@@ -283,24 +283,63 @@ clean_n_exit:
 }
 
 static void
-kdb_setup_opt_functions(db_library lib)
+copy_vtable(const kdb_vftabl *in, kdb_vftabl *out)
 {
-    if (lib->vftabl.fetch_master_key == NULL)
-        lib->vftabl.fetch_master_key = krb5_db_def_fetch_mkey;
-    if (lib->vftabl.fetch_master_key_list == NULL)
-        lib->vftabl.fetch_master_key_list = krb5_def_fetch_mkey_list;
-    if (lib->vftabl.store_master_key_list == NULL)
-        lib->vftabl.store_master_key_list = krb5_def_store_mkey_list;
-    if (lib->vftabl.dbe_search_enctype == NULL)
-        lib->vftabl.dbe_search_enctype = krb5_dbe_def_search_enctype;
-    if (lib->vftabl.change_pwd == NULL)
-        lib->vftabl.change_pwd = krb5_dbe_def_cpw;
-    if (lib->vftabl.decrypt_key_data == NULL)
-        lib->vftabl.decrypt_key_data = krb5_dbe_def_decrypt_key_data;
-    if (lib->vftabl.encrypt_key_data == NULL)
-        lib->vftabl.encrypt_key_data = krb5_dbe_def_encrypt_key_data;
-    if (lib->vftabl.rename_principal == NULL)
-        lib->vftabl.rename_principal = krb5_db_def_rename_principal;
+    /* Copy fields for minor version 0. */
+    out->maj_ver = in->maj_ver;
+    out->min_ver = in->min_ver;
+    out->init_library = in->init_library;
+    out->fini_library = in->fini_library;
+    out->init_module = in->init_module;
+    out->fini_module = in->fini_module;
+    out->create = in->create;
+    out->destroy = in->destroy;
+    out->get_age = in->get_age;
+    out->lock = in->lock;
+    out->unlock = in->unlock;
+    out->get_principal = in->get_principal;
+    out->put_principal = in->put_principal;
+    out->delete_principal = in->delete_principal;
+    out->rename_principal = in->rename_principal;
+    out->iterate = in->iterate;
+    out->create_policy = in->create_policy;
+    out->get_policy = in->get_policy;
+    out->put_policy = in->put_policy;
+    out->iter_policy = in->iter_policy;
+    out->delete_policy = in->delete_policy;
+    out->fetch_master_key = in->fetch_master_key;
+    out->fetch_master_key_list = in->fetch_master_key_list;
+    out->store_master_key_list = in->store_master_key_list;
+    out->dbe_search_enctype = in->dbe_search_enctype;
+    out->change_pwd = in->change_pwd;
+    out->promote_db = in->promote_db;
+    out->decrypt_key_data = in->decrypt_key_data;
+    out->encrypt_key_data = in->encrypt_key_data;
+    out->sign_authdata = in->sign_authdata;
+    out->check_transited_realms = in->check_transited_realms;
+    out->check_policy_as = in->check_policy_as;
+    out->check_policy_tgs = in->check_policy_tgs;
+    out->audit_as_req = in->audit_as_req;
+    out->refresh_config = in->refresh_config;
+    out->check_allowed_to_delegate = in->check_allowed_to_delegate;
+
+    /* Set defaults for optional fields. */
+    if (out->fetch_master_key == NULL)
+        out->fetch_master_key = krb5_db_def_fetch_mkey;
+    if (out->fetch_master_key_list == NULL)
+        out->fetch_master_key_list = krb5_def_fetch_mkey_list;
+    if (out->store_master_key_list == NULL)
+        out->store_master_key_list = krb5_def_store_mkey_list;
+    if (out->dbe_search_enctype == NULL)
+        out->dbe_search_enctype = krb5_dbe_def_search_enctype;
+    if (out->change_pwd == NULL)
+        out->change_pwd = krb5_dbe_def_cpw;
+    if (out->decrypt_key_data == NULL)
+        out->decrypt_key_data = krb5_dbe_def_decrypt_key_data;
+    if (out->encrypt_key_data == NULL)
+        out->encrypt_key_data = krb5_dbe_def_encrypt_key_data;
+    if (out->rename_principal == NULL)
+        out->rename_principal = krb5_db_def_rename_principal;
 }
 
 #ifdef STATIC_PLUGINS
@@ -334,8 +373,7 @@ kdb_load_library(krb5_context kcontext, char *lib_name, db_library *libptr)
         return ENOMEM;
 
     strlcpy(lib->name, lib_name, sizeof(lib->name));
-    memcpy(&lib->vftabl, vftabl_addr, sizeof(kdb_vftabl));
-    kdb_setup_opt_functions(lib);
+    copy_vtable(vftabl_addr, &lib->vftabl);
 
     status = lib->vftabl.init_library();
     if (status)
@@ -433,8 +471,7 @@ kdb_load_library(krb5_context kcontext, char *lib_name, db_library *lib)
         goto clean_n_exit;
     }
 
-    memcpy(&(*lib)->vftabl, vftabl_addrs[0], sizeof(kdb_vftabl));
-    kdb_setup_opt_functions(*lib);
+    copy_vtable(vftabl_addrs[0], &(*lib)->vftabl);
 
     if ((status = (*lib)->vftabl.init_library()))
         goto clean_n_exit;


### PR DESCRIPTION
There are projects out there which provide kdb modules and use a
different memory allocator than malloc. One example is Samba which uses
talloc. Those projects should to be able to free e_data using their
memory allocation functions.