### PR TITLE
Apply TCP timeouts to HTTPS (KKDCP) transport

### DIFF
--- a/src/lib/krb5/os/sendto_kdc.c
+++ b/src/lib/krb5/os/sendto_kdc.c
@@ -1372,8 +1372,7 @@ get_endtime(time_ms endtime, struct conn_state *conns)
     struct conn_state *state;
 
     for (state = conns; state != NULL; state = state->next) {
-        if (state->addr.transport == TCP &&
-            (state->state == READING || state->state == WRITING) &&
+        if ((state->state == READING || state->state == WRITING) &&
             state->endtime > endtime)
             endtime = state->endtime;
     }


### PR DESCRIPTION
We apply (as of ticket #7604) a ten-second minimum delay after a TCP
connection is accepted before creating new connections or sending UDP
packets.  Apply this timeout to HTTPS connections as well, by removing
the transport check in get_endtime().  As the endtime field is only
set by service_tcp_connect(), it will always have the value 0 for UDP
connection state objects, so there is no need to check the transport
type.
