### PR TITLE
Initialize uninitialized variables (make gcc 7 happy)

### DIFF
--- a/src/lib/krb5/krb/appdefault.c
+++ b/src/lib/krb5/krb/appdefault.c
@@ -44,6 +44,8 @@ appdefault_get(krb5_context context, const char *appname, const krb5_data *realm
     krb5_error_code retval;
     const char * realmstr =  realm?realm->data:NULL;
 
+    *ret_value = NULL;
+
     if (!context || (context->magic != KV5M_CONTEXT))
         return KV5M_CONTEXT;
 


### PR DESCRIPTION
Without this change, a build with gcc 7 fails with:
```
appdefault.c: In function 'krb5_appdefault_string':
appdefault.c:163:20: error: 'string' may be used uninitialized in this function [-Werror=maybe-uninitialized]
         *ret_value = string;
         ~~~~~~~~~~~^~~~~~~~
cc1: some warnings being treated as errors
make[3]: *** [appdefault.so] Error 1
```