### PR TITLE
Fix krb5_conf.rst syntax

### DIFF
--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -781,7 +781,7 @@ in for this interface.
 .. _kadm5_auth:
 
 kadm5_auth interface
-====================
+####################
 
 The kadm5_auth section (introduced in release 1.16) controls modules
 for the kadmin authorization interface, which determines whether a


### PR DESCRIPTION
Commit 92a1a7efe2fc43337416098f2227038a72f1e35a used the wrong header
underline in krb5_conf.rst for the kadm5_auth interface subsection.
Fix it.
