### PR TITLE
Fix all warnings with clang

### DIFF
--- a/src/aclocal.m4
+++ b/src/aclocal.m4
@@ -1367,7 +1367,6 @@ dnl =============================================================
 dnl Internal function for testing for getpeername prototype
 dnl
 AC_DEFUN([KRB5_GETPEERNAME_ARGS],[
-AC_DEFINE([GETPEERNAME_ARG2_TYPE],GETSOCKNAME_ARG2_TYPE,[Type of getpeername second argument.])
 AC_DEFINE([GETPEERNAME_ARG3_TYPE],GETSOCKNAME_ARG3_TYPE,[Type of getpeername second argument.])
 ])
 dnl
@@ -1412,7 +1411,6 @@ if test "$sock_set" = no; then
 fi
 res1=`echo "$res1" | tr -d '*' | sed -e 's/ *$//'`
 res2=`echo "$res2" | tr -d '*' | sed -e 's/ *$//'`
-AC_DEFINE_UNQUOTED([GETSOCKNAME_ARG2_TYPE],$res1,[Type of pointer target for argument 2 to getsockname])
 AC_DEFINE_UNQUOTED([GETSOCKNAME_ARG3_TYPE],$res2,[Type of pointer target for argument 3 to getsockname])
 ])
 dnl

--- a/src/include/k5-platform.h
+++ b/src/include/k5-platform.h
@@ -71,6 +71,13 @@
 #define CAN_COPY_VA_LIST
 #endif
 
+/* This attribute prevents unused function warnings in gcc and clang. */
+#ifdef __GNUC__
+#define UNUSED __attribute__((__unused__))
+#else
+#define UNUSED
+#endif
+
 #if defined(macintosh) || (defined(__MACH__) && defined(__APPLE__))
 #include <TargetConditionals.h>
 #endif
@@ -357,14 +364,11 @@ typedef struct { int error; unsigned char did_run; } k5_init_t;
 #if !defined(SHARED) && !defined(_WIN32)
 
 /*
- * In this case, we just don't care about finalization.
- *
- * The code will still define the function, but we won't do anything
- * with it.  Annoying: This may generate unused-function warnings.
+ * In this case, we just don't care about finalization.  The code will still
+ * define the function, but we won't do anything with it.
  */
-
 # define MAKE_FINI_FUNCTION(NAME)               \
-        static void NAME(void)
+        static void NAME(void) UNUSED
 
 #elif defined(USE_LINKER_FINI_OPTION) || defined(_WIN32)
 /* If we're told the linker option will be used, it doesn't really

--- a/src/include/kdb_log.h
+++ b/src/include/kdb_log.h
@@ -21,9 +21,8 @@ extern "C" {
 /*
  * DB macros
  */
-#define INDEX(ulog, i) (kdb_ent_header_t *)((char *)(ulog) +            \
-                                            sizeof(kdb_hlog_t) +        \
-                                            (i) * ulog->kdb_block)
+#define INDEX(ulog, i) (kdb_ent_header_t *)(void *)                     \
+    ((char *)(ulog) + sizeof(kdb_hlog_t) + (i) * ulog->kdb_block)
 
 /*
  * Current DB version #

--- a/src/include/win-mac.h
+++ b/src/include/win-mac.h
@@ -225,9 +225,7 @@ typedef _W64 int         ssize_t;
 
 HINSTANCE get_lib_instance(void);
 
-#define GETSOCKNAME_ARG2_TYPE   struct sockaddr
 #define GETSOCKNAME_ARG3_TYPE   size_t
-#define GETPEERNAME_ARG2_TYPE   GETSOCKNAME_ARG2_TYPE
 #define GETPEERNAME_ARG3_TYPE   GETSOCKNAME_ARG3_TYPE
 
 #endif /* !RES_ONLY */

--- a/src/kadmin/cli/getdate.y
+++ b/src/kadmin/cli/getdate.y
@@ -6,7 +6,7 @@
 **  <rsalz@bbn.com> and Jim Berets <jberets@bbn.com> in August, 1990;
 **  send any email to Rich.
 **
-**  This grammar has nine shift/reduce conflicts.
+**  This grammar has four shift/reduce conflicts.
 **
 **  This code is in the public domain and has no copyright.
 */
@@ -175,6 +175,9 @@ static time_t	yyRelMonth;
 static time_t	yyRelSeconds;
 
 %}
