### PR TITLE
Remove unused async binding code in LDAP

### DIFF
--- a/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.h
@@ -171,7 +171,6 @@ typedef struct _krb5_ldap_server_info krb5_ldap_server_info;
 typedef struct  _krb5_ldap_server_handle {
     int                              msgid;
     LDAP                             *ldap_handle;
-    krb5_boolean                     server_info_update_pending;
     krb5_ldap_server_info            *server_info;
     struct _krb5_ldap_server_handle  *next;
 } krb5_ldap_server_handle;

--- a/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap_conn.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap_conn.c
@@ -193,7 +193,6 @@ initialize_server(krb5_ldap_context *ldap_context, krb5_ldap_server_info *info)
         return ret;
     }
 
-    server->server_info_update_pending = FALSE;
     server->next = info->ldap_server_handles;
     info->ldap_server_handles = server;
     info->num_conns++;


### PR DESCRIPTION
The server_info_update_pending field of krb5_ldap_server_handle was
never set to true, and we never define ASYNC_BIND.  Noted by Will
Fiveash.