### PR TITLE
Remove unused SAM setup code

### DIFF
--- a/src/kdc/extern.c
+++ b/src/kdc/extern.c
@@ -37,7 +37,6 @@
 kdc_realm_t     **kdc_realmlist = (kdc_realm_t **) NULL;
 int             kdc_numrealms = 0;
 krb5_data empty_string = {0, 0, ""};
-krb5_keyblock   psr_key;
 krb5_int32      max_dgram_reply_size = MAX_DGRAM_SIZE;
 
 /* With ts_after(), this is the largest timestamp value. */

--- a/src/kdc/extern.h
+++ b/src/kdc/extern.h
@@ -29,7 +29,6 @@
 /* various externs for KDC */
 extern krb5_data        empty_string;   /* an empty string */
 extern krb5_timestamp   kdc_infinity;   /* greater than all other timestamps */
-extern krb5_keyblock    psr_key;        /* key for predicted sam response */
 extern const int        kdc_modifies_kdb;
 extern krb5_int32       max_dgram_reply_size; /* maximum datagram size */
 

--- a/src/kdc/main.c
+++ b/src/kdc/main.c
@@ -53,8 +53,6 @@ extern int daemon(int, int);
 
 static void usage (char *);
 
-static krb5_error_code setup_sam (void);
-
 static void initialize_realms(krb5_context kcontext, int argc, char **argv,
                               int *tcp_listen_backlog_out);
 
@@ -590,13 +588,6 @@ create_workers(verto_ctx *ctx, int num)
     exit(0);
 }
 
-static krb5_error_code
-setup_sam(void)
-{
-    krb5_context ctx = shandle.kdc_err_context;
-    return krb5_c_make_random_key(ctx, ENCTYPE_DES_CBC_MD5, &psr_key);
-}
-
 static void
 usage(char *name)
 {
@@ -990,13 +981,6 @@ int main(int argc, char **argv)
     retval = load_kdcpolicy_plugins(kcontext);
     if (retval) {
         kdc_err(kcontext, retval, _("while loading KDC policy plugin"));
-        finish_realms();
-        return 1;
-    }
-
-    retval = setup_sam();
-    if (retval) {
-        kdc_err(kcontext, retval, _("while initializing SAM"));
         finish_realms();
         return 1;
     }


### PR DESCRIPTION
Improves startup of the KDC slightly by no longer generating a DES-MD5
key which isn't used for anything.