### PR TITLE
Remove stray exit in t_referral.py

### DIFF
--- a/src/tests/t_referral.py
+++ b/src/tests/t_referral.py
@@ -23,7 +23,6 @@ def testref(realm, nametype):
         fail('unexpected number of lines in klist output')
     if out[5].split()[4] != 'a/x.d@' or out[6].split()[4] != 'a/x.d@REFREALM':
         fail('unexpected service principals in klist output')
-    exit(0)
 
 # Get credentials and check that we get an error, not a referral.
 def testfail(realm, nametype):


### PR DESCRIPTION
Commit 1dc619624421002b1e64d3b8c7e270508381b3e6 included a stray
"exit(0)" for debugging.  Remove it.
