### PR TITLE
Add aes-sha2 to default enctypes in docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -272,7 +272,7 @@ else:
     rst_epilog += '''
 .. |krb5conf| replace:: ``/etc/krb5.conf``
 .. |defkeysalts| replace:: ``aes256-cts-hmac-sha1-96:normal aes128-cts-hmac-sha1-96:normal des3-cbc-sha1:normal arcfour-hmac-md5:normal``
-.. |defetypes| replace:: ``aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 des3-cbc-sha1 arcfour-hmac-md5 camellia256-cts-cmac camellia128-cts-cmac des-cbc-crc des-cbc-md5 des-cbc-md4``
+.. |defetypes| replace:: ``aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes128-cts-hmac-sha256-128 aes256-cts-hmac-sha384-192 des3-cbc-sha1 arcfour-hmac-md5 camellia256-cts-cmac camellia128-cts-cmac des-cbc-crc des-cbc-md5 des-cbc-md4``
 .. |defmkey| replace:: ``aes256-cts-hmac-sha1-96``
 .. |copy| unicode:: U+000A9
 '''


### PR DESCRIPTION
Commit d1ec317288278d10ae34fde9b2414e4fca5c52dd added aes-sha2 to the
default permitted enctype lists and the aes family, but didn't update
the documentation.  Commit 33a500ea14286b0d42c3ad63df8b88b3849b33a3
updated the documentation for the aes family, but not for the default
enctype lists.  Reported by Weijun Wang.
