### PR TITLE
Clarify "all privileges" in kadm5.acl docs

### DIFF
--- a/doc/admin/conf_files/kadm5_acl.rst
+++ b/doc/admin/conf_files/kadm5_acl.rst
@@ -116,16 +116,17 @@ Here is an example of a kadm5.acl file::
     */root@ATHENA.MIT.EDU     l   *                           # line 5
     sms@ATHENA.MIT.EDU        x   * -maxlife 9h -postdateable # line 6
 
-(line 1) Any principal in the ``ATHENA.MIT.EDU`` realm with
-an ``admin`` instance has all administrative privileges.
+(line 1) Any principal in the ``ATHENA.MIT.EDU`` realm with an
+``admin`` instance has all administrative privileges except extracting
+keys.
 
-(lines 1-3) The user ``joeadmin`` has all permissions with his
-``admin`` instance, ``joeadmin/admin@ATHENA.MIT.EDU`` (matches line
-1).  He has no permissions at all with his null instance,
-``joeadmin@ATHENA.MIT.EDU`` (matches line 2).  His ``root`` and other
-non-``admin``, non-null instances (e.g., ``extra`` or ``dbadmin``) have
-inquire permissions with any principal that has the instance ``root``
-(matches line 3).
+(lines 1-3) The user ``joeadmin`` has all permissions except
+extracting keys with his ``admin`` instance,
+``joeadmin/admin@ATHENA.MIT.EDU`` (matches line 1).  He has no
+permissions at all with his null instance, ``joeadmin@ATHENA.MIT.EDU``
+(matches line 2).  His ``root`` and other non-``admin``, non-null
+instances (e.g., ``extra`` or ``dbadmin``) have inquire permissions
+with any principal that has the instance ``root`` (matches line 3).
 
 (line 4) Any ``root`` principal in ``ATHENA.MIT.EDU`` can inquire
 or change the password of their null instance, but not any other
@@ -139,9 +140,9 @@ permission can only be granted globally, not to specific target
 principals.
 
 (line 6) Finally, the Service Management System principal
-``sms@ATHENA.MIT.EDU`` has all permissions, but any principal that it
-creates or modifies will not be able to get postdateable tickets or
-tickets with a life of longer than 9 hours.
+``sms@ATHENA.MIT.EDU`` has all permissions except extracting keys, but
+any principal that it creates or modifies will not be able to get
+postdateable tickets or tickets with a life of longer than 9 hours.
 
 SEE ALSO
 --------


### PR DESCRIPTION
[A recent discussion on the Heimdal list led me to review how we express privileges now that we have an extract-keys operation which requires explicit authorization.  I think we are in a slightly better place because we use "*" or "x" rather than "all" to mean "all privileges except extracting keys", but our documentation is a little misleading.]

In the kadm5.acl example, be more careful about saying "all
privileges", as the recently added extract privilege is not covered by
"*" or "x".
