### PR TITLE
Improve com_err() logs from KDC plugin modules

### DIFF
--- a/doc/admin/conf_files/kdc_conf.rst
+++ b/doc/admin/conf_files/kdc_conf.rst
@@ -599,19 +599,15 @@ Logging specifications may have the following forms:
 **SYSLOG**\ [\ **:**\ *severity*\ [\ **:**\ *facility*\ ]]
     This causes the daemon's logging messages to go to the system log.
 
-    The severity argument specifies the default severity of system log
-    messages.  This may be any of the following severities supported
-    by the syslog(3) call, minus the ``LOG_`` prefix: **EMERG**,
-    **ALERT**, **CRIT**, **ERR**, **WARNING**, **NOTICE**, **INFO**,
-    and **DEBUG**.
+    For backward compatibility, a severity argument may be specified,
+    and must be specified in order to specify a facility.  This
+    argument will be ignored.
 
     The facility argument specifies the facility under which the
     messages are logged.  This may be any of the following facilities
     supported by the syslog(3) call minus the LOG\_ prefix: **KERN**,
     **USER**, **MAIL**, **DAEMON**, **AUTH**, **LPR**, **NEWS**,
-    **UUCP**, **CRON**, and **LOCAL0** through **LOCAL7**.
-
-    If no severity is specified, the default is **ERR**.  If no
+    **UUCP**, **CRON**, and **LOCAL0** through **LOCAL7**.  If no
     facility is specified, the default is **AUTH**.
 
 In the following example, the logging messages from the KDC will go to

--- a/doc/plugindev/general.rst
+++ b/doc/plugindev/general.rst
@@ -94,5 +94,25 @@ fictional pluggable interface named fences, for a module named
         return 0;
     }
 
+Logging from KDC and kadmind plugin modules
+-------------------------------------------
+
+Plugin modules for the KDC or kadmind daemons can write to the
+configured logging outputs (see :ref:`logging`) by calling the
+**com_err** function.  The first argument (*whoami*) is ignored.  If
+the second argument (*code*) is zero, the formatted message is logged
+at informational severity; otherwise, the formatted message is logged
+at error severity and includes the error message for the supplied
+code.  Here are examples::
+
+    com_err("", 0, "Client message contains %d items", nitems);
+    com_err("", retval, "while decoding client message");
+
+(The behavior described above is new in release 1.17.  In prior
+releases, the *whoami* argument is included for some logging output
+types, the logged message does not include the usual header for some
+output types, and the severity for syslog outputs is configured as
+part of the logging specification, defaulting to error severity.)
+
 .. _automake: http://www.gnu.org/software/automake/
 .. _libtool: http://www.gnu.org/software/libtool/

--- a/src/include/adm_proto.h
+++ b/src/include/adm_proto.h
@@ -48,6 +48,7 @@ typedef struct ___krb5_key_salt_tuple krb5_key_salt_tuple;
 
 /* logger.c */
 krb5_error_code krb5_klog_init(krb5_context, char *, char *, krb5_boolean);
+void krb5_klog_set_context(krb5_context);
 void krb5_klog_close(krb5_context);
 int krb5_klog_syslog(int, const char *, ...)
 #if !defined(__cplusplus) && (__GNUC__ > 2)

--- a/src/include/k5-buf.h
+++ b/src/include/k5-buf.h
@@ -76,6 +76,14 @@ void k5_buf_add_fmt(struct k5buf *buf, const char *fmt, ...)
 #endif
     ;
 
+/* Add sprintf-style formatted data to BUF, with a va_list.  The value of ap is
+ * undefined after the call. */
+void k5_buf_add_vfmt(struct k5buf *buf, const char *fmt, va_list ap)
+#if !defined(__cplusplus) && (__GNUC__ > 2)
+    __attribute__((__format__(__printf__, 2, 0)))
+#endif
+    ;
+
 /* Extend the length of buf by len and return a pointer to the reserved space,
  * to be filled in by the caller.  Return NULL on error. */
 void *k5_buf_get_space(struct k5buf *buf, size_t len);

--- a/src/kdc/main.c
+++ b/src/kdc/main.c
@@ -127,14 +127,16 @@ setup_server_realm(struct server_handle *handle, krb5_principal sprinc)
         return NULL;
 
     if (kdc_numrealms > 1) {
-        if (!(newrealm = find_realm_data(handle, sprinc->realm.data,
-                                         (krb5_ui_4) sprinc->realm.length)))
-            return NULL;
-        else
-            return newrealm;
+        newrealm = find_realm_data(handle, sprinc->realm.data,
+                                   sprinc->realm.length);
+    } else {
+        newrealm = kdc_realmlist[0];
     }
-    else
-        return kdc_realmlist[0];
+    if (newrealm != NULL) {
+        krb5_klog_set_context(newrealm->realm_context);
+        shandle.kdc_err_context = newrealm->realm_context;
+    }
+    return newrealm;
 }
 
 static void

--- a/src/lib/kadm5/clnt/libkadm5clnt_mit.exports
+++ b/src/lib/kadm5/clnt/libkadm5clnt_mit.exports
@@ -62,6 +62,7 @@ krb5_keysalt_iterate
 krb5_klog_close
 krb5_klog_init
 krb5_klog_reopen
+krb5_klog_set_context
 krb5_klog_syslog
 krb5_string_to_keysalts
 xdr_chpass3_arg

--- a/src/lib/kadm5/logger.c
+++ b/src/lib/kadm5/logger.c
@@ -116,7 +116,6 @@ struct log_entry {
         } log_file;
         struct log_syslog {
             int         ls_facility;
-            int         ls_severity;
         } log_syslog;
         struct log_device {
             FILE        *ld_filep;
@@ -127,7 +126,6 @@ struct log_entry {
 #define lfu_filep       log_union.log_file.lf_filep
 #define lfu_fname       log_union.log_file.lf_fname
 #define lsu_facility    log_union.log_syslog.ls_facility
-#define lsu_severity    log_union.log_syslog.ls_severity
 #define ldu_filep       log_union.log_device.ld_filep
 #define ldu_devname     log_union.log_device.ld_devname
 
@@ -332,9 +330,8 @@ krb5_klog_init(krb5_context kcontext, char *ename, char *whoami, krb5_boolean do
                 else if (!strncasecmp(cp, "SYSLOG", 6)) {
                     error = 0;
                     log_control.log_entries[i].lsu_facility = LOG_AUTH;
-                    log_control.log_entries[i].lsu_severity = LOG_ERR;
                     /*
-                     * Is there a severify specified?
+                     * Is there a severify (which is now ignored) specified?
                      */
                     if (cp[6] == ':') {
                         /*
@@ -346,41 +343,6 @@ krb5_klog_init(krb5_context kcontext, char *ename, char *whoami, krb5_boolean do
                             *cp2 = '\0';
                             cp2++;
                         }
-
-                        /*
-                         * Match a severity.
-                         */
-                        if (!strcasecmp(&cp[7], "ERR")) {
-                            log_control.log_entries[i].lsu_severity = LOG_ERR;
-                        }
-                        else if (!strcasecmp(&cp[7], "EMERG")) {
-                            log_control.log_entries[i].lsu_severity =
-                                LOG_EMERG;
-                        }
-                        else if (!strcasecmp(&cp[7], "ALERT")) {
-                            log_control.log_entries[i].lsu_severity =
-                                LOG_ALERT;
-                        }
-                        else if (!strcasecmp(&cp[7], "CRIT")) {
-                            log_control.log_entries[i].lsu_severity = LOG_CRIT;
-                        }
-                        else if (!strcasecmp(&cp[7], "WARNING")) {
-                            log_control.log_entries[i].lsu_severity =
-                                LOG_WARNING;
-                        }
-                        else if (!strcasecmp(&cp[7], "NOTICE")) {
-                            log_control.log_entries[i].lsu_severity =
-                                LOG_NOTICE;
-                        }
-                        else if (!strcasecmp(&cp[7], "INFO")) {
-                            log_control.log_entries[i].lsu_severity = LOG_INFO;
-                        }
-                        else if (!strcasecmp(&cp[7], "DEBUG")) {
-                            log_control.log_entries[i].lsu_severity =
-                                LOG_DEBUG;
-                        }
-                        else
-                            error = 1;
 
                         /*
                          * If there is a facility present, then parse that.
@@ -535,7 +497,6 @@ krb5_klog_init(krb5_context kcontext, char *ename, char *whoami, krb5_boolean do
         log_control.log_entries->log_type = K_LOG_SYSLOG;
         log_control.log_entries->log_2free = (krb5_pointer) NULL;
         log_facility = log_control.log_entries->lsu_facility = LOG_AUTH;
-        log_control.log_entries->lsu_severity = LOG_ERR;
         do_openlog = 1;
         log_control.log_nentries = 1;
     }

--- a/src/lib/kadm5/srv/libkadm5srv_mit.exports
+++ b/src/lib/kadm5/srv/libkadm5srv_mit.exports
@@ -71,6 +71,7 @@ krb5_keysalt_iterate
 krb5_klog_close
 krb5_klog_init
 krb5_klog_reopen
+krb5_klog_set_context
 krb5_klog_syslog
 krb5_string_to_keysalts
 master_db

--- a/src/util/support/libkrb5support-fixed.exports
+++ b/src/util/support/libkrb5support-fixed.exports
@@ -6,6 +6,7 @@ k5_buf_init_dynamic
 k5_buf_add
 k5_buf_add_len
 k5_buf_add_fmt
+k5_buf_add_vfmt
 k5_buf_get_space
 k5_buf_truncate
 k5_buf_status


### PR DESCRIPTION
Background is here: http://krbdev.mit.edu/rt/Ticket/Display.html?id=8630

This PR cleans up the logging behavior of com_err() from KDC/kadmind plugin modules, allowing us to expand its use without adding lots of weirdly formatted messages to log files.  If we later determine a need for a logging facility with a closer fit to krb5_klog_syslog(), we can add a kdcpreauth callback (or two) to handle it, but for now I think com_err() should be adequate.
