### PR TITLE
Check for zero argc in ksu

### DIFF
--- a/src/clients/ksu/main.c
+++ b/src/clients/ksu/main.c
@@ -138,6 +138,8 @@ main (argc, argv)
         exit(1);
     }
 
+    if (argc == 0)
+        exit(1);
     if (strrchr(argv[0], '/'))
         argv[0] = strrchr(argv[0], '/')+1;
     prog_name = argv[0];


### PR DESCRIPTION
Most programs in the tree will perform a null dereference when argc is
zero, but as a setuid program ksu should be extra careful about memory
errors, even if this one is harmless.  Check and exit with status 1
immediately.
