### PR TITLE
Fix make-certs.sh for OpenSSL 1.1

### DIFF
--- a/src/tests/dejagnu/pkinit-certs/make-certs.sh
+++ b/src/tests/dejagnu/pkinit-certs/make-certs.sh
@@ -122,15 +122,14 @@ SUBJECT=ca openssl req -config openssl.cnf -new -x509 -extensions exts_ca \
     -set_serial 1 -days $DAYS -key privkey.pem -out ca.pem
 
 # Generate a KDC certificate.
-SUBJECT=kdc openssl req -config openssl.cnf -new -subj /CN=kdc \
-    -key privkey.pem -out kdc.csr
+SUBJECT=kdc openssl req -config openssl.cnf -new -key privkey.pem -out kdc.csr
 SUBJECT=kdc openssl x509 -extfile openssl.cnf -extensions exts_kdc \
     -set_serial 2 -days $DAYS -req -CA ca.pem -CAkey privkey.pem \
     -out kdc.pem -in kdc.csr
 
 # Generate a client certificate and PKCS#12 bundles.
-SUBJECT=user openssl req -config openssl.cnf -new -subj /CN=user \
-    -key privkey.pem -out user.csr
+SUBJECT=user openssl req -config openssl.cnf -new -key privkey.pem \
+    -out user.csr
 SUBJECT=user openssl x509 -extfile openssl.cnf -extensions exts_client \
     -set_serial 3 -days $DAYS -req -CA ca.pem -CAkey privkey.pem \
     -out user.pem -in user.csr
@@ -140,24 +139,24 @@ openssl pkcs12 -export -in user.pem -inkey privkey.pem -out user-enc.p12 \
     -passout pass:encrypted
 
 # Generate a client certificate and PKCS#12 bundles with a UPN SAN.
-SUBJECT=user openssl req -config openssl.cnf -new -subj /CN=user \
-    -key privkey.pem -out user-upn.csr
+SUBJECT=user openssl req -config openssl.cnf -new -key privkey.pem \
+    -out user-upn.csr
 SUBJECT=user openssl x509 -extfile openssl.cnf -extensions exts_upn_client \
     -set_serial 4 -days $DAYS -req -CA ca.pem -CAkey privkey.pem \
     -out user-upn.pem -in user-upn.csr
 openssl pkcs12 -export -in user-upn.pem -inkey privkey.pem -out user-upn.p12 \
     -passout pass:
 
-SUBJECT=user openssl req -config openssl.cnf -new -subj /CN=user \
-    -key privkey.pem -out user-upn2.csr
+SUBJECT=user openssl req -config openssl.cnf -new -key privkey.pem \
+    -out user-upn2.csr
 SUBJECT=user openssl x509 -extfile openssl.cnf -extensions exts_upn2_client \
     -set_serial 5 -days $DAYS -req -CA ca.pem -CAkey privkey.pem \
     -out user-upn2.pem -in user-upn2.csr
 openssl pkcs12 -export -in user-upn2.pem -inkey privkey.pem \
      -out user-upn2.p12 -passout pass:
 
-SUBJECT=user openssl req -config openssl.cnf -new -subj /CN=user \
-    -key privkey.pem -out user-upn3.csr
+SUBJECT=user openssl req -config openssl.cnf -new -key privkey.pem \
+    -out user-upn3.csr
 SUBJECT=user openssl x509 -extfile openssl.cnf -extensions exts_upn3_client \
     -set_serial 6 -days $DAYS -req -CA ca.pem -CAkey privkey.pem \
     -out user-upn3.pem -in user-upn3.csr
@@ -165,8 +164,8 @@ openssl pkcs12 -export -in user-upn3.pem -inkey privkey.pem \
      -out user-upn3.p12 -passout pass:
 
 # Generate a client certificate and PKCS#12 bundle with no PKINIT extensions.
-SUBJECT=user openssl req -config openssl.cnf -new -subj /CN=user \
-    -key privkey.pem -out generic.csr
+SUBJECT=user openssl req -config openssl.cnf -new -key privkey.pem \
+    -out generic.csr
 SUBJECT=user openssl x509 -set_serial 7 -days $DAYS -req -CA ca.pem \
     -CAkey privkey.pem -out generic.pem -in generic.csr
 openssl pkcs12 -export -in generic.pem -inkey privkey.pem -out generic.p12 \


### PR DESCRIPTION
The openssl req commands in make-certs.sh contain -subj options which
were ignored in favor of the config file prior to OpenSSL 1.1.  When
they are used, they remove elements of the subject which are now
required by t_pkinit.py.