### PR TITLE
Set error message on KCM get_princ failure

### DIFF
--- a/src/lib/krb5/ccache/cc_kcm.c
+++ b/src/lib/krb5/ccache/cc_kcm.c
@@ -721,12 +721,18 @@ kcm_get_princ(krb5_context context, krb5_ccache cache,
 {
     krb5_error_code ret;
     struct kcmreq req;
+    struct kcm_cache_data *data = cache->data;
 
     kcmreq_init(&req, KCM_OP_GET_PRINCIPAL, cache);
     ret = cache_call(context, cache, &req, FALSE);
     /* Heimdal KCM can respond with code 0 and no principal. */
     if (!ret && req.reply.len == 0)
         ret = KRB5_FCC_NOFILE;
+    if (ret == KRB5_FCC_NOFILE) {
+        k5_setmsg(context, ret, _("Credentials cache 'KCM:%s' not found"),
+                  data->residual);
+    }
+
     if (!ret)
         ret = k5_unmarshal_princ(req.reply.ptr, req.reply.len, 4, princ_out);
     kcmreq_free(&req);


### PR DESCRIPTION
This matches the expected behavior from other ccache types.  Most
notably, the KEYRING equivalent was added in
c25fc42e8eac7350209df61e4a7b9960d17755ca