### PR TITLE
Make public headers work with gcc -Wundef

### DIFF
--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -106,7 +106,7 @@
 
 KRB5INT_BEGIN_DECLS
 
-#if TARGET_OS_MAC
+#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
 #    pragma pack(push,2)
 #endif
 
@@ -8481,7 +8481,7 @@ krb5_set_kdc_recv_hook(krb5_context context, krb5_post_recv_fn recv_hook,
                        void *data);
 
 
-#if TARGET_OS_MAC
+#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
 #    pragma pack(pop)
 #endif
 

--- a/src/lib/gssapi/generic/gssapi.hin
+++ b/src/lib/gssapi/generic/gssapi.hin
@@ -39,7 +39,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#if TARGET_OS_MAC
+#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
 #    pragma pack(push,2)
 #endif
 
@@ -816,7 +816,7 @@ gss_set_neg_mechs(
     gss_cred_id_t,      /* cred_handle */
     const gss_OID_set); /* mech_set */
 
-#if TARGET_OS_MAC
+#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
 #    pragma pack(pop)
 #endif
 


### PR DESCRIPTION
The C standard allows undefined symbols in #if statements, giving them
the value 0 (C99 section 6.10.1).  However, some software builds with
gcc -Wundef, which issues a warning on undefined symbols in
preprocessor expressions.  Make the public headers safe for that
environment by using #ifdef instead of #if for TARGET_OS_MAC.
Reported by Ben Kaduk.
