### PR TITLE
Pass down the local address to the KDB AS request audit functions

### DIFF
--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -695,9 +695,9 @@ krb5_error_code krb5_db_check_policy_tgs(krb5_context kcontext,
                                          krb5_pa_data ***e_data);
 
 void krb5_db_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
-                          krb5_address *from, krb5_db_entry *client,
-                          krb5_db_entry *server, krb5_timestamp authtime,
-                          krb5_error_code error_code);
+                          const krb5_address *remote_addr,
+                          krb5_db_entry *client, krb5_db_entry *server,
+                          krb5_timestamp authtime, krb5_error_code error_code);
 
 void krb5_db_refresh_config(krb5_context kcontext);
 
@@ -1357,9 +1357,9 @@ typedef struct _kdb_vftabl {
      * AS request.
      */
     void (*audit_as_req)(krb5_context kcontext, krb5_kdc_req *request,
-                         krb5_address *from, krb5_db_entry *client,
-                         krb5_db_entry *server, krb5_timestamp authtime,
-                         krb5_error_code error_code);
+                         const krb5_address *remote_addr,
+                         krb5_db_entry *client, krb5_db_entry *server,
+                         krb5_timestamp authtime, krb5_error_code error_code);
 
     /* Note: there is currently no method for auditing TGS requests. */
 

--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -695,6 +695,7 @@ krb5_error_code krb5_db_check_policy_tgs(krb5_context kcontext,
                                          krb5_pa_data ***e_data);
 
 void krb5_db_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
+                          const krb5_address *local_addr,
                           const krb5_address *remote_addr,
                           krb5_db_entry *client, krb5_db_entry *server,
                           krb5_timestamp authtime, krb5_error_code error_code);
