### PR TITLE
Cleanups for preauth fallback work

### DIFF
--- a/src/include/k5-trace.h
+++ b/src/include/k5-trace.h
@@ -301,8 +301,11 @@ void krb5int_trace(krb5_context context, const char *fmt, ...);
 #define TRACE_PREAUTH_SKIP(c, name, patype)                           \
     TRACE(c, "Skipping previously used preauth module {str} ({int})", \
           name, (int) patype)
-#define TRACE_PREAUTH_TRYAGAIN_INPUT(c, padata)                 \
-    TRACE(c, "Preauth tryagain input types: {patypes}", padata)
+#define TRACE_PREAUTH_TRYAGAIN_INPUT(c, patype, padata)                 \
+    TRACE(c, "Preauth tryagain input types ({int}): {patypes}", patype, padata)
+#define TRACE_PREAUTH_TRYAGAIN(c, name, patype, code)                   \
+    TRACE(c, "Preauth module {str} ({int}) tryagain returned: {kerr}",  \
+          name, (int)patype, code)
 #define TRACE_PREAUTH_TRYAGAIN_OUTPUT(c, padata)                        \
     TRACE(c, "Followup preauth for next request: {patypes}", padata)
 #define TRACE_PREAUTH_WRONG_CONTEXT(c)                                  \

--- a/src/lib/krb5/krb/get_in_tkt.c
+++ b/src/lib/krb5/krb/get_in_tkt.c
@@ -1377,8 +1377,6 @@ init_creds_step_request(krb5_context context,
         krb5_free_data(context, ctx->encoded_previous_request);
         ctx->encoded_previous_request = NULL;
     }
-    if (ctx->request->padata)
-        ctx->sent_nontrivial_preauth = TRUE;
     if (ctx->enc_pa_rep_permitted) {
         code = add_padata(&ctx->request->padata, KRB5_ENCPADATA_REQ_ENC_PA_REP,
                           NULL, 0);
@@ -1503,7 +1501,7 @@ init_creds_step_reply(krb5_context context,
             ctx->restarted = TRUE;
             code = restart_init_creds_loop(context, ctx, TRUE);
         } else if (!ctx->restarted && reply_code == KDC_ERR_PREAUTH_FAILED &&
-                   !ctx->sent_nontrivial_preauth) {
+                   ctx->selected_preauth_type == KRB5_PADATA_NONE) {
             /* The KDC didn't like our informational padata (probably a pre-1.7
              * MIT krb5 KDC).  Retry without it. */
             ctx->enc_pa_rep_permitted = FALSE;
@@ -1543,7 +1541,6 @@ init_creds_step_reply(krb5_context context,
                 goto cleanup;
             /* Reset per-realm negotiation state. */
             ctx->restarted = FALSE;
-            ctx->sent_nontrivial_preauth = FALSE;
             ctx->enc_pa_rep_permitted = TRUE;
             code = restart_init_creds_loop(context, ctx, FALSE);
         } else {

--- a/src/lib/krb5/krb/get_in_tkt.c
+++ b/src/lib/krb5/krb/get_in_tkt.c
@@ -1514,8 +1514,6 @@ init_creds_step_reply(krb5_context context,
             code = restart_init_creds_loop(context, ctx, FALSE);
         } else if ((reply_code == KDC_ERR_MORE_PREAUTH_DATA_REQUIRED ||
                     reply_code == KDC_ERR_PREAUTH_REQUIRED) && retry) {
-            /* reset the list of preauth types to try */
-            k5_reset_preauth_types_tried(ctx);
             krb5_free_pa_data(context, ctx->preauth_to_use);
             ctx->preauth_to_use = ctx->err_padata;
             ctx->err_padata = NULL;
@@ -1565,7 +1563,6 @@ init_creds_step_reply(krb5_context context,
         goto cleanup;
 
     /* process any preauth data in the as_reply */
-    k5_reset_preauth_types_tried(ctx);
     code = krb5int_fast_process_response(context, ctx->fast_state,
                                          ctx->reply, &strengthen_key);
     if (code != 0)

--- a/src/lib/krb5/krb/init_creds_ctx.h
+++ b/src/lib/krb5/krb/init_creds_ctx.h
@@ -58,7 +58,6 @@ struct _krb5_init_creds_context {
     krb5_enctype etype;
     krb5_boolean enc_pa_rep_permitted;
     krb5_boolean restarted;
-    krb5_boolean sent_nontrivial_preauth;
     krb5_boolean preauth_required;
     struct krb5_responder_context_st rctx;
     krb5_preauthtype selected_preauth_type;

--- a/src/lib/krb5/krb/int-proto.h
+++ b/src/lib/krb5/krb/int-proto.h
@@ -199,6 +199,9 @@ k5_free_preauth_context(krb5_context context);
 void
 k5_reset_preauth_types_tried(krb5_init_creds_context ctx);
 
+krb5_error_code
+k5_preauth_note_failed(krb5_init_creds_context ctx, krb5_preauthtype pa_type);
+
 void
 k5_preauth_prepare_request(krb5_context context, krb5_get_init_creds_opt *opt,
                            krb5_kdc_req *request);

--- a/src/lib/krb5/krb/int-proto.h
+++ b/src/lib/krb5/krb/int-proto.h
@@ -187,7 +187,8 @@ k5_preauth(krb5_context context, krb5_init_creds_context ctx,
 
 krb5_error_code
 k5_preauth_tryagain(krb5_context context, krb5_init_creds_context ctx,
-                    krb5_pa_data **in_padata, krb5_pa_data ***padata_out);
+                    krb5_preauthtype pa_type, krb5_error *err,
+                    krb5_pa_data **err_padata, krb5_pa_data ***padata_out);
 
 void
 k5_init_preauth_context(krb5_context context);


### PR DESCRIPTION
Here are four commits which simplify the preauth framework in preparation for better fallback behavior.  I am putting these up for review separately to make it easier to review the main body of the preauth fallback work later on.

The changes to k5_preauth_tryagain() do change how that part of the preauth framework works, by only consulting the module that we previously selected.  Preauth tryagain is used exclusively by PKINIT, so this should not be a risky change.
