### PR TITLE
Check for FAST in encrypted challenge client

### DIFF
--- a/src/lib/krb5/krb/preauth_ec.c
+++ b/src/lib/krb5/krb/preauth_ec.c
@@ -58,6 +58,8 @@ ec_process(krb5_context context, krb5_clpreauth_moddata moddata,
     krb5_keyblock *challenge_key = NULL, *armor_key, *as_key;
 
     armor_key = cb->fast_armor(context, rock);
+    if (armor_key == NULL)
+        return ENOENT;
     retval = cb->get_as_key(context, rock, &as_key);
     if (retval == 0 && padata->length) {
         krb5_enc_data *enc = NULL;


### PR DESCRIPTION
If we reach the encrypted challenge clpreauth process method without
an armor key, error out instead of crashing.  This can happen if (a)
the KDC offers encrypted challenge even though the request doesn't use
FAST (the Heimdal KDC apparently does this), and (b) we fall back to
that preauth method before generating a preauthenticated request,
typically because of a prompter failure in encrypted timestamp.
