### PR TITLE
Export GSS_KRB5_GET_CRED_IMPERSONATOR on Windows

### DIFF
--- a/src/lib/gssapi32.def
+++ b/src/lib/gssapi32.def
@@ -182,3 +182,5 @@ EXPORTS
 	gss_verify_mic_iov				@146
 ; Added in 1.14
 	GSS_KRB5_CRED_NO_CI_FLAGS_X			@147	DATA
+; Added in 1.16
+	GSS_KRB5_GET_CRED_IMPERSONATOR			@148	DATA


### PR DESCRIPTION
[Corrects an oversight in PR #601]

Add the new public data symbol GSS_KRB5_GET_CRED_IMPERSONATOR to the
gssapi DLL export list.
