### PR TITLE
Suppress y2038 GSS tests when time_t is 32-bit

### DIFF
--- a/src/tests/gssapi/t_gssapi.py
+++ b/src/tests/gssapi/t_gssapi.py
@@ -185,10 +185,11 @@ realm.run(['./t_ciflags', 'p:' + realm.host_princ])
 # contexts.
 realm.run(['./t_inq_ctx', 'user', password('user'), 'p:%s' % realm.host_princ])
 
+if runenv.sizeof_time_t <= 4:
+    skip_rest('y2038 GSSAPI tests', 'platform has 32-bit time_t')
+
 # Test lifetime results, using a realm with a large maximum lifetime
-# so that we can test ticket end dates after y2038.  There are no
-# time_t conversions involved, so we can run these tests on platforms
-# with 32-bit time_t.
+# so that we can test ticket end dates after y2038.
 realm.stop()
 conf = {'realms': {'$realm': {'max_life': '9000d'}}}
 realm = K5Realm(kdc_conf=conf, get_creds=False)


### PR DESCRIPTION
The GSSAPI time_t tests do not run correctly on 32-bit Solaris because
time_t conversions are involved in the "kinit -l 8500d" step.
Suppress the GSS y2038 tests when time_t is 32-bit.
