### PR TITLE
y2038 followup work

### DIFF
--- a/src/clients/klist/klist.c
+++ b/src/clients/klist/klist.c
@@ -56,7 +56,7 @@ int show_adtype = 0, show_all = 0, list_all = 0, use_client_keytab = 0;
 int show_config = 0;
 char *defname;
 char *progname;
-krb5_int32 now;
+krb5_timestamp now;
 unsigned int timestamp_width;
 
 krb5_context kcontext;

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -721,7 +721,7 @@ krb5_error_code krb5int_c_copy_keyblock_contents(krb5_context context,
                                                  const krb5_keyblock *from,
                                                  krb5_keyblock *to);
 
-krb5_error_code krb5_crypto_us_timeofday(krb5_int32 *, krb5_int32 *);
+krb5_error_code krb5_crypto_us_timeofday(krb5_timestamp *, krb5_int32 *);
 
 /*
  * End "los-proto.h"

--- a/src/kadmin/server/misc.c
+++ b/src/kadmin/server/misc.c
@@ -184,7 +184,7 @@ check_min_life(void *server_handle, krb5_principal principal,
             (void) kadm5_free_principal_ent(handle->lhandle, &princ);
             return (ret == KADM5_UNK_POLICY) ? 0 : ret;
         }
-        if((now - princ.last_pwd_change) < pol.pw_min_life &&
+        if(ts_delta(now, princ.last_pwd_change) < pol.pw_min_life &&
            !(princ.attributes & KRB5_KDB_REQUIRES_PWCHANGE)) {
             if (msg_ret != NULL) {
                 time_t until;

--- a/src/kadmin/server/misc.c
+++ b/src/kadmin/server/misc.c
@@ -159,7 +159,7 @@ kadm5_ret_t
 check_min_life(void *server_handle, krb5_principal principal,
                char *msg_ret, unsigned int msg_len)
 {
-    krb5_int32                  now;
+    krb5_timestamp              now;
     kadm5_ret_t                 ret;
     kadm5_policy_ent_rec        pol;
     kadm5_principal_ent_rec     princ;

--- a/src/kdc/dispatch.c
+++ b/src/kdc/dispatch.c
@@ -94,8 +94,8 @@ static void
 reseed_random(krb5_context kdc_err_context)
 {
     krb5_error_code retval;
-    krb5_int32 now, now_usec;
-    krb5_int32 usec_difference;
+    krb5_timestamp now;
+    krb5_int32 now_usec, usec_difference;
     krb5_data data;
 
     retval = krb5_crypto_us_timeofday(&now, &now_usec);

--- a/src/kdc/dispatch.c
+++ b/src/kdc/dispatch.c
@@ -104,7 +104,7 @@ reseed_random(krb5_context kdc_err_context)
         if (last_os_random == 0)
             last_os_random = now;
         /* Grab random data from OS every hour*/
