### PR TITLE
Fix small leak in wshelper DLL

### DIFF
--- a/src/util/wshelper/dllmain.c
+++ b/src/util/wshelper/dllmain.c
@@ -43,8 +43,6 @@ DllMain(
             return FALSE;
 	if ((dwHesPwUidIndex = TlsAlloc()) == TLS_OUT_OF_INDEXES)
             return FALSE;
-	if ((dwHesPwUidIndex = TlsAlloc()) == TLS_OUT_OF_INDEXES)
-            return FALSE;
 	if ((dwGhnIndex = TlsAlloc()) == TLS_OUT_OF_INDEXES)
             return FALSE;
 	if ((dwGhaIndex = TlsAlloc()) == TLS_OUT_OF_INDEXES)


### PR DESCRIPTION
[I can't test this without a lot of setup, but it's really clear from code inspection that this shouldn't change the behavior apart from fixing the memory leak.  I checked that after this change there are seven initializations for seven handles; that is, the second initialization was actually a duplicate and not a failure to change a variable name.

We aren't using the Hesiod code in wshelper and could presumably rip the whole thing out, but doing that would definitely require setting up a test environment.]

Remove a double initialization of dwHesPwUidIndex in wshelper which
caused the first initialization to leak a thread-local storage handle.
Reported by Sergey Ilinykh.
