### PR TITLE
always initialize keyblock to zero

### DIFF
--- a/src/kadmin/dbutil/dump.c
+++ b/src/kadmin/dbutil/dump.c
@@ -104,6 +104,7 @@ master_key_convert(krb5_context context, krb5_db_entry *db_entry)
     krb5_kvno kvno;
     int i, j;
 
+    memset(&v5plainkey, 0, sizeof(krb5_keyblock));
     is_mkey = krb5_principal_compare(context, master_princ, db_entry->princ);
 
     if (is_mkey) {

--- a/src/kadmin/dbutil/kdb5_create.c
+++ b/src/kadmin/dbutil/kdb5_create.c
@@ -373,6 +373,7 @@ tgt_keysalt_iterate(ksent, ptr)
     krb5_int32          ind;
     krb5_data   pwd;
 
+    memset(&key, 0, sizeof(krb5_keyblock));
     iargs = (struct iterate_args *) ptr;
     kret = 0;
 

--- a/src/kadmin/ktutil/ktutil_funcs.c
+++ b/src/kadmin/ktutil/ktutil_funcs.c
@@ -111,6 +111,7 @@ krb5_error_code ktutil_add(context, list, princ_str, kvno,
     int i, tmp;
     unsigned int pwsize = BUFSIZ;
 
+    memset(&key, 0, sizeof(krb5_keyblock));
     retval = krb5_parse_name(context, princ_str, &princ);
     if (retval)
         return retval;

--- a/src/kdc/cammac.c
+++ b/src/kdc/cammac.c
@@ -65,6 +65,7 @@ cammac_create(krb5_context context, krb5_enc_tkt_part *enc_tkt,
     krb5_keyblock tgtkey;
     krb5_checksum kdc_cksum, svc_cksum;
 
+    memset(&tgtkey, 0, sizeof(krb5_keyblock));
     *cammac_out = NULL;
     memset(&tgtkey, 0, sizeof(tgtkey));
     memset(&kdc_cksum, 0, sizeof(kdc_cksum));

--- a/src/kdc/do_tgs_req.c
+++ b/src/kdc/do_tgs_req.c
@@ -144,7 +144,8 @@ process_tgs_req(struct server_handle *handle, krb5_data *pkt,
     memset(&reply_encpart, 0, sizeof(reply_encpart));
     memset(&ticket_reply, 0, sizeof(ticket_reply));
     memset(&enc_tkt_reply, 0, sizeof(enc_tkt_reply));
-    session_key.contents = NULL;
+    memset(&encrypting_key, 0, sizeof(krb5_keyblock));
+    memset(&session_key, 0, sizeof(krb5_keyblock));
 
     retval = decode_krb5_tgs_req(pkt, &request);
     if (retval)
@@ -553,6 +554,7 @@ process_tgs_req(struct server_handle *handle, krb5_data *pkt,
          * Convert server.key into a real key
          * (it may be encrypted in the database)
          */
+	memset(&encrypting_key, 0, sizeof (encrypting_key));
         if ((errcode = krb5_dbe_decrypt_key_data(kdc_context, NULL,
                                                  server_key, &encrypting_key,
                                                  NULL))) {

--- a/src/kdc/kdc_preauth.c
+++ b/src/kdc/kdc_preauth.c
@@ -464,6 +464,7 @@ client_keys(krb5_context context, krb5_kdcpreauth_rock rock,
         if (krb5_dbe_find_enctype(context, client, request->ktype[i],
                                   -1, 0, &entry_key) != 0)
             continue;
+	memset(&key, 0, sizeof(krb5_keyblock));
         if (krb5_dbe_decrypt_key_data(context, NULL, entry_key,
                                       &key, NULL) != 0)
             continue;
@@ -1290,6 +1291,8 @@ return_padata(krb5_context context, krb5_kdcpreauth_rock rock,
     krb5_kdcpreauth_modreq      *modreq_ptr;
     krb5_boolean                key_modified;
     krb5_keyblock               original_key;
+
+    memset(&original_key, 0, sizeof(krb5_keyblock));
     if ((!*padata_context) &&
         (make_padata_context(context, padata_context) != 0)) {
         return KRB5KRB_ERR_GENERIC;

--- a/src/kdc/kdc_preauth_encts.c
+++ b/src/kdc/kdc_preauth_encts.c
@@ -59,6 +59,7 @@ enc_ts_verify(krb5_context context, krb5_data *req_pkt, krb5_kdc_req *request,
     krb5_key_data *             client_key;
     krb5_int32                  start;
 
+    memset(&key, 0, sizeof(krb5_keyblock));
     scratch.data = (char *)pa->contents;
     scratch.length = pa->length;
 

--- a/src/kdc/kdc_util.c
+++ b/src/kdc/kdc_util.c
@@ -515,6 +515,7 @@ find_server_key(krb5_context context,
         return KRB5KDC_ERR_S_PRINCIPAL_UNKNOWN;
     if ((key = (krb5_keyblock *)malloc(sizeof *key)) == NULL)
         return ENOMEM;
+    memset(key, 0, sizeof(krb5_keyblock));
     retval = krb5_dbe_decrypt_key_data(context, NULL, server_key,
                                        key, NULL);
     if (retval)

--- a/src/lib/crypto/builtin/pbkdf2.c
+++ b/src/lib/crypto/builtin/pbkdf2.c
@@ -228,6 +228,7 @@ krb5int_pbkdf2_hmac(const struct krb5_hash_provider *hash,
     krb5_crypto_iov iov;
     krb5_error_code err;
 
+    memset(&keyblock, 0, sizeof(krb5_keyblock));
     assert(hash->hashsize <= sizeof(tmp));
     if (pass->length > hash->blocksize) {
         d = make_data(tmp, hash->hashsize);

--- a/src/lib/crypto/crypto_tests/t_cksum.c
+++ b/src/lib/crypto/crypto_tests/t_cksum.c
@@ -94,6 +94,7 @@ main(argc, argv)
     krb5_checksum         checksum, knowncksum;
 
     /* this is a terrible seed, but that's ok for the test. */
+    memset(&keyblock, 0, sizeof(krb5_keyblock));
 
     plaintext.length = 8;
     plaintext.data = (char *) testkey;

--- a/src/lib/crypto/crypto_tests/t_cksums.c
+++ b/src/lib/crypto/crypto_tests/t_cksums.c
@@ -201,6 +201,7 @@ main(int argc, char **argv)
     krb5_boolean valid, verbose = FALSE;
     int status = 0;
 
+    memset(&kb, 0, sizeof(krb5_keyblock));
     if (argc >= 2 && strcmp(argv[1], "-v") == 0)
         verbose = TRUE;
     for (i = 0; i < sizeof(test_cases) / sizeof(*test_cases); i++) {

--- a/src/lib/crypto/crypto_tests/t_cmac.c
+++ b/src/lib/crypto/crypto_tests/t_cmac.c
@@ -108,6 +108,7 @@ main(int argc, char **argv)
     unsigned char resultbuf[16];
     krb5_data result = make_data(resultbuf, 16);
 
+    memset(&keyblock, 0, sizeof(krb5_keyblock));
     /* Create the example key. */
     keyblock.magic = KV5M_KEYBLOCK;
     keyblock.enctype = ENCTYPE_CAMELLIA128_CTS_CMAC;

--- a/src/lib/crypto/crypto_tests/t_combine.c
+++ b/src/lib/crypto/crypto_tests/t_combine.c
@@ -48,6 +48,9 @@ main(int argc, char **argv)
 {
     krb5_keyblock kb1, kb2, result;
 
+    memset(&kb1, 0, sizeof(krb5_keyblock));
+    memset(&kb2, 0, sizeof(krb5_keyblock));
+    memset(&result, 0, sizeof(krb5_keyblock));
     kb1.enctype = ENCTYPE_DES_CBC_CRC;
     kb1.contents = des_key1;
     kb1.length = 8;

--- a/src/lib/crypto/crypto_tests/t_cts.c
+++ b/src/lib/crypto/crypto_tests/t_cts.c
@@ -119,6 +119,7 @@ static void test_cts()
     krb5_key key;
     krb5_error_code err;
 
+    memset(&keyblock, 0, sizeof(krb5_keyblock));
     iov.flags = KRB5_CRYPTO_TYPE_DATA;
     iov.data.data = outbuf;
     in.data = (char *)input;

--- a/src/lib/crypto/crypto_tests/t_decrypt.c
+++ b/src/lib/crypto/crypto_tests/t_decrypt.c
@@ -706,6 +706,7 @@ generate(krb5_context context)
     size_t enclen;
     char buf[64];
 
+    memset(&kb, 0, sizeof(krb5_keyblock));
     ret = krb5_c_random_seed(context, &seed);
     assert(!ret);
     for (i = 0; i < sizeof(enctypes) / sizeof(*enctypes); i++) {
@@ -742,6 +743,8 @@ main(int argc, char **argv)
     struct test *test;
     krb5_keyblock kb;
     krb5_enc_data enc;
+
+    memset(&kb, 0, sizeof(krb5_keyblock));
 
     if (argc >= 2 && strcmp(argv[1], "-g") == 0)
         return generate(context);

--- a/src/lib/crypto/crypto_tests/t_derive.c
+++ b/src/lib/crypto/crypto_tests/t_derive.c
@@ -326,6 +326,7 @@ main(int argc, char **argv)
     krb5_boolean verbose = FALSE;
     int status = 0;
 
+    memset(&kb, 0, sizeof(krb5_keyblock));
     if (argc >= 2 && strcmp(argv[1], "-v") == 0)
         verbose = TRUE;
     for (i = 0; i < sizeof(test_cases) / sizeof(*test_cases); i++) {

--- a/src/lib/crypto/crypto_tests/t_fork.c
+++ b/src/lib/crypto/crypto_tests/t_fork.c
@@ -64,6 +64,8 @@ main()
     pid_t pid, wpid;
     int status;
 
+    memset(&kb_aes, 0, sizeof(krb5_keyblock));
+    memset(&kb_rc4, 0, sizeof(krb5_keyblock));
     /* Seed the PRNG instead of creating a context, so we don't need
      * krb5.conf. */
     t(krb5_c_random_seed(ctx, &plain));

--- a/src/lib/crypto/crypto_tests/t_hmac.c
+++ b/src/lib/crypto/crypto_tests/t_hmac.c
@@ -232,6 +232,7 @@ static void test_hmac()
         },
     };
 
+    memset(&key, 0, sizeof(krb5_keyblock));
     for (i = 0; i < sizeof(md5tests)/sizeof(md5tests[0]); i++) {
         key.contents = (krb5_octet *)md5tests[i].key;
         key.length = md5tests[i].key_len;

--- a/src/lib/crypto/crypto_tests/t_kperf.c
+++ b/src/lib/crypto/crypto_tests/t_kperf.c
@@ -57,6 +57,7 @@ main(int argc, char **argv)
     krb5_checksum sum;
     krb5_boolean val;
 
+    memset(&key, 0, sizeof(krb5_keyblock));
     if (argc != 5) {
         fprintf(stderr, "Usage: t_kperf {c|k}{e|d|m|v} type size nblocks\n");
         exit(1);

--- a/src/lib/crypto/crypto_tests/t_mdcksum.c
+++ b/src/lib/crypto/crypto_tests/t_mdcksum.c
@@ -106,6 +106,7 @@ main(argc, argv)
     krb5_data             pwdata;
     char                  *pwd;
 
+    memset(&keyblock, 0, sizeof(krb5_keyblock));
     pwd = "test password";
     pwdata.length = strlen(pwd);
     pwdata.data = pwd;

--- a/src/lib/crypto/crypto_tests/t_prf.c
+++ b/src/lib/crypto/crypto_tests/t_prf.c
@@ -124,6 +124,7 @@ main()
     size_t i, prfsz;
     const struct test *test;
 
+    memset(&kb, 0, sizeof(krb5_keyblock));
     for (i = 0; i < sizeof(tests) / sizeof(*tests); i++) {
         test = &tests[i];
         kb.magic = KV5M_KEYBLOCK;

--- a/src/lib/crypto/crypto_tests/t_short.c
+++ b/src/lib/crypto/crypto_tests/t_short.c
@@ -83,6 +83,7 @@ test_enctype(krb5_enctype enctype)
     unsigned int dummy;
     size_t min_len, len;
 
+    memset(&keyblock, 0, sizeof(krb5_keyblock));
     printf("Testing enctype %d\n", (int) enctype);
     x(krb5_c_encrypt_length(NULL, enctype, 0, &min_len));
     x(krb5_c_make_random_key(NULL, enctype, &keyblock));

--- a/src/lib/crypto/crypto_tests/vectors.c
+++ b/src/lib/crypto/crypto_tests/vectors.c
@@ -122,6 +122,7 @@ test_mit_des_s2k ()
         krb5_error_code r;
         char buf[80];
 
+	memset(&key, 0, sizeof(krb5_keyblock));
         key.contents = key_contents;
 
         pd.length = strlen (p);
@@ -168,6 +169,7 @@ test_s2k (krb5_enctype enctype)
         krb5_error_code r;
         char buf[80];
 
+	memset(&key, 0, sizeof(krb5_keyblock));
         pd.length = strlen (p);
         pd.data = (char *) p;
         sd.length = strlen (s);
@@ -326,6 +328,8 @@ void test_dr_dk ()
         unsigned char dkData[KEYLENGTH];
         krb5_keyblock dk;
 
+	memset(&key, 0, sizeof(krb5_keyblock));
+	memset(&dk, 0, sizeof(krb5_keyblock));
         key.length = KEYLENGTH, key.contents = D.keydata;
         usage.length = D.usage_len, usage.data = D.usage;
         dr.length = KEYBYTES, dr.data = drData;
@@ -397,6 +401,8 @@ test_pbkdf2()
     krb5_keyblock k, dk;
     krb5_data usage, pass, salt;
 
+    memset(&k, 0, sizeof(krb5_keyblock));
+    memset(&dk, 0, sizeof(krb5_keyblock));
     d.data = x;
     dk.contents = x2;
 

--- a/src/lib/crypto/krb/checksum_confounder.c
+++ b/src/lib/crypto/krb/checksum_confounder.c
@@ -41,6 +41,7 @@ mk_xorkey(krb5_key origkey, krb5_key *xorkey)
     krb5_keyblock xorkeyblock;
     size_t i = 0;
 
+    memset(&xorkeyblock, 0, sizeof(krb5_keyblock));
     xorbytes = k5memdup(origkey->keyblock.contents, origkey->keyblock.length,
                         &retval);
     if (xorbytes == NULL)

--- a/src/lib/crypto/krb/checksum_etm.c
+++ b/src/lib/crypto/krb/checksum_etm.c
@@ -40,8 +40,9 @@ krb5int_etm_checksum(const struct krb5_cksumtypes *ctp, krb5_key key,
     krb5_error_code ret;
     uint8_t label[5];
     krb5_data label_data = make_data(label, 5), kc = empty_data();
-    krb5_keyblock kb = { 0 };
+    krb5_keyblock kb;
 
+    memset(&kb, 0, sizeof(krb5_keyblock));
     /* Derive the checksum key. */
     store_32_be(usage, label);
     label[4] = 0x99;

--- a/src/lib/crypto/krb/checksum_hmac_md5.c
+++ b/src/lib/crypto/krb/checksum_hmac_md5.c
@@ -46,6 +46,7 @@ krb5_error_code krb5int_hmacmd5_checksum(const struct krb5_cksumtypes *ctp,
     krb5_data ds = empty_data(), hashval = empty_data();
     char t[4];
 
+    memset(&ks, 0, sizeof(krb5_keyblock));
     if (key == NULL || key->keyblock.length > ctp->hash->blocksize)
         return KRB5_BAD_ENCTYPE;
     if (ctp->ctype == CKSUMTYPE_HMAC_MD5_ARCFOUR) {

--- a/src/lib/crypto/krb/combine_keys.c
+++ b/src/lib/crypto/krb/combine_keys.c
@@ -85,6 +85,7 @@ krb5int_c_combine_keys(krb5_context context, krb5_keyblock *key1,
     const struct krb5_keytypes *ktp;
     krb5_boolean myalloc = FALSE;
 
+    memset(&tkeyblock, 0, sizeof(krb5_keyblock));
     if (!enctype_ok(key1->enctype) || !enctype_ok(key2->enctype))
         return KRB5_CRYPTO_INTERNAL;
 

--- a/src/lib/crypto/krb/derive.c
+++ b/src/lib/crypto/krb/derive.c
@@ -321,6 +321,7 @@ krb5int_derive_key(const struct krb5_enc_provider *enc,
     krb5_error_code ret;
     krb5_key dkey;
 
+    memset(&keyblock, 0, sizeof(krb5_keyblock));
     *outkey = NULL;
 
     /* Check for a cached result. */

--- a/src/lib/crypto/krb/enc_etm.c
+++ b/src/lib/crypto/krb/enc_etm.c
@@ -102,8 +102,9 @@ hmac_ivec_data(const struct krb5_keytypes *ktp, const krb5_data *ki,
     krb5_error_code ret;
     krb5_data zeroivec = empty_data();
     krb5_crypto_iov *iovs = NULL;
-    krb5_keyblock kb = { 0 };
+    krb5_keyblock kb;
 
+    memset(&kb, 0, sizeof(krb5_keyblock));
     if (ivec == NULL) {
         ret = ktp->enc->init_state(NULL, 0, &zeroivec);
         if (ret)

--- a/src/lib/crypto/krb/keyblocks.c
+++ b/src/lib/crypto/krb/keyblocks.c
@@ -38,6 +38,7 @@ krb5int_c_init_keyblock(krb5_context context, krb5_enctype enctype,
     kb = malloc(sizeof(krb5_keyblock));
     if (kb == NULL)
         return ENOMEM;
+    memset(kb, 0, sizeof(krb5_keyblock));
     kb->magic = KV5M_KEYBLOCK;
     kb->enctype = enctype;
     kb->length = length;
@@ -83,6 +84,7 @@ krb5int_c_copy_keyblock(krb5_context context, const krb5_keyblock *from,
     new_key = malloc(sizeof(*new_key));
     if (!new_key)
         return ENOMEM;
+    memset(new_key, 0, sizeof(krb5_keyblock));
     code = krb5int_c_copy_keyblock_contents(context, from, new_key);
     if (code) {
         free(new_key);

--- a/src/lib/crypto/krb/old_api_glue.c
+++ b/src/lib/crypto/krb/old_api_glue.c
@@ -163,6 +163,7 @@ krb5_random_key(krb5_context context, const krb5_encrypt_block *eblock,
     key = malloc(sizeof(krb5_keyblock));
     if (key == NULL)
         return ENOMEM;
+    memset(key, 0, sizeof(krb5_keyblock));
 
     ret = krb5_c_make_random_key(context, eblock->crypto_entry, key);
     if (ret) {
@@ -241,6 +242,7 @@ krb5_calculate_checksum(krb5_context context, krb5_cksumtype ctype,
     krb5_error_code ret;
     krb5_checksum cksum;
 
+    memset(&keyblock, 0, sizeof(krb5_keyblock));
     if (seed != NULL) {
         keyblock.enctype = guess_enctype(ctype);
         keyblock.length = seed_length;
@@ -279,6 +281,7 @@ krb5_verify_checksum(krb5_context context, krb5_cksumtype ctype,
     krb5_error_code ret;
     krb5_boolean valid;
 
+    memset(&keyblock, 0, sizeof(krb5_keyblock));
     if (seed != NULL) {
         keyblock.enctype = guess_enctype(ctype);
         keyblock.length = seed_length;

--- a/src/lib/crypto/krb/s2k_des.c
+++ b/src/lib/crypto/krb/s2k_des.c
@@ -50,6 +50,7 @@ des_cbc_mac(const unsigned char *keybits, const unsigned char *ivec,
     unsigned char zero[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
     krb5_data outd, ivecd;
 
+    memset(&kb, 0, sizeof(krb5_keyblock));
     /* Make a key from keybits. */
     kb.magic = KV5M_KEYBLOCK;
     kb.enctype = ENCTYPE_DES_CBC_CRC;

--- a/src/lib/crypto/krb/s2k_pbkdf2.c
+++ b/src/lib/crypto/krb/s2k_pbkdf2.c
@@ -44,6 +44,7 @@ krb5int_dk_string_to_key(const struct krb5_keytypes *ktp,
 
     /* keyblock->length is checked by krb5int_derive_key. */
 
+    memset(&foldkeyblock, 0, sizeof(krb5_keyblock));
     keybytes = ktp->enc->keybytes;
     keylength = ktp->enc->keylength;
 

--- a/src/lib/kadm5/srv/svr_principal.c
+++ b/src/lib/kadm5/srv/svr_principal.c
@@ -937,6 +937,8 @@ check_pw_reuse(krb5_context context,
     krb5_key_data *key_data;
     krb5_error_code ret;
 
+    memset(&newkey, 0, sizeof(krb5_keyblock));
+    memset(&histkey, 0, sizeof(krb5_keyblock));
     assert (n_new_key_data >= 0);
     for (x = 0; x < (unsigned) n_new_key_data; x++) {
         /* Check only entries with the most recent kvno. */

--- a/src/lib/kdb/kdb_cpw.c
+++ b/src/lib/kdb/kdb_cpw.c
@@ -100,6 +100,7 @@ preserve_one_old_key(krb5_context context, krb5_keyblock *mkey,
     krb5_keysalt salt;
 
     memset(new_kd, 0, sizeof(*new_kd));
+    memset(&kb, 0, sizeof(krb5_keyblock));
 
     ret = krb5_dbe_decrypt_key_data(context, mkey, old_kd, &kb, NULL);
     if (ret == 0) {
@@ -162,6 +163,7 @@ add_key_rnd(context, master_key, ks_tuple, ks_tuple_count, db_entry, kvno)
     krb5_error_code       retval;
     krb5_key_data        *kd_slot;
 
+    memset(&key, 0, sizeof(krb5_keyblock));
     for (i = 0; i < ks_tuple_count; i++) {
         krb5_boolean similar;
 
@@ -264,6 +266,8 @@ add_key_pwd(context, master_key, ks_tuple, ks_tuple_count, passwd,
     int                   i, j;
     krb5_key_data        *kd_slot;
 
+    memset(&key, 0, sizeof(krb5_keyblock));
+    memset(&key_salt, 0, sizeof(krb5_keysalt));
     for (i = 0; i < ks_tuple_count; i++) {
         krb5_boolean similar;
 
@@ -351,9 +355,12 @@ add_key_pwd(context, master_key, ks_tuple, ks_tuple_count, passwd,
         retval = krb5_dbe_encrypt_key_data(context, master_key, &key,
                                            (const krb5_keysalt *)&key_salt,
                                            kvno, kd_slot);
-        if (key_salt.data.data)
+        if (key_salt.data.data) {
             free(key_salt.data.data);
+	    memset(&key_salt, 0, sizeof(krb5_keysalt));
+	}
         free(key.contents);
+	memset(&key, 0, sizeof(krb5_keyblock));
 
         if( retval )
             return retval;

--- a/src/lib/krb5/krb/gen_subkey.c
+++ b/src/lib/krb5/krb/gen_subkey.c
@@ -57,6 +57,7 @@ krb5_generate_subkey_extended(krb5_context context,
     keyblock = malloc(sizeof(krb5_keyblock));
     if (!keyblock)
         return ENOMEM;
+    memset(keyblock, 0, sizeof(krb5_keyblock));
 
     retval = krb5_c_make_random_key(context, enctype, keyblock);
     if (retval) {

--- a/src/lib/krb5/krb/gic_keytab.c
+++ b/src/lib/krb5/krb/gic_keytab.c
@@ -46,6 +46,7 @@ get_as_key_keytab(krb5_context context,
     krb5_keytab_entry kt_ent;
     krb5_keyblock *kt_key;
 
+    memset(&kt_ent, 0, sizeof(krb5_keytab_entry));
     /* We don't need the password from the responder to create the AS key. */
     if (as_key == NULL)
         return 0;

--- a/src/lib/krb5/krb/preauth_sam2.c
+++ b/src/lib/krb5/krb/preauth_sam2.c
@@ -234,6 +234,7 @@ sam2_process(krb5_context context, krb5_clpreauth_moddata moddata,
         if (!(sc2b->sam_flags & KRB5_SAM_SEND_ENCRYPTED_SAD)) {
             /* as_key = combine_key (as_key, string_to_key(SAD)) */
             krb5_keyblock tmp_kb;
+	    memset(&tmp_kb, 0, sizeof(krb5_keyblock));
 
             retval = krb5_c_string_to_key(context, sc2b->sam_etype,
                                           &response_data, salt, &tmp_kb);

--- a/src/lib/krb5/krb/rd_req_dec.c
+++ b/src/lib/krb5/krb/rd_req_dec.c
@@ -331,6 +331,7 @@ try_one_princ(krb5_context context, const krb5_ap_req *req,
     krb5_enctype tkt_etype = req->ticket->enc_part.enctype;
     krb5_principal tkt_server = req->ticket->server;
 
+    memset(&ent, 0, sizeof(krb5_keytab_entry));
     ret = krb5_kt_get_entry(context, keytab, princ, tkt_kvno, tkt_etype, &ent);
     if (ret) {
         return keytab_fetch_error(context, ret, princ, tkt_server, tkt_kvno,

--- a/src/plugins/kdb/ldap/ldap_util/kdb5_ldap_realm.c
+++ b/src/plugins/kdb/ldap/ldap_util/kdb5_ldap_realm.c
@@ -1226,6 +1226,7 @@ kdb_ldap_tgt_keysalt_iterate(krb5_key_salt_tuple *ksent, krb5_pointer ptr)
     krb5_data   pwd;
     krb5_db_entry       *entry;
 
+    memset(&key, 0, sizeof(krb5_keyblock));
     iargs = (struct iterate_args *) ptr;
     kret = 0;
 
@@ -1288,6 +1289,7 @@ kdb_ldap_create_principal(krb5_context context, krb5_principal princ,
     krb5_actkvno_node     actkvno;
 
     memset(&entry, 0, sizeof(entry));
+    memset(&key, 0, sizeof(krb5_keyblock));
 
     if ((pblock == NULL) || (context == NULL)) {
         retval = EINVAL;

--- a/src/plugins/kdb/test/kdb_test.c
+++ b/src/plugins/kdb/test/kdb_test.c
@@ -242,6 +242,7 @@ make_keys(char **strings, const char *princstr, krb5_db_entry *ent)
     for (i = 0; i < nstrings; i++) {
         ks = ks_lists[i];
         for (j = 0; j < ks_list_sizes[i]; j++) {
+	    memset(&kb, 0, sizeof(krb5_keyblock));
             make_keyblock(kvnos[i], ks[j].ks_enctype, ks[j].ks_salttype,
                           princstr, &kb);
             kd->key_data_ver = 2;

--- a/src/plugins/preauth/pkinit/pkinit_clnt.c
+++ b/src/plugins/preauth/pkinit/pkinit_clnt.c
@@ -1166,6 +1166,7 @@ pkinit_client_process(krb5_context context, krb5_clpreauth_moddata moddata,
     pkiDebug("pkinit_client_process %p %p %p %p\n",
              context, plgctx, reqctx, request);
 
+    memset(&as_key, 0, sizeof(krb5_keyblock));
 
     if (plgctx == NULL || reqctx == NULL)
         return EINVAL;

--- a/src/plugins/preauth/securid_sam2/grail.c
+++ b/src/plugins/preauth/securid_sam2/grail.c
@@ -119,7 +119,7 @@ encrypt_track_data(krb5_context context, krb5_db_entry *client,
 
     *output = empty_data();
     enc.ciphertext = empty_data();
-    sam_key.contents = NULL;
+    memset(&sam_key, 0, sizeof(krb5_keyblock));
 
     ret = get_grail_key(context, client, &sam_key);
     if (ret != 0)

--- a/src/plugins/preauth/securid_sam2/securid2.c
+++ b/src/plugins/preauth/securid_sam2/securid2.c
@@ -129,7 +129,8 @@ securid_decrypt_track_data_2(krb5_context context, krb5_db_entry *client,
     krb5_error_code retval;
     krb5_keyblock sam_key;
     krb5_enc_data tmp_enc_data;
-    sam_key.contents = NULL;
+
+    memset(&sam_key, 0, sizeof(krb5_keyblock));
 
     retval = get_securid_key(context, client, &sam_key);
     if (retval != 0)
@@ -168,6 +169,8 @@ securid_encrypt_track_data_2(krb5_context context, krb5_db_entry *client,
     size_t olen;
     krb5_keyblock sam_key;
     krb5_enc_data tmp_enc_data;
+
+    memset(&sam_key, 0, sizeof(krb5_keyblock));
 
     output->data = NULL;
 

--- a/src/tests/adata.c
+++ b/src/tests/adata.c
@@ -107,6 +107,7 @@ make_container(krb5_authdatatype ad_type, krb5_authdata *content)
     krb5_authdata *list[2], **enclist, *ad;
     krb5_keyblock kb;
 
+    memset(&kb, 0, sizeof(krb5_keyblock));
     list[0] = content;
     list[1] = NULL;
 

--- a/src/tests/asn.1/krb5_decode_leak.c
+++ b/src/tests/asn.1/krb5_decode_leak.c
@@ -135,6 +135,8 @@ main(int argc, char **argv)
     {
         krb5_keyblock keyblk, *tmp;
 
+	memset(&keyblk, 0, sizeof(krb5_keyblock));
+
         ktest_make_sample_keyblock(&keyblk);
         leak_test(keyblk, encode_krb5_encryption_key,
                   decode_krb5_encryption_key, krb5_free_keyblock);

--- a/src/tests/asn.1/krb5_encode_test.c
+++ b/src/tests/asn.1/krb5_encode_test.c
@@ -165,6 +165,9 @@ main(argc, argv)
     /* encode_krb5_encryption_key */
     {
         krb5_keyblock keyblk;
+
+	memset(&keyblk, 0, sizeof(krb5_keyblock));
+
         ktest_make_sample_keyblock(&keyblk);
         current_appl_type = 1005;
         encode_run(keyblk, "keyblock", "", encode_krb5_encryption_key);

--- a/src/tests/create/kdb5_mkdums.c
+++ b/src/tests/create/kdb5_mkdums.c
@@ -268,6 +268,8 @@ add_princ(context, str_newprinc)
         krb5_data pwd, salt;
         krb5_keyblock key;
 
+	memset(&key, 0, sizeof(krb5_keyblock));
+
         if ((retval = krb5_principal2salt(context, newprinc, &salt))) {
             com_err(progname, retval, "while converting princ to salt for '%s'",
                     princ_name);

--- a/src/tests/gssapi/t_invalid.c
+++ b/src/tests/gssapi/t_invalid.c
@@ -128,6 +128,8 @@ make_fake_cfx_context()
     krb5_gss_ctx_id_t kgctx;
     krb5_keyblock kb;
 
+    memset(&kb, 0, sizeof(krb5_keyblock));
+
     kgctx = calloc(1, sizeof(*kgctx));
     if (kgctx == NULL)
         abort();
@@ -162,6 +164,8 @@ make_fake_context(const struct test *test)
     krb5_keyblock kb;
     unsigned char encbuf[8];
     size_t i;
+
+    memset(&kb, 0, sizeof(krb5_keyblock));
 
     kgctx = calloc(1, sizeof(*kgctx));
     if (kgctx == NULL)

--- a/src/tests/gssapi/t_pcontok.c
+++ b/src/tests/gssapi/t_pcontok.c
@@ -69,6 +69,8 @@ make_delete_token(gss_krb5_lucid_context_v1_t *lctx, gss_buffer_desc *out)
     gss_krb5_lucid_key_t *lkey = &lctx->rfc1964_kd.ctx_key;
     int signalg = lctx->rfc1964_kd.sign_alg;
 
+    memset(&seqkb, 0, sizeof(krb5_keyblock));
+
     ret = krb5_init_context(&context);
     check_k5err(context, "krb5_init_context", ret);
 

--- a/src/tests/gssapi/t_prf.c
+++ b/src/tests/gssapi/t_prf.c
@@ -130,6 +130,8 @@ main(int argc, char *argv[])
     unsigned char k1buf[32], k2buf[32], outbuf[44];
     size_t i;
 
+    memset(&kb1, 0, sizeof(krb5_keyblock));
+    memset(&kb2, 0, sizeof(krb5_keyblock));
     /*
      * Fake up just enough of a krb5 GSS context to make gss_pseudo_random
      * work, with chosen subkeys and acceptor subkeys.  If we implement

--- a/src/tests/hammer/kdc5_hammer.c
+++ b/src/tests/hammer/kdc5_hammer.c
@@ -293,6 +293,7 @@ get_server_key(context, server, enctype, key)
     pwd.length = strlen(string);
 
     if ((*key = (krb5_keyblock *)malloc(sizeof(krb5_keyblock)))) {
+	memset(*key, 0, sizeof(krb5_keyblock));
     	krb5_use_enctype(context, &eblock, enctype);
     	if ((retval = krb5_string_to_key(context, &eblock, *key, &pwd, &salt)))
 	    free(*key);

--- a/src/tests/test1.c
+++ b/src/tests/test1.c
@@ -43,6 +43,8 @@ tkt_test_1()
     static krb5_octet ip_addr_1[4] = { 18, 72, 0, 122 };
     char *out;
 
+    memset(&sess_k, 0, sizeof(krb5_keyblock));
+    memset(&serv_k, 0, sizeof(krb5_keyblock));
     /*
      * fill in some values on the "in" side of the ticket
      */

--- a/src/tests/verify/kdb5_verify.c
+++ b/src/tests/verify/kdb5_verify.c
@@ -235,6 +235,9 @@ check_princ(context, str_princ)
 
     snprintf(princ_name, sizeof(princ_name), "%s@%s", str_princ, cur_realm);
 
+    memset(&pwd_key, 0, sizeof(krb5_keyblock));
+    memset(&db_key, 0, sizeof(krb5_keyblock));
+
     if ((retval = krb5_parse_name(context, princ_name, &princ))) {
         com_err(progname, retval, "while parsing '%s'", princ_name);
         goto out;


### PR DESCRIPTION
Same patch has been sent to [krbdev](http://mailman.mit.edu/pipermail/krbdev/2018-February/012901.html) from my Alexandr.Nedvedicky company email.