### PR TITLE
Display an error message if pkinit_kdc_ocsp is specified

### DIFF
--- a/doc/admin/conf_files/kdc_conf.rst
+++ b/doc/admin/conf_files/kdc_conf.rst
@@ -770,9 +770,6 @@ For information about the syntax of some of these options, see
     pkinit is used to authenticate.  This option may be specified
     multiple times.  (New in release 1.14.)
 
-**pkinit_kdc_ocsp**
-    Specifies the location of the KDC's OCSP.
-
 **pkinit_pool**
     Specifies the location of intermediate certificates which may be
     used by the KDC to complete the trust chain between a client's

--- a/src/man/kdc.conf.man
+++ b/src/man/kdc.conf.man
@@ -891,9 +891,6 @@ Specifies an authentication indicator to include in the ticket if
 pkinit is used to authenticate.  This option may be specified
 multiple times.  (New in release 1.14.)
 .TP
-.B \fBpkinit_kdc_ocsp\fP
-Specifies the location of the KDC\(aqs OCSP.
-.TP
 .B \fBpkinit_pool\fP
 Specifies the location of intermediate certificates which may be
 used by the KDC to complete the trust chain between a client\(aqs

--- a/src/plugins/preauth/pkinit/pkinit.h
+++ b/src/plugins/preauth/pkinit/pkinit.h
@@ -73,6 +73,7 @@
 #define KRB5_CONF_PKINIT_IDENTITIES             "pkinit_identities"
 #define KRB5_CONF_PKINIT_IDENTITY               "pkinit_identity"
 #define KRB5_CONF_PKINIT_KDC_HOSTNAME           "pkinit_kdc_hostname"
+/* pkinit_kdc_ocsp has been removed */
 #define KRB5_CONF_PKINIT_KDC_OCSP               "pkinit_kdc_ocsp"
 #define KRB5_CONF_PKINIT_POOL                   "pkinit_pool"
 #define KRB5_CONF_PKINIT_REQUIRE_CRL_CHECKING   "pkinit_require_crl_checking"
@@ -173,7 +174,6 @@ typedef struct _pkinit_identity_opts {
     char **anchors;
     char **intermediates;
     char **crls;
-    char *ocsp;
     int  idtype;
     char *cert_filename;
     char *key_filename;

--- a/src/plugins/preauth/pkinit/pkinit_identity.c
+++ b/src/plugins/preauth/pkinit/pkinit_identity.c
@@ -122,7 +122,6 @@ pkinit_init_identity_opts(pkinit_identity_opts **idopts)
     opts->anchors = NULL;
     opts->intermediates = NULL;
     opts->crls = NULL;
-    opts->ocsp = NULL;
 
     opts->cert_filename = NULL;
     opts->key_filename = NULL;
@@ -170,12 +169,6 @@ pkinit_dup_identity_opts(pkinit_identity_opts *src_opts,
     retval = copy_list(&newopts->crls, src_opts->crls);
     if (retval)
         goto cleanup;
-
-    if (src_opts->ocsp != NULL) {
-        newopts->ocsp = strdup(src_opts->ocsp);
-        if (newopts->ocsp == NULL)
-            goto cleanup;
-    }
 
     if (src_opts->cert_filename != NULL) {
         newopts->cert_filename = strdup(src_opts->cert_filename);
@@ -652,10 +645,6 @@ pkinit_identity_prompt(krb5_context context,
                                        CATYPE_CRLS);
         if (retval)
             goto errout;
-    }
-    if (idopts->ocsp != NULL) {
-        retval = ENOTSUP;
-        goto errout;
     }
 
 errout:

--- a/src/plugins/preauth/pkinit/pkinit_srv.c
+++ b/src/plugins/preauth/pkinit/pkinit_srv.c
@@ -1254,7 +1254,7 @@ static krb5_error_code
 pkinit_init_kdc_profile(krb5_context context, pkinit_kdc_context plgctx)
 {
     krb5_error_code retval;
-    char *eku_string = NULL;
+    char *eku_string = NULL, *ocsp_check = NULL;
 
     pkiDebug("%s: entered for realm %s\n", __FUNCTION__, plgctx->realmname);
     retval = pkinit_kdcdefault_string(context, plgctx->realmname,
@@ -1289,7 +1289,15 @@ pkinit_init_kdc_profile(krb5_context context, pkinit_kdc_context plgctx)
 
     pkinit_kdcdefault_string(context, plgctx->realmname,
                              KRB5_CONF_PKINIT_KDC_OCSP,
-                             &plgctx->idopts->ocsp);
+                             &ocsp_check);
+    if (ocsp_check != NULL) {
+        free(ocsp_check);
+        retval = ENOTSUP;
+        krb5_set_error_message(context, retval,
+                               _("OCSP is not supported: (realm: %s)"),
+                               plgctx->realmname);
+        goto errout;
+    }
 
     pkinit_kdcdefault_integer(context, plgctx->realmname,
                               KRB5_CONF_PKINIT_DH_MIN_BITS,


### PR DESCRIPTION
pkinit_kdc_ocsp is non-functional in the OpenSSL backend, so remove most
traces of it, including its man page entry.  Detect its presence and error out
instead of silently ignoring the realm entirely.

I'm happy to leave the man page entries around if that would make it more clear.  If we want to add support back into the KDC in the future, it may also make sense to leave the struct entries and such around.