### PR TITLE
Avoid repeating typedef in certauth_plugin.h

### DIFF
--- a/src/include/krb5/certauth_plugin.h
+++ b/src/include/krb5/certauth_plugin.h
@@ -44,7 +44,9 @@
 /* Abstract module data type. */
 typedef struct krb5_certauth_moddata_st *krb5_certauth_moddata;
 
-typedef struct _krb5_db_entry_new krb5_db_entry;
+/* A module can optionally include <kdb.h> to inspect the client principal
+ * entry when authorizing a request. */
+struct _krb5_db_entry_new;
 
 /*
  * Optional: Initialize module data.
@@ -80,7 +82,7 @@ typedef krb5_error_code
                               krb5_certauth_moddata moddata,
                               const uint8_t *cert, size_t cert_len,
                               krb5_const_principal princ, const void *opts,
-                              const krb5_db_entry *db_entry,
+                              const struct _krb5_db_entry_new *db_entry,
                               char ***authinds_out);
 
 /*
@@ -93,7 +95,7 @@ typedef void
                                    char **authinds);
 
 typedef struct krb5_certauth_vtable_st {
-    char *name;
+    const char *name;
     krb5_certauth_init_fn init;
     krb5_certauth_fini_fn fini;
     krb5_certauth_authorize_fn authorize;

--- a/src/plugins/certauth/test/main.c
+++ b/src/plugins/certauth/test/main.c
@@ -42,7 +42,8 @@ static krb5_error_code
 test1_authorize(krb5_context context, krb5_certauth_moddata moddata,
                 const uint8_t *cert, size_t cert_len,
                 krb5_const_principal princ, const void *opts,
-                const krb5_db_entry *db_entry, char ***authinds_out)
+                const struct _krb5_db_entry_new *db_entry,
+                char ***authinds_out)
 {
     char **ais = NULL;
 
@@ -136,7 +137,8 @@ static krb5_error_code
 test2_authorize(krb5_context context, krb5_certauth_moddata moddata,
                 const uint8_t *cert, size_t cert_len,
                 krb5_const_principal princ, const void *opts,
-                const krb5_db_entry *db_entry, char ***authinds_out)
+                const struct _krb5_db_entry_new *db_entry,
+                char ***authinds_out)
 {
     krb5_error_code ret;
     char *name = NULL, **ais = NULL;

--- a/src/plugins/preauth/pkinit/pkinit_srv.c
+++ b/src/plugins/preauth/pkinit/pkinit_srv.c
@@ -1449,7 +1449,8 @@ static krb5_error_code
 pkinit_san_authorize(krb5_context context, krb5_certauth_moddata moddata,
                      const uint8_t *cert, size_t cert_len,
                      krb5_const_principal princ, const void *opts,
-                     const krb5_db_entry *db_entry, char ***authinds_out)
+                     const struct _krb5_db_entry_new *db_entry,
+                     char ***authinds_out)
 {
     krb5_error_code ret;
     int valid_san;
@@ -1476,7 +1477,8 @@ static krb5_error_code
 pkinit_eku_authorize(krb5_context context, krb5_certauth_moddata moddata,
                      const uint8_t *cert, size_t cert_len,
                      krb5_const_principal princ, const void *opts,
-                     const krb5_db_entry *db_entry, char ***authinds_out)
+                     const struct _krb5_db_entry_new *db_entry,
+                     char ***authinds_out)
 {
     krb5_error_code ret;
     int valid_eku;
@@ -1535,7 +1537,8 @@ static krb5_error_code
 dbmatch_authorize(krb5_context context, krb5_certauth_moddata moddata,
                   const uint8_t *cert, size_t cert_len,
                   krb5_const_principal princ, const void *opts,
-                  const krb5_db_entry *db_entry, char ***authinds_out)
+                  const struct _krb5_db_entry_new *db_entry,
+                  char ***authinds_out)
 {
     krb5_error_code ret;
     const struct certauth_req_opts *req_opts = opts;


### PR DESCRIPTION
Repeating an identical typedef is allowed by C11, but not C99 or C89.
Use the underlying structure type in certauth_plugin.h so that it can
safely be included along with kdb.h.
