### PR TITLE
Fix SPAKE memory leak

### DIFF
--- a/src/plugins/preauth/spake/openssl.c
+++ b/src/plugins/preauth/spake/openssl.c
@@ -69,6 +69,7 @@ ossl_fini(groupdata *gd)
     EC_POINT_free(gd->N);
     BN_CTX_free(gd->ctx);
     BN_free(gd->order);
+    free(gd);
 }
 
 static krb5_error_code

--- a/src/plugins/preauth/spake/spake_kdc.c
+++ b/src/plugins/preauth/spake/spake_kdc.c
@@ -75,6 +75,7 @@ parse_data(struct k5input *in, krb5_data *out)
 {
     out->length = k5_input_get_uint32_be(in);
     out->data = (char *)k5_input_get_bytes(in, out->length);
+    out->magic = KV5M_DATA;
 }
 
 /* Parse a received cookie into its components.  The pointers stored in the


### PR DESCRIPTION
[We run Coverity Scan over our code base a few times a week via a buildbot worker, but can't easily run it on pull requests at present.  For the SPAKE code, it found one memory leak and two harmless copies of krb5_data magic fields.]

In the NIST group implementations, ossl_fini() needs to free the
groupdata container as well as its fields.  Also in
spake_kdc.c:parse_data(), initialize the magic field of the resulting
data object to avoid a harmless uninitialized memory copy.
