### PR TITLE
Use a random nonce in TGS requests

### DIFF
--- a/src/lib/krb5/krb/get_in_tkt.c
+++ b/src/lib/krb5/krb/get_in_tkt.c
@@ -762,23 +762,6 @@ k5_init_creds_current_time(krb5_context context, krb5_init_creds_context ctx,
     }
 }
 
-/* Choose a random nonce for ctx->request. */
-static krb5_error_code
-pick_nonce(krb5_context context, krb5_init_creds_context ctx)
-{
-    krb5_error_code code = 0;
-    unsigned char random_buf[4];
-    krb5_data random_data = make_data(random_buf, 4);
-
-    /* We incorrectly encode this as signed, so make sure we use an unsigned
-     * value to avoid interoperability issues. */
-    code = krb5_c_random_make_octets(context, &random_data);
-    if (code != 0)
-        return code;
-    ctx->request->nonce = 0x7fffffff & load_32_n(random_buf);
-    return 0;
-}
-
 /* Set the timestamps for ctx->request based on the desired lifetimes. */
 static krb5_error_code
 set_request_times(krb5_context context, krb5_init_creds_context ctx)
@@ -1334,7 +1317,7 @@ init_creds_step_request(krb5_context context,
     }
 
     /* RFC 6113 requires a new nonce for the inner request on each try. */
-    code = pick_nonce(context, ctx);
+    code = k5_generate_nonce(context, &ctx->request->nonce);
     if (code != 0)
         goto cleanup;
 

--- a/src/lib/krb5/krb/int-proto.h
+++ b/src/lib/krb5/krb/int-proto.h
@@ -103,6 +103,9 @@ krb5_get_cred_via_tkt_ext(krb5_context context, krb5_creds *tkt,
                           krb5_keyblock **out_subkey);
 
 krb5_error_code
+k5_generate_nonce(krb5_context context, int32_t *out);
+
+krb5_error_code
 k5_make_tgs_req(krb5_context context, struct krb5int_fast_request_state *,
                 krb5_creds *tkt, krb5_flags kdcoptions,
                 krb5_address *const *address, krb5_pa_data **in_padata,


### PR DESCRIPTION
[KDC-REQ nonces equal to the current timestamp won't work reliably after 2038, because of a disagreement between RFC 4120 and MIT krb5/Heimdal on whether the nonce field is signed.  Of course we could mask off the high bit from the timestamp just as easily as from random bytes, but this is better.]

Commit ae0fee058ad883b2e82fa2b34f4e5f059e827a1b (ticket #5425) changed
the AS client code to use a random nonce, but left the TGS client code
using the current timestamp.  Use a random nonce for TGS requests as
well.
