### PR TITLE
Update Travis CI distribution to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c++
 
 sudo: required
 
-dist: trusty
+dist: xenial
 
 matrix:
   include:


### PR DESCRIPTION
Update the Travis CI OS distribution to Ubuntu 16.04 LTS (Xenial Xerus). The current OS distribution, Ubuntu 14.04 LTS (Trusty Tahr), was chosen before 16.04 LTS was released and, presumably, the update was simply overlooked.