@@ -1357,6 +1358,7 @@ typedef struct _kdb_vftabl {
      * AS request.
      */
     void (*audit_as_req)(krb5_context kcontext, krb5_kdc_req *request,
+                         const krb5_address *local_addr,
                          const krb5_address *remote_addr,
                          krb5_db_entry *client, krb5_db_entry *server,
                          krb5_timestamp authtime, krb5_error_code error_code);

--- a/src/include/net-server.h
+++ b/src/include/net-server.h
@@ -86,7 +86,7 @@ void loop_free(verto_ctx *ctx);
  */
 typedef void (*loop_respond_fn)(void *arg, krb5_error_code code,
                                 krb5_data *response);
-void dispatch(void *handle, struct sockaddr *local_addr,
+void dispatch(void *handle, const krb5_fulladdr *local_addr,
               const krb5_fulladdr *remote_addr, krb5_data *request,
               int is_tcp, verto_ctx *vctx, loop_respond_fn respond, void *arg);
 krb5_error_code make_toolong_error (void *handle, krb5_data **);

--- a/src/kadmin/server/schpw.c
+++ b/src/kadmin/server/schpw.c
@@ -444,20 +444,11 @@ dispatch(void *handle, struct sockaddr *local_saddr,
     krb5_keytab kt = NULL;
     kadm5_server_handle_t server_handle = (kadm5_server_handle_t)handle;
     krb5_fulladdr local_faddr;
-    krb5_address **local_kaddrs = NULL, local_kaddr_buf;
+    krb5_address local_kaddr_buf;
     krb5_data *response = NULL;
 
-    if (local_saddr == NULL) {
-        ret = krb5_os_localaddr(server_handle->context, &local_kaddrs);
-        if (ret != 0)
-            goto egress;
-
-        local_faddr.address = local_kaddrs[0];
-        local_faddr.port = 0;
-    } else {
-        local_faddr.address = &local_kaddr_buf;
-        init_addr(&local_faddr, local_saddr);
-    }
+    local_faddr.address = &local_kaddr_buf;
+    init_addr(&local_faddr, local_saddr);
 
     ret = krb5_kt_resolve(server_handle->context, "KDB:", &kt);
     if (ret != 0) {
@@ -481,7 +472,6 @@ dispatch(void *handle, struct sockaddr *local_saddr,
 egress:
     if (ret)
         krb5_free_data(server_handle->context, response);
-    krb5_free_addresses(server_handle->context, local_kaddrs);
     krb5_kt_close(server_handle->context, kt);
     (*respond)(arg, ret, ret == 0 ? response : NULL);
 }

--- a/src/kadmin/server/schpw.c
+++ b/src/kadmin/server/schpw.c
@@ -18,8 +18,8 @@
 
 static krb5_error_code
 process_chpw_request(krb5_context context, void *server_handle, char *realm,
-                     krb5_keytab keytab, const krb5_fulladdr *local_faddr,
-                     const krb5_fulladdr *remote_faddr, krb5_data *req,
+                     krb5_keytab keytab, const krb5_fulladdr *local_addr,
+                     const krb5_fulladdr *remote_addr, krb5_data *req,
                      krb5_data *rep)
 {
     krb5_error_code ret;
@@ -42,7 +42,7 @@ process_chpw_request(krb5_context context, void *server_handle, char *realm,
     struct sockaddr_storage ss;
     socklen_t salen;
     char addrbuf[100];
-    krb5_address *addr = remote_faddr->address;
+    krb5_address *addr = remote_addr->address;
 
     *rep = empty_data();
 
@@ -237,7 +237,7 @@ process_chpw_request(krb5_context context, void *server_handle, char *realm,
 
         sin->sin_family = AF_INET;
         memcpy(&sin->sin_addr, addr->contents, addr->length);
-        sin->sin_port = htons(remote_faddr->port);
+        sin->sin_port = htons(remote_addr->port);
         salen = sizeof(*sin);
         break;
     }
@@ -246,7 +246,7 @@ process_chpw_request(krb5_context context, void *server_handle, char *realm,
 
         sin6->sin6_family = AF_INET6;
         memcpy(&sin6->sin6_addr, addr->contents, addr->length);
-        sin6->sin6_port = htons(remote_faddr->port);
+        sin6->sin6_port = htons(remote_addr->port);
         salen = sizeof(*sin6);
         break;
     }
@@ -326,7 +326,7 @@ chpwfail:
 
     if (ap_rep.length) {
         ret = krb5_auth_con_setaddrs(context, auth_context,
-                                     local_faddr->address, NULL);
+                                     local_addr->address, NULL);
         if (ret) {
             numresult = KRB5_KPASSWD_HARDERROR;
             strlcpy(strresult,
@@ -437,7 +437,7 @@ bailout:
 /* Dispatch routine for set/change password */
 void
 dispatch(void *handle, struct sockaddr *local_saddr,
-         const krb5_fulladdr *remote_faddr, krb5_data *request, int is_tcp,
+         const krb5_fulladdr *remote_addr, krb5_data *request, int is_tcp,
          verto_ctx *vctx, loop_respond_fn respond, void *arg)
 {
     krb5_error_code ret;
@@ -466,7 +466,7 @@ dispatch(void *handle, struct sockaddr *local_saddr,
                                server_handle->params.realm,
                                kt,
                                &local_faddr,
-                               remote_faddr,
+                               remote_addr,
                                request,
                                response);
 egress:

--- a/src/kadmin/server/schpw.c
+++ b/src/kadmin/server/schpw.c
@@ -436,19 +436,14 @@ bailout:
 
 /* Dispatch routine for set/change password */
 void
-dispatch(void *handle, struct sockaddr *local_saddr,
+dispatch(void *handle, const krb5_fulladdr *local_addr,
          const krb5_fulladdr *remote_addr, krb5_data *request, int is_tcp,
          verto_ctx *vctx, loop_respond_fn respond, void *arg)
 {
     krb5_error_code ret;
     krb5_keytab kt = NULL;
     kadm5_server_handle_t server_handle = (kadm5_server_handle_t)handle;
-    krb5_fulladdr local_faddr;
-    krb5_address local_kaddr_buf;
     krb5_data *response = NULL;
-
-    local_faddr.address = &local_kaddr_buf;
-    init_addr(&local_faddr, local_saddr);
 
     ret = krb5_kt_resolve(server_handle->context, "KDB:", &kt);
     if (ret != 0) {
@@ -465,7 +460,7 @@ dispatch(void *handle, struct sockaddr *local_saddr,
                                handle,
                                server_handle->params.realm,
                                kt,
-                               &local_faddr,
+                               local_addr,
                                remote_addr,
                                request,
                                response);

--- a/src/kdc/dispatch.c
+++ b/src/kdc/dispatch.c
@@ -120,7 +120,7 @@ reseed_random(krb5_context kdc_err_context)
 
 void
 dispatch(void *cb, struct sockaddr *local_saddr,
-         const krb5_fulladdr *from, krb5_data *pkt, int is_tcp,
+         const krb5_fulladdr *remote_addr, krb5_data *pkt, int is_tcp,
          verto_ctx *vctx, loop_respond_fn respond, void *arg)
 {
     krb5_error_code retval;
@@ -150,8 +150,8 @@ dispatch(void *cb, struct sockaddr *local_saddr,
         const char *name = 0;
         char buf[46];
 
-        name = inet_ntop (ADDRTYPE2FAMILY (from->address->addrtype),
-                          from->address->contents, buf, sizeof (buf));
+        name = inet_ntop(ADDRTYPE2FAMILY(remote_addr->address->addrtype),
+                         remote_addr->address->contents, buf, sizeof(buf));
         if (name == 0)
             name = "[unknown address type]";
         if (response)
@@ -177,7 +177,7 @@ dispatch(void *cb, struct sockaddr *local_saddr,
     /* try TGS_REQ first; they are more common! */
 
     if (krb5_is_tgs_req(pkt)) {
-        retval = process_tgs_req(handle, pkt, from, &response);
+        retval = process_tgs_req(handle, pkt, remote_addr, &response);
     } else if (krb5_is_as_req(pkt)) {
         if (!(retval = decode_krb5_as_req(pkt, &as_req))) {
             /*
@@ -187,8 +187,8 @@ dispatch(void *cb, struct sockaddr *local_saddr,
              */
             state->active_realm = setup_server_realm(handle, as_req->server);
             if (state->active_realm != NULL) {
-                process_as_req(as_req, pkt, from, state->active_realm, vctx,
-                               finish_dispatch_cache, state);
+                process_as_req(as_req, pkt, remote_addr, state->active_realm,
+                               vctx, finish_dispatch_cache, state);
                 return;
             } else {
                 retval = KRB5KDC_ERR_WRONG_REALM;

--- a/src/kdc/dispatch.c
+++ b/src/kdc/dispatch.c
@@ -187,8 +187,9 @@ dispatch(void *cb, const krb5_fulladdr *local_addr,
              */
             state->active_realm = setup_server_realm(handle, as_req->server);
             if (state->active_realm != NULL) {
-                process_as_req(as_req, pkt, remote_addr, state->active_realm,
-                               vctx, finish_dispatch_cache, state);
+                process_as_req(as_req, pkt, local_addr, remote_addr,
+                               state->active_realm, vctx,
+                               finish_dispatch_cache, state);
                 return;
             } else {
                 retval = KRB5KDC_ERR_WRONG_REALM;

--- a/src/kdc/dispatch.c
+++ b/src/kdc/dispatch.c
@@ -119,7 +119,7 @@ reseed_random(krb5_context kdc_err_context)
 }
 
 void
-dispatch(void *cb, struct sockaddr *local_saddr,
+dispatch(void *cb, const krb5_fulladdr *local_addr,
          const krb5_fulladdr *remote_addr, krb5_data *pkt, int is_tcp,
          verto_ctx *vctx, loop_respond_fn respond, void *arg)
 {

--- a/src/kdc/do_as_req.c
+++ b/src/kdc/do_as_req.c
@@ -160,7 +160,7 @@ struct as_req_state {
     struct kdc_request_state *rstate;
     char *sname, *cname;
     void *pa_context;
-    const krb5_fulladdr *from;
+    const krb5_fulladdr *remote_addr;
     krb5_data **auth_indicators;
 
     krb5_error_code preauth_err;
@@ -359,7 +359,7 @@ finish_process_as_req(struct as_req_state *state, krb5_error_code errcode)
            state->reply.enc_part.ciphertext.length);
     free(state->reply.enc_part.ciphertext.data);
 
-    log_as_req(kdc_context, state->from, state->request, &state->reply,
+    log_as_req(kdc_context, state->remote_addr, state->request, &state->reply,
                state->client, state->cname, state->server,
                state->sname, state->authtime, 0, 0, 0);
     did_log = 1;
@@ -381,10 +381,10 @@ egress:
         emsg = krb5_get_error_message(kdc_context, errcode);
 
     if (state->status) {
-        log_as_req(kdc_context,
-                   state->from, state->request, &state->reply, state->client,
-                   state->cname, state->server, state->sname, state->authtime,
-                   state->status, errcode, emsg);
+        log_as_req(kdc_context, state->remote_addr, state->request,
+                   &state->reply, state->client, state->cname, state->server,
+                   state->sname, state->authtime, state->status, errcode,
+                   emsg);
         did_log = 1;
     }
     if (errcode) {
@@ -492,7 +492,7 @@ finish_preauth(void *arg, krb5_error_code code)
 /*ARGSUSED*/
 void
 process_as_req(krb5_kdc_req *request, krb5_data *req_pkt,
-               const krb5_fulladdr *from, kdc_realm_t *kdc_active_realm,
+               const krb5_fulladdr *remote_addr, kdc_realm_t *kdc_active_realm,
                verto_ctx *vctx, loop_respond_fn respond, void *arg)
 {
     krb5_error_code errcode;
@@ -511,7 +511,7 @@ process_as_req(krb5_kdc_req *request, krb5_data *req_pkt,
     state->arg = arg;
     state->request = request;
     state->req_pkt = req_pkt;
-    state->from = from;
+    state->remote_addr = remote_addr;
     state->active_realm = kdc_active_realm;
 
     errcode = kdc_make_rstate(kdc_active_realm, &state->rstate);
@@ -522,7 +522,8 @@ process_as_req(krb5_kdc_req *request, krb5_data *req_pkt,
     }
 
     /* Initialize audit state. */
-    errcode = kau_init_kdc_req(kdc_context, state->request, from, &au_state);
+    errcode = kau_init_kdc_req(kdc_context, state->request, remote_addr,
+                               &au_state);
     if (errcode) {
         (*respond)(arg, errcode, NULL);
         kdc_free_rstate(state->rstate);

--- a/src/kdc/kdc_log.c
+++ b/src/kdc/kdc_log.c
@@ -54,7 +54,7 @@
 /* Someday, pass local address/port as well.  */
 /* Currently no info about name canonicalization is logged.  */
 void
-log_as_req(krb5_context context, const krb5_fulladdr *from,
+log_as_req(krb5_context context, const krb5_fulladdr *remote_addr,
            krb5_kdc_req *request, krb5_kdc_rep *reply,
            krb5_db_entry *client, const char *cname,
            krb5_db_entry *server, const char *sname,
@@ -67,8 +67,8 @@ log_as_req(krb5_context context, const krb5_fulladdr *from,
     const char *cname2 = cname ? cname : "<unknown client>";
     const char *sname2 = sname ? sname : "<unknown server>";
 
-    fromstring = inet_ntop(ADDRTYPE2FAMILY (from->address->addrtype),
-                           from->address->contents,
+    fromstring = inet_ntop(ADDRTYPE2FAMILY(remote_addr->address->addrtype),
+                           remote_addr->address->contents,
                            fromstringbuf, sizeof(fromstringbuf));
     if (!fromstring)
         fromstring = "<unknown>";
@@ -89,14 +89,14 @@ log_as_req(krb5_context context, const krb5_fulladdr *from,
                          ktypestr, fromstring, status,
                          cname2, sname2, emsg ? ", " : "", emsg ? emsg : "");
     }
-    krb5_db_audit_as_req(context, request, from->address, client, server,
-                         authtime, errcode);
+    krb5_db_audit_as_req(context, request, remote_addr->address, client,
+                         server, authtime, errcode);
 #if 0
     /* Sun (OpenSolaris) version would probably something like this.
        The client and server names passed can be null, unlike in the
        logging routines used above.  Note that a struct in_addr is
        used, but the real address could be an IPv6 address.  */
-    audit_krb5kdc_as_req(some in_addr *, (in_port_t)from->port, 0,
+    audit_krb5kdc_as_req(some in_addr *, (in_port_t)remote_addr->port, 0,
                          cname, sname, errcode);
 #endif
 }

--- a/src/kdc/kdc_log.c
+++ b/src/kdc/kdc_log.c
@@ -54,7 +54,9 @@
 /* Someday, pass local address/port as well.  */
 /* Currently no info about name canonicalization is logged.  */
 void
-log_as_req(krb5_context context, const krb5_fulladdr *remote_addr,
+log_as_req(krb5_context context,
+           const krb5_fulladdr *local_addr,
+           const krb5_fulladdr *remote_addr,
            krb5_kdc_req *request, krb5_kdc_rep *reply,
            krb5_db_entry *client, const char *cname,
            krb5_db_entry *server, const char *sname,
@@ -89,8 +91,9 @@ log_as_req(krb5_context context, const krb5_fulladdr *remote_addr,
                          ktypestr, fromstring, status,
                          cname2, sname2, emsg ? ", " : "", emsg ? emsg : "");
     }
-    krb5_db_audit_as_req(context, request, remote_addr->address, client,
-                         server, authtime, errcode);
+    krb5_db_audit_as_req(context, request,
+                         local_addr->address, remote_addr->address,
+                         client, server, authtime, errcode);
 #if 0
     /* Sun (OpenSolaris) version would probably something like this.
        The client and server names passed can be null, unlike in the

--- a/src/kdc/kdc_util.h
+++ b/src/kdc/kdc_util.h
@@ -346,7 +346,7 @@ kdc_get_ticket_renewtime(kdc_realm_t *realm, krb5_kdc_req *request,
                          krb5_db_entry *server, krb5_enc_tkt_part *tkt);
 
 void
-log_as_req(krb5_context context, const krb5_fulladdr *from,
+log_as_req(krb5_context context, const krb5_fulladdr *remote_addr,
            krb5_kdc_req *request, krb5_kdc_rep *reply,
            krb5_db_entry *client, const char *cname,
            krb5_db_entry *server, const char *sname,

--- a/src/kdc/kdc_util.h
+++ b/src/kdc/kdc_util.h
@@ -140,7 +140,7 @@ cammac_check_kdcver(krb5_context context, krb5_cammac *cammac,
 /* do_as_req.c */
 void
 process_as_req (krb5_kdc_req *, krb5_data *,
-                const krb5_fulladdr *, kdc_realm_t *,
+                const krb5_fulladdr *, const krb5_fulladdr *, kdc_realm_t *,
                 verto_ctx *, loop_respond_fn, void *);
 
 /* do_tgs_req.c */
@@ -346,7 +346,9 @@ kdc_get_ticket_renewtime(kdc_realm_t *realm, krb5_kdc_req *request,
                          krb5_db_entry *server, krb5_enc_tkt_part *tkt);
 
 void
-log_as_req(krb5_context context, const krb5_fulladdr *remote_addr,
+log_as_req(krb5_context context,
+           const krb5_fulladdr *local_addr,
+           const krb5_fulladdr *remote_addr,
            krb5_kdc_req *request, krb5_kdc_rep *reply,
            krb5_db_entry *client, const char *cname,
            krb5_db_entry *server, const char *sname,

--- a/src/kdc/kdc_util.h
+++ b/src/kdc/kdc_util.h
@@ -151,7 +151,7 @@ process_tgs_req (struct server_handle *, krb5_data *,
 /* dispatch.c */
 void
 dispatch (void *,
-          struct sockaddr *,
+          const krb5_fulladdr *,
           const krb5_fulladdr *,
           krb5_data *,
           int,

--- a/src/lib/kdb/kdb5.c
+++ b/src/lib/kdb/kdb5.c
@@ -2672,7 +2672,7 @@ krb5_db_check_policy_tgs(krb5_context kcontext, krb5_kdc_req *request,
 
 void
 krb5_db_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
-                     krb5_address *from, krb5_db_entry *client,
+                     const krb5_address *remote_addr, krb5_db_entry *client,
                      krb5_db_entry *server, krb5_timestamp authtime,
                      krb5_error_code error_code)
 {
@@ -2682,7 +2682,7 @@ krb5_db_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
     status = get_vftabl(kcontext, &v);
     if (status || v->audit_as_req == NULL)
         return;
-    v->audit_as_req(kcontext, request, from, client, server, authtime,
+    v->audit_as_req(kcontext, request, remote_addr, client, server, authtime,
                     error_code);
 }
 

--- a/src/lib/kdb/kdb5.c
+++ b/src/lib/kdb/kdb5.c
@@ -2672,6 +2672,7 @@ krb5_db_check_policy_tgs(krb5_context kcontext, krb5_kdc_req *request,
 
 void
 krb5_db_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
+                     const krb5_address *local_addr,
                      const krb5_address *remote_addr, krb5_db_entry *client,
                      krb5_db_entry *server, krb5_timestamp authtime,
                      krb5_error_code error_code)
@@ -2682,8 +2683,8 @@ krb5_db_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
     status = get_vftabl(kcontext, &v);
     if (status || v->audit_as_req == NULL)
         return;
-    v->audit_as_req(kcontext, request, remote_addr, client, server, authtime,
-                    error_code);
+    v->audit_as_req(kcontext, request, local_addr, remote_addr,
+                    client, server, authtime, error_code);
 }
 
 void

--- a/src/plugins/kdb/db2/db2_exp.c
+++ b/src/plugins/kdb/db2/db2_exp.c
@@ -166,10 +166,12 @@ WRAP_K (krb5_db2_check_policy_as,
         (kcontext, request, client, server, kdc_time, status, e_data));
 
 WRAP_VOID (krb5_db2_audit_as_req,
-           (krb5_context kcontext, krb5_kdc_req *request, krb5_address *from,
+           (krb5_context kcontext, krb5_kdc_req *request,
+            const krb5_address *remote_addr,
             krb5_db_entry *client, krb5_db_entry *server,
             krb5_timestamp authtime, krb5_error_code error_code),
-           (kcontext, request, from, client, server, authtime, error_code));
+           (kcontext, request, remote_addr, client, server,
+            authtime, error_code));
 
 static krb5_error_code
 hack_init (void)

--- a/src/plugins/kdb/db2/db2_exp.c
+++ b/src/plugins/kdb/db2/db2_exp.c
@@ -167,10 +167,11 @@ WRAP_K (krb5_db2_check_policy_as,
 
 WRAP_VOID (krb5_db2_audit_as_req,
            (krb5_context kcontext, krb5_kdc_req *request,
+            const krb5_address *local_addr,
             const krb5_address *remote_addr,
             krb5_db_entry *client, krb5_db_entry *server,
             krb5_timestamp authtime, krb5_error_code error_code),
-           (kcontext, request, remote_addr, client, server,
+           (kcontext, request, local_addr, remote_addr, client, server,
             authtime, error_code));
 
 static krb5_error_code

--- a/src/plugins/kdb/db2/kdb_db2.c
+++ b/src/plugins/kdb/db2/kdb_db2.c
@@ -1551,7 +1551,7 @@ krb5_db2_check_policy_as(krb5_context kcontext, krb5_kdc_req *request,
 
 void
 krb5_db2_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
-                      krb5_address *from, krb5_db_entry *client,
+                      const krb5_address *remote_addr, krb5_db_entry *client,
                       krb5_db_entry *server, krb5_timestamp authtime,
                       krb5_error_code error_code)
 {

--- a/src/plugins/kdb/db2/kdb_db2.c
+++ b/src/plugins/kdb/db2/kdb_db2.c
@@ -1551,6 +1551,7 @@ krb5_db2_check_policy_as(krb5_context kcontext, krb5_kdc_req *request,
 
 void
 krb5_db2_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
+                      const krb5_address *local_addr,
                       const krb5_address *remote_addr, krb5_db_entry *client,
                       krb5_db_entry *server, krb5_timestamp authtime,
                       krb5_error_code error_code)

--- a/src/plugins/kdb/db2/kdb_db2.h
+++ b/src/plugins/kdb/db2/kdb_db2.h
@@ -134,8 +134,9 @@ krb5_db2_check_policy_as(krb5_context kcontext, krb5_kdc_req *request,
 
 void
 krb5_db2_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
-                      krb5_address *from, krb5_db_entry *client,
-                      krb5_db_entry *server, krb5_timestamp authtime,
+                      const krb5_address *remote_addr,
+                      krb5_db_entry *client, krb5_db_entry *server,
+                      krb5_timestamp authtime,
                       krb5_error_code error_code);
 
 #endif /* KRB5_KDB_DB2_H */

--- a/src/plugins/kdb/db2/kdb_db2.h
+++ b/src/plugins/kdb/db2/kdb_db2.h
@@ -134,6 +134,7 @@ krb5_db2_check_policy_as(krb5_context kcontext, krb5_kdc_req *request,
 
 void
 krb5_db2_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
+                      const krb5_address *local_addr,
                       const krb5_address *remote_addr,
                       krb5_db_entry *client, krb5_db_entry *server,
                       krb5_timestamp authtime,

--- a/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.c
@@ -277,7 +277,7 @@ krb5_ldap_check_policy_as(krb5_context kcontext, krb5_kdc_req *request,
 
 void
 krb5_ldap_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
-                       krb5_address *from, krb5_db_entry *client,
+                       const krb5_address *remote_addr, krb5_db_entry *client,
                        krb5_db_entry *server, krb5_timestamp authtime,
                        krb5_error_code error_code)
 {

--- a/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.c
@@ -277,6 +277,7 @@ krb5_ldap_check_policy_as(krb5_context kcontext, krb5_kdc_req *request,
 
 void
 krb5_ldap_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
+                       const krb5_address *local_addr,
                        const krb5_address *remote_addr, krb5_db_entry *client,
                        krb5_db_entry *server, krb5_timestamp authtime,
                        krb5_error_code error_code)

--- a/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.h
@@ -282,7 +282,7 @@ krb5_ldap_check_policy_as(krb5_context kcontext, krb5_kdc_req *request,
 
 void
 krb5_ldap_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
-                       krb5_address *from, krb5_db_entry *client,
+                       const krb5_address *remote_addr, krb5_db_entry *client,
                        krb5_db_entry *server, krb5_timestamp authtime,
                        krb5_error_code error_code);
 

--- a/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.h
@@ -282,6 +282,7 @@ krb5_ldap_check_policy_as(krb5_context kcontext, krb5_kdc_req *request,
 
 void
 krb5_ldap_audit_as_req(krb5_context kcontext, krb5_kdc_req *request,
+                       const krb5_address *local_addr,
                        const krb5_address *remote_addr, krb5_db_entry *client,
                        krb5_db_entry *server, krb5_timestamp authtime,
                        krb5_error_code error_code);

--- a/src/tests/kdbtest.c
+++ b/src/tests/kdbtest.c
@@ -243,8 +243,9 @@ check_entry(krb5_db_entry *ent)
 static void
 sim_preauth(krb5_timestamp authtime, krb5_boolean ok, krb5_db_entry **entp)
 {
-    /* Both back ends ignore the request and from parameters for now. */
-    krb5_db_audit_as_req(ctx, NULL, NULL, *entp, *entp, authtime,
+    /* Both back ends ignore the request, local_addr, and remote_addr
+     * parameters for now. */
+    krb5_db_audit_as_req(ctx, NULL, NULL, NULL, *entp, *entp, authtime,
                          ok ? 0 : KRB5KDC_ERR_PREAUTH_FAILED);
     krb5_db_free_principal(ctx, *entp);
     CHECK(krb5_db_get_principal(ctx, &sample_princ, 0, entp));


### PR DESCRIPTION
As we already broke the API it might be useful to know over which IP address the client connection came in.

It also does some code cleanup to have consistent naming (local_addr, remote_addr) and use const when passing the buffer down.