### PR TITLE
Bump bundled libverto for 0.3.0 release

### DIFF
--- a/src/util/verto/README
+++ b/src/util/verto/README
@@ -36,5 +36,5 @@ BUILTIN_MODULE define.
 
 The libverto and libev upstream project pages are at:
 
-  https://fedorahosted.org/libverto/
+  https://github.com/latchset/libverto/
   http://software.schmorp.de/pkg/libev.html

--- a/src/util/verto/libverto.exports
+++ b/src/util/verto/libverto.exports
@@ -4,6 +4,7 @@ verto_add_io
 verto_add_signal
 verto_add_timeout
 verto_break
+verto_cleanup
 verto_convert_module
 verto_default
 verto_del

--- a/src/util/verto/verto-k5ev.c
+++ b/src/util/verto/verto-k5ev.c
@@ -114,6 +114,11 @@ libev_callback(EV_P_ ev_watcher *w, int revents)
 {
     verto_ev_flag state = VERTO_EV_FLAG_NONE;
 
+#if EV_MULTIPLICITY
+    /* Match the check in ev.h, which doesn't mark this unused */
+    (void) EV_A;
+#endif
+
     if (verto_get_type(w->data)== VERTO_EV_TYPE_CHILD)
         verto_set_proc_status(w->data, ((ev_child*) w)->rstatus);
 

--- a/src/util/verto/verto-libev.c
+++ b/src/util/verto/verto-libev.c
@@ -80,6 +80,11 @@ libev_callback(EV_P_ ev_watcher *w, int revents)
 {
     verto_ev_flag state = VERTO_EV_FLAG_NONE;
 
+#if EV_MULTIPLICITY
+    /* Match the check in ev.h, which doesn't mark this unused */
+    (void) EV_A;
+#endif
+
     if (verto_get_type(w->data)== VERTO_EV_TYPE_CHILD)
         verto_set_proc_status(w->data, ((ev_child*) w)->rstatus);
 


### PR DESCRIPTION
Local changes:
  - Update upstream URL for fedorahosted deprecation.
  - Add verto_cleanup() to exports.

Upstream changes:
  - Strict c89 compliance.
  - Remove local asprintf() implementation.
  - Fix memleak when memory allocator is realloc().
  - Fix leaks of filenames during load.
  - Fix many unused variable warnings.
  - Factor out mutability check.
  - Properly handle _GNU_SOURCE checking.