### PR TITLE
Free checksum data deterministically.

### DIFF
--- a/src/lib/gssapi/krb5/init_sec_context.c
+++ b/src/lib/gssapi/krb5/init_sec_context.c
@@ -356,9 +356,6 @@ make_gss_checksum (krb5_context context, krb5_auth_context auth_context,
     TWRITE_STR(ptr, data->md5.contents, data->md5.length);
     TWRITE_INT(ptr, data->ctx->gss_flags, 0);
 
-    /* done with this, free it */
-    xfree(data->md5.contents);
-
     if (credmsg.data) {
         TWRITE_INT16(ptr, KRB5_GSS_FOR_CREDS_OPTION, 0);
         TWRITE_INT16(ptr, credmsg.length, 0);
@@ -430,6 +427,7 @@ make_ap_req_v1(context, ctx, cred, k_cred, ad_context,
     code = krb5_mk_req_extended(context, &ctx->auth_context, mk_req_flags,
                                 NULL, k_cred, &ap_req);
     krb5_auth_con_set_authdata_context(context, ctx->auth_context, NULL);
+    krb5_free_checksum_contents(context, &cksum_struct.md5);
     krb5_free_data_contents(context, &cksum_struct.checksum_data);
     if (code)
         goto cleanup;


### PR DESCRIPTION
In nomal course of execution, md5.contents allocated by
kg_checksum_channel_bindings() in make_ap_req_v1() is freed in
make_gss_checksum(). But when there is a failure in
krb5_mk_req_extended() or in make_gss_checksum() before free is called,
the memory leaks.

This patch frees the memory unconditionally in make_ap_req_v1().