### PR TITLE
Fix recent use-before-free in kadmin ACL code

### DIFF
--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -781,7 +781,7 @@ in for this interface.
 .. _kadm5_auth:
 
 kadm5_auth interface
-====================
+####################
 
 The kadm5_auth section (introduced in release 1.16) controls modules
 for the kadmin authorization interface, which determines whether a

--- a/src/kadmin/server/auth_acl.c
+++ b/src/kadmin/server/auth_acl.c
@@ -418,12 +418,12 @@ load_acl_file(krb5_context context, const char *fname, struct acl_state *state)
             krb5_klog_syslog(LOG_ERR,
                              _("%s: syntax error at line %d <%.10s...>"),
                              fname, lineno, line);
-            free_acl_entries(state);
-            free(line);
-            fclose(fp);
             k5_setmsg(context, EINVAL,
                       _("%s: syntax error at line %d <%.10s...>"),
                       fname, lineno, line);
+            free_acl_entries(state);
+            free(line);
+            fclose(fp);
             return EINVAL;
         }
         entry_slot = &(*entry_slot)->next;


### PR DESCRIPTION
[Coverity found this.  Incorporating Coverity into pre-merge CI isn't really practical at this time, unfortunately, although we could consider an integration which uses a manual step.]

Commit 92a1a7efe2fc43337416098f2227038a72f1e35a uses line after it is
freed in load_acl_file().  Move the k5_setmsg() call earlier to fix
it.
