### PR TITLE
Compile less libev code

### DIFF
--- a/src/util/verto/verto-k5ev.c
+++ b/src/util/verto/verto-k5ev.c
@@ -41,7 +41,12 @@
 /* Avoid using clock_gettime, which would create a dependency on librt. */
 #define EV_USE_MONOTONIC 0
 #define EV_USE_REALTIME 0
-#define EV_FEATURES 0x5f        /* Everything but back ends */
+#define EV_FEATURES 0x4f        /* No back ends or optional watchers */
+/* Enable the optional watcher types we use. */
+#define EV_IDLE_ENABLE 1
+#define EV_SIGNAL_ENABLE 1
+#define EV_CHILD_ENABLE 1
+/* Enable the back ends we want. */
 #ifdef HAVE_POLL_H
 #define EV_USE_POLL 1
 #endif


### PR DESCRIPTION
[Building less libev code reduces our library size a small amount, and also reduces the amount of third-party code seen by static analyzers.]

In verto-k5ev.c, turn off optional watchers in ev.c, and enable the
specific watcher types we use.