### PR TITLE
Add kpropd pid-file option

### DIFF
--- a/doc/admin/admin_commands/kpropd.rst
+++ b/doc/admin/admin_commands/kpropd.rst
@@ -14,6 +14,7 @@ SYNOPSIS
 [**-F** *principal_database*]
 [**-p** *kdb5_util_prog*]
 [**-P** *port*]
+[**--pid-file**\ =\ *pid_file*]
 [**-d**]
 [**-t**]
 
@@ -103,6 +104,10 @@ OPTIONS
 **-a** *acl_file*
     Allows the user to specify the path to the kpropd.acl file; by
     default the path used is |kdcdir|\ ``/kpropd.acl``.
+
+**--pid-file**\ =\ *pid_file*
+    In standalone mode, write the process ID of the daemon into
+    *pid_file*.
 
 
 ENVIRONMENT

--- a/src/slave/kprop.c
+++ b/src/slave/kprop.c
@@ -121,56 +121,34 @@ main(int argc, char **argv)
 static void
 parse_args(krb5_context context, int argc, char **argv)
 {
-    char *word, ch;
+    int c;
     krb5_error_code ret;
 
-    progname = *argv++;
-    while (--argc && (word = *argv++) != NULL) {
-        if (*word != '-') {
-            if (slave_host != NULL)
-                usage();
-            else
-                slave_host = word;
-            continue;
-        }
-        word++;
-        while (word != NULL && (ch = *word++) != '\0') {
-            switch (ch) {
-            case 'r':
-                realm = (*word != '\0') ? word : *argv++;
-                if (realm == NULL)
-                    usage();
-                word = NULL;
-                break;
-            case 'f':
-                file = (*word != '\0') ? word : *argv++;
-                if (file == NULL)
-                    usage();
-                word = NULL;
-                break;
-            case 'd':
-                debug++;
-                break;
-            case 'P':
-                port = (*word != '\0') ? word : *argv++;
-                if (port == NULL)
-                    usage();
-                word = NULL;
-                break;
-            case 's':
-                srvtab = (*word != '\0') ? word : *argv++;
-                if (srvtab == NULL)
-                    usage();
-                word = NULL;
-                break;
-            default:
-                usage();
-            }
-
+    progname = argv[0];
+    while ((c = getopt(argc, argv, "r:f:dP:s:")) != -1) {
+        switch (c) {
+        case 'r':
+            realm = optarg;
+            break;
+        case 'f':
+            file = optarg;
+            break;
+        case 'd':
+            debug++;
+            break;
+        case 'P':
+            port = optarg;
+            break;
+        case 's':
+            srvtab = optarg;
+            break;
+        default:
+            usage();
         }
     }
-    if (slave_host == NULL)
+    if (argc - optind != 1)
         usage();
+    slave_host = argv[optind];
 
     if (realm == NULL) {
         ret = krb5_get_default_realm(context, &def_realm);


### PR DESCRIPTION
All of the intuitive single-letter option names for pid-file in kpropd were already taken, so I made it a long option, which necessitated converting kpropd to getopt.  I converted kprop while I was there.  The currently supported option syntax appears to be a subset of the POSIX syntax, so I don't think anything should break.
