### PR TITLE
kdc.conf(5): aes-sha2 enctypes are part of the aes family

### DIFF
--- a/doc/admin/conf_files/kdc_conf.rst
+++ b/doc/admin/conf_files/kdc_conf.rst
@@ -829,7 +829,7 @@ camellia256-cts-cmac camellia256-cts                 Camellia-256 CTS mode with 
 camellia128-cts-cmac camellia128-cts                 Camellia-128 CTS mode with CMAC
 des                                                  The DES family: des-cbc-crc, des-cbc-md5, and des-cbc-md4 (weak)
 des3                                                 The triple DES family: des3-cbc-sha1
-aes                                                  The AES family: aes256-cts-hmac-sha1-96 and aes128-cts-hmac-sha1-96
+aes                                                  The AES family: aes256-cts-hmac-sha1-96, aes128-cts-hmac-sha1-96, aes256-cts-hmac-sha384-192, and aes128-cts-hmac-sha256-128
 rc4                                                  The RC4 family: arcfour-hmac
 camellia                                             The Camellia family: camellia256-cts-cmac and camellia128-cts-cmac
 ==================================================== =========================================================


### PR DESCRIPTION
The functional portion of this change was made in d1ec317288278d10ae34fde9b2414e4fca5c52dd.

(As an additional note, looking at the generated kdc.conf.man file, it looks like this may not have been regenerated recently - in addition to a lot of formatting churn, I see a note about the sha2 enctypes being new in 1.15, so I'm not sure it was updated prior to release.  I'd update it with this PR but for the churn.)