-        if (now-last_os_random >= 60 * 60) {
+        if (ts_delta(now, last_os_random) >= 60 * 60) {
             krb5_c_random_os_entropy(kdc_err_context, 0, NULL);
             last_os_random = now;
         }

--- a/src/lib/kadm5/srv/server_acl.c
+++ b/src/lib/kadm5/srv/server_acl.c
@@ -375,7 +375,7 @@ kadm5int_acl_impose_restrictions(kcontext, recp, maskp, rp)
     restriction_t              *rp;
 {
     krb5_error_code     code;
-    krb5_int32          now;
+    krb5_timestamp      now;
 
     DPRINT(DEBUG_CALLS, acl_debug_level,
            ("* kadm5int_acl_impose_restrictions(..., *maskp=0x%08x, rp=0x%08x)\n",

--- a/src/lib/kadm5/srv/server_kdb.c
+++ b/src/lib/kadm5/srv/server_kdb.c
@@ -365,7 +365,7 @@ kdb_put_entry(kadm5_server_handle_t handle,
               krb5_db_entry *kdb, osa_princ_ent_rec *adb)
 {
     krb5_error_code ret;
-    krb5_int32 now;
+    krb5_timestamp now;
     XDR xdrs;
     krb5_tl_data tl_data;
 

--- a/src/lib/kadm5/srv/svr_principal.c
+++ b/src/lib/kadm5/srv/svr_principal.c
@@ -296,7 +296,7 @@ kadm5_create_principal_3(void *server_handle,
     osa_princ_ent_rec           adb;
     kadm5_policy_ent_rec        polent;
     krb5_boolean                have_polent = FALSE;
-    krb5_int32                  now;
+    krb5_timestamp              now;
     krb5_tl_data                *tl_data_tail;
     unsigned int                ret;
     kadm5_server_handle_t handle = server_handle;
@@ -1322,7 +1322,7 @@ kadm5_chpass_principal_3(void *server_handle,
                          int n_ks_tuple, krb5_key_salt_tuple *ks_tuple,
                          char *password)
 {
-    krb5_int32                  now;
+    krb5_timestamp              now;
     kadm5_policy_ent_rec        pol;
     osa_princ_ent_rec           adb;
     krb5_db_entry               *kdb;
@@ -1544,7 +1544,7 @@ kadm5_randkey_principal_3(void *server_handle,
 {
     krb5_db_entry               *kdb;
     osa_princ_ent_rec           adb;
-    krb5_int32                  now;
+    krb5_timestamp              now;
     kadm5_policy_ent_rec        pol;
     int                         ret, last_pwd, n_new_keys;
     krb5_boolean                have_pol = FALSE;
@@ -1686,7 +1686,7 @@ kadm5_setv4key_principal(void *server_handle,
 {
     krb5_db_entry               *kdb;
     osa_princ_ent_rec           adb;
-    krb5_int32                  now;
+    krb5_timestamp              now;
     kadm5_policy_ent_rec        pol;
     krb5_keysalt                keysalt;
     int                         i, kvno, ret;
@@ -1888,7 +1888,7 @@ kadm5_setkey_principal_4(void *server_handle, krb5_principal principal,
 {
     krb5_db_entry *kdb;
     osa_princ_ent_rec adb;
-    krb5_int32 now;
+    krb5_timestamp now;
     kadm5_policy_ent_rec pol;
     krb5_key_data *new_key_data = NULL;
     int i, j, ret, n_new_key_data = 0;

--- a/src/lib/kadm5/srv/svr_principal.c
+++ b/src/lib/kadm5/srv/svr_principal.c
@@ -1326,7 +1326,7 @@ kadm5_chpass_principal_3(void *server_handle,
     kadm5_policy_ent_rec        pol;
     osa_princ_ent_rec           adb;
     krb5_db_entry               *kdb;
-    int                         ret, ret2, last_pwd, hist_added;
+    int                         ret, ret2, hist_added;
     krb5_boolean                have_pol = FALSE;
     kadm5_server_handle_t       handle = server_handle;
     osa_pw_hist_ent             hist;
@@ -1398,24 +1398,6 @@ kadm5_chpass_principal_3(void *server_handle,
 
     if ((adb.aux_attributes & KADM5_POLICY)) {
         /* the policy was loaded before */
-
-        ret = krb5_dbe_lookup_last_pwd_change(handle->context, kdb, &last_pwd);
-        if (ret)
-            goto done;
-
-#if 0
-        /*
-         * The spec says this check is overridden if the caller has
-         * modify privilege.  The admin server therefore makes this
-         * check itself (in chpass_principal_wrapper, misc.c). A
-         * local caller implicitly has all authorization bits.
-         */
-        if ((now - last_pwd) < pol.pw_min_life &&
-            !(kdb->attributes & KRB5_KDB_REQUIRES_PWCHANGE)) {
-            ret = KADM5_PASS_TOOSOON;
-            goto done;
-        }
-#endif
 
         ret = check_pw_reuse(handle->context, hist_keyblocks,
                              kdb->n_key_data, kdb->key_data,
@@ -1546,7 +1528,7 @@ kadm5_randkey_principal_3(void *server_handle,
     osa_princ_ent_rec           adb;
     krb5_timestamp              now;
     kadm5_policy_ent_rec        pol;
-    int                         ret, last_pwd, n_new_keys;
+    int                         ret, n_new_keys;
     krb5_boolean                have_pol = FALSE;
     kadm5_server_handle_t       handle = server_handle;
     krb5_keyblock               *act_mkey;
@@ -1605,24 +1587,6 @@ kadm5_randkey_principal_3(void *server_handle,
             goto done;
     }
     if (have_pol) {
-        ret = krb5_dbe_lookup_last_pwd_change(handle->context, kdb, &last_pwd);
-        if (ret)
-            goto done;
-
-#if 0
-        /*
-         * The spec says this check is overridden if the caller has
-         * modify privilege.  The admin server therefore makes this
-         * check itself (in chpass_principal_wrapper, misc.c).  A
-         * local caller implicitly has all authorization bits.
-         */
-        if((now - last_pwd) < pol.pw_min_life &&
-           !(kdb->attributes & KRB5_KDB_REQUIRES_PWCHANGE)) {
-            ret = KADM5_PASS_TOOSOON;
-            goto done;
-        }
-#endif
-
         if (pol.pw_max_life)
             kdb->pw_expiration = ts_incr(now, pol.pw_max_life);
         else
@@ -1691,9 +1655,6 @@ kadm5_setv4key_principal(void *server_handle,
     krb5_keysalt                keysalt;
     int                         i, kvno, ret;
     krb5_boolean                have_pol = FALSE;
-#if 0
-    int                         last_pwd;
-#endif
     kadm5_server_handle_t       handle = server_handle;
     krb5_key_data               tmp_key_data;
     krb5_keyblock               *act_mkey;
@@ -1756,23 +1717,6 @@ kadm5_setv4key_principal(void *server_handle,
             goto done;
     }
     if (have_pol) {
-#if 0
-        /*
-         * The spec says this check is overridden if the caller has
-         * modify privilege.  The admin server therefore makes this
-         * check itself (in chpass_principal_wrapper, misc.c).  A
-         * local caller implicitly has all authorization bits.
-         */
-        if (ret = krb5_dbe_lookup_last_pwd_change(handle->context,
-                                                  kdb, &last_pwd))
-            goto done;
-        if((now - last_pwd) < pol.pw_min_life &&
-           !(kdb->attributes & KRB5_KDB_REQUIRES_PWCHANGE)) {
-            ret = KADM5_PASS_TOOSOON;
-            goto done;
-        }
-#endif
-
         if (pol.pw_max_life)
             kdb->pw_expiration = ts_incr(now, pol.pw_max_life);
         else

--- a/src/lib/krb5/krb/gen_save_subkey.c
+++ b/src/lib/krb5/krb/gen_save_subkey.c
@@ -38,7 +38,8 @@ k5_generate_and_save_subkey(krb5_context context,
        to guarantee randomness, but to make it less likely that multiple
        sessions could pick the same subkey.  */
     struct {
-        krb5_int32 sec, usec;
+        krb5_timestamp sec;
+        krb5_int32 usec;
     } rnd_data;
     krb5_data d;
     krb5_error_code retval;

--- a/src/lib/krb5/krb/get_in_tkt.c
+++ b/src/lib/krb5/krb/get_in_tkt.c
@@ -1831,7 +1831,7 @@ k5_populate_gic_opt(krb5_context context, krb5_get_init_creds_opt **out,
                     krb5_creds *creds)
 {
     int i;
-    krb5_int32 starttime;
+    krb5_timestamp starttime;
     krb5_deltat lifetime;
     krb5_get_init_creds_opt *opt;
     krb5_error_code retval;

--- a/src/lib/krb5/krb/init_ctx.c
+++ b/src/lib/krb5/krb/init_ctx.c
@@ -139,7 +139,8 @@ krb5_init_context_profile(profile_t profile, krb5_flags flags,
     krb5_context ctx = 0;
     krb5_error_code retval;
     struct {
-        krb5_int32 now, now_usec;
+        krb5_timestamp now;
+        krb5_int32 now_usec;
         long pid;
     } seed_data;
     krb5_data seed;

--- a/src/lib/krb5/os/c_ustime.c
+++ b/src/lib/krb5/os/c_ustime.c
@@ -29,7 +29,10 @@
 
 k5_mutex_t krb5int_us_time_mutex = K5_MUTEX_PARTIAL_INITIALIZER;
 
-struct time_now { krb5_int32 sec, usec; };
+struct time_now {
+    krb5_timestamp sec;
+    krb5_int32 usec;
+};
 
 #if defined(_WIN32)
 
@@ -73,7 +76,7 @@ get_time_now(struct time_now *n)
 static struct time_now last_time;
 
 krb5_error_code
-krb5_crypto_us_timeofday(krb5_int32 *seconds, krb5_int32 *microseconds)
+krb5_crypto_us_timeofday(krb5_timestamp *seconds, krb5_int32 *microseconds)
 {
     struct time_now now;
     krb5_error_code err;

--- a/src/lib/krb5/os/c_ustime.c
+++ b/src/lib/krb5/os/c_ustime.c
@@ -102,17 +102,17 @@ krb5_crypto_us_timeofday(krb5_int32 *seconds, krb5_int32 *microseconds)
        putting now.sec in the past.  But don't just use '<' because we
        need to properly handle the case where the administrator intentionally
        adjusted time backwards. */
-    if ((now.sec == last_time.sec-1) ||
-        ((now.sec == last_time.sec) && (now.usec <= last_time.usec))) {
+    if (now.sec == ts_incr(last_time.sec, -1) ||
+        (now.sec == last_time.sec && !ts_after(last_time.usec, now.usec))) {
         /* Correct 'now' to be exactly one microsecond later than 'last_time'.
            Note that _because_ we perform this hack, 'now' may be _earlier_
            than 'last_time', even though the system time is monotonically
            increasing. */
 
         now.sec = last_time.sec;
-        now.usec = ++last_time.usec;
+        now.usec = ts_incr(last_time.usec, 1);
         if (now.usec >= 1000000) {
-            ++now.sec;
+            now.sec = ts_incr(now.sec, 1);
             now.usec = 0;
         }
     }

--- a/src/lib/krb5/os/toffset.c
+++ b/src/lib/krb5/os/toffset.c
@@ -40,7 +40,8 @@ krb5_error_code KRB5_CALLCONV
 krb5_set_real_time(krb5_context context, krb5_timestamp seconds, krb5_int32 microseconds)
 {
     krb5_os_context os_ctx = &context->os_context;
-    krb5_int32 sec, usec;
+    krb5_timestamp sec;
+    krb5_int32 usec;
     krb5_error_code retval;
 
     retval = krb5_crypto_us_timeofday(&sec, &usec);

--- a/src/lib/krb5/os/trace.c
+++ b/src/lib/krb5/os/trace.c
@@ -340,7 +340,8 @@ krb5int_trace(krb5_context context, const char *fmt, ...)
     va_list ap;
     krb5_trace_info info;
     char *str = NULL, *msg = NULL;
-    krb5_int32 sec, usec;
+    krb5_timestamp sec;
+    krb5_int32 usec;
 
     if (context == NULL || context->trace_callback == NULL)
         return;

--- a/src/lib/krb5/os/trace.c
+++ b/src/lib/krb5/os/trace.c
@@ -350,7 +350,7 @@ krb5int_trace(krb5_context context, const char *fmt, ...)
         goto cleanup;
     if (krb5_crypto_us_timeofday(&sec, &usec) != 0)
         goto cleanup;
-    if (asprintf(&msg, "[%d] %d.%d: %s\n", (int) getpid(), (int) sec,
+    if (asprintf(&msg, "[%d] %u.%d: %s\n", (int) getpid(), (unsigned int) sec,
                  (int) usec, str) < 0)
         goto cleanup;
     info.message = msg;

--- a/src/lib/krb5/os/ustime.c
+++ b/src/lib/krb5/os/ustime.c
@@ -40,7 +40,8 @@ krb5_error_code
 k5_time_with_offset(krb5_timestamp offset, krb5_int32 offset_usec,
                     krb5_timestamp *time_out, krb5_int32 *usec_out)
 {
-    krb5_int32 sec, usec;
+    krb5_timestamp sec;
+    krb5_int32 usec;
     krb5_error_code retval;
 
     retval = krb5_crypto_us_timeofday(&sec, &usec);

--- a/src/lib/krb5/rcache/rc_dfl.c
+++ b/src/lib/krb5/rcache/rc_dfl.c
@@ -93,7 +93,7 @@ cmp(krb5_donot_replay *old, krb5_donot_replay *new1, krb5_deltat t)
 }
 
 static int
-alive(krb5_int32 mytime, krb5_donot_replay *new1, krb5_deltat t)
+alive(krb5_timestamp mytime, krb5_donot_replay *new1, krb5_deltat t)
 {
     if (mytime == 0)
         return CMP_HOHUM; /* who cares? */
@@ -129,7 +129,7 @@ struct authlist
 
 static int
 rc_store(krb5_context context, krb5_rcache id, krb5_donot_replay *rep,
-         krb5_int32 now, krb5_boolean fromfile)
+         krb5_timestamp now, krb5_boolean fromfile)
 {
     struct dfl_data *t = (struct dfl_data *)id->data;
     unsigned int rephash;
@@ -536,7 +536,7 @@ krb5_rc_dfl_recover_locked(krb5_context context, krb5_rcache id)
     krb5_error_code retval;
     long max_size;
     int expired_entries = 0;
-    krb5_int32 now;
+    krb5_timestamp now;
 
     if ((retval = krb5_rc_io_open(context, &t->d, t->name))) {
         return retval;
@@ -706,7 +706,7 @@ krb5_rc_dfl_store(krb5_context context, krb5_rcache id, krb5_donot_replay *rep)
 {
     krb5_error_code ret;
     struct dfl_data *t;
-    krb5_int32 now;
+    krb5_timestamp now;
 
     ret = krb5_timeofday(context, &now);
     if (ret)
@@ -762,7 +762,7 @@ krb5_rc_dfl_expunge_locked(krb5_context context, krb5_rcache id)
     struct authlist **qt;
     struct authlist *r;
     struct authlist *rt;
-    krb5_int32 now;
+    krb5_timestamp now;
 
     if (krb5_timestamp(context, &now))
         now = 0;

--- a/src/tests/create/kdb5_mkdums.c
+++ b/src/tests/create/kdb5_mkdums.c
@@ -247,7 +247,7 @@ add_princ(context, str_newprinc)
 
     {
         /* Add mod princ to db entry */
-        krb5_int32 now;
+        krb5_timestamp now;
 
         retval = krb5_timeofday(context, &now);
         if (retval) {


### PR DESCRIPTION
While doing the y2038 work I noted that some code used krb5_int32 directly instead of krb5_timestamp to hold timestamp values, and figured that would be simplest to treat as a cleanup opportunity for later.  It turns out I should have done it as part of the original PR, because in searching for those uses I found four areas of timestamp manipulation code that I had missed.  This PR has three commits:

1. Fix up the untouched timestamp manipulations.
2. krb5_int32 -> krb5_timestamp where needed
3. Clean up some really ancient libkadm5 code that should have been deleted rather than stuck inside ``#if 0``.