### PR TITLE
Fix uninitialized krb5_lcc_data.flags in cc_mslsa

### DIFF
--- a/src/lib/krb5/ccache/cc_mslsa.c
+++ b/src/lib/krb5/ccache/cc_mslsa.c
@@ -1553,6 +1553,7 @@ krb5_lcc_resolve (krb5_context context, krb5_ccache *id, const char *residual)
     data->LogonHandle = LogonHandle;
     data->PackageId = PackageId;
     data->princ = NULL;
+    data->flags = 0;
 
     data->cc_name = (char *)malloc(strlen(residual)+1);
     if (data->cc_name == NULL) {


### PR DESCRIPTION
**Symptom:**
  Using MSLSA CC sometimes fails with error:
    major: 851968='Unspecified GSS failure.  Minor code may provide more information',
    minor: 2529639055='Request did not supply a ticket'

  This manifests itself on Windows 10 with production build and using MSVC and
  works on Windows 7 or using debug build (again with MSVC).

**Problem:**
  krb5_lcc_data.flags is not initialized when krb5_lcc_data is allocated so
  flags content is random. krb5_lcc_next_cred() checks if flags has
  KRB5_TC_NOTICKET bit set and returns error if it is.

**Fix:**
  Initialize flags to 0.