### PR TITLE
Display more extended errors in kdb5_util

### DIFF
--- a/src/kadmin/dbutil/kadm5_create.c
+++ b/src/kadmin/dbutil/kadm5_create.c
@@ -68,28 +68,22 @@ static int add_admin_princs(void *handle, krb5_context context, char *realm);
 int kadm5_create(kadm5_config_params *params)
 {
     int retval;
-    krb5_context context;
-
     kadm5_config_params lparams;
-
-    if ((retval = kadm5_init_krb5_context(&context)))
-        exit(ERR);
 
     /*
      * The lock file has to exist before calling kadm5_init, but
      * params->admin_lockfile may not be set yet...
      */
-    if ((retval = kadm5_get_config_params(context, 1,
-                                          params, &lparams))) {
+    retval = kadm5_get_config_params(util_context, 1, params, &lparams);
+    if (retval) {
         com_err(progname, retval, _("while looking up the Kerberos "
                                     "configuration"));
         return 1;
     }
 
-    retval = kadm5_create_magic_princs(&lparams, context);
+    retval = kadm5_create_magic_princs(&lparams, util_context);
 
-    kadm5_free_config_params(context, &lparams);
-    krb5_free_context(context);
+    kadm5_free_config_params(util_context, &lparams);
 
     return retval;
 }


### PR DESCRIPTION
[I noticed this while debugging the LMDB KDB module I've been working on.  Normally it's not an issue because if the database is created successfully, kadm5_create() will be able to add the admin principals.]

In kadm5_create(), use the global context instead of a newly created
context, so that extended error messages are displayed properly by
extended_com_err_fn().
