### PR TITLE
PKINIT certid fixes

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -4636,6 +4636,43 @@ reassemble_pkcs11_name(pkinit_identity_opts *idopts)
     return ret;
 }
 
+static int
+hex_string_to_bin(const char *str, int *bin_len_out, CK_BYTE **bin_out)
+{
+    size_t str_len, i;
+    CK_BYTE *bin;
+    char *endptr, tmp[3] = { '\0', '\0', '\0' };
+    long val;
+
+    *bin_len_out = 0;
+    *bin_out = NULL;
+
+    str_len = strlen(str);
+    if (str_len % 2 != 0)
+        return EINVAL;
+    bin = malloc(str_len / 2);
+    if (bin == NULL)
+        return ENOMEM;
+
+    errno = 0;
+    for (i = 0; i < str_len / 2; i++) {
+        tmp[0] = str[i * 2];
+        tmp[1] = str[i * 2 + 1];
+
+        val = strtol(tmp, &endptr, 16);
+        if (val < 0 || val > 255 || errno != 0 || endptr != &tmp[2]) {
+            free(bin);
+            return EINVAL;
+        }
+
+        bin[i] = (CK_BYTE)val;
+    }
+
+    *bin_len_out = str_len / 2;
+    *bin_out = bin;
+    return 0;
+}
+
 static krb5_error_code
 pkinit_get_certs_pkcs11(krb5_context context,
                         pkinit_plg_crypto_context plg_cryptoctx,
@@ -4678,18 +4715,14 @@ pkinit_get_certs_pkcs11(krb5_context context,
     }
     /* Convert the ascii cert_id string into a binary blob */
     if (idopts->cert_id_string != NULL) {
-        BIGNUM *bn = NULL;
-        BN_hex2bn(&bn, idopts->cert_id_string);
-        if (bn == NULL)
-            return ENOMEM;
-        id_cryptoctx->cert_id_len = BN_num_bytes(bn);
-        id_cryptoctx->cert_id = malloc((size_t) id_cryptoctx->cert_id_len);
-        if (id_cryptoctx->cert_id == NULL) {
-            BN_free(bn);
-            return ENOMEM;
+        r = hex_string_to_bin(idopts->cert_id_string,
+                              &id_cryptoctx->cert_id_len,
+                              &id_cryptoctx->cert_id);
+        if (r != 0) {
+            pkiDebug("Failed to convert certid string [%s]\n",
+                     idopts->cert_id_string);
+            return r;
         }
-        BN_bn2bin(bn, id_cryptoctx->cert_id);
-        BN_free(bn);
     }
     id_cryptoctx->slotid = idopts->slotid;
     id_cryptoctx->pkcs11_method = 1;

--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.h
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.h
@@ -87,8 +87,8 @@ struct _pkinit_identity_crypto_context {
     void *p11_module;
     CK_SESSION_HANDLE session;
     CK_FUNCTION_LIST_PTR p11;
-    CK_BYTE_PTR cert_id;
-    int cert_id_len;
+    uint8_t *cert_id;
+    size_t cert_id_len;
     CK_MECHANISM_TYPE mech;
 #endif
     krb5_boolean defer_id_prompt;


### PR DESCRIPTION
This is http://krbdev.mit.edu/rt/Ticket/Display.html?id=8636 converted to a PR, without any changes to the code diffs yet.

I want to poke around for less verbose approaches to converting from hex to binary, or possibly add something to libkrb5support for hex conversion.  Hex conversion is simple enough that just repeating it everywhere isn't totally unreasonable, but once you add in unit tests that stops being the case.

(It would be possible to use the OpenSSL bignum functions correctly, but by the time we added the necessary length adjustments it would be about as much code as converting from hex ourselves.  And semantically, converting a hex string to a bignum to a binary string isn't very elegant.)