### PR TITLE
Update cmocka to 1.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ before_install:
   - sudo apt-get install -y bison dejagnu gettext keyutils ldap-utils libldap2-dev libkeyutils-dev libssl-dev python-cjson python-paste python-pyrad slapd tcl-dev tcsh
   - mkdir -p cmocka/build
   - cd cmocka
-  - wget https://cmocka.org/files/1.0/cmocka-1.0.1.tar.xz
-  - tar -xvf cmocka-1.0.1.tar.xz
+  - wget https://cmocka.org/files/1.1/cmocka-1.1.1.tar.xz
+  - tar -xvf cmocka-1.1.1.tar.xz
   - cd build
-  - cmake ../cmocka-1.0.1 -DCMAKE_INSTALL_PREFIX=/usr
+  - cmake ../cmocka-1.1.1 -DCMAKE_INSTALL_PREFIX=/usr
   - make
   - sudo make install
   - cd ../..


### PR DESCRIPTION
Update cmocka used in Travis builds to version 1.1.1; this version
was released on April 4, 2017. As of release 1.1.0, new features like
support to verify call ordering, to pass initial data to test cases,
catch multiple exceptions and improved XML output have been added.
Release 1.1.1 fixes several bugs in 1.1.0.