### PR TITLE
Fix Leash AddDisplayItem() declaration

### DIFF
--- a/src/windows/leash/LeashView.h
+++ b/src/windows/leash/LeashView.h
@@ -218,9 +218,9 @@ private:
                                CCacheDisplayData *elem,
                                int iItem,
                                char *principal,
-                               long issued,
-                               long valid_until,
-                               long renew_until,
+                               time_t issued,
+                               time_t valid_until,
+                               time_t renew_until,
                                char *encTypes,
                                unsigned long flags,
                                char *cache_name);


### PR DESCRIPTION
Commit a9cbbf0899f270fbb14f63ffbed1b6d542333641 changed three
parameters in AddDisplayItem() from long to time_t, but did not change
the corresponding declaration in LeashView.h.  Fix that now.

[http://krbdev.mit.edu/rt/Ticket/Display.html?id=8640 for context.]
