### PR TITLE
Add zapping k5buf variant

### DIFF
--- a/src/include/k5-buf.h
+++ b/src/include/k5-buf.h
@@ -45,7 +45,7 @@
  */
 
 /* Buffer type values */
-enum k5buftype { K5BUF_ERROR, K5BUF_FIXED, K5BUF_DYNAMIC };
+enum k5buftype { K5BUF_ERROR, K5BUF_FIXED, K5BUF_DYNAMIC, K5BUF_DYNAMIC_ZAP };
 
 struct k5buf {
     enum k5buftype buftype;
@@ -62,6 +62,10 @@ void k5_buf_init_fixed(struct k5buf *buf, char *data, size_t space);
 
 /* Initialize a k5buf using an internally allocated dynamic buffer. */
 void k5_buf_init_dynamic(struct k5buf *buf);
+
+/* Initialize a k5buf using an internally allocated dynamic buffer, zeroing
+ * memory when reallocating or freeing. */
+void k5_buf_init_dynamic_zap(struct k5buf *buf);
 
 /* Add a C string to BUF. */
 void k5_buf_add(struct k5buf *buf, const char *data);

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -638,51 +638,6 @@ krb5int_arcfour_gsscrypt(const krb5_keyblock *keyblock, krb5_keyusage usage,
 krb5_error_code
 k5_sha256(const krb5_data *in, size_t n, uint8_t out[K5_SHA256_HASHLEN]);
 
-/*
- * Attempt to zero memory in a way that compilers won't optimize out.
- *
- * This mechanism should work even for heap storage about to be freed,
- * or automatic storage right before we return from a function.
- *
- * Then, even if we leak uninitialized memory someplace, or UNIX
- * "core" files get created with world-read access, some of the most
- * sensitive data in the process memory will already be safely wiped.
- *
- * We're not going so far -- yet -- as to try to protect key data that
- * may have been written into swap space....
- */
-#ifdef _WIN32
-# define zap(ptr, len) SecureZeroMemory(ptr, len)
-#elif defined(__STDC_LIB_EXT1__)
-/*
- * Use memset_s() which cannot be optimized out.  Avoid memset_s(NULL, 0, 0, 0)
- * which would cause a runtime constraint violation.
- */
-static inline void zap(void *ptr, size_t len)
-{
-    if (len > 0)
-        memset_s(ptr, len, 0, len);
-}
-#elif defined(__GNUC__) || defined(__clang__)
-/*
- * Use an asm statement which declares a memory clobber to force the memset to
- * be carried out.  Avoid memset(NULL, 0, 0) which has undefined behavior.
- */
-static inline void zap(void *ptr, size_t len)
-{
-    if (len > 0)
-        memset(ptr, 0, len);
-    __asm__ __volatile__("" : : "r" (ptr) : "memory");
-}
-#else
-/*
- * Use a function from libkrb5support to defeat inlining unless link-time
- * optimization is used.  The function uses a volatile pointer, which prevents
- * current compilers from optimizing out the memset.
- */
-# define zap(ptr, len) krb5int_zap(ptr, len)
-#endif
-
 /* Convenience function: zap and free ptr if it is non-NULL. */
 static inline void
 zapfree(void *ptr, size_t len)

--- a/src/include/k5-platform.h
+++ b/src/include/k5-platform.h
@@ -40,7 +40,7 @@
  * + [v]asprintf
  * + strerror_r
  * + mkstemp
- * + zap (support function; macro is in k5-int.h)
+ * + zap (support function and macro)
  * + constant time memory comparison
  * + path manipulation
  * + _, N_, dgettext, bindtextdomain (for localization)
@@ -1020,6 +1020,51 @@ extern int krb5int_mkstemp(char *);
 #ifndef HAVE_GETTIMEOFDAY
 extern int krb5int_gettimeofday(struct timeval *tp, void *ignore);
 #define gettimeofday krb5int_gettimeofday
+#endif
+
+/*
+ * Attempt to zero memory in a way that compilers won't optimize out.
+ *
+ * This mechanism should work even for heap storage about to be freed,
+ * or automatic storage right before we return from a function.
+ *
+ * Then, even if we leak uninitialized memory someplace, or UNIX
+ * "core" files get created with world-read access, some of the most
+ * sensitive data in the process memory will already be safely wiped.
+ *
+ * We're not going so far -- yet -- as to try to protect key data that
+ * may have been written into swap space....
+ */
+#ifdef _WIN32
+# define zap(ptr, len) SecureZeroMemory(ptr, len)
+#elif defined(__STDC_LIB_EXT1__)
+/*
+ * Use memset_s() which cannot be optimized out.  Avoid memset_s(NULL, 0, 0, 0)
+ * which would cause a runtime constraint violation.
+ */
+static inline void zap(void *ptr, size_t len)
+{
+    if (len > 0)
+        memset_s(ptr, len, 0, len);
+}
+#elif defined(__GNUC__) || defined(__clang__)
+/*
+ * Use an asm statement which declares a memory clobber to force the memset to
+ * be carried out.  Avoid memset(NULL, 0, 0) which has undefined behavior.
+ */
+static inline void zap(void *ptr, size_t len)
+{
+    if (len > 0)
+        memset(ptr, 0, len);
+    __asm__ __volatile__("" : : "r" (ptr) : "memory");
+}
+#else
+/*
+ * Use a function from libkrb5support to defeat inlining unless link-time
+ * optimization is used.  The function uses a volatile pointer, which prevents
+ * current compilers from optimizing out the memset.
+ */
+# define zap(ptr, len) krb5int_zap(ptr, len)
 #endif
 
 extern void krb5int_zap(void *ptr, size_t len);

--- a/src/lib/krb5/ccache/cc_file.c
+++ b/src/lib/krb5/ccache/cc_file.c
@@ -758,7 +758,7 @@ fcc_next_cred(krb5_context context, krb5_ccache id, krb5_cc_cursor *cursor,
 
     memset(creds, 0, sizeof(*creds));
     k5_cc_mutex_lock(context, &data->lock);
-    k5_buf_init_dynamic(&buf);
+    k5_buf_init_dynamic_zap(&buf);
 
     ret = krb5_lock_file(context, fileno(fcursor->fp), KRB5_LOCKMODE_SHARED);
     if (ret)
@@ -982,7 +982,7 @@ fcc_store(krb5_context context, krb5_ccache id, krb5_creds *creds)
         goto cleanup;
 
     /* Marshal the cred and write it to the file with a single append write. */
-    k5_buf_init_dynamic(&buf);
+    k5_buf_init_dynamic_zap(&buf);
     k5_marshal_cred(&buf, version, creds);
     ret = k5_buf_status(&buf);
     if (ret)

--- a/src/lib/krb5/ccache/cc_keyring.c
+++ b/src/lib/krb5/ccache/cc_keyring.c
@@ -1295,7 +1295,7 @@ krcc_store(krb5_context context, krb5_ccache id, krb5_creds *creds)
         goto errout;
 
     /* Serialize credential using the file ccache version 4 format. */
-    k5_buf_init_dynamic(&buf);
+    k5_buf_init_dynamic_zap(&buf);
     k5_marshal_cred(&buf, 4, creds);
     ret = k5_buf_status(&buf);
     if (ret)

--- a/src/util/support/k5buf.c
+++ b/src/util/support/k5buf.c
@@ -37,7 +37,7 @@
 /*
  * Structure invariants:
  *
- * buftype is K5BUF_FIXED, K5BUF_DYNAMIC, or K5BUF_ERROR
+ * buftype is K5BUF_FIXED, K5BUF_DYNAMIC, K5BUF_DYNAMIC_ZAP, or K5BUF_ERROR
  * if buftype is K5BUF_ERROR, the other fields are NULL or 0
  * if buftype is not K5BUF_ERROR:
  *   space > 0
@@ -77,22 +77,35 @@ ensure_space(struct k5buf *buf, size_t len)
         return 1;
     if (buf->buftype == K5BUF_FIXED) /* Can't resize a fixed buffer. */
         goto error_exit;
-    assert(buf->buftype == K5BUF_DYNAMIC);
+    assert(buf->buftype == K5BUF_DYNAMIC || buf->buftype == K5BUF_DYNAMIC_ZAP);
     new_space = buf->space * 2;
     while (new_space - buf->len - 1 < len) {
         if (new_space > SIZE_MAX / 2)
             goto error_exit;
         new_space *= 2;
     }
-    new_data = realloc(buf->data, new_space);
-    if (new_data == NULL)
-        goto error_exit;
+    if (buf->buftype == K5BUF_DYNAMIC_ZAP) {
+        /* realloc() could leave behind a partial copy of sensitive data. */
+        new_data = malloc(new_space);
+        if (new_data == NULL)
+            goto error_exit;
+        memcpy(new_data, buf->data, buf->len);
+        new_data[buf->len] = '\0';
+        zap(buf->data, buf->len);
+        free(buf->data);
+    } else {
+        new_data = realloc(buf->data, new_space);
+        if (new_data == NULL)
+            goto error_exit;
+    }
     buf->data = new_data;
     buf->space = new_space;
     return 1;
 
 error_exit:
-    if (buf->buftype == K5BUF_DYNAMIC)
+    if (buf->buftype == K5BUF_DYNAMIC_ZAP)
+        zap(buf->data, buf->len);
+    if (buf->buftype == K5BUF_DYNAMIC_ZAP || buf->buftype == K5BUF_DYNAMIC)
         free(buf->data);
     set_error(buf);
     return 0;
@@ -121,6 +134,14 @@ k5_buf_init_dynamic(struct k5buf *buf)
     }
     buf->len = 0;
     *endptr(buf) = '\0';
+}
+
+void
+k5_buf_init_dynamic_zap(struct k5buf *buf)
+{
+    k5_buf_init_dynamic(buf);
+    if (buf->buftype == K5BUF_DYNAMIC)
+        buf->buftype = K5BUF_DYNAMIC_ZAP;
 }
 
 void
@@ -163,7 +184,7 @@ k5_buf_add_vfmt(struct k5buf *buf, const char *fmt, va_list ap)
     }
 
     /* Optimistically format the data directly into the dynamic buffer. */
