### PR TITLE
Fix doubled "kadmind:" in kadmind fail_to_start()

### DIFF
--- a/src/kadmin/server/ovsec_kadmd.c
+++ b/src/kadmin/server/ovsec_kadmd.c
@@ -106,7 +106,6 @@ fail_to_start(krb5_error_code code, const char *msg)
 {
     const char *errmsg;
 
-    fprintf(stderr, "%s: ", progname);
     if (code) {
         errmsg = krb5_get_error_message(context, code);
         fprintf(stderr, _("%s: %s while %s, aborting\n"), progname, errmsg,


### PR DESCRIPTION
Commit 779a335f4e2deb2d76caf7d0dd3de847a040c050 added the
fail_to_start() helper in ovsec_kadmd.c, accidentally sending the
program name to stderr twice.  Remove one of them.
