### PR TITLE
Ignore dotfiles in profile includedir

### DIFF
--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -55,9 +55,10 @@ following directives at the beginning of a line::
 directory must exist and be readable.  Including a directory includes
 all files within the directory whose names consist solely of
 alphanumeric characters, dashes, or underscores.  Starting in release
-1.15, files with names ending in ".conf" are also included.  Included
-profile files are syntactically independent of their parents, so each
-included file must begin with a section header.
+1.15, files with names ending in ".conf" are also included, unless the
+name begins with ".".  Included profile files are syntactically
+independent of their parents, so each included file must begin with a
+section header.
 
 The krb5.conf file can specify that configuration should be obtained
 from a loadable module, rather than the file itself, using the

--- a/src/util/profile/prof_parse.c
+++ b/src/util/profile/prof_parse.c
@@ -222,11 +222,15 @@ static errcode_t parse_include_file(const char *filename,
 }
 
 /* Return non-zero if filename contains only alphanumeric characters, dashes,
- * and underscores, or if the filename ends in ".conf". */
+ * and underscores, or if the filename ends in ".conf" and is not a dotfile. */
 static int valid_name(const char *filename)
 {
     const char *p;
     size_t len = strlen(filename);
+
+    /* Ignore dotfiles, which might be editor or filesystem artifacts. */
+    if (*filename == '.')
+        return 0;
 
     if (len >= 5 && !strcmp(filename + len - 5, ".conf"))
         return 1;


### PR DESCRIPTION
[From list discussion.  I decided to mark this for pullup as it could be considered a bug, and so that we limit the number of different includedir behaviors in different release lines.]

Editors and filesystems may create artifacts related to .conf files
which don't change the file suffix; these artifacts generally begin
with "." so that they don't appear in normal directory listings
(e.g. ".#filename" for emacs interlock files).  Make sure to ignore
any such artifacts when processing a profile includedir directive.

ticket: 8563 (new)
target_version: 1.15-next
tags: pullup