### PR TITLE
Correct error handling bug in prior commit

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -6114,10 +6114,10 @@ crypto_encode_der_cert(krb5_context context, pkinit_req_crypto_context reqctx,
     if (len <= 0)
         return EINVAL;
     p = der = malloc(len);
-    if (p == NULL)
+    if (der == NULL)
         return ENOMEM;
     if (i2d_X509(reqctx->received_cert, &p) <= 0) {
-        free(p);
+        free(der);
         return EINVAL;
     }
     *der_out = der;


### PR DESCRIPTION
[In my final review pass of PR #610 I fixed an omission in my revised crypto_encode_der_cert() code, but made a mistake in an error path.]

In crypto_encode_der_cert(), if the second i2d_X509() invocation
fails, make sure to free the allocated pointer and not the
possibly-modified alias.
