### PR TITLE
Allow unspecified kvno in keytab entries

### DIFF
--- a/src/kadmin/ktutil/ktutil.c
+++ b/src/kadmin/ktutil/ktutil.c
@@ -140,7 +140,7 @@ void ktutil_add_entry(argc, argv)
     char *princ = NULL;
     char *enctype = NULL;
     krb5_kvno kvno = 0;
-    int use_pass = 0, use_key = 0, i;
+    int use_pass = 0, use_key = 0, use_kvno = 0, i;
 
     for (i = 1; i < argc; i++) {
         if ((strlen(argv[i]) == 2) && !strncmp(argv[i], "-p", 2)) {
@@ -149,6 +149,7 @@ void ktutil_add_entry(argc, argv)
         }
         if ((strlen(argv[i]) == 2) && !strncmp(argv[i], "-k", 2)) {
             kvno = (krb5_kvno) atoi(argv[++i]);
+            use_kvno++;
             continue;
         }
         if ((strlen(argv[i]) == 2) && !strncmp(argv[i], "-e", 2)) {
@@ -165,7 +166,8 @@ void ktutil_add_entry(argc, argv)
         }
     }
 
-    if (argc != 8 || !(princ && kvno && enctype) || (use_pass+use_key != 1)) {
+    if (argc != 8 || !(princ && use_kvno && enctype) ||
+        use_pass + use_key != 1) {
         fprintf(stderr, _("usage: %s (-key | -password) -p principal "
                           "-k kvno -e enctype\n"), argv[0]);
         return;

--- a/src/lib/krb5/keytab/kt_file.c
+++ b/src/lib/krb5/keytab/kt_file.c
@@ -359,7 +359,7 @@ krb5_ktfile_get_entry(krb5_context context, krb5_keytab id,
 
         }
 
-        if (kvno == IGNORE_VNO) {
+        if (kvno == IGNORE_VNO || new_entry.vno == IGNORE_VNO) {
             /* If this entry is more recent (or the first match), free the
              * current and keep the new.  Otherwise, free the new. */
             if (cur_entry.principal == NULL ||

--- a/src/lib/krb5/keytab/kt_memory.c
+++ b/src/lib/krb5/keytab/kt_memory.c
@@ -403,7 +403,7 @@ krb5_mkt_get_entry(krb5_context context, krb5_keytab id,
                 continue;
         }
 
-        if (kvno == IGNORE_VNO) {
+        if (kvno == IGNORE_VNO || entry->vno == IGNORE_VNO) {
             if (match == NULL)
                 match = entry;
             else if (entry->vno > match->vno)

--- a/src/lib/krb5/keytab/kt_srvtab.c
+++ b/src/lib/krb5/keytab/kt_srvtab.c
@@ -205,7 +205,7 @@ krb5_ktsrvtab_get_entry(krb5_context context, krb5_keytab id, krb5_const_princip
     while ((kerror = krb5_ktsrvint_read_entry(context, id, &ent)) == 0) {
         ent.key.enctype = enctype;
         if (krb5_principal_compare(context, principal, ent.principal)) {
-            if (kvno == IGNORE_VNO) {
+            if (kvno == IGNORE_VNO || ent.vno == IGNORE_VNO) {
                 if (!best_entry.principal || (best_entry.vno < ent.vno)) {
                     krb5_kt_free_entry(context, &best_entry);
                     best_entry = ent;


### PR DESCRIPTION
[I updated Luke's old patch from ticket 3349 and prepared it as a pull request.  The keytab side of this bugs me, I think just because of the inherent complexity of keytab matching with this new feature added.  In the file keytab type, adding the new chekc to any of the three existing match conditionals will basically work, but none of them feel precisely appropriate, and the edge-case semantics are slightly different if we treat it as an exact match like Luke's patch did.]

In ktutil, make "-k 0" work when creating a keytab entry.  In the
keytab implementations, treat entries with unspecified kvnos as
low-priority matches.

[ghudson@mit.edu: adjusted to current file keytab code; added logic
for other keytab types; wrote commit message]
