### PR TITLE
Fix type error in klog com_err hook

### DIFF
--- a/src/lib/kadm5/logger.c
+++ b/src/lib/kadm5/logger.c
@@ -201,7 +201,7 @@ klog_com_err_proc(const char *whoami, long int code, const char *format, va_list
     k5_buf_add_vfmt(&buf, format, ap);
 
     if (k5_buf_status(&buf) == 0)
-        krb5_klog_syslog(code ? LOG_ERR : LOG_INFO, "%s", buf.data);
+        krb5_klog_syslog(code ? LOG_ERR : LOG_INFO, "%s", (char *)buf.data);
 
     k5_buf_free(&buf);
 }


### PR DESCRIPTION
As a variable argument, buf.data won't be automatically cast from
void * to char * when passed to krb5_klog_syslog(), so to be correct
we must do it manually.

[Coverity caught this.  gcc issued a warning but I didn't notice, and we don't have a warning-clean gcc build restriction as yet.  clang didn't catch it for some reason.  Of course testing didn't catch it since void * and char * generally have the same representation.]