### PR TITLE
Pass the address from the connecting client to audit_as_req

### DIFF
--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -69,7 +69,7 @@
 
 /* This version will be incremented when incompatible changes are made to the
  * KDB API, and will be kept in sync with the libkdb major version. */
-#define KRB5_KDB_API_VERSION 8
+#define KRB5_KDB_API_VERSION 9
 
 /* Salt types */
 #define KRB5_KDB_SALTTYPE_NORMAL        0
@@ -695,8 +695,9 @@ krb5_error_code krb5_db_check_policy_tgs(krb5_context kcontext,
                                          krb5_pa_data ***e_data);
 
 void krb5_db_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
-                          krb5_db_entry *client, krb5_db_entry *server,
-                          krb5_timestamp authtime, krb5_error_code error_code);
+                          krb5_address *from, krb5_db_entry *client,
+                          krb5_db_entry *server, krb5_timestamp authtime,
+                          krb5_error_code error_code);
 
 void krb5_db_refresh_config(krb5_context kcontext);
 
@@ -865,7 +866,7 @@ krb5_error_code krb5_db_register_keytab(krb5_context context);
  * This number indicates the date of the last incompatible change to the DAL.
  * The maj_ver field of the module's vtable structure must match this version.
  */
-#define KRB5_KDB_DAL_MAJOR_VERSION 6
+#define KRB5_KDB_DAL_MAJOR_VERSION 7
 
 /*
  * A krb5_context can hold one database object.  Modules should use
@@ -1356,8 +1357,9 @@ typedef struct _kdb_vftabl {
      * AS request.
      */
     void (*audit_as_req)(krb5_context kcontext, krb5_kdc_req *request,
-                         krb5_db_entry *client, krb5_db_entry *server,
-                         krb5_timestamp authtime, krb5_error_code error_code);
+                         krb5_address *from, krb5_db_entry *client,
+                         krb5_db_entry *server, krb5_timestamp authtime,
+                         krb5_error_code error_code);
 
     /* Note: there is currently no method for auditing TGS requests. */
 

--- a/src/kdc/kdc_log.c
+++ b/src/kdc/kdc_log.c
@@ -89,8 +89,8 @@ log_as_req(krb5_context context, const krb5_fulladdr *from,
                          ktypestr, fromstring, status,
                          cname2, sname2, emsg ? ", " : "", emsg ? emsg : "");
     }
-    krb5_db_audit_as_req(context, request, client, server, authtime,
-                         errcode);
+    krb5_db_audit_as_req(context, request, from->address, client, server,
+                         authtime, errcode);
 #if 0
     /* Sun (OpenSolaris) version would probably something like this.
        The client and server names passed can be null, unlike in the

--- a/src/lib/kdb/Makefile.in
+++ b/src/lib/kdb/Makefile.in
@@ -5,7 +5,7 @@ LOCALINCLUDES= -I.
 
 # Keep LIBMAJOR in sync with KRB5_KDB_API_VERSION in include/kdb.h.
 LIBBASE=kdb5
-LIBMAJOR=8
+LIBMAJOR=9
 LIBMINOR=0
 LIBINITFUNC=kdb_init_lock_list
 LIBFINIFUNC=kdb_fini_lock_list

--- a/src/lib/kdb/kdb5.c
+++ b/src/lib/kdb/kdb5.c
@@ -322,12 +322,7 @@ copy_vtable(const kdb_vftabl *in, kdb_vftabl *out)
     out->audit_as_req = in->audit_as_req;
     out->refresh_config = in->refresh_config;
     out->check_allowed_to_delegate = in->check_allowed_to_delegate;
-
-    /* Copy fields for minor version 1 (major version 6). */
-    assert(KRB5_KDB_DAL_MAJOR_VERSION == 6);
-    out->free_principal_e_data = NULL;
-    if (in->min_ver >= 1)
-        out->free_principal_e_data = in->free_principal_e_data;
+    out->free_principal_e_data = in->free_principal_e_data;
 
     /* Set defaults for optional fields. */
     if (out->fetch_master_key == NULL)
@@ -2677,8 +2672,9 @@ krb5_db_check_policy_tgs(krb5_context kcontext, krb5_kdc_req *request,
 
 void
 krb5_db_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
-                     krb5_db_entry *client, krb5_db_entry *server,
-                     krb5_timestamp authtime, krb5_error_code error_code)
+                     krb5_address *from, krb5_db_entry *client,
+                     krb5_db_entry *server, krb5_timestamp authtime,
+                     krb5_error_code error_code)
 {
     krb5_error_code status;
     kdb_vftabl *v;
@@ -2686,7 +2682,8 @@ krb5_db_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
     status = get_vftabl(kcontext, &v);
     if (status || v->audit_as_req == NULL)
         return;
-    v->audit_as_req(kcontext, request, client, server, authtime, error_code);
+    v->audit_as_req(kcontext, request, from, client, server, authtime,
+                    error_code);
 }
 
 void