-    assert(buf->buftype == K5BUF_DYNAMIC);
+    assert(buf->buftype == K5BUF_DYNAMIC || buf->buftype == K5BUF_DYNAMIC_ZAP);
     va_copy(apcopy, ap);
     r = vsnprintf(endptr(buf), remaining, fmt, apcopy);
     va_end(apcopy);
@@ -197,6 +218,8 @@ k5_buf_add_vfmt(struct k5buf *buf, const char *fmt, va_list ap)
         memcpy(endptr(buf), tmp, r + 1);
         buf->len += r;
     }
+    if (buf->buftype == K5BUF_DYNAMIC_ZAP)
+        zap(tmp, strlen(tmp));
     free(tmp);
 }
 
@@ -241,7 +264,9 @@ k5_buf_free(struct k5buf *buf)
 {
     if (buf->buftype == K5BUF_ERROR)
         return;
-    assert(buf->buftype == K5BUF_DYNAMIC);
+    assert(buf->buftype == K5BUF_DYNAMIC || buf->buftype == K5BUF_DYNAMIC_ZAP);
+    if (buf->buftype == K5BUF_DYNAMIC_ZAP)
+        zap(buf->data, buf->len);
     free(buf->data);
     set_error(buf);
 }

--- a/src/util/support/libkrb5support-fixed.exports
+++ b/src/util/support/libkrb5support-fixed.exports
@@ -3,6 +3,7 @@ k5_base64_encode
 k5_bcmp
 k5_buf_init_fixed
 k5_buf_init_dynamic
