### PR TITLE
Turn off -Wmaybe-uninitialized

### DIFF
--- a/src/aclocal.m4
+++ b/src/aclocal.m4
@@ -543,7 +543,7 @@ if test "$GCC" = yes ; then
     TRY_WARN_CC_FLAG(-Wno-format-zero-length)
     # Other flags here may not be supported on some versions of
     # gcc that people want to use.
-    for flag in overflow strict-overflow missing-format-attribute missing-prototypes return-type missing-braces parentheses switch unused-function unused-label unused-variable unused-value unknown-pragmas sign-compare newline-eof error=uninitialized error=pointer-arith error=int-conversion error=incompatible-pointer-types error=discarded-qualifiers error=implicit-int ; do
+    for flag in overflow strict-overflow missing-format-attribute missing-prototypes return-type missing-braces parentheses switch unused-function unused-label unused-variable unused-value unknown-pragmas sign-compare newline-eof error=uninitialized no-maybe-uninitialized error=pointer-arith error=int-conversion error=incompatible-pointer-types error=discarded-qualifiers error=implicit-int ; do
       TRY_WARN_CC_FLAG(-W$flag)
     done
     #  old-style-definition? generates many, many warnings

--- a/src/lib/krb5/krb/deltat.c
+++ b/src/lib/krb5/krb/deltat.c
@@ -72,9 +72,6 @@
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuninitialized"
-#ifndef __clang__
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
 #endif
 
 #include "k5-int.h"
@@ -155,7 +152,7 @@ static int mylex(int *intp, struct param *tmv);
 static int yyparse(struct param *);
 
 
-#line 159 "deltat.c" /* yacc.c:339  */
+#line 156 "deltat.c" /* yacc.c:339  */
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -199,10 +196,10 @@ extern int yydebug;
 typedef union YYSTYPE YYSTYPE;
 union YYSTYPE
 {
-#line 131 "x-deltat.y" /* yacc.c:355  */
+#line 128 "x-deltat.y" /* yacc.c:355  */
 int val;
 
-#line 206 "deltat.c" /* yacc.c:355  */
+#line 203 "deltat.c" /* yacc.c:355  */
 };
 # define YYSTYPE_IS_TRIVIAL 1
 # define YYSTYPE_IS_DECLARED 1
@@ -216,7 +213,7 @@ int yyparse (struct param *tmv);
 
 /* Copy the second part of user declarations.  */
 
-#line 220 "deltat.c" /* yacc.c:358  */
+#line 217 "deltat.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -514,9 +511,9 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,   145,   145,   146,   146,   147,   147,   148,   148,   149,
-     150,   152,   153,   154,   155,   156,   157,   158,   159,   164,
-     165,   168,   169,   172,   173
+       0,   142,   142,   143,   143,   144,   144,   145,   145,   146,
+     147,   149,   150,   151,   152,   153,   154,   155,   156,   161,
+     162,   165,   166,   169,   170
 };
 #endif
 
