### PR TITLE
Add option to specify salt to ktutil add_entry command

### DIFF
--- a/doc/admin/admin_commands/ktutil.rst
+++ b/doc/admin/admin_commands/ktutil.rst
@@ -87,7 +87,7 @@ add_entry
 ~~~~~~~~~
 
     **add_entry** {**-key**\|\ **-password**} **-p** *principal*
-    **-k** *kvno* **-e** *enctype*
+    **-k** *kvno* **-e** *enctype* [**-s** *salt*]
 
 Add *principal* to keylist using key or password.
 

--- a/src/kadmin/ktutil/ktutil.c
+++ b/src/kadmin/ktutil/ktutil.c
@@ -141,6 +141,7 @@ void ktutil_add_entry(argc, argv)
     char *enctype = NULL;
     krb5_kvno kvno = 0;
     int use_pass = 0, use_key = 0, use_kvno = 0, i;
+    char *salt = NULL;
 
     for (i = 1; i < argc; i++) {
         if ((strlen(argv[i]) == 2) && !strncmp(argv[i], "-p", 2)) {
@@ -164,16 +165,22 @@ void ktutil_add_entry(argc, argv)
             use_key++;
             continue;
         }
+        if ((strlen(argv[i]) == 2) && !strncmp(argv[i], "-s", 2)) {
+            salt = argv[++i];
+            continue;
+        }
     }
 
-    if (argc != 8 || !(princ && use_kvno && enctype) ||
+    if (!((argc == 8 && princ && use_kvno && enctype) ||
+          (argc == 10 && princ && use_kvno && enctype && salt)) ||
         use_pass + use_key != 1) {
         fprintf(stderr, _("usage: %s (-key | -password) -p principal "
-                          "-k kvno -e enctype\n"), argv[0]);
+                          "-k kvno -e enctype [-s salt]\n"), argv[0]);
         return;
     }
 
-    retval = ktutil_add(kcontext, &ktlist, princ, kvno, enctype, use_pass);
+    retval = ktutil_add(kcontext, &ktlist, princ, kvno, enctype, use_pass,
+                        salt);
     if (retval)
         com_err(argv[0], retval, _("while adding new entry"));
 }

--- a/src/kadmin/ktutil/ktutil.h
+++ b/src/kadmin/ktutil/ktutil.h
@@ -38,7 +38,8 @@ krb5_error_code ktutil_add (krb5_context,
                             char *,
                             krb5_kvno,
                             char *,
-                            int);
+                            int,
+                            char *);
 
 krb5_error_code ktutil_read_keytab (krb5_context,
                                     char *,

--- a/src/man/ktutil.man
+++ b/src/man/ktutil.man
@@ -113,7 +113,7 @@ Alias: \fBdelent\fP
 .INDENT 0.0
 .INDENT 3.5
 \fBadd_entry\fP {\fB\-key\fP|\fB\-password\fP} \fB\-p\fP \fIprincipal\fP
-\fB\-k\fP \fIkvno\fP \fB\-e\fP \fIenctype\fP
+\fB\-k\fP \fIkvno\fP \fB\-e\fP \fIenctype\fP [\fB\-s\fP \fIsalt\fP]
 .UNINDENT
 .UNINDENT
 .sp


### PR DESCRIPTION
This change adds ability to specify an optional argument salt to the ktutil add_entry command. This helps in creating user keytabs where the salt is not derived from the user principal name. Some uses of this are in creating keytabs for IPA which uses random salting and for Active Directory where enterprise UPNs are used. If the salt argument is not specified then the original behavior of deriving salt from principal is used.