### PR TITLE
Hardware preauth salt fixes

### DIFF
--- a/src/kdc/kdc_preauth.c
+++ b/src/kdc/kdc_preauth.c
@@ -144,7 +144,7 @@ static preauth_system static_preauth_systems[] = {
     {
         "etype-info",
         KRB5_PADATA_ETYPE_INFO,
-        0,
+        PA_HARDWARE,
         NULL,
         NULL,
         NULL,
@@ -155,7 +155,7 @@ static preauth_system static_preauth_systems[] = {
     {
         "etype-info2",
         KRB5_PADATA_ETYPE_INFO2,
-        0,
+        PA_HARDWARE,
         NULL,
         NULL,
         NULL,

--- a/src/plugins/preauth/securid_sam2/grail.c
+++ b/src/plugins/preauth/securid_sam2/grail.c
@@ -213,8 +213,7 @@ verify_grail_data(krb5_context context, krb5_db_entry *client,
         return KRB5KDC_ERR_PREAUTH_FAILED;
 
     ret = krb5_dbe_find_enctype(context, client,
-                                sr2->sam_enc_nonce_or_sad.enctype,
-                                KRB5_KDB_SALTTYPE_NORMAL,
+                                sr2->sam_enc_nonce_or_sad.enctype, -1,
                                 sr2->sam_enc_nonce_or_sad.kvno,
                                 &client_key_data);
     if (ret)

--- a/src/plugins/preauth/securid_sam2/securid2.c
+++ b/src/plugins/preauth/securid_sam2/securid2.c
@@ -313,8 +313,7 @@ verify_securid_data_2(krb5_context context, krb5_db_entry *client,
     }
 
     retval = krb5_dbe_find_enctype(context, client,
-                                   sr2->sam_enc_nonce_or_sad.enctype,
-                                   KRB5_KDB_SALTTYPE_NORMAL,
+                                   sr2->sam_enc_nonce_or_sad.enctype, -1,
                                    sr2->sam_enc_nonce_or_sad.kvno,
                                    &client_key_data);
     if (retval) {


### PR DESCRIPTION
If a principal has the requires_hwauth bit set, include PA-ETYPE-INFO or PA-ETYPE-INFO2 padata in the PREAUTH_REQUIRED error, as preauth mechs involving hardware tokens may also use the principal's Kerberos password.

When looking up the client long-term key in the securid_sam2 preauth module, look for any salt type, not just the default salt type.
