### PR TITLE
- better user experience with 'kadmin -proponly'

### DIFF
--- a/src/kadmin/server/ovsec_kadmd.c
+++ b/src/kadmin/server/ovsec_kadmd.c
@@ -468,6 +468,10 @@ main(int argc, char *argv[])
         fail_to_start(0, _("Missing required realm configuration"));
     if (!(params.mask & KADM5_CONFIG_ACL_FILE))
         fail_to_start(0, _("Missing required ACL file configuration"));
+    if (proponly && !params.iprop_enabled) {
+        fail_to_start(0, _("-proponly can only be used when "
+                           "iprop_enable is true"));
+    }
 
     ret = setup_loop(&params, proponly, &vctx);
     if (ret)


### PR DESCRIPTION
I forgot to add 'iprop_enable = true' to kdc.conf for my test realm.
Then I tried to run kadmin with -proponly flag. It gave me message:
	root@kdc1:~#  /usr/lib/krb5/kadmind -nofork -proponly
	kadmind: kadmind: Invalid argument while initializing network, aborting

the message is not helpful much. My first idea was to let kadmin
fail with more user friendly message such as:
	'-proponly requires to put 'iprop_enable = true' for realm in kdc.conf

thinking more about I believe the '-noprop' flag should just override
iprop_enable = false.