+k5_buf_init_dynamic_zap
 k5_buf_add
 k5_buf_add_len
 k5_buf_add_fmt

--- a/src/util/support/utf8_conv.c
+++ b/src/util/support/utf8_conv.c
@@ -99,7 +99,9 @@ k5_utf8_to_utf16le(const char *utf8, uint8_t **utf16_out, size_t *nbytes_out)
     *utf16_out = NULL;
     *nbytes_out = 0;
 
-    k5_buf_init_dynamic(&buf);
+    /* UTF-16 conversion is used for RC4 string-to-key, so treat this data as
+     * sensitive. */
+    k5_buf_init_dynamic_zap(&buf);
 
     /* Examine next UTF-8 character. */
     while (*utf8 != '\0') {

--- a/src/util/support/zap.c
+++ b/src/util/support/zap.c
@@ -25,8 +25,8 @@
  */
 
 /*
- * krb5int_zap() is used by zap() (a static inline function defined in
- * k5-int.h) on non-Windows, non-gcc compilers, in order to prevent the
+ * krb5int_zap() is used by zap() (a macro or static inline function defined in
+ * k5-platform.h) on non-Windows, non-gcc compilers, in order to prevent the
  * compiler from inlining and optimizing out the memset() call.
  */
 


### PR DESCRIPTION
Dynamic string buffers are a good way to safely compose complex values, but when used with sensitive values, the potential to reallocate the buffer defeats our ability to correctly zero out the value after we are done with it.  These commits create a zapping k5buf variant for use with sensitive values.

(It's not great that the UTF-16 conversion function has to know that it is used for RC4 keys, but I don't have a good alternative.)
