### PR TITLE
etype-info behavior cleanups

### DIFF
--- a/src/include/krb5/clpreauth_plugin.h
+++ b/src/include/krb5/clpreauth_plugin.h
@@ -84,10 +84,9 @@ typedef struct krb5_clpreauth_callbacks_st {
     int vers;
 
     /*
-     * Get the enctype expected to be used to encrypt the encrypted portion of
-     * the AS_REP packet.  When handling a PREAUTH_REQUIRED error, this
-     * typically comes from etype-info2.  When handling an AS reply, it is
-     * initialized from the AS reply itself.
+     * If an AS-REP has been received, return the enctype of the AS-REP
+     * encrypted part.  Otherwise return the enctype chosen from etype-info, or
+     * the first requested enctype if no etype-info was received.
      */
     krb5_enctype (*get_etype)(krb5_context context, krb5_clpreauth_rock rock);
 

--- a/src/lib/krb5/krb/preauth2.c
+++ b/src/lib/krb5/krb/preauth2.c
@@ -428,7 +428,11 @@ grow_pa_list(krb5_pa_data ***out_pa_list, int *out_pa_list_size,
 static krb5_enctype
 get_etype(krb5_context context, krb5_clpreauth_rock rock)
 {
-    return ((krb5_init_creds_context)rock)->etype;
+    krb5_init_creds_context ctx = (krb5_init_creds_context)rock;
+
+    if (ctx->reply != NULL)
+        return ctx->reply->enc_part.enctype;
+    return ctx->etype;
 }
 
 static krb5_keyblock *


### PR DESCRIPTION
These two commits clean up a couple of misbehaviors described at http://krbdev.mit.edu/rt/Ticket/Display.html?id=8642
