### PR TITLE
client_pubkey always leaks in server_process_dh()

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -2979,6 +2979,7 @@ server_process_dh(krb5_context context,
 
     retval = 0;
 
+    BN_free(client_pubkey);
     if (dh_server != NULL)
         DH_free(dh_server);
     return retval;


### PR DESCRIPTION
Same patch has been sent to [krbdev](http://mailman.mit.edu/pipermail/krbdev/2018-February/012898.html) few days ago from my Alexandr.Nedvedicky company address.