### PR TITLE
Point to kerberos.org/dist

### DIFF
--- a/doc/build/index.rst
+++ b/doc/build/index.rst
@@ -29,7 +29,7 @@ Obtaining the software
 ----------------------
 
 The source code can be obtained from MIT Kerberos Distribution page,
-at http://web.mit.edu/kerberos/dist/index.html.
+at https://kerberos.org/dist/index.html.
 The MIT Kerberos distribution comes in an archive file, generally
 named krb5-VERSION-signed.tar, where *VERSION* is a placeholder for
 the major and minor versions of MIT Kerberos.  (For example, MIT


### PR DESCRIPTION
web.mit.edu has two problems for distributing the krb5 code: first, if we point people to https://web.mit.edu/, people inside MITnet will be asked for a client certificate; and second, it serves .tar.gz files with "Content-Encoding: x-gzip" which can cause clients to uncompress them when saving (but generally not change the filename).

I made a "dist" link at kerberos.org pointing to the same AFS content as web.mit.edu/kerberos/dist contains.  This commit updates the documentation reference there.

We also have a fair amount of content at http://web.mit.edu/kerberos (not under "dist") including the per-release documentation.  It didn't seem as elegant to have something like "https://kerberos.org/kerberos" pointing to that content, so for now I'm just treating that as a separate and less important problem, but I am open to opinions.  Since the current content at https://kerberos.org/ is largely defunct, we could conceivably just replace it with a pointer to the http://web.mit.edu/kerberos content (via a link to AFS) in the future.