### PR TITLE
Use the client DB principal name for OTP

### DIFF
--- a/src/include/krb5/kdcpreauth_plugin.h
+++ b/src/include/krb5/kdcpreauth_plugin.h
@@ -232,6 +232,12 @@ typedef struct krb5_kdcpreauth_callbacks_st {
                                  krb5_kdcpreauth_rock rock,
                                  krb5_principal princ);
 
+    /*
+     * Get an alias to the client DB entry principal (possibly canonicalized).
+     */
+    krb5_principal (*client_name)(krb5_context context,
+                                  krb5_kdcpreauth_rock rock);
+
     /* End of version 4 kdcpreauth callbacks. */
 
 } *krb5_kdcpreauth_callbacks;

--- a/src/kdc/kdc_preauth.c
+++ b/src/kdc/kdc_preauth.c
@@ -591,6 +591,12 @@ match_client(krb5_context context, krb5_kdcpreauth_rock rock,
     return match;
 }
 
+static krb5_principal
+client_name(krb5_context context, krb5_kdcpreauth_rock rock)
+{
+    return rock->client->princ;
+}
+
 static struct krb5_kdcpreauth_callbacks_st callbacks = {
     4,
     max_time_skew,
@@ -607,7 +613,8 @@ static struct krb5_kdcpreauth_callbacks_st callbacks = {
     add_auth_indicator,
     get_cookie,
     set_cookie,
-    match_client
+    match_client,
+    client_name
 };
 
 static krb5_error_code

--- a/src/plugins/preauth/otp/main.c
+++ b/src/plugins/preauth/otp/main.c
@@ -331,7 +331,8 @@ otp_verify(krb5_context context, krb5_data *req_pkt, krb5_kdc_req *request,
 
     /* Send the request. */
     otp_state_verify((otp_state *)moddata, cb->event_context(context, rock),
-                     request->client, config, req, on_response, rs);
+                     cb->client_name(context, rock), config, req, on_response,
+                     rs);
     cb->free_string(context, rock, config);
 
     k5_free_pa_otp_req(context, req);


### PR DESCRIPTION
Add the kdcpreauth callback client_name() to return the client DB
principal and use it when calling otp_state_verify().  This allows
canonicalization of the name before passing it along as the username
for RADIUS.