### PR TITLE
Back off Travis build to default dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: c++
 
 sudo: required
 
-dist: xenial
-
 matrix:
   include:
   - compiler: clang


### PR DESCRIPTION
Travis appears to have deployed a testing xenial environment which
runs a daemon that sometimes interferes with apt commands.  Remove the
"dist: xenial" line so we run in the default, supported distribution
(currently trusty).

[Evidence that "dist: xenial" is hurting us with locking failures:

* https://github.com/mlpack/mlpack/blob/master/.travis.yml uses "dist: xenial" and has several iterations of workarounds for the same locking failure we've been having

* https://github.com/travis-ci/travis-ci/issues/9080
]