### PR TITLE
process_tgs_req() must release encrypting_key

### DIFF
--- a/src/kdc/do_tgs_req.c
+++ b/src/kdc/do_tgs_req.c
@@ -144,6 +144,7 @@ process_tgs_req(struct server_handle *handle, krb5_data *pkt,
     memset(&reply_encpart, 0, sizeof(reply_encpart));
     memset(&ticket_reply, 0, sizeof(ticket_reply));
     memset(&enc_tkt_reply, 0, sizeof(enc_tkt_reply));
+    memset(&encrypting_key, 0, sizeof(encrypting_key));
     session_key.contents = NULL;
 
     retval = decode_krb5_tgs_req(pkt, &request);
@@ -719,8 +720,6 @@ process_tgs_req(struct server_handle *handle, krb5_data *pkt,
 
     errcode = krb5_encrypt_tkt_part(kdc_context, &encrypting_key,
                                     &ticket_reply);
-    if (!isflagset(request->kdc_options, KDC_OPT_ENC_TKT_IN_SKEY))
-        krb5_free_keyblock_contents(kdc_context, &encrypting_key);
     if (errcode)
         goto cleanup;
     ticket_reply.enc_part.kvno = ticket_kvno;
@@ -810,6 +809,8 @@ process_tgs_req(struct server_handle *handle, krb5_data *pkt,
 cleanup:
     if (status == NULL)
         status = "UNKNOWN_REASON";
+    if (!isflagset(request->kdc_options, KDC_OPT_ENC_TKT_IN_SKEY))
+        krb5_free_keyblock_contents(kdc_context, &encrypting_key);
     if (reply_key)
         krb5_free_keyblock(kdc_context, reply_key);
     if (errcode)


### PR DESCRIPTION
Same patch has been sent to [krbdev](http://mailman.mit.edu/pipermail/krbdev/2018-February/012903.html) few days ago from Alexandr.Nedvedicky company email