### PR TITLE
Fix errors from -Werror=maybe-unitialized with -Og

### DIFF
--- a/src/kadmin/ktutil/ktutil_funcs.c
+++ b/src/kadmin/ktutil/ktutil_funcs.c
@@ -64,7 +64,8 @@ krb5_error_code ktutil_delete(context, list, idx)
     krb5_kt_list *list;
     int idx;
 {
-    krb5_kt_list lp, prev;
+    krb5_kt_list lp = *list;
+    krb5_kt_list prev = NULL;
     int i;
 
     for (lp = *list, i = 1; lp; prev = lp, lp = lp->next, i++) {

--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -3774,7 +3774,7 @@ pkinit_open_session(krb5_context context,
 {
     CK_ULONG i, r;
     unsigned char *cp;
-    size_t label_len;
+    size_t label_len = 0;
     CK_ULONG count = 0;
     CK_SLOT_ID_PTR slotlist;
     CK_TOKEN_INFO tinfo;

--- a/src/plugins/preauth/pkinit/pkinit_matching.c
+++ b/src/plugins/preauth/pkinit/pkinit_matching.c
@@ -258,8 +258,8 @@ parse_rule_component(krb5_context context,
 {
     krb5_error_code retval;
     rule_component *rc = NULL;
-    keyword_type kw_type;
-    kw_value_type kwval_type;
+    keyword_type kw_type = kw_undefined;
+    kw_value_type kwval_type = kwvaltype_undefined;
     char err_buf[128];
     int ret;
     struct keyword_desc *kw, *nextkw;

--- a/src/util/profile/prof_file.c
+++ b/src/util/profile/prof_file.c
@@ -309,7 +309,7 @@ errcode_t profile_update_file_data_locked(prf_data_t data, char **ret_modspec)
     unsigned long frac;
     time_t now;
 #endif
-    FILE *f;
+    FILE *f = NULL;
     int isdir = 0;
 
 #ifdef HAVE_STAT
@@ -368,7 +368,8 @@ errcode_t profile_update_file_data_locked(prf_data_t data, char **ret_modspec)
         retval = profile_process_directory(data->filespec, &data->root);
     } else {
         retval = profile_parse_file(f, &data->root, ret_modspec);
-        (void)fclose(f);
+        if (f != NULL)
+            (void)fclose(f);
     }
     if (retval) {
         return retval;


### PR DESCRIPTION
When building for debug with:

    CFLAGS="-Og -ggdb" ./configure

gcc throws four errors due to -Og including the -Werror=maybe-uninitialized flag. This PR fixes those errors. Note that the if guard around the fclose() call is necessary due to fclose(NULL) being undefined behavior, potentially causing a [segmentation fault](https://opensource.apple.com/source/Libc/Libc-186/stdio.subproj/fclose.c). 


Thanks,
Alex