### PR TITLE
Avoid rereading non-regular profile files

### DIFF
--- a/src/util/profile/prof_int.h
+++ b/src/util/profile/prof_int.h
@@ -72,11 +72,8 @@ typedef struct _prf_file_t *prf_file_t;
 
 /*
  * The profile flags
- *
- * Deprecated use of read/write profile flag.
- * Check whether file is writable lazily so we don't call access as often.
  */
-#define PROFILE_FILE_DEPRECATED_RW	0x0001
+#define PROFILE_FILE_NO_RELOAD		0x0001
 #define PROFILE_FILE_DIRTY		0x0002
 #define PROFILE_FILE_SHARED		0x0004
 


### PR DESCRIPTION
If a profile file is a special device such as a pipe, then reloading
it will cause us to discard its contents.  Repurpose the first
PROFILE_FILE flag bit to indicate that the file should not be
reloaded.  In profile_update_file_data_locked(), set the flag on the
first load if stat() doesn't indicate a regular file, and check the
flag before testing whether we need to perform any subsequent reload.

Later on in profile_update_file_data_locked(), specifically unset the
DIRTY flag rather than unsetting all flags other than SHARED, so that
we don't clear the NO_RELOAD flag.

[The hardest part of this patch is figuring out what to do with that line "data->flags &= PROFILE_FILE_SHARED;".  The facts are these:

* Flags were first introduced in commit c04da8d90f3548ea66b5968e9a13fcc4a3f7c01f, with RW and DIRTY bits.  The DIRTY flag was set or reset as needed, and the RW flag was tested but never set.  There were no blanket flag initializations or resets.

* Commit 04df12f7fcb6663231290cbba39f7d4d2db99d0c introduced a blanket reset of flags to 0 in profile_update_file(), followed by a conditional set of the RW flag.

* Commit 7c28091d5daeb6431e6e76aeeca9ba1d33665d66 added the SHARED flag, indicating that a profile object was part of g_shared_trees.  Commit b3410d48ba12ba973944c202876240bdb5af71b3 changed the aforementioned blanket reset to ``data->flags &= PROFILE_FILE_SHARED;`` so that the SHARED flag survives, but all other flags are still reset.

* Commit 4130bdde9450dd7b399aa3650ef7ae3ff7d738da deprecated the RW flag and added a FIXME comment to ``data->flags &= PROFILE_FILE_SHARED;`` suggesting that it looked like a bug (as one normally expects to see ``|= FLAG`` or ``&= ~FLAG``).

It is hard to tell why commit 04df12f7fcb6663231290cbba39f7d4d2db99d0c introduced the flag reset on update.  The effect at the time was to unset the DIRTY flag and then reset the RW flag to the appropriate value, and the first part of that is what I preserved in this commit.  It seems to me that if we're updating a dirty profile data object from the backing file, something has gone wrong, although I don't see any code to prevent that from happening.  If it does happen, the data object is no longer dirty, so it does make sense to unset the flag.]