### PR TITLE
Add FAST encrypted challenge auth indicator

### DIFF
--- a/doc/admin/conf_files/kdc_conf.rst
+++ b/doc/admin/conf_files/kdc_conf.rst
@@ -198,6 +198,11 @@ The following tags may be specified in a [realms] subsection:
     if there is no policy assigned to the principal, no dictionary
     checks of passwords will be performed.
 
+**encrypted_challenge_indicator**
+    (String.)  Specifies the authentication indicator value that the KDC
+    asserts into tickets obtained using FAST encrypted challenge
+    pre-authentication.  New in 1.16.
+
 **host_based_services**
     (Whitespace- or comma-separated list.)  Lists services which will
     get host-based referral processing even if the server principal is

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -212,6 +212,7 @@ typedef unsigned char   u_char;
 #define KRB5_CONF_DNS_URI_LOOKUP               "dns_uri_lookup"
 #define KRB5_CONF_DOMAIN_REALM                 "domain_realm"
 #define KRB5_CONF_ENABLE_ONLY                  "enable_only"
+#define KRB5_CONF_ENCRYPTED_CHALLENGE_INDICATOR "encrypted_challenge_indicator"
 #define KRB5_CONF_ERR_FMT                      "err_fmt"
 #define KRB5_CONF_EXTRA_ADDRESSES              "extra_addresses"
 #define KRB5_CONF_FORWARDABLE                  "forwardable"

--- a/src/tests/gssapi/t_authind.py
+++ b/src/tests/gssapi/t_authind.py
@@ -34,4 +34,19 @@ if '6f6e65' not in out or '74776f' not in out:
     fail('Expected auth indicator not seen in name attributes')
 
 realm.stop()
+
+# Test the FAST encrypted challenge auth indicator.
+kdcconf = {'realms': {'$realm': {'encrypted_challenge_indicator': 'fast'}}}
+realm = K5Realm(kdc_conf=kdcconf)
+realm.run([kadminl, 'modprinc', '+requires_preauth', realm.user_princ])
+realm.run([kadminl, 'xst', realm.host_princ])
+realm.kinit(realm.user_princ, password('user'))
+realm.kinit(realm.user_princ, password('user'), ['-T', realm.ccache])
+out = realm.run(['./t_srcattrs', 'p:' + realm.host_princ])
+if ('Attribute auth-indicators Authenticated Complete') not in out:
+    fail('Expected attribute type not seen')
+if '66617374' not in out:
+    fail('Expected auth indicator not seen in name attributes')
+
+realm.stop()
 success('GSSAPI auth indicator tests')


### PR DESCRIPTION
Here's my attempt at adding AI capabilities to the FAST ec module. The configuration option may be inadequate as only a kdcdefaults section option, but currently the module does not use any realm-specific moddata in order to handle separate FAST AIs.