### PR TITLE
Fix kadm5 setkey operation with LDAP KDB

### DIFF
--- a/src/lib/kadm5/srv/svr_principal.c
+++ b/src/lib/kadm5/srv/svr_principal.c
@@ -1732,6 +1732,9 @@ kadm5_setv4key_principal(void *server_handle,
     /* unlock principal on this KDC */
     kdb->fail_auth_count = 0;
 
+    /* key data changed, let the database provider know */
+    kdb->mask = KADM5_KEY_DATA | KADM5_FAIL_AUTH_COUNT;
+
     if ((ret = kdb_put_entry(handle, kdb, &adb)))
         goto done;
 
@@ -1981,6 +1984,9 @@ kadm5_setkey_principal_4(void *server_handle, krb5_principal principal,
 
     /* Unlock principal on this KDC. */
     kdb->fail_auth_count = 0;
+
+    /* key data changed, let the database provider know */
+    kdb->mask = KADM5_KEY_DATA | KADM5_FAIL_AUTH_COUNT;
 
     ret = kdb_put_entry(handle, kdb, &adb);
     if (ret)


### PR DESCRIPTION
[The comments in these changes aren't properly capitalized or punctuated, because they're copies of similar comments in other functions.  The non-setv4key part of this change was tested by Frank, and it's not a great time for me to create a setkey test harness that we could use in t_kdb.py, so for now I'm not going to worry about automated tests to go with the fix.]

Add mask assignments to kadm5_setv4key_principal() and
kadm5_setkey_principal_4() so that their changes to the principal are
properly written to KDB modules which use the mask flag, such as the
LDAP KDB module.  Reported by Frank Lonigro.

