### PR TITLE
Memory leak fixes, checking

### DIFF
--- a/src/clients/kvno/kvno.c
+++ b/src/clients/kvno/kvno.c
@@ -326,9 +326,7 @@ static void do_v5_kvno (int count, char *names[],
                 printf(_("%s: kvno = %d\n"), princ, ticket->enc_part.kvno);
         }
 
-        continue;
-
-    error:
+    cleanup:
         if (server != NULL)
             krb5_free_principal(context, server);
         if (ticket != NULL)
@@ -337,7 +335,11 @@ static void do_v5_kvno (int count, char *names[],
             krb5_free_creds(context, out_creds);
         if (princ != NULL)
             krb5_free_unparsed_name(context, princ);
+        continue;
+
+    error:
         errors++;
+        goto cleanup;
     }
 
     if (keytab)

--- a/src/kdc/t_replay.c
+++ b/src/kdc/t_replay.c
@@ -620,6 +620,8 @@ test_kdc_check_lookaside_hit(void **state)
     assert_true(data_eq(rep, *result_data));
     assert_int_equal(hits, 1);
     assert_int_equal(e->num_hits, 1);
+
+    krb5_free_data(context, result_data);
 }
 
 static void
@@ -697,6 +699,8 @@ test_kdc_check_lookaside_hit_multiple(void **state)
     assert_int_equal(e1->num_hits, 1);
     assert_int_equal(e2->num_hits, 0);
 
+    krb5_free_data(context, result_data);
+
     /* Set result_data so we can verify that it is reset to NULL. */
     result_data = &req1;
     result = kdc_check_lookaside(context, &req2, &result_data);
@@ -729,6 +733,8 @@ test_kdc_check_lookaside_hit_hash_collision(void **state)
     assert_int_equal(hits, 1);
     assert_int_equal(e1->num_hits, 1);
     assert_int_equal(e2->num_hits, 0);
+
+    krb5_free_data(context, result_data);
 
     /* Set result_data so we can verify that it is reset to NULL. */
     result_data = &req1;

--- a/src/lib/gssapi/mechglue/g_inq_cred_oid.c
+++ b/src/lib/gssapi/mechglue/g_inq_cred_oid.c
@@ -85,11 +85,6 @@ gss_inquire_cred_by_oid(OM_uint32 *minor_status,
 
     union_cred = (gss_union_cred_t) cred_handle;
 
-    status = gss_create_empty_buffer_set(minor_status, &ret_set);
-    if (status != GSS_S_COMPLETE) {
-	return status;
-    }
-
     status = GSS_S_UNAVAILABLE;
 
     for (i = 0; i < union_cred->count; i++) {

--- a/src/tests/icinterleave.c
+++ b/src/tests/icinterleave.c
@@ -119,6 +119,10 @@ main(int argc, char **argv)
         }
     }
 
+    for (i = 0; i < nclients; i++)
+        krb5_free_data_contents(ctx, &reps[i]);
+    free(reps);
+    free(iccs);
     krb5_free_context(ctx);
     return 0;
 }

--- a/src/tests/t_kdb.py
+++ b/src/tests/t_kdb.py
@@ -328,8 +328,7 @@ realm.run([kadminl, 'getprinc', 'alias'],
           expected_msg='Principal: canon@KRBTEST.COM\n')
 realm.run([kadminl, 'getprinc', 'canon'],
           expected_msg='Principal: canon@KRBTEST.COM\n')
-realm.run([kvno, 'alias'])
-realm.run([kvno, 'canon'])
+realm.run([kvno, 'alias', 'canon'])
 out = realm.run([klist])
 if 'alias@KRBTEST.COM\n' not in out or 'canon@KRBTEST.COM' not in out:
     fail('After fetching alias and canon, klist is missing one or both')


### PR DESCRIPTION
I did another round of asan leak checking after a report of a memory leak in kvno.  (That leak turns out to be quite old, and wasn't caught by asan because we never run kvno with multiple principal arguments in the test suite.)  This PR has five commits:

* Fix two leaks that crept into test programs since the last round of fixes.
* Fix a leak in gss_inquire_cred_by_oid(), which is old but wasn't caught by asan until 750cd27317d8e8af506c3b9e412a3ccbeef299b0.
* Fix the reported leak in kvno, minimally but somewhat awkwardly.
* Refactor the kvno loop into a helper function so its memory management isn't as awkward.
* Enable asan for Travis builds.

That last change will have a significant impact on the time it takes to run checks on PRs, but it's clear that we need it in order for the test suite to remain leak-clean.  I had originally intended on adding asan checking to a buildbot worker instead, but that would lead to a lot of follow-on commits after we merge a PR without realizing that it introduces a leak (or other memory error).