--- a/src/plugins/kdb/db2/db2_exp.c
+++ b/src/plugins/kdb/db2/db2_exp.c
@@ -166,10 +166,10 @@ WRAP_K (krb5_db2_check_policy_as,
         (kcontext, request, client, server, kdc_time, status, e_data));
 
 WRAP_VOID (krb5_db2_audit_as_req,
-           (krb5_context kcontext, krb5_kdc_req *request,
+           (krb5_context kcontext, krb5_kdc_req *request, krb5_address *from,
             krb5_db_entry *client, krb5_db_entry *server,
             krb5_timestamp authtime, krb5_error_code error_code),
-           (kcontext, request, client, server, authtime, error_code));
+           (kcontext, request, from, client, server, authtime, error_code));
 
 static krb5_error_code
 hack_init (void)

--- a/src/plugins/kdb/db2/kdb_db2.c
+++ b/src/plugins/kdb/db2/kdb_db2.c
@@ -1551,8 +1551,9 @@ krb5_db2_check_policy_as(krb5_context kcontext, krb5_kdc_req *request,
 
 void
 krb5_db2_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
-                      krb5_db_entry *client, krb5_db_entry *server,
-                      krb5_timestamp authtime, krb5_error_code error_code)
+                      krb5_address *from, krb5_db_entry *client,
+                      krb5_db_entry *server, krb5_timestamp authtime,
+                      krb5_error_code error_code)
 {
     (void) krb5_db2_lockout_audit(kcontext, client, authtime, error_code);
 }

--- a/src/plugins/kdb/db2/kdb_db2.h
+++ b/src/plugins/kdb/db2/kdb_db2.h
@@ -134,7 +134,8 @@ krb5_db2_check_policy_as(krb5_context kcontext, krb5_kdc_req *request,
 
 void
 krb5_db2_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
-                      krb5_db_entry *client, krb5_db_entry *server,
-                      krb5_timestamp authtime, krb5_error_code error_code);
+                      krb5_address *from, krb5_db_entry *client,
+                      krb5_db_entry *server, krb5_timestamp authtime,
+                      krb5_error_code error_code);
 
 #endif /* KRB5_KDB_DB2_H */

--- a/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.c
@@ -277,8 +277,9 @@ krb5_ldap_check_policy_as(krb5_context kcontext, krb5_kdc_req *request,
 
 void
 krb5_ldap_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
-                       krb5_db_entry *client, krb5_db_entry *server,
-                       krb5_timestamp authtime, krb5_error_code error_code)
+                       krb5_address *from, krb5_db_entry *client,
+                       krb5_db_entry *server, krb5_timestamp authtime,
+                       krb5_error_code error_code)
 {
     (void) krb5_ldap_lockout_audit(kcontext, client, authtime, error_code);
 }

--- a/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.h
@@ -282,8 +282,9 @@ krb5_ldap_check_policy_as(krb5_context kcontext, krb5_kdc_req *request,
 
 void
 krb5_ldap_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
-                       krb5_db_entry *client, krb5_db_entry *server,
-                       krb5_timestamp authtime, krb5_error_code error_code);
+                       krb5_address *from, krb5_db_entry *client,
+                       krb5_db_entry *server, krb5_timestamp authtime,
+                       krb5_error_code error_code);
 
 krb5_error_code
 krb5_ldap_check_allowed_to_delegate(krb5_context context,

--- a/src/tests/kdbtest.c
+++ b/src/tests/kdbtest.c
@@ -243,8 +243,8 @@ check_entry(krb5_db_entry *ent)
 static void
 sim_preauth(krb5_timestamp authtime, krb5_boolean ok, krb5_db_entry **entp)
 {
-    /* Both back ends ignore the request parameter for now. */
-    krb5_db_audit_as_req(ctx, NULL, *entp, *entp, authtime,
+    /* Both back ends ignore the request and from parameters for now. */
+    krb5_db_audit_as_req(ctx, NULL, NULL, *entp, *entp, authtime,
                          ok ? 0 : KRB5KDC_ERR_PREAUTH_FAILED);
     krb5_db_free_principal(ctx, *entp);
     CHECK(krb5_db_get_principal(ctx, &sample_princ, 0, entp));


### PR DESCRIPTION
In Samba we've added an audit logging system. To be able to call that from the Samba KDB module I need the client address. We have that information but it is not passed down to the KDB module.

As this is an incompatible change to the API also raise the DAL version.