### PR TITLE
Echo KDC cookies in preauth tryagain

### DIFF
--- a/src/lib/krb5/krb/preauth2.c
+++ b/src/lib/krb5/krb/preauth2.c
@@ -923,7 +923,7 @@ k5_preauth_tryagain(krb5_context context, krb5_init_creds_context ctx,
     krb5_pa_data **mod_pa;
     krb5_clpreauth_modreq modreq;
     clpreauth_handle h;
-    int i;
+    int i, count;
 
     *padata_out = NULL;
 
@@ -942,6 +942,12 @@ k5_preauth_tryagain(krb5_context context, krb5_init_creds_context ctx,
                                  ctx->err_reply, ctx->err_padata,
                                  ctx->prompter, ctx->prompter_data, &mod_pa);
         if (ret == 0 && mod_pa != NULL) {
+            for (count = 0; mod_pa[count] != NULL; count++);
+            ret = copy_cookie(context, ctx->err_padata, &mod_pa, &count);
+            if (ret) {
+                krb5_free_pa_data(context, mod_pa);
+                return ret;
+            }
             TRACE_PREAUTH_TRYAGAIN_OUTPUT(context, mod_pa);
             *padata_out = mod_pa;
             return 0;

--- a/src/tests/t_pkinit.py
+++ b/src/tests/t_pkinit.py
@@ -171,14 +171,16 @@ realm.kinit(realm.user_princ,
 realm.klist(realm.user_princ)
 
 # Test a DH parameter renegotiation by temporarily setting a 4096-bit
-# minimum on the KDC.
+# minimum on the KDC.  (Preauth type 16 is PKINIT PA_PK_AS_REQ;
+# 133 is FAST PA-FX-COOKIE.)
 minbits_kdc_conf = {'realms': {'$realm': {'pkinit_dh_min_bits': '4096'}}}
 minbits_env = realm.special_env('restrict', True, kdc_conf=minbits_kdc_conf)
 realm.stop_kdc()
 realm.start_kdc(env=minbits_env)
 expected_trace = ('Key parameters not accepted',
                   'Preauth tryagain input types',
-                  'trying again with KDC-provided parameters')
+                  'trying again with KDC-provided parameters',
+                  'Followup preauth for next request: 16, 133')
 realm.kinit(realm.user_princ,
             flags=['-X', 'X509_user_identity=%s' % file_identity],
             expected_trace=expected_trace)


### PR DESCRIPTION
[This will be tested in the preauth fallback work.  I want the change reviewed separately as it's a behavior change independent of improving preauth fallback.]

When trying again after a mechanism-specific error, we should send the
KDC cookie for conformance with RFC 6113.

ticket: 8539