@@ -1312,93 +1309,93 @@ yyreduce:
   switch (yyn)
     {
         case 6:
-#line 147 "x-deltat.y" /* yacc.c:1646  */
+#line 144 "x-deltat.y" /* yacc.c:1646  */
     { (yyval.val) = - (yyvsp[0].val); }
-#line 1318 "deltat.c" /* yacc.c:1646  */
+#line 1315 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 9:
-#line 149 "x-deltat.y" /* yacc.c:1646  */
+#line 146 "x-deltat.y" /* yacc.c:1646  */
     { (yyval.val) = (yyvsp[0].val); }
-#line 1324 "deltat.c" /* yacc.c:1646  */
+#line 1321 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 10:
-#line 150 "x-deltat.y" /* yacc.c:1646  */
+#line 147 "x-deltat.y" /* yacc.c:1646  */
     { YYERROR; }
-#line 1330 "deltat.c" /* yacc.c:1646  */
+#line 1327 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 11:
-#line 152 "x-deltat.y" /* yacc.c:1646  */
+#line 149 "x-deltat.y" /* yacc.c:1646  */
     { DO ((yyvsp[-2].val),  0,  0, (yyvsp[0].val)); }
-#line 1336 "deltat.c" /* yacc.c:1646  */
+#line 1333 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 12:
-#line 153 "x-deltat.y" /* yacc.c:1646  */
+#line 150 "x-deltat.y" /* yacc.c:1646  */
     { DO ( 0, (yyvsp[-2].val),  0, (yyvsp[0].val)); }
-#line 1342 "deltat.c" /* yacc.c:1646  */
+#line 1339 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 13:
-#line 154 "x-deltat.y" /* yacc.c:1646  */
+#line 151 "x-deltat.y" /* yacc.c:1646  */
     { DO ( 0,  0, (yyvsp[-2].val), (yyvsp[0].val)); }
-#line 1348 "deltat.c" /* yacc.c:1646  */
+#line 1345 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 14:
-#line 155 "x-deltat.y" /* yacc.c:1646  */
+#line 152 "x-deltat.y" /* yacc.c:1646  */
     { DO ( 0,  0,  0, (yyvsp[-1].val)); }
-#line 1354 "deltat.c" /* yacc.c:1646  */
+#line 1351 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 15:
-#line 156 "x-deltat.y" /* yacc.c:1646  */
+#line 153 "x-deltat.y" /* yacc.c:1646  */
     { DO ((yyvsp[-6].val), (yyvsp[-4].val), (yyvsp[-2].val), (yyvsp[0].val)); }
-#line 1360 "deltat.c" /* yacc.c:1646  */
+#line 1357 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 16:
-#line 157 "x-deltat.y" /* yacc.c:1646  */
+#line 154 "x-deltat.y" /* yacc.c:1646  */
     { DO ( 0, (yyvsp[-4].val), (yyvsp[-2].val), (yyvsp[0].val)); }
-#line 1366 "deltat.c" /* yacc.c:1646  */
+#line 1363 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 17:
-#line 158 "x-deltat.y" /* yacc.c:1646  */
+#line 155 "x-deltat.y" /* yacc.c:1646  */
     { DO ( 0, (yyvsp[-2].val), (yyvsp[0].val),  0); }
-#line 1372 "deltat.c" /* yacc.c:1646  */
+#line 1369 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 18:
-#line 159 "x-deltat.y" /* yacc.c:1646  */
+#line 156 "x-deltat.y" /* yacc.c:1646  */
     { DO ( 0,  0,  0, (yyvsp[0].val)); }
-#line 1378 "deltat.c" /* yacc.c:1646  */
+#line 1375 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 20:
-#line 165 "x-deltat.y" /* yacc.c:1646  */
+#line 162 "x-deltat.y" /* yacc.c:1646  */
     { if (HOUR_NOT_OK((yyvsp[-2].val))) YYERROR;
 	                                  DO_SUM((yyval.val), (yyvsp[-2].val) * 3600, (yyvsp[0].val)); }
-#line 1385 "deltat.c" /* yacc.c:1646  */
+#line 1382 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 22:
-#line 169 "x-deltat.y" /* yacc.c:1646  */
+#line 166 "x-deltat.y" /* yacc.c:1646  */
     { if (MIN_NOT_OK((yyvsp[-2].val))) YYERROR;
 	                                  DO_SUM((yyval.val), (yyvsp[-2].val) * 60, (yyvsp[0].val)); }
-#line 1392 "deltat.c" /* yacc.c:1646  */
+#line 1389 "deltat.c" /* yacc.c:1646  */
     break;
 
   case 23:
-#line 172 "x-deltat.y" /* yacc.c:1646  */
+#line 169 "x-deltat.y" /* yacc.c:1646  */
     { (yyval.val) = 0; }
-#line 1398 "deltat.c" /* yacc.c:1646  */
+#line 1395 "deltat.c" /* yacc.c:1646  */
     break;
 
 
-#line 1402 "deltat.c" /* yacc.c:1646  */
+#line 1399 "deltat.c" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -1626,7 +1623,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 175 "x-deltat.y" /* yacc.c:1906  */
+#line 172 "x-deltat.y" /* yacc.c:1906  */
 
 
 #ifdef __GNUC__

--- a/src/lib/krb5/krb/x-deltat.y
+++ b/src/lib/krb5/krb/x-deltat.y
@@ -44,9 +44,6 @@
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuninitialized"
-#ifndef __clang__
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
 #endif
 
 #include "k5-int.h"


### PR DESCRIPTION
In gcc, maybe-uninitialized gives different warnings depending on the
optimization level, and in our experience usually gives false
positives.  We don't ask for it (except implicitly through -Wall), but
gcc bundles it into the error behavior of -Werror=uninitialized.
Explicitly turn it off so that builds with -Og and -Os don't error
out.