### PR TITLE
Avoid peeking into server handle in kadmind

### DIFF
--- a/src/kadmin/server/Makefile.in
+++ b/src/kadmin/server/Makefile.in
@@ -4,7 +4,7 @@ KDB_DEP_LIB=$(DL_LIB) $(THREAD_LINKOPTS)
 
 LOCALINCLUDES = -I$(top_srcdir)/lib/gssapi/generic \
 	-I$(top_srcdir)/lib/gssapi/krb5 -I$(BUILDTOP)/lib/gssapi/generic \
-	-I$(BUILDTOP)/lib/gssapi/krb5 -I$(top_srcdir)/lib/kadm5/srv
+	-I$(BUILDTOP)/lib/gssapi/krb5
 
 PROG = kadmind
 OBJS = auth.o auth_acl.o auth_self.o kadm_rpc_svc.o server_stubs.o \

--- a/src/kadmin/server/deps
+++ b/src/kadmin/server/deps
@@ -83,9 +83,8 @@ $(OUTPRE)server_stubs.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
 $(OUTPRE)ovsec_kadmd.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
   $(BUILDTOP)/include/gssapi/gssapi.h $(BUILDTOP)/include/gssapi/gssapi_alloc.h \
   $(BUILDTOP)/include/gssapi/gssapi_ext.h $(BUILDTOP)/include/gssrpc/types.h \
-  $(BUILDTOP)/include/kadm5/admin.h $(BUILDTOP)/include/kadm5/admin_internal.h \
-  $(BUILDTOP)/include/kadm5/chpass_util_strings.h $(BUILDTOP)/include/kadm5/kadm_err.h \
-  $(BUILDTOP)/include/kadm5/kadm_rpc.h $(BUILDTOP)/include/kadm5/server_internal.h \
+  $(BUILDTOP)/include/kadm5/admin.h $(BUILDTOP)/include/kadm5/chpass_util_strings.h \
+  $(BUILDTOP)/include/kadm5/kadm_err.h $(BUILDTOP)/include/kadm5/kadm_rpc.h \
   $(BUILDTOP)/include/krb5/krb5.h $(BUILDTOP)/include/osconf.h \
   $(BUILDTOP)/include/profile.h $(BUILDTOP)/lib/gssapi/generic/gssapi_err_generic.h \
   $(BUILDTOP)/lib/gssapi/krb5/gssapi_err_krb5.h $(COM_ERR_DEPS) \


### PR DESCRIPTION
setup_loop() does not need to peer into the server handle for network
parameters, as kadmind makes its own call to kadm5_get_config_params()
in main().  Use kadmind's copy of the parameters instead.

[Relevant history, which I decided not to inflict upon the commit message:

* Commit 416d9a774090ee78c30a844025887bd2b9e79d16 made kadmind aware of the internal structure of the server handle, in order to fetch the context for the KDB keytab.  That became unnecessary in commit 1b8c72b7ef064eabb37d726e831b4618cb37d2c7 when libkadm5 stopped creating internal krb5_contexts for server handles, but the code remained.

* Commit 17d926a4ce8bc2ede57a86f23948a3e9b68266a6 compounded the layering violation by pulling network params from global_server_handle even though the parameters are separately available in params.

* Commit 779a335f4e2deb2d76caf7d0dd3de847a040c050 cleaned up the first misuse.]
