### PR TITLE
Remove all calls to krb5_c_random_add_entropy()

### DIFF
--- a/src/kdc/dispatch.c
+++ b/src/kdc/dispatch.c
@@ -33,7 +33,7 @@
 #include <arpa/inet.h>
 #include <string.h>
 
-static krb5_int32 last_usec = 0, last_os_random = 0;
+static krb5_int32 last_os_random = 0;
 
 static krb5_error_code make_too_big_error(kdc_realm_t *kdc_active_realm,
                                           krb5_data **out);
@@ -95,12 +95,9 @@ reseed_random(krb5_context kdc_err_context)
 {
     krb5_error_code retval;
     krb5_int32 now, now_usec;
-    krb5_int32 usec_difference;
-    krb5_data data;
-
+    
     retval = krb5_crypto_us_timeofday(&now, &now_usec);
     if (retval == 0) {
-        usec_difference = now_usec - last_usec;
         if (last_os_random == 0)
             last_os_random = now;
         /* Grab random data from OS every hour*/
@@ -108,13 +105,6 @@ reseed_random(krb5_context kdc_err_context)
             krb5_c_random_os_entropy(kdc_err_context, 0, NULL);
             last_os_random = now;
         }
-
-        data.length = sizeof(krb5_int32);
-        data.data = (void *)&usec_difference;
-
-        krb5_c_random_add_entropy(kdc_err_context,
-                                  KRB5_C_RANDSOURCE_TIMING, &data);
-        last_usec = now_usec;
     }
 }
 

--- a/src/kdc/main.c
+++ b/src/kdc/main.c
@@ -63,7 +63,6 @@ static int nofork = 0;
 static int workers = 0;
 static int time_offset = 0;
 static const char *pid_file = NULL;
-static int rkey_init_done = 0;
 static volatile int signal_received = 0;
 static volatile int sighup_received = 0;
 
@@ -398,28 +397,11 @@ init_realm(kdc_realm_t * rdp, krb5_pointer aprof, char *realm,
         goto whoops;
     }
 
-    if (!rkey_init_done) {
-        krb5_data seed;
-        /*
-         * If all that worked, then initialize the random key
-         * generators.
-         */
-
-        seed.length = rdp->realm_mkey.length;
-        seed.data = (char *)rdp->realm_mkey.contents;
-
-        if ((kret = krb5_c_random_add_entropy(rdp->realm_context,
-                                              KRB5_C_RANDSOURCE_TRUSTEDPARTY, &seed)))
-            goto whoops;
-
-        rkey_init_done = 1;
-    }
 whoops:
     /*
      * If we choked, then clean up any dirt we may have dropped on the floor.
      */
     if (kret) {
-
         finish_realm(rdp);
     }
     return(kret);

--- a/src/lib/crypto/krb/prng_fortuna.c
+++ b/src/lib/crypto/krb/prng_fortuna.c
@@ -419,6 +419,13 @@ krb5_c_random_make_octets(krb5_context context, krb5_data *outdata)
 #endif
     unsigned char pidbuf[4];
 
