### PR TITLE
Port pkinit debug code to OpenSSL 1.1.0 API

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -3572,12 +3572,14 @@ openssl_callback(int ok, X509_STORE_CTX * ctx)
 {
 #ifdef DEBUG
     if (!ok) {
+        X509 *cert = X509_STORE_CTX_get_current_cert(ctx);
+        int err = X509_STORE_CTX_get_error(ctx);
+        const char *errmsg = X509_verify_cert_error_string(err);
         char buf[DN_BUF_LEN];
 
-        X509_NAME_oneline(X509_get_subject_name(ctx->current_cert), buf, sizeof(buf));
+        X509_NAME_oneline(X509_get_subject_name(cert), buf, sizeof(buf));
         pkiDebug("cert = %s\n", buf);
-        pkiDebug("callback function: %d (%s)\n", ctx->error,
-                 X509_verify_cert_error_string(ctx->error));
+        pkiDebug("callback function: %d (%s)\n", err, errmsg);
     }
 #endif
     return ok;


### PR DESCRIPTION
there are still missing bits using old OpenSSL 1.0.x API in the DEBUG ifdefs. I ran into this one while building `pkinit` with `DEBUG` so I am providing a fix, but there might be others in other parts of the project.