### PR TITLE
Prevent KDC unset status assertion failures

### DIFF
--- a/src/kdc/do_as_req.c
+++ b/src/kdc/do_as_req.c
@@ -366,8 +366,8 @@ finish_process_as_req(struct as_req_state *state, krb5_error_code errcode)
     did_log = 1;
 
 egress:
-    if (errcode != 0)
-        assert (state->status != 0);
+    if (errcode != 0 && state->status == NULL)
+        state->status = "UNKNOWN_REASON";
 
     au_state->status = state->status;
     au_state->reply = &state->reply;

--- a/src/kdc/do_tgs_req.c
+++ b/src/kdc/do_tgs_req.c
@@ -823,7 +823,8 @@ process_tgs_req(struct server_handle *handle, krb5_data *pkt,
     free(reply.enc_part.ciphertext.data);
 
 cleanup:
-    assert(status != NULL);
+    if (status == NULL)
+        status = "UNKNOWN_REASON";
     if (reply_key)
         krb5_free_keyblock(kdc_context, reply_key);
     if (errcode)

--- a/src/kdc/kdc_util.c
+++ b/src/kdc/kdc_util.c
@@ -1220,8 +1220,10 @@ kdc_process_for_user(kdc_realm_t *kdc_active_realm,
     req_data.data = (char *)pa_data->contents;
 
     code = decode_krb5_pa_for_user(&req_data, &for_user);
-    if (code)
+    if (code) {
+        *status = "DECODE_PA_FOR_USER";
         return code;
+    }
 
     code = verify_for_user_checksum(kdc_context, tgs_session, for_user);
     if (code) {
@@ -1320,8 +1322,10 @@ kdc_process_s4u_x509_user(krb5_context context,
     req_data.data = (char *)pa_data->contents;
 
     code = decode_krb5_pa_s4u_x509_user(&req_data, s4u_x509_user);
-    if (code)
+    if (code) {
+        *status = "DECODE_PA_S4U_X509_USER";
         return code;
+    }
 
     code = verify_s4u_x509_user_checksum(context,
                                          tgs_subkey ? tgs_subkey :
@@ -1624,6 +1628,7 @@ kdc_process_s4u2proxy_req(kdc_realm_t *kdc_active_realm,
      * that is validated previously in validate_tgs_request().
      */
     if (request->kdc_options & (NON_TGT_OPTION | KDC_OPT_ENC_TKT_IN_SKEY)) {
+        *status = "INVALID_S4U2PROXY_OPTIONS";
         return KRB5KDC_ERR_BADOPTION;
     }
 
@@ -1631,6 +1636,7 @@ kdc_process_s4u2proxy_req(kdc_realm_t *kdc_active_realm,
     if (!krb5_principal_compare(kdc_context,
                                 server->princ, /* after canon */
                                 server_princ)) {
+        *status = "EVIDENCE_TICKET_MISMATCH";
         return KRB5KDC_ERR_SERVER_NOMATCH;
     }
 


### PR DESCRIPTION
Assign status values if S4U2Self padata fails to decode, if an
S4U2Proxy request uses invalid KDC options, or if an S4U2Proxy request
uses an evidence ticket which does not match the canonicalized request
server principal name.  Reported by Samuel Cabrero.
    
If a status value is not assigned during KDC processing, default to
"UNKNOWN_REASON" rather than failing an assertion.  This change will
prevent future denial of service bugs due to similar mistakes, and
will allow us to omit assigning status values for unlikely errors such
as small memory allocation failures.

[There is a second non-backport commit to remove status assignments for error conditions which don't look practically reachable to me.]