### PR TITLE
KCM: Be tolerant to CC_END errors in ptcursor_next()

### DIFF
--- a/src/lib/krb5/ccache/cc_kcm.c
+++ b/src/lib/krb5/ccache/cc_kcm.c
@@ -966,6 +966,9 @@ kcm_ptcursor_next(krb5_context context, krb5_cc_ptcursor cursor,
         kcmreq_init(&req, KCM_OP_GET_CACHE_BY_UUID, NULL);
         k5_buf_add_len(&req.reqbuf, id, KCM_UUID_LEN);
         ret = kcmio_call(context, data->io, &req);
+        /* Continue if the cache has been deleted. */
+        if (ret == KRB5_CC_END)
+            continue;
         if (ret)
             goto cleanup;
         ret = kcmreq_get_name(&req, &name);


### PR DESCRIPTION
When doing a `kdestroy -A` the current code does:
- Destroy the primary cache (by its name);
- Iterate over all the caches' uuids:
  - Destroy each cache (by its uuid);

The problem with the following approach is that once the cache is
destroyed a follow GET_CACHE_BY_UUID using the primary cache's uuid will
simply fail as the uuid won't be found anymore (it's been destroyed
already).

In order to avoid such issues, let's relax the check for errors on
GET_CACHE_BY_UUID calls and when the cache is not found, let's just skip
it and continue looping over the other caches' uuid.

For some reason Heidmal's returns KRB5_CC_END when the cache is not
found and SSSD follows the very same implementation (that's the reason
we're checking KRB5_CC_END instead of KRB5_CC_NOT_FOUND).