### PR TITLE
Factor out clock skew checks

### DIFF
--- a/src/kdc/kdc_preauth_encts.c
+++ b/src/kdc/kdc_preauth_encts.c
@@ -58,7 +58,6 @@ enc_ts_verify(krb5_context context, krb5_data *req_pkt, krb5_kdc_req *request,
     krb5_keyblock               key;
     krb5_key_data *             client_key;
     krb5_int32                  start;
-    krb5_timestamp              timenow;
 
     scratch.data = (char *)pa->contents;
     scratch.length = pa->length;
@@ -95,13 +94,9 @@ enc_ts_verify(krb5_context context, krb5_data *req_pkt, krb5_kdc_req *request,
     if ((retval = decode_krb5_pa_enc_ts(&enc_ts_data, &pa_enc)) != 0)
         goto cleanup;
 
-    if ((retval = krb5_timeofday(context, &timenow)) != 0)
+    retval = krb5_check_clockskew(context, pa_enc->patimestamp);
+    if (retval)
         goto cleanup;
-
-    if (labs(timenow - pa_enc->patimestamp) > context->clockskew) {
-        retval = KRB5KRB_AP_ERR_SKEW;
-        goto cleanup;
-    }
 
     setflag(enc_tkt_reply->flags, TKT_FLG_PRE_AUTH);
 

--- a/src/lib/krb5/krb/gc_via_tkt.c
+++ b/src/lib/krb5/krb/gc_via_tkt.c
@@ -305,7 +305,7 @@ krb5int_process_tgs_reply(krb5_context context,
         goto cleanup;
 
     if (!in_cred->times.starttime &&
-        !in_clock_skew(dec_rep->enc_part2->times.starttime,
+        !in_clock_skew(context, dec_rep->enc_part2->times.starttime,
                        timestamp)) {
         retval = KRB5_KDCREP_SKEW;
         goto cleanup;

--- a/src/lib/krb5/krb/get_in_tkt.c
+++ b/src/lib/krb5/krb/get_in_tkt.c
@@ -287,8 +287,8 @@ verify_as_reply(krb5_context            context,
             return retval;
     } else {
         if ((request->from == 0) &&
-            (labs(as_reply->enc_part2->times.starttime - time_now)
-             > context->clockskew))
+            !in_clock_skew(context, as_reply->enc_part2->times.starttime,
+                           time_now))
             return (KRB5_KDCREP_SKEW);
     }
     return 0;

--- a/src/lib/krb5/krb/int-proto.h
+++ b/src/lib/krb5/krb/int-proto.h
@@ -83,7 +83,8 @@ krb5int_construct_matching_creds(krb5_context context, krb5_flags options,
                                  krb5_creds *in_creds, krb5_creds *mcreds,
                                  krb5_flags *fields);
 
-#define in_clock_skew(date, now) (labs((date)-(now)) < context->clockskew)
+#define in_clock_skew(context, date, now)               \
+    (labs((date) - (now)) < (context)->clockskew)
 
 #define IS_TGS_PRINC(p) ((p)->length == 2 &&                            \
                          data_eq_string((p)->data[0], KRB5_TGS_NAME))


### PR DESCRIPTION
While working on the y2038 stuff I noticed five occurrences of ``labs(timestamp1 - timestamp2) < context->clockskew``, which is a somewhat awkward construction that gets more awkward after accounting for post-2038 stuff.  These commits reduce that pattern to two occurrences.

There are a couple of changes in the fencepost case where the timestamps being checked are exactly context->clockskew seconds apart.  I don't think that's important enough to warrant a ticket or a mention in the commit messages.