+
+/* Mute shift/reduce warning as per header comment. */
+%expect 4
 
 %union {
     time_t		Number;

--- a/src/kadmin/server/ipropd_svc.c
+++ b/src/kadmin/server/ipropd_svc.c
@@ -532,9 +532,9 @@ krb5_iprop_prog_1(struct svc_req *rqstp,
     union {
 	kdb_last_t iprop_get_updates_1_arg;
     } argument;
-    char *result;
+    void *result;
     bool_t (*_xdr_argument)(), (*_xdr_result)();
-    char *(*local)(/* union XXX *, struct svc_req * */);
+    void *(*local)(/* union XXX *, struct svc_req * */);
     char *whoami = "krb5_iprop_prog_1";
 
     if (!check_iprop_rpcsec_auth(rqstp)) {
@@ -555,19 +555,19 @@ krb5_iprop_prog_1(struct svc_req *rqstp,
     case IPROP_GET_UPDATES:
 	_xdr_argument = xdr_kdb_last_t;
 	_xdr_result = xdr_kdb_incr_result_t;
-	local = (char *(*)()) iprop_get_updates_1_svc;
+	local = (void *(*)()) iprop_get_updates_1_svc;
 	break;
 
     case IPROP_FULL_RESYNC:
 	_xdr_argument = xdr_void;
 	_xdr_result = xdr_kdb_fullresync_result_t;
-	local = (char *(*)()) iprop_full_resync_1_svc;
+	local = (void *(*)()) iprop_full_resync_1_svc;
 	break;
 
     case IPROP_FULL_RESYNC_EXT:
 	_xdr_argument = xdr_u_int32;
 	_xdr_result = xdr_kdb_fullresync_result_t;
-	local = (char *(*)()) iprop_full_resync_ext_1_svc;
+	local = (void *(*)()) iprop_full_resync_ext_1_svc;
 	break;
 
     default:

--- a/src/kadmin/server/schpw.c
+++ b/src/kadmin/server/schpw.c
@@ -366,7 +366,7 @@ chpwfail:
            to mk_error do. */
         krberror.error = ret;
         krberror.error -= ERROR_TABLE_BASE_krb5;
-        if (krberror.error < 0 || krberror.error > KRB_ERR_MAX)
+        if (krberror.error > KRB_ERR_MAX)
             krberror.error = KRB_ERR_GENERIC;
 
         krberror.client = NULL;

--- a/src/kadmin/server/server_stubs.c
+++ b/src/kadmin/server/server_stubs.c
@@ -1079,8 +1079,8 @@ exit_func:
     return TRUE;
 }
 
-/* Empty out *keys/*nkeys if princ is protected with the lockdown attribute, or
- * if we fail to check. */
+/* Empty out *keys / *nkeys if princ is protected with the lockdown
+ * attribute, or if we fail to check. */
 static kadm5_ret_t
 chrand_check_lockdown(kadm5_server_handle_t handle, krb5_principal princ,
                       krb5_keyblock **keys, int *nkeys)

--- a/src/lib/crypto/builtin/des/destest.c
+++ b/src/lib/crypto/builtin/des/destest.c
@@ -52,6 +52,7 @@
 /* Test a DES implementation against known inputs & outputs. */
 
 #include "des_int.h"
+#include <ctype.h>
 #include <stdio.h>
 
 void convert (char *, unsigned char []);
@@ -160,7 +161,7 @@ convert(text, cblock)
 {
     register int i;
     for (i = 0; i < 8; i++) {
-        if (text[i*2] < 0 || text[i*2] >= 128)
+        if (!isascii((unsigned char)text[i * 2]))
             abort ();
         if (value[(int) text[i*2]] == -1 || value[(int) text[i*2+1]] == -1) {
             printf("Bad value byte %d in %s\n", i, text);

--- a/src/lib/crypto/builtin/enc_provider/rc4.c
+++ b/src/lib/crypto/builtin/enc_provider/rc4.c
@@ -113,7 +113,7 @@ k5_arcfour_docrypt(krb5_key key, const krb5_data *state, krb5_crypto_iov *data,
         return KRB5_BAD_MSIZE;
 
     if (state != NULL) {
-        cipher_state = (ArcFourCipherState *)state->data;
+        cipher_state = (ArcFourCipherState *)(void *)state->data;
         arcfour_ctx = &cipher_state->ctx;
         if (cipher_state->initialized == 0) {
             ret = k5_arcfour_init(arcfour_ctx, key->keyblock.contents,

--- a/src/lib/crypto/builtin/sha2/sha256.c
+++ b/src/lib/crypto/builtin/sha2/sha256.c
@@ -211,14 +211,14 @@ k5_sha256_update(SHA256_CTX *m, const void *v, size_t len)
 #if !defined(WORDS_BIGENDIAN) || defined(_CRAY)
 	    int i;
 	    uint32_t current[16];
-	    struct x32 *u = (struct x32*)m->save;
+	    struct x32 *u = (struct x32*)(void*)m->save;
 	    for(i = 0; i < 8; i++){
 		current[2*i+0] = swap_uint32_t(u[i].a);
 		current[2*i+1] = swap_uint32_t(u[i].b);
 	    }
 	    calc(m, current);
 #else
-	    calc(m, (uint32_t*)m->save);
+	    calc(m, (uint32_t*)(void*)m->save);
 #endif
 	    offset = 0;
 	}

--- a/src/lib/crypto/builtin/sha2/sha512.c
+++ b/src/lib/crypto/builtin/sha2/sha512.c
@@ -217,14 +217,14 @@ k5_sha512_update (SHA512_CTX *m, const void *v, size_t len)
 #if !defined(WORDS_BIGENDIAN) || defined(_CRAY)
 	    int i;
 	    uint64_t current[16];
-	    struct x64 *us = (struct x64*)m->save;
+	    struct x64 *us = (struct x64*)(void*)m->save;
 	    for(i = 0; i < 8; i++){
 		current[2*i+0] = swap_uint64_t(us[i].a);
 		current[2*i+1] = swap_uint64_t(us[i].b);
 	    }
 	    calc(m, current);
 #else
-	    calc(m, (uint64_t*)m->save);
+	    calc(m, (uint64_t*)(void*)m->save);
 #endif
 	    offset = 0;
 	}

--- a/src/lib/crypto/krb/t_fortuna.c
+++ b/src/lib/crypto/krb/t_fortuna.c
@@ -85,7 +85,7 @@ head_tail_test(struct fortuna_state *st)
 {
     static unsigned char buffer[1024 * 1024];
     unsigned char c;
-    size_t i, len = sizeof(buffer);
+    int i, len = sizeof(buffer);
     int bit, bits[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
     double res;
 

--- a/src/lib/gssapi/krb5/k5unseal.c
+++ b/src/lib/gssapi/krb5/k5unseal.c
@@ -219,7 +219,7 @@ kg_unseal_v1(context, minor_status, ctx, ptr, bodysize, message_buffer,
         plainlen = tmsglen;
 
         conflen = kg_confounder_size(context, ctx->enc->keyblock.enctype);
-        if (tmsglen < conflen) {
+        if (tmsglen < (size_t)conflen) {
             if (sealalg != 0xffff)
                 xfree(plain);
             *minor_status = 0;

--- a/src/lib/kadm5/unit-test/setkey-test.c
+++ b/src/lib/kadm5/unit-test/setkey-test.c
@@ -69,7 +69,8 @@ main(int argc, char **argv)
     char *whoami, *principal, *authprinc, *authpwd;
     krb5_data pwdata;
     void *handle;
-    int ret, i, test, encnum;
+    int ret, test, encnum;
+    unsigned int i;
 
     whoami = argv[0];
 

--- a/src/lib/kdb/kdb_convert.c
+++ b/src/lib/kdb/kdb_convert.c
@@ -228,7 +228,7 @@ conv_princ_2ulog(krb5_principal princ, kdb_incr_update_t *upd,
 static void
 set_from_utf8str(krb5_data *d, utf8str_t u)
 {
-    if (u.utf8str_t_len > INT_MAX-1 || u.utf8str_t_len >= SIZE_MAX-1) {
+    if (u.utf8str_t_len > INT_MAX - 1) {
         d->data = NULL;
         return;
     }
@@ -419,7 +419,7 @@ ulog_conv_2logentry(krb5_context context, krb5_db_entry *entry,
             break;
 
         case AT_FAIL_AUTH_COUNT:
-            if (!exclude_nra && entry->fail_auth_count >= (krb5_kvno)0) {
+            if (!exclude_nra) {
                 ULOG_ENTRY_TYPE(update, ++final).av_type =
                     AT_FAIL_AUTH_COUNT;
                 ULOG_ENTRY(update, final).av_fail_auth_count =

--- a/src/lib/krb5/ccache/cc_retr.c
+++ b/src/lib/krb5/ccache/cc_retr.c
@@ -211,7 +211,6 @@ krb5_cc_retrieve_cred_seq (krb5_context context, krb5_ccache id,
         int pref;
     } fetched, best;
     int have_creds = 0;
-    krb5_flags oflags = 0;
 #define fetchcreds (fetched.creds)
 
     kret = krb5_cc_start_seq_get(context, id, &cursor);

--- a/src/lib/krb5/krb/deltat.c
+++ b/src/lib/krb5/krb/deltat.c
@@ -72,7 +72,9 @@
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuninitialized"
+#ifndef __clang__
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #endif
 
 #include "k5-int.h"
@@ -153,7 +155,7 @@ static int mylex(int *intp, struct param *tmv);
 static int yyparse(struct param *);
 
 
-#line 157 "deltat.c" /* yacc.c:339  */
+#line 159 "deltat.c" /* yacc.c:339  */
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -197,10 +199,10 @@ extern int yydebug;
 typedef union YYSTYPE YYSTYPE;
 union YYSTYPE
 {
-#line 129 "x-deltat.y" /* yacc.c:355  */
+#line 131 "x-deltat.y" /* yacc.c:355  */
 int val;
 
-#line 204 "deltat.c" /* yacc.c:355  */
+#line 206 "deltat.c" /* yacc.c:355  */
 };
 # define YYSTYPE_IS_TRIVIAL 1
 # define YYSTYPE_IS_DECLARED 1
@@ -214,7 +216,7 @@ int yyparse (struct param *tmv);
 
 /* Copy the second part of user declarations.  */
 
-#line 218 "deltat.c" /* yacc.c:358  */
+#line 220 "deltat.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -512,9 +514,9 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,   143,   143,   144,   144,   145,   145,   146,   146,   147,
-     148,   150,   151,   152,   153,   154,   155,   156,   157,   162,
-     163,   166,   167,   170,   171
+       0,   145,   145,   146,   146,   147,   147,   148,   148,   149,
+     150,   152,   153,   154,   155,   156,   157,   158,   159,   164,
+     165,   168,   169,   172,   173
 };
 #endif
 
@@ -1310,93 +1312,93 @@ yyreduce:
   switch (yyn)
     {
         case 6:
-#line 145 "x-deltat.y" /* yacc.c:1646  */
+#line 147 "x-deltat.y" /* yacc.c:1646  */
     { (yyval.val) = - (yyvsp[0].val); }
-#line 1316 "deltat.c" /* yacc.c:1646  */
+#line 1318 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 9:
-#line 147 "x-deltat.y" /* yacc.c:1646  */
+#line 149 "x-deltat.y" /* yacc.c:1646  */
     { (yyval.val) = (yyvsp[0].val); }
-#line 1322 "deltat.c" /* yacc.c:1646  */
+#line 1324 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 10:
-#line 148 "x-deltat.y" /* yacc.c:1646  */
+#line 150 "x-deltat.y" /* yacc.c:1646  */
     { YYERROR; }
-#line 1328 "deltat.c" /* yacc.c:1646  */
+#line 1330 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 11:
-#line 150 "x-deltat.y" /* yacc.c:1646  */
+#line 152 "x-deltat.y" /* yacc.c:1646  */
     { DO ((yyvsp[-2].val),  0,  0, (yyvsp[0].val)); }
-#line 1334 "deltat.c" /* yacc.c:1646  */
+#line 1336 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 12:
-#line 151 "x-deltat.y" /* yacc.c:1646  */
+#line 153 "x-deltat.y" /* yacc.c:1646  */
     { DO ( 0, (yyvsp[-2].val),  0, (yyvsp[0].val)); }
-#line 1340 "deltat.c" /* yacc.c:1646  */
+#line 1342 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 13:
-#line 152 "x-deltat.y" /* yacc.c:1646  */
+#line 154 "x-deltat.y" /* yacc.c:1646  */
     { DO ( 0,  0, (yyvsp[-2].val), (yyvsp[0].val)); }
-#line 1346 "deltat.c" /* yacc.c:1646  */
+#line 1348 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 14:
-#line 153 "x-deltat.y" /* yacc.c:1646  */
+#line 155 "x-deltat.y" /* yacc.c:1646  */
     { DO ( 0,  0,  0, (yyvsp[-1].val)); }
-#line 1352 "deltat.c" /* yacc.c:1646  */
+#line 1354 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 15:
-#line 154 "x-deltat.y" /* yacc.c:1646  */
+#line 156 "x-deltat.y" /* yacc.c:1646  */
     { DO ((yyvsp[-6].val), (yyvsp[-4].val), (yyvsp[-2].val), (yyvsp[0].val)); }
-#line 1358 "deltat.c" /* yacc.c:1646  */
+#line 1360 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 16:
-#line 155 "x-deltat.y" /* yacc.c:1646  */
+#line 157 "x-deltat.y" /* yacc.c:1646  */
     { DO ( 0, (yyvsp[-4].val), (yyvsp[-2].val), (yyvsp[0].val)); }
-#line 1364 "deltat.c" /* yacc.c:1646  */
+#line 1366 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 17:
-#line 156 "x-deltat.y" /* yacc.c:1646  */
+#line 158 "x-deltat.y" /* yacc.c:1646  */
     { DO ( 0, (yyvsp[-2].val), (yyvsp[0].val),  0); }
-#line 1370 "deltat.c" /* yacc.c:1646  */
+#line 1372 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 18:
-#line 157 "x-deltat.y" /* yacc.c:1646  */
+#line 159 "x-deltat.y" /* yacc.c:1646  */
     { DO ( 0,  0,  0, (yyvsp[0].val)); }
-#line 1376 "deltat.c" /* yacc.c:1646  */
+#line 1378 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 20:
-#line 163 "x-deltat.y" /* yacc.c:1646  */
+#line 165 "x-deltat.y" /* yacc.c:1646  */
     { if (HOUR_NOT_OK((yyvsp[-2].val))) YYERROR;
 	                                  DO_SUM((yyval.val), (yyvsp[-2].val) * 3600, (yyvsp[0].val)); }
-#line 1383 "deltat.c" /* yacc.c:1646  */
+#line 1385 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 22:
-#line 167 "x-deltat.y" /* yacc.c:1646  */
+#line 169 "x-deltat.y" /* yacc.c:1646  */
     { if (MIN_NOT_OK((yyvsp[-2].val))) YYERROR;
 	                                  DO_SUM((yyval.val), (yyvsp[-2].val) * 60, (yyvsp[0].val)); }
-#line 1390 "deltat.c" /* yacc.c:1646  */
+#line 1392 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 23:
-#line 170 "x-deltat.y" /* yacc.c:1646  */
+#line 172 "x-deltat.y" /* yacc.c:1646  */
     { (yyval.val) = 0; }
-#line 1396 "deltat.c" /* yacc.c:1646  */
+#line 1398 "deltat.c" /* yacc.c:1646  */
     break;
 
 
-#line 1400 "deltat.c" /* yacc.c:1646  */
+#line 1402 "deltat.c" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -1624,7 +1626,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 173 "x-deltat.y" /* yacc.c:1906  */
+#line 175 "x-deltat.y" /* yacc.c:1906  */
 
 
 #ifdef __GNUC__

--- a/src/lib/krb5/krb/sendauth.c
+++ b/src/lib/krb5/krb/sendauth.c
@@ -131,22 +131,21 @@ krb5_sendauth(krb5_context context, krb5_auth_context *auth_context,
            This isn't strong cryptographically; the point here is
            not to guarantee randomness, but to make it less likely
            that multiple sessions could pick the same subkey.  */
-        char rnd_data[1024];
+        struct sockaddr_storage rnd_data;
         GETPEERNAME_ARG3_TYPE len2;
-        krb5_data d;
-        d.length = sizeof (rnd_data);
-        d.data = rnd_data;
-        len2 = sizeof (rnd_data);
-        if (getpeername (*(int*)fd, (GETPEERNAME_ARG2_TYPE *) rnd_data,
-                         &len2) == 0) {
+        krb5_data d = make_data(&rnd_data, sizeof(rnd_data));
+
+        len2 = sizeof(rnd_data);
+        if (getpeername(*(int *)fd, ss2sa(&rnd_data), &len2) == 0) {
             d.length = len2;
-            (void) krb5_c_random_add_entropy (context, KRB5_C_RANDSOURCE_EXTERNAL_PROTOCOL, &d);
+            (void)krb5_c_random_add_entropy(
+                context, KRB5_C_RANDSOURCE_EXTERNAL_PROTOCOL, &d);
         }
-        len2 = sizeof (rnd_data);
-        if (getsockname (*(int*)fd, (GETSOCKNAME_ARG2_TYPE *) rnd_data,
-                         &len2) == 0) {
+        len2 = sizeof(rnd_data);
+        if (getsockname(*(int *)fd, ss2sa(&rnd_data), &len2) == 0) {
             d.length = len2;
-            (void) krb5_c_random_add_entropy (context, KRB5_C_RANDSOURCE_EXTERNAL_PROTOCOL, &d);
+            (void)krb5_c_random_add_entropy(
+                context, KRB5_C_RANDSOURCE_EXTERNAL_PROTOCOL, &d);
         }
     }
 

--- a/src/lib/krb5/krb/x-deltat.y
+++ b/src/lib/krb5/krb/x-deltat.y
@@ -44,7 +44,9 @@
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuninitialized"
+#ifndef __clang__
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 #endif
 
 #include "k5-int.h"

--- a/src/lib/krb5/os/accessor.c
+++ b/src/lib/krb5/os/accessor.c
@@ -30,11 +30,14 @@
 
 /* If this trick gets used elsewhere, move it to k5-platform.h.  */
 #ifndef DESIGNATED_INITIALIZERS
-#define DESIGNATED_INITIALIZERS                         \
-    /* ANSI/ISO C 1999 supports this...  */             \
-    (__STDC_VERSION__ >= 199901L                        \
-     /* ...as does GCC, since version 2.something.  */  \
-     || (!defined __cplusplus && __GNUC__ >= 3))
+/* ANSI/ISO C 1999 supports this...  */
+#if __STDC_VERSION__ >= 199901L                       \
+    /* ...as does GCC, since version 2.something.  */ \
+    || (!defined __cplusplus && __GNUC__ >= 3)
+#define DESIGNATED_INITIALIZERS 1
+#else
+#define DESIGNATED_INITIALIZERS 0
+#endif
 #endif
 
 krb5_error_code KRB5_CALLCONV

--- a/src/lib/krb5/os/genaddrs.c
+++ b/src/lib/krb5/os/genaddrs.c
@@ -79,8 +79,8 @@ krb5_auth_con_genaddrs(krb5_context context, krb5_auth_context auth_context, int
     ssize = sizeof(struct sockaddr_storage);
     if ((flags & KRB5_AUTH_CONTEXT_GENERATE_LOCAL_FULL_ADDR) ||
         (flags & KRB5_AUTH_CONTEXT_GENERATE_LOCAL_ADDR)) {
-        if ((retval = getsockname(fd, (GETSOCKNAME_ARG2_TYPE *) &lsaddr,
-                                  &ssize)))
+        retval = getsockname(fd, ss2sa(&lsaddr), &ssize);
+        if (retval)
             return retval;
 
         if (cvtaddr (&lsaddr, &laddrs)) {
@@ -99,8 +99,8 @@ krb5_auth_con_genaddrs(krb5_context context, krb5_auth_context auth_context, int
     ssize = sizeof(struct sockaddr_storage);
     if ((flags & KRB5_AUTH_CONTEXT_GENERATE_REMOTE_FULL_ADDR) ||
         (flags & KRB5_AUTH_CONTEXT_GENERATE_REMOTE_ADDR)) {
-        if ((retval = getpeername(fd, (GETPEERNAME_ARG2_TYPE *) &rsaddr,
-                                  &ssize)))
+        retval = getpeername(fd, ss2sa(&rsaddr), &ssize);
+        if (retval)
             return errno;
 
         if (cvtaddr (&rsaddr, &raddrs)) {

--- a/src/lib/krb5/os/hostaddr.c
+++ b/src/lib/krb5/os/hostaddr.c
@@ -83,12 +83,12 @@ k5_os_hostaddr(krb5_context context, const char *name,
         switch (aip->ai_addr->sa_family) {
         case AF_INET:
             addrlen = sizeof (struct in_addr);
-            ptr = &((struct sockaddr_in *)aip->ai_addr)->sin_addr;
+            ptr = &sa2sin(aip->ai_addr)->sin_addr;
             atype = ADDRTYPE_INET;
             break;
         case AF_INET6:
             addrlen = sizeof (struct in6_addr);
-            ptr = &((struct sockaddr_in6 *)aip->ai_addr)->sin6_addr;
+            ptr = &sa2sin6(aip->ai_addr)->sin6_addr;
             atype = ADDRTYPE_INET6;
             break;
         default:

--- a/src/lib/krb5/os/localaddr.c
+++ b/src/lib/krb5/os/localaddr.c
@@ -181,11 +181,11 @@ is_loopback_address(struct sockaddr *sa)
 {
     switch (sa->sa_family) {
     case AF_INET: {
-        struct sockaddr_in *s4 = (struct sockaddr_in *)sa;
+        struct sockaddr_in *s4 = sa2sin(sa);
         return s4->sin_addr.s_addr == htonl(INADDR_LOOPBACK);
     }
     case AF_INET6: {
-        struct sockaddr_in6 *s6 = (struct sockaddr_in6 *)sa;
+        struct sockaddr_in6 *s6 = sa2sin6(sa);
         return IN6_IS_ADDR_LOOPBACK(&s6->sin6_addr);
     }
     default:
@@ -239,16 +239,17 @@ printifaddr(struct ifaddrs *ifp)
 #include <stdlib.h>
 
 static int
-addr_eq (const struct sockaddr *s1, const struct sockaddr *s2)
+addr_eq (struct sockaddr *s1, struct sockaddr *s2)
 {
     if (s1->sa_family != s2->sa_family)
         return 0;
-#define CMPTYPE(T,F) (!memcmp(&((const T*)s1)->F,&((const T*)s2)->F,sizeof(((const T*)s1)->F)))
     switch (s1->sa_family) {
     case AF_INET:
-        return CMPTYPE (struct sockaddr_in, sin_addr);
+        return !memcmp(&sa2sin(s1)->sin_addr, &sa2sin(s2)->sin_addr,
+                       sizeof(sa2sin(s1)->sin_addr));
     case AF_INET6:
-        return CMPTYPE (struct sockaddr_in6, sin6_addr);
+        return !memcmp(&sa2sin6(s1)->sin6_addr, &sa2sin6(s2)->sin6_addr,
+                       sizeof(sa2sin6(s1)->sin6_addr));
     default:
         /* Err on side of duplicate listings.  */
         return 0;
@@ -1183,14 +1184,14 @@ add_addr (void *P_data, struct sockaddr *a)
 #ifdef HAVE_NETINET_IN_H
     case AF_INET:
         address = make_addr (ADDRTYPE_INET, sizeof (struct in_addr),
-                             &((const struct sockaddr_in *) a)->sin_addr);
+                             &sa2sin(a)->sin_addr);
         if (address == NULL)
             data->mem_err++;
         break;
 
     case AF_INET6:
     {
-        const struct sockaddr_in6 *in = (const struct sockaddr_in6 *) a;
+        const struct sockaddr_in6 *in = sa2sin6(a);
 
         if (IN6_IS_ADDR_LINKLOCAL (&in->sin6_addr))
             break;

--- a/src/lib/rpc/pmap_rmt.c
+++ b/src/lib/rpc/pmap_rmt.c
@@ -60,6 +60,7 @@ static char sccsid[] = "@(#)pmap_rmt.c 1.21 87/08/27 Copyr 1984 Sun Micro";
 #include <arpa/inet.h>
 #define MAX_BROADCAST_SIZE 1400
 #include <port-sockets.h>
+#include "socket-utils.h"
 
 static struct timeval timeout = { 3, 0 };
 
@@ -208,12 +209,11 @@ getbroadcastnets(
 			if (ioctl(sock, SIOCGIFBRDADDR, (char *)&ifreq) < 0) {
 				addrs[i++].s_addr = INADDR_ANY;
 			} else {
-				addrs[i++] = ((struct sockaddr_in*)
-				  &ifreq.ifr_addr)->sin_addr;
+				addrs[i++] = sa2sin(&ifreq.ifr_addr)->sin_addr;
 			}
 #else /* 4.2 BSD */
 			struct sockaddr_in *sockin;
-			sockin = (struct sockaddr_in *)&ifr->ifr_addr;
+			sockin = sa2sin(&ifr->ifr_addr);
 			addrs[i++] = inet_makeaddr(inet_netof
 			  (sockin->sin_addr.s_addr), INADDR_ANY);
 #endif

--- a/src/plugins/audit/kdc_j_encode.c
+++ b/src/plugins/audit/kdc_j_encode.c
@@ -861,22 +861,19 @@ tkt_to_value(krb5_ticket *tkt, k5_json_object obj,
         ret = int32_to_value(part2->session->enctype, tmp, AU_SESS_ETYPE);
         if (ret)
             goto error;
-        if (&part2->times) {
-            ret = int32_to_value(part2->times.starttime, tmp, AU_START);
-            if (ret)
-                goto error;
-            ret = int32_to_value(part2->times.endtime, tmp, AU_END);
-            if (ret)
-                goto error;
-            ret = int32_to_value(part2->times.renew_till, tmp, AU_RENEW_TILL);
-            if (ret)
-                goto error;
-            ret = int32_to_value(part2->times.authtime, tmp, AU_AUTHTIME);
-            if (ret)
-                goto error;
-        }
-        if (&part2->transited && &part2->transited.tr_contents &&
-            part2->transited.tr_contents.length > 0) {
+        ret = int32_to_value(part2->times.starttime, tmp, AU_START);
+        if (ret)
+            goto error;
+        ret = int32_to_value(part2->times.endtime, tmp, AU_END);
+        if (ret)
+            goto error;
+        ret = int32_to_value(part2->times.renew_till, tmp, AU_RENEW_TILL);
+        if (ret)
+            goto error;
+        ret = int32_to_value(part2->times.authtime, tmp, AU_AUTHTIME);
+        if (ret)
+            goto error;
+        if (part2->transited.tr_contents.length > 0) {
             ret = data_to_value(&part2->transited.tr_contents,
                                tmp, AU_TR_CONTENTS);
             if (ret)

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_tkt_policy.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_tkt_policy.c
@@ -431,7 +431,7 @@ krb5_ldap_list(krb5_context context, char ***list, char *objectclass,
 {
     char                        *filter=NULL, *dn=NULL;
     krb5_error_code             st=0, tempst=0;
-    int                         i=0, count=0, filterlen=0;
+    int                         count=0, filterlen=0;
     LDAP                        *ld=NULL;
     LDAPMessage                 *result=NULL,*ent=NULL;
     kdb5_dal_handle             *dal_handle=NULL;

--- a/src/slave/kprop_util.c
+++ b/src/slave/kprop_util.c
@@ -45,12 +45,12 @@ sockaddr2krbaddr(krb5_context context, int family, struct sockaddr *sa,
 
     addr.magic = KV5M_ADDRESS;
     if (family == AF_INET) {
-        struct sockaddr_in *sa4 = (struct sockaddr_in *) sa;
+        struct sockaddr_in *sa4 = sa2sin(sa);
         addr.addrtype = ADDRTYPE_INET;
         addr.length = sizeof(sa4->sin_addr);
         addr.contents = (krb5_octet *) &sa4->sin_addr;
     } else if (family == AF_INET6) {
-        struct sockaddr_in6 *sa6 = (struct sockaddr_in6 *) sa;
+        struct sockaddr_in6 *sa6 = sa2sin6(sa);
         if (IN6_IS_ADDR_V4MAPPED(&sa6->sin6_addr)) {
             addr.addrtype = ADDRTYPE_INET;
             addr.contents = (krb5_octet *) &sa6->sin6_addr + 12;

--- a/src/slave/kpropd.c
+++ b/src/slave/kpropd.c
@@ -483,8 +483,7 @@ doit(int fd)
         perror("getpeername");
         exit(1);
     }
-    if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, (caddr_t) &on,
-                   sizeof(on)) < 0) {
+    if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &on, sizeof(on)) < 0) {
         com_err(progname, errno,
                 _("while attempting setsockopt (SO_KEEPALIVE)"));
     }
@@ -589,13 +588,12 @@ full_resync(CLIENT *clnt)
     memset(&clnt_res, 0, sizeof(clnt_res));
 
     status = clnt_call(clnt, IPROP_FULL_RESYNC_EXT, (xdrproc_t)xdr_u_int32,
-                       (caddr_t)&vers, (xdrproc_t)xdr_kdb_fullresync_result_t,
-                       (caddr_t)&clnt_res, full_resync_timeout);
+                       &vers, (xdrproc_t)xdr_kdb_fullresync_result_t,
+                       &clnt_res, full_resync_timeout);
     if (status == RPC_PROCUNAVAIL) {
         status = clnt_call(clnt, IPROP_FULL_RESYNC, (xdrproc_t)xdr_void,
-                           (caddr_t *)&vers,
-                           (xdrproc_t)xdr_kdb_fullresync_result_t,
-                           (caddr_t)&clnt_res, full_resync_timeout);
+                           &vers, (xdrproc_t)xdr_kdb_fullresync_result_t,
+                           &clnt_res, full_resync_timeout);
     }
 
     return (status == RPC_SUCCESS) ? &clnt_res : NULL;

--- a/src/util/profile/profile_tcl.c
+++ b/src/util/profile/profile_tcl.c
@@ -3102,8 +3102,6 @@ SWIG_InitializeModule(void *clientdata) {
   swig_module_info *module_head, *iter;
   int found, init;
 
-  clientdata = clientdata;
-
   /* check to see if the circular list has been setup, if not, set it up */
   if (swig_module.next==0) {
     /* Initialize the swig_module */

--- a/src/util/ss/data.c
+++ b/src/util/ss/data.c
@@ -10,8 +10,5 @@
 #include "ss_internal.h"
 #include "copyright.h"
 
-const static char copyright[] =
-    "Copyright 1987, 1988, 1989 by the Massachusetts Institute of Technology";
-
 ss_data **_ss_table = (ss_data **)NULL;
 char *_ss_pager_name = (char *)NULL;

--- a/src/util/support/fake-addrinfo.c
+++ b/src/util/support/fake-addrinfo.c
@@ -331,18 +331,6 @@ system_freeaddrinfo (struct addrinfo *ai)
     freeaddrinfo(ai);
 }
 
-/* Note: Implementations written to RFC 2133 use size_t, while RFC
-   2553 implementations use socklen_t, for the second parameter.
-
-   Mac OS X (10.2) and AIX 4.3.3 appear to be in the RFC 2133 camp,
-   but we don't have an autoconf test for that right now.  */
-static inline int
-system_getnameinfo (const struct sockaddr *sa, socklen_t salen,
-                    char *host, size_t hostlen, char *serv, size_t servlen,
-                    int flags)
-{
-    return getnameinfo(sa, salen, host, hostlen, serv, servlen, flags);
-}
 #endif
 
 #if !defined (HAVE_GETADDRINFO) || defined(WRAP_GETADDRINFO) || defined(FAI_CACHE)

--- a/src/util/support/threads.c
+++ b/src/util/support/threads.c
@@ -237,7 +237,6 @@ void *k5_getspecific (k5_key_t keynum)
     if (err)
         return NULL;
 
-    assert(keynum >= 0 && keynum < K5_KEY_MAX);
     assert(destructors_set[keynum] == 1);
 
 #ifndef ENABLE_THREADS
@@ -271,7 +270,6 @@ int k5_setspecific (k5_key_t keynum, void *value)
     if (err)
         return err;
 
-    assert(keynum >= 0 && keynum < K5_KEY_MAX);
     assert(destructors_set[keynum] == 1);
 
 #ifndef ENABLE_THREADS
@@ -334,8 +332,6 @@ int k5_key_register (k5_key_t keynum, void (*destructor)(void *))
     if (err)
         return err;
 
-    assert(keynum >= 0 && keynum < K5_KEY_MAX);
-
 #ifndef ENABLE_THREADS
 
     assert(destructors_set[keynum] == 0);
@@ -365,8 +361,6 @@ int k5_key_register (k5_key_t keynum, void (*destructor)(void *))
 
 int k5_key_delete (k5_key_t keynum)
 {
-    assert(keynum >= 0 && keynum < K5_KEY_MAX);
-
 #ifndef ENABLE_THREADS
 
     assert(destructors_set[keynum] == 1);


### PR DESCRIPTION
If I've done this right, as promised, the clang build on Travis should now pass without any warnings.

* I thought about turning on -Werror for clang (on Travis only, not in general) but could not find a good way to do this.
* Second-last commit is again to db2; I'm not sure what we want to do about this.  I think in the past we submitted it to NetBSD?
* Last commit touches the SWIG-generated TCL profiling code committed into the tree.  I assume there's a better way to fix this issue, and would appreciate suggestions.  (I do not know SWIG.)
* How would people feel about our CI running `make -s`?  It would make poring over these logs easier, I think.

Thanks!