### PR TITLE
Force autoconf rebuild in maintainer rules

### DIFF
--- a/src/config/post.in
+++ b/src/config/post.in
@@ -185,7 +185,7 @@ $(top_srcdir)/configure: @MAINT@ \
 		$(top_srcdir)/patchlevel.h \
 		$(top_srcdir)/aclocal.m4
 	(cd $(top_srcdir) && \
-		$(AUTOCONF) --include=$(CONFIG_RELTOPDIR) $(AUTOCONFFLAGS))
+		$(AUTOCONF) -f --include=$(CONFIG_RELTOPDIR) $(AUTOCONFFLAGS))
 
 RECURSE_TARGETS=all-recurse clean-recurse distclean-recurse install-recurse \
 	generate-files-mac-recurse \


### PR DESCRIPTION
autoconf normally avoids recreating files that it does not consider
obsolete.  Since it knows nothing about patchlevel.h (which we read at
autoconf time using m4's esyscmd()), changes to patchlevel.h won't be
reflected in configure unless another input to configure has changed,
and the maintainer rule will re-run autoconf over and over again.  Fix
this issue by passing the force flag to autoconf when we invoke it
from the maintainer rule.
