### PR TITLE
Fix PKINIT two-component matching rule parsing

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_matching.c
+++ b/src/plugins/preauth/pkinit/pkinit_matching.c
@@ -409,7 +409,7 @@ parse_rule_set(krb5_context context,
     }
     rs->num_crs = 0;
     while (remaining > 0) {
-        if (rs->relation == relation_none && rs->num_crs > 1) {
+        if (rs->relation == relation_none && rs->num_crs > 0) {
             pkiDebug("%s: Assuming AND relation for multiple components in rule '%s'\n",
                      __FUNCTION__, rule_in);
             rs->relation = relation_and;


### PR DESCRIPTION
[As far as I can tell, we have no automated tests for PKINIT matching rules, and no described manual test procedure.  I may try to find time to create tests, but since we want to get a 1.15.1 out soon, I may decide not to.  The fix is pretty easy to verify by eye, and Sumit and I agreed on it in prior discussion.]

In pkinit_matching.c:parse_rule_set(), apply the default relation when
parsing the second component of a rule, not the third.  Otherwise we
apply no default relation to two-component matching rules, effectively
reducing such rules to their second components.  Reported by Sumit
Bose.