+    if (!have_entropy) {
+        /* add_entropy may not have been called, so try to seed from the most
+         * reasonable entropy source we have.  We don't error out if this
+         * fails because someone else may have also tried to seed. */
+        krb5_c_random_os_entropy(context, 1, NULL);
+    }
+
     k5_mutex_lock(&fortuna_lock);
 
     if (!have_entropy) {

--- a/src/lib/krb5/krb/gen_save_subkey.c
+++ b/src/lib/krb5/krb/gen_save_subkey.c
@@ -33,22 +33,8 @@ k5_generate_and_save_subkey(krb5_context context,
                             krb5_auth_context auth_context,
                             krb5_keyblock *keyblock, krb5_enctype enctype)
 {
-    /* Provide some more fodder for random number code.
-       This isn't strong cryptographically; the point here is not
-       to guarantee randomness, but to make it less likely that multiple
-       sessions could pick the same subkey.  */
-    struct {
-        krb5_int32 sec, usec;
-    } rnd_data;
-    krb5_data d;
     krb5_error_code retval;
     krb5_keyblock *kb = NULL;
-
-    if (krb5_crypto_us_timeofday(&rnd_data.sec, &rnd_data.usec) == 0) {
-        d.length = sizeof(rnd_data);
-        d.data = (char *) &rnd_data;
-        krb5_c_random_add_entropy(context, KRB5_C_RANDSOURCE_TIMING, &d);
-    }
 
     retval = krb5_generate_subkey_extended(context, keyblock, enctype, &kb);
     if (retval)

--- a/src/lib/krb5/krb/gen_seqnum.c
+++ b/src/lib/krb5/krb/gen_seqnum.c
@@ -53,9 +53,6 @@ krb5_generate_seq_number(krb5_context context, const krb5_keyblock *key, krb5_ui
     krb5_error_code retval;
 
     seed = key2data(*key);
-    if ((retval = krb5_c_random_add_entropy(context, KRB5_C_RANDSOURCE_TRUSTEDPARTY, &seed)))
-        return(retval);
-
     seed.length = sizeof(*seqno);
     seed.data = (char *) seqno;
     retval = krb5_c_random_make_octets(context, &seed);

--- a/src/lib/krb5/krb/gen_subkey.c
+++ b/src/lib/krb5/krb/gen_subkey.c
@@ -26,16 +26,6 @@
 
 #include "k5-int.h"
 
-static inline krb5_data
-key2data (krb5_keyblock k)
-{
-    krb5_data d;
-    d.magic = KV5M_DATA;
-    d.length = k.length;
-    d.data = (char *) k.contents;
-    return d;
-}
-
 krb5_error_code
 krb5_generate_subkey_extended(krb5_context context,
                               const krb5_keyblock *key,
@@ -43,16 +33,9 @@ krb5_generate_subkey_extended(krb5_context context,
                               krb5_keyblock **subkey)
 {
     krb5_error_code retval;
-    krb5_data seed;
     krb5_keyblock *keyblock;
 
     *subkey = NULL;
-
-    seed = key2data(*key);
-    retval = krb5_c_random_add_entropy(context, KRB5_C_RANDSOURCE_TRUSTEDPARTY,
-                                       &seed);
-    if (retval)
-        return retval;
 
     keyblock = malloc(sizeof(krb5_keyblock));
     if (!keyblock)

--- a/src/lib/krb5/krb/init_ctx.c
+++ b/src/lib/krb5/krb/init_ctx.c
@@ -138,11 +138,6 @@ krb5_init_context_profile(profile_t profile, krb5_flags flags,
 {
     krb5_context ctx = 0;
     krb5_error_code retval;
-    struct {
-        krb5_int32 now, now_usec;
-        long pid;
-    } seed_data;
-    krb5_data seed;
     int tmp;
 
     /* Verify some assumptions.  If the assumptions hold and the
@@ -215,17 +210,6 @@ krb5_init_context_profile(profile_t profile, krb5_flags flags,
     if (retval)
         goto cleanup;
     ctx->dns_canonicalize_hostname = tmp;
-
-    /* initialize the prng (not well, but passable) */
-    if ((retval = krb5_c_random_os_entropy( ctx, 0, NULL)) !=0)
-        goto cleanup;
-    if ((retval = krb5_crypto_us_timeofday(&seed_data.now, &seed_data.now_usec)))
-        goto cleanup;
-    seed_data.pid = getpid ();
-    seed.length = sizeof(seed_data);
-    seed.data = (char *) &seed_data;
-    if ((retval = krb5_c_random_add_entropy(ctx, KRB5_C_RANDSOURCE_TIMING, &seed)))
-        goto cleanup;
 
     ctx->default_realm = 0;
     get_integer(ctx, KRB5_CONF_CLOCKSKEW, DEFAULT_CLOCKSKEW, &tmp);

--- a/src/lib/krb5/krb/sendauth.c
+++ b/src/lib/krb5/krb/sendauth.c
@@ -126,30 +126,6 @@ krb5_sendauth(krb5_context context, krb5_auth_context *auth_context,
         credsp = in_creds;
     }
 
-    if (ap_req_options & AP_OPTS_USE_SUBKEY) {
-        /* Provide some more fodder for random number code.
-           This isn't strong cryptographically; the point here is
-           not to guarantee randomness, but to make it less likely
-           that multiple sessions could pick the same subkey.  */
-        char rnd_data[1024];
-        GETPEERNAME_ARG3_TYPE len2;
-        krb5_data d;
-        d.length = sizeof (rnd_data);
-        d.data = rnd_data;
-        len2 = sizeof (rnd_data);
-        if (getpeername (*(int*)fd, (GETPEERNAME_ARG2_TYPE *) rnd_data,
-                         &len2) == 0) {
-            d.length = len2;
-            (void) krb5_c_random_add_entropy (context, KRB5_C_RANDSOURCE_EXTERNAL_PROTOCOL, &d);
-        }
-        len2 = sizeof (rnd_data);
-        if (getsockname (*(int*)fd, (GETSOCKNAME_ARG2_TYPE *) rnd_data,
-                         &len2) == 0) {
-            d.length = len2;
-            (void) krb5_c_random_add_entropy (context, KRB5_C_RANDSOURCE_EXTERNAL_PROTOCOL, &d);
-        }
-    }
-
     outbuf[0].data = NULL;      /* Coverity is confused otherwise */
     if ((retval = krb5_mk_req_extended(context, auth_context,
                                        ap_req_options, in_data, credsp,


### PR DESCRIPTION
Feeding PRNG output back into the PRNG has never been helpful, and in
almost all non-Fortuna cases it will be ignored.  Seed Fortuna from the OS
if asked for octets and there isn't entropy.

I don't enable Fortuna, so this is a minor performance/convenience improvement for me.  I believe Debian does though; @kaduk, do you want to take a look at this?