### PR TITLE
Remove unneeded conditional in hex.c

### DIFF
--- a/src/util/support/hex.c
+++ b/src/util/support/hex.c
@@ -37,7 +37,7 @@
 static inline char
 hex_digit(uint8_t bval, int uppercase)
 {
-    assert(bval >= 0 && bval <= 0xF);
+    assert(bval <= 0xF);
     if (bval < 10)
         return '0' + bval;
     else if (uppercase)


### PR DESCRIPTION
hex_digit() accepts bval as an unsigned parameter, so we don't need to
test if bval >= 0.

[Coverity Scan has been down for an extended period of time due to a security breach.  When it finally came back up and we successfully ran a scan, it noticed a conditional-is-always-true defect in the new hex code.  We don't use compiler flags to detect this sort of thing, I think because we have some comparisons which are always true if char is signed, but not always true if char is unsigned, and compilers aren't smart enough to handle that.]