### PR TITLE
Trace log on k5tls load failure

### DIFF
--- a/src/include/k5-trace.h
+++ b/src/include/k5-trace.h
@@ -364,6 +364,8 @@ void krb5int_trace(krb5_context context, const char *fmt, ...);
 #define TRACE_SENDTO_KDC(c, len, rlm, master, tcp)                     \
     TRACE(c, "Sending request ({int} bytes) to {data}{str}{str}", len,  \
           rlm, (master) ? " (master)" : "", (tcp) ? " (tcp only)" : "")
+#define TRACE_SENDTO_KDC_K5TLS_LOAD_ERROR(c, ret)       \
+    TRACE(c, "Error loading k5tls module: {kerr}", ret)
 #define TRACE_SENDTO_KDC_MASTER(c, master)                              \
     TRACE(c, "Response was{str} from master KDC", (master) ? "" : " not")
 #define TRACE_SENDTO_KDC_RESOLVING(c, hostname)         \

--- a/src/lib/krb5/os/sendto_kdc.c
+++ b/src/lib/krb5/os/sendto_kdc.c
@@ -151,6 +151,7 @@ static krb5_error_code
 init_tls_vtable(krb5_context context)
 {
     krb5_plugin_initvt_fn initfn;
+    krb5_error_code ret;
 
     if (context->tls != NULL)
         return 0;
@@ -161,8 +162,11 @@ init_tls_vtable(krb5_context context)
 
     /* Attempt to load the module; just let it stay nulled out on failure. */
     k5_plugin_register_dyn(context, PLUGIN_INTERFACE_TLS, "k5tls", "tls");
-    if (k5_plugin_load(context, PLUGIN_INTERFACE_TLS, "k5tls", &initfn) == 0)
+    ret = k5_plugin_load(context, PLUGIN_INTERFACE_TLS, "k5tls", &initfn);
+    if (!ret)
         (*initfn)(context, 0, 0, (krb5_plugin_vtable)context->tls);
+    else
+        TRACE_SENDTO_KDC_K5TLS_LOAD_ERROR(context, ret);
 
     return 0;
 }


### PR DESCRIPTION
If sendto_kdc fails to establish an MS-KKDCP connection because the
k5tls module cannot be loaded, output a trace log before closing the
connection.  Reported by Jochen Hein.
