### PR TITLE
Abort client preauth on keyboard interrupt

### DIFF
--- a/src/lib/krb5/krb/get_in_tkt.c
+++ b/src/lib/krb5/krb/get_in_tkt.c
@@ -1358,6 +1358,9 @@ init_creds_step_request(krb5_context context,
             code = ctx->err_reply->error + ERROR_TABLE_BASE_krb5;
         }
     }
+    /* Don't continue after a keyboard interrupt. */
+    if (code == KRB5_LIBOS_PWDINTR)
+        goto cleanup;
     if (code) {
         /* See if we can try a different preauth mech before giving up. */
         k5_save_ctx_error(context, code, &save);

--- a/src/lib/krb5/krb/preauth2.c
+++ b/src/lib/krb5/krb/preauth2.c
@@ -688,6 +688,9 @@ process_pa_data(krb5_context context, krb5_init_creds_context ctx,
                 }
                 free(mod_pa);
             }
+            /* Don't continue to try mechanisms after a keyboard interrupt. */
+            if (ret == KRB5_LIBOS_PWDINTR)
+                goto cleanup;
             if (ret == 0 && real) {
                 /* Stop now and record which real padata type we answered. */
                 *out_type = pa->pa_type;


### PR DESCRIPTION
Continuing client preauth after a keyboard interrupt is unexpected and
can manifest bugs (such as the one in ticket 8596) by invoking preauth
mechs we wouldn't ordinarily reach.  Based on a patch by Marc Dionne.
