### PR TITLE
Fix read overflow in KDC sort_pa_data()

### DIFF
--- a/src/kdc/kdc_preauth.c
+++ b/src/kdc/kdc_preauth.c
@@ -598,17 +598,18 @@ sort_pa_order(krb5_context context, krb5_kdc_req *request, int *pa_order)
                 break;
             }
         }
+        /* If we didn't find one, we have moved all of the key-replacing
+         * modules, and i is the count of those modules. */
+        if (j == n_repliers)
+            break;
     }
+    n_key_replacers = i;
 
     if (request->padata != NULL) {
         /* Now reorder the subset of modules which replace the key,
          * bubbling those which handle pa_data types provided by the
          * client ahead of the others.
          */
-        for (i = 0; preauth_systems[pa_order[i]].flags & PA_REPLACES_KEY; i++) {
-            continue;
-        }
-        n_key_replacers = i;
         for (i = 0; i < n_key_replacers; i++) {
             if (pa_list_includes(request->padata,
                                  preauth_systems[pa_order[i]].type))


### PR DESCRIPTION
sort_pa_data() could read past the end of pa_order if all preauth
systems in the table have the PA_REPLACES_KEY flag, causing a
dereference of preauth_systems[-1].  This situation became possible
after commit fea1a488924faa3938ef723feaa1ff12d22a91ff with the
elimination of static_preauth_systems; before that there were always
table entries which did not have PA_REPLACES_KEY set.

Fix this bug by removing the loop to count n_key_replacers, and
instead get the count from the prior loop by stopping once we move all
of the key-replacing modules to the front.

[I do not like sort_pa_data().  It does a complicated thing in a complicated way, mostly only affects hypothetical cases such as a client using multiple preauth requests in parallel in the same request, and does not clearly always produce the correct behavior in those hypothetical cases.  It was the main obstacle to refactoring kdc_preauth.c further than I did; I had hoped to get rid of the preauth_systems table entirely.  And it has a bad contract: the caller counts the number of preauth systems with return_padata methods to allocate the result array, and then the function counts them again.  I think it would be practical to remove it now that add_etype_info() and add_pw_salt() are called separately from the module loop.  But for now let's just fix the bug.]
