### PR TITLE
Don't set ctime in KDC error replies

### DIFF
--- a/src/kdc/do_as_req.c
+++ b/src/kdc/do_as_req.c
@@ -840,7 +840,7 @@ prepare_error_as(struct kdc_request_state *rstate, krb5_kdc_req *request,
         e_data[count] = cookie;
     }
 
-    errpkt.ctime = request->nonce;
+    errpkt.ctime = 0;
     errpkt.cusec = 0;
 
     retval = krb5_us_timeofday(kdc_context, &errpkt.stime, &errpkt.susec);

--- a/src/kdc/do_tgs_req.c
+++ b/src/kdc/do_tgs_req.c
@@ -896,7 +896,7 @@ prepare_error_tgs (struct kdc_request_state *state,
     kdc_realm_t *kdc_active_realm = state->realm_data;
 
     errpkt.magic = KV5M_ERROR;
-    errpkt.ctime = request->nonce;
+    errpkt.ctime = 0;
     errpkt.cusec = 0;
 
     if ((retval = krb5_us_timeofday(kdc_context, &errpkt.stime,


### PR DESCRIPTION
Setting the error ctime field to the client nonce assumes that the
client used its system time as the nonce, which is not recommended by
RFC 1510 and is prohibited by RFC 4120.  Omit the field instead, by
setting the structure field to 0.
