### PR TITLE
Fix AIX build issues

### DIFF
--- a/src/appl/simple/client/sim_client.c
+++ b/src/appl/simple/client/sim_client.c
@@ -62,7 +62,7 @@ int
 main(int argc, char *argv[])
 {
     int sock, i;
-    unsigned int len;
+    socklen_t len;
     int flags = 0;                      /* flags for sendto() */
     struct servent *serv;
     struct hostent *host;

--- a/src/appl/simple/server/sim_server.c
+++ b/src/appl/simple/server/sim_server.c
@@ -33,6 +33,7 @@
  */
 
 #include "krb5.h"
+#include "port-sockets.h"
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
@@ -64,7 +65,7 @@ int
 main(int argc, char *argv[])
 {
     int sock, i;
-    unsigned int len;
+    socklen_t len;
     int flags = 0;                      /* for recvfrom() */
     int on = 1;
     struct servent *serv;

--- a/src/include/k5-platform.h
+++ b/src/include/k5-platform.h
@@ -361,16 +361,7 @@ typedef struct { int error; unsigned char did_run; } k5_init_t;
 
 
 
-#if !defined(SHARED) && !defined(_WIN32)
-
-/*
- * In this case, we just don't care about finalization.  The code will still
- * define the function, but we won't do anything with it.
- */
-# define MAKE_FINI_FUNCTION(NAME)               \
-        static void NAME(void) UNUSED
-
-#elif defined(USE_LINKER_FINI_OPTION) || defined(_WIN32)
+#if defined(USE_LINKER_FINI_OPTION) || defined(_WIN32)
 /* If we're told the linker option will be used, it doesn't really
    matter what compiler we're using.  Do it the same way
    regardless.  */
@@ -403,6 +394,15 @@ typedef struct { int error; unsigned char did_run; } k5_init_t;
         void NAME(void)
 
 # endif
+
+#elif !defined(SHARED)
+
+/*
+ * In this case, we just don't care about finalization.  The code will still
+ * define the function, but we won't do anything with it.
+ */
+# define MAKE_FINI_FUNCTION(NAME)               \
+        static void NAME(void) UNUSED
 
 #elif defined(__GNUC__) && defined(DESTRUCTOR_ATTR_WORKS)
 /* If we're using gcc, if the C++ support works, the compiler should

--- a/src/lib/krb5/os/expand_path.c
+++ b/src/lib/krb5/os/expand_path.c
@@ -351,7 +351,7 @@ expand_null(krb5_context context, PTYPE param, const char *postfix, char **ret)
     return 0;
 }
 
-static const struct token {
+static const struct {
     const char *tok;
     PTYPE param;
     const char *postfix;

--- a/src/lib/krb5/os/localaddr.c
+++ b/src/lib/krb5/os/localaddr.c
@@ -862,6 +862,9 @@ get_ifreq_array(char **bufp, size_t *np, int s)
     int numifs = -1;
 #endif
 
+    *bufp = NULL;
+    *np = 0;
+
     /* At least on NetBSD, an ifreq can hold an IPv4 address, but
        isn't big enough for an IPv6 or ethernet address.  So add a
        little more space.  */
@@ -938,9 +941,9 @@ foreach_localaddr (/*@null@*/ void *data,
 #endif
 {
     struct ifreq *ifr, ifreq, *ifr2;
-    int s, code;
+    int s;
     char *buf = 0;
-    size_t size, n, i, j;
+    size_t n, i, j;
     int retval = 0;
 #ifdef LINUX_IPV6_HACK
     struct linux_ipv6_addr_list *linux_ipv6_addrs = get_linux_ipv6_addrs ();


### PR DESCRIPTION
In k5-platform.h, only test for SHARED and define the finalizer as
static if we don't expect linker options to be used for finalizers.
SHARED is not a robust test (it isn't defined when building objects
for shared libraries on AIX, OSF/1, or sometimes IRIX because they
don't use separate PIC objects), and as linker finalizer options are
only applied when shared libraries are created, we don't have to worry
about finalizers happening for static libraries.

In expand_path.c, remove the unnecessary structure tag from "struct
token" as it conflicts with <net/if_arp.h> on AIX.

In localaddr.c, initialize output parameters at the beginning of
get_ifreq_array().  Otherwise, gcc cannot be sure that they are always
set when get_ifreq_array() returns 0, because we use errno as a return
value in one case.  Also remove two unused variables.

Based on patches from Tony Reix.

ticket: 8608 (new)