### PR TITLE
Allow clock skew in krb5 gss_context_time()

### DIFF
--- a/src/lib/gssapi/krb5/context_time.c
+++ b/src/lib/gssapi/krb5/context_time.c
@@ -51,7 +51,10 @@ krb5_gss_context_time(minor_status, context_handle, time_rec)
         return(GSS_S_FAILURE);
     }
 
-    if ((lifetime = ctx->krb_times.endtime - now) <= 0) {
+    lifetime = ctx->krb_times.endtime - now;
+    if (!ctx->initiate)
+        lifetime += ctx->k5_context->clockskew;
+    if (lifetime <= 0) {
         *time_rec = 0;
         *minor_status = 0;
         return(GSS_S_CONTEXT_EXPIRED);


### PR DESCRIPTION
[I had no idea that gss_context_time() existed until I started combing the source tree for y2038 issues.  It seems like a special case of gss_inquire_context(), maybe still present in the API for historical reasons.]

Commit b496ce4095133536e0ace36b74130e4b9ecb5e11 (ticket #8268) adds
the clock skew to krb5 acceptor context lifetimes for
gss_accept_sec_context() and gss_inquire_context(), but not for
gss_context_time().  Add the clock skew in gss_context_time() as well.

ticket: 8581 (new)
target_version: 1.14-next
target_version: 1.15-next
tags: pullup