### PR TITLE
Exit with status 0 from kadmind

### DIFF
--- a/src/kadmin/server/ovsec_kadmd.c
+++ b/src/kadmin/server/ovsec_kadmd.c
@@ -560,5 +560,5 @@ main(int argc, char *argv[])
 
     krb5_klog_close(context);
     krb5_free_context(context);
-    exit(2);
+    exit(0);
 }


### PR DESCRIPTION
Typically, 0 denotes successful exit.  In particular, init systems
will complain if another different value is returned.  This presents a
problem for automated installation jobs which want to restart kadmind.

`service kadmin stop` typically sends SIGTERM, which is caught by
verto and passed to our handler.  Besides cleanup, we then call
verto_break(), which causes the verto_run() event loop to return.  The
weird return code has been present since the addition of the kadmin
code, which used a similar event model for signals.