### PR TITLE
Expose context errors in pkinit_server_plugin_init

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_trace.h
+++ b/src/plugins/preauth/pkinit/pkinit_trace.h
@@ -102,6 +102,9 @@
     TRACE(c, "PKINIT server skipping EKU check due to configuration")
 #define TRACE_PKINIT_SERVER_INIT_REALM(c, realm)                \
     TRACE(c, "PKINIT server initializing realm {str}", realm)
+#define TRACE_PKINIT_SERVER_INIT_FAIL(c, realm, retval)                 \
+    TRACE(c, "PKINIT server initialization failed for realm {str}: {kerr}", \
+          realm, retval)
 #define TRACE_PKINIT_SERVER_MATCHING_UPN_FOUND(c)                       \
     TRACE(c, "PKINIT server found a matching UPN SAN in client cert")
 #define TRACE_PKINIT_SERVER_MATCHING_SAN_FOUND(c)                       \


### PR DESCRIPTION
3ff426b9048a8024e5c175256c63cd0ad0572320 attempted to display an error
when OCSP support was requested, but this error message was suppressed
in pkinit_server_plugin_init().  Other error messages from
pkinit_init_kdc_profile(), missing pkinit_identity or pkinit_anchors,
are also now exposted.