### PR TITLE
Fix missing dependencies in gssrpc headers

### DIFF
--- a/src/include/gssrpc/auth.h
+++ b/src/include/gssrpc/auth.h
@@ -42,6 +42,7 @@
 #ifndef GSSRPC_AUTH_H
 #define GSSRPC_AUTH_H
 
+#include <gssrpc/types.h>
 #include <gssrpc/xdr.h>
 
 GSSRPC__BEGIN_DECLS

--- a/src/include/gssrpc/auth_gssapi.h
+++ b/src/include/gssrpc/auth_gssapi.h
@@ -8,6 +8,10 @@
 
 GSSRPC__BEGIN_DECLS
 
+#include <gssapi/gssapi.h>
+#include <gssrpc/clnt.h>
+#include <gssrpc/svc.h>
+
 #define AUTH_GSSAPI_EXIT		0
 #define AUTH_GSSAPI_INIT 		1
 #define AUTH_GSSAPI_CONTINUE_INIT 	2

--- a/src/include/gssrpc/auth_unix.h
+++ b/src/include/gssrpc/auth_unix.h
@@ -40,6 +40,8 @@
 #ifndef GSSRPC_AUTH_UNIX_H
 #define GSSRPC_AUTH_UNIX_H
 
+#include <gssrpc/auth.h>
+
 GSSRPC__BEGIN_DECLS
 /*
  * The system is very weak.  The client uses no encryption for  it

--- a/src/include/gssrpc/clnt.h
+++ b/src/include/gssrpc/clnt.h
@@ -39,6 +39,8 @@
 #ifndef GSSRPC_CLNT_H
 #define GSSRPC_CLNT_H
 
+#include <gssrpc/auth.h>
+
 GSSRPC__BEGIN_DECLS
 /*
  * Rpc calls return an enum clnt_stat.  This should be looked at more,

--- a/src/include/gssrpc/pmap_clnt.h
+++ b/src/include/gssrpc/pmap_clnt.h
@@ -40,6 +40,8 @@
 #ifndef GSSRPC_PMAP_CLNT_H
 #define GSSRPC_PMAP_CLNT_H
 
+#include <gssrpc/auth.h>
+
 /*
  * Usage:
  *	success = pmap_set(program, version, protocol, port);

--- a/src/include/gssrpc/pmap_prot.h
+++ b/src/include/gssrpc/pmap_prot.h
@@ -69,6 +69,9 @@
 
 #ifndef GSSRPC_PMAP_PROT_H
 #define GSSRPC_PMAP_PROT_H
+
+#include <gssrpc/auth.h>
+
 GSSRPC__BEGIN_DECLS
 
 #define PMAPPORT		((u_short)111)

--- a/src/include/gssrpc/pmap_rmt.h
+++ b/src/include/gssrpc/pmap_rmt.h
@@ -39,6 +39,9 @@
 
 #ifndef GSSRPC_PMAP_RMT_H
 #define GSSRPC_PMAP_RMT_H
+
+#include <gssrpc/auth.h>
+
 GSSRPC__BEGIN_DECLS
 
 struct rmtcallargs {

--- a/src/include/gssrpc/rpc_msg.h
+++ b/src/include/gssrpc/rpc_msg.h
@@ -41,6 +41,8 @@
 #ifndef GSSRPC_RPC_MSG_H
 #define GSSRPC_RPC_MSG_H
 
+#include <gssrpc/auth.h>
+
 GSSRPC__BEGIN_DECLS
 
 #define RPC_MSG_VERSION		((uint32_t) 2)

--- a/src/include/gssrpc/svc.h
+++ b/src/include/gssrpc/svc.h
@@ -39,6 +39,7 @@
 #ifndef GSSRPC_SVC_H
 #define GSSRPC_SVC_H
 
+#include <gssrpc/auth.h>
 #include <gssrpc/svc_auth.h>
 
 GSSRPC__BEGIN_DECLS

--- a/src/include/gssrpc/svc_auth.h
+++ b/src/include/gssrpc/svc_auth.h
@@ -45,6 +45,8 @@
 #define GSSRPC_SVC_AUTH_H
 
 #include <gssapi/gssapi.h>
+#include <gssrpc/types.h>
+#include <gssrpc/xdr.h>
 
 GSSRPC__BEGIN_DECLS
 

--- a/src/include/gssrpc/xdr.h
+++ b/src/include/gssrpc/xdr.h
@@ -41,6 +41,7 @@
 #define GSSRPC_XDR_H
 
 #include <stdio.h>		/* for FILE */
+#include <gssrpc/types.h>
 
 GSSRPC__BEGIN_DECLS
 /*


### PR DESCRIPTION
This is intended to allow each header file to be included individually without missing definitions.