### PR TITLE
Update copyright years to 2018

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright (C) 1985-2017 by the Massachusetts Institute of Technology.
+Copyright (C) 1985-2018 by the Massachusetts Institute of Technology.
 
 All rights reserved.
 

--- a/README
+++ b/README
@@ -6,7 +6,7 @@
 Copyright and Other Notices
 ---------------------------
 
-Copyright (C) 1985-2017 by the Massachusetts Institute of Technology
+Copyright (C) 1985-2018 by the Massachusetts Institute of Technology
 and its contributors.  All rights reserved.
 
 Please see the file named NOTICE for additional notices.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,7 +45,7 @@ else:
 
 # General information about the project.
 project = u'MIT Kerberos'
-copyright = u'1985-2017, MIT'
+copyright = u'1985-2018, MIT'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/copyright.rst
+++ b/doc/copyright.rst
@@ -1,7 +1,7 @@
 Copyright
 =========
 
-Copyright |copy| 1985-2017 by the Massachusetts Institute of
+Copyright |copy| 1985-2018 by the Massachusetts Institute of
 Technology and its contributors.  All rights reserved.
 
 See :ref:`mitK5license` for additional copyright and license

--- a/doc/notice.rst
+++ b/doc/notice.rst
@@ -1,4 +1,4 @@
-Copyright |copy| 1985-2017 by the Massachusetts Institute of Technology.
+Copyright |copy| 1985-2018 by the Massachusetts Institute of Technology.
 
 All rights reserved.
 

--- a/src/prototype/prototype.c
+++ b/src/prototype/prototype.c
@@ -1,7 +1,7 @@
 /* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 /* prototype/prototype.c - <<< One-line description of file >>> */
 /*
- * Copyright (C) 2017 by the Massachusetts Institute of Technology.
+ * Copyright (C) 2018 by the Massachusetts Institute of Technology.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/prototype/prototype.h
+++ b/src/prototype/prototype.h
@@ -1,7 +1,7 @@
 /* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
 /* prototype/prototype.h - <<< One-line description of file >>> */
 /*
- * Copyright (C) 2017 by the Massachusetts Institute of Technology.
+ * Copyright (C) 2018 by the Massachusetts Institute of Technology.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/windows/version.rc
+++ b/src/windows/version.rc
@@ -41,7 +41,7 @@
 #define K5_PRODUCT_VERSION_STRING MAJOR_MINOR MAYBE_PATCH RELTAIL "\0"
 #define K5_PRODUCT_VERSION        KRB5_MAJOR_RELEASE, KRB5_MINOR_RELEASE, KRB5_PATCHLEVEL, KRB5_BUILDLEVEL
 
-#define K5_COPYRIGHT "Copyright (C) 1997-2017 by the Massachusetts Institute of Technology\0"
+#define K5_COPYRIGHT "Copyright (C) 1997-2018 by the Massachusetts Institute of Technology\0"
 #define K5_COMPANY_NAME "Massachusetts Institute of Technology.\0"
 
 /* 


### PR DESCRIPTION
Update copyright years to 2018 where appropriate given the new year