### PR TITLE
krb5: let k5_pac_validate_client handle S4U2Self with enterprise prin…

### DIFF
--- a/src/lib/krb5/krb/pac.c
+++ b/src/lib/krb5/krb/pac.c
@@ -413,6 +413,7 @@ k5_pac_validate_client(krb5_context context,
     krb5_ui_2 pac_princname_length;
     int64_t pac_nt_authtime;
     krb5_principal pac_principal;
+    int flags;
 
     ret = k5_pac_locate_buffer(context, pac, KRB5_PAC_CLIENT_INFO,
                                &client_info);
@@ -440,8 +441,12 @@ k5_pac_validate_client(krb5_context context,
     if (ret != 0)
         return ret;
 
-    ret = krb5_parse_name_flags(context, pac_princname,
-                                KRB5_PRINCIPAL_PARSE_NO_REALM, &pac_principal);
+    /* Parse the UTF-8 name as an enterprise principal if we are matching
+     * against one; otherwise parse it as a regular principal with no realm. */
+    flags = KRB5_PRINCIPAL_PARSE_NO_REALM;
+    if (principal->type == KRB5_NT_ENTERPRISE_PRINCIPAL)
+        flags |= KRB5_PRINCIPAL_PARSE_ENTERPRISE;
+    ret = krb5_parse_name_flags(context, pac_princname, flags, &pac_principal);
     if (ret != 0) {
         free(pac_princname);
         return ret;


### PR DESCRIPTION
…cipals

Tested-by: Isaac Boukris <iboukris@gmail.com>

References:
http://mailman.mit.edu/pipermail/krbdev/2017-August/012806.html
https://lists.samba.org/archive/samba-technical/2018-March/126192.html

I didn't manage to add a test , as I can't find a way to get the returned pac-principal with an '@' sign.
(otherwise note that S4U2Self test in t_authdata.py uses 'kvno', which I think always parses client name as enterprise principal).

Also, please let me know if a bug is needed in order to allow for back-ports.
Thank you.