### PR TITLE
Report extended errors in kinit -k -t KDB:

### DIFF
--- a/src/clients/kinit/kinit.c
+++ b/src/clients/kinit/kinit.c
@@ -718,6 +718,7 @@ k5_kinit(struct k_opts *opts, struct k5_data *k5)
 #ifndef _WIN32
         if (strncmp(opts->keytab_name, "KDB:", 4) == 0) {
             ret = kinit_kdb_init(&k5->ctx, k5->me->realm.data);
+            errctx = k5->ctx;
             if (ret) {
                 com_err(progname, ret,
                         _("while setting up KDB keytab for realm %s"),


### PR DESCRIPTION
In kinit, if we recreate the context using kinit_kdb_init(), also
reset the global errctx so that we use the new context to retrieve
extended error messages.

[kinit should just use a global context variable like klist does.  But there are 50+ uses of "k5->ctx" which would need to be changed, which is far more than appropriate for a bugfix commit.  There is some other residual complexity left behind from supporting v4 and v5 kinit which should probably be simplified out at the same time as moving to a global context.]