### PR TITLE
Remove unrecognized "-nodes" argument from cert scripts

### DIFF
--- a/src/tests/dejagnu/pkinit-certs/make-certs.sh
+++ b/src/tests/dejagnu/pkinit-certs/make-certs.sh
@@ -114,7 +114,7 @@ extendedKeyUsage = $CLIENT_EKU_LIST
 EOF
 
 # Generate a private key.
-openssl genrsa $KEYSIZE -nodes > privkey.pem
+openssl genrsa $KEYSIZE > privkey.pem
 openssl rsa -in privkey.pem -out privkey-enc.pem -des3 -passout pass:encrypted
 
 # Generate a "CA" certificate.

--- a/src/tests/dejagnu/proxy-certs/make-certs.sh
+++ b/src/tests/dejagnu/proxy-certs/make-certs.sh
@@ -79,7 +79,7 @@ extendedKeyUsage = $PROXY_EKU_LIST
 EOF
 
 # Generate a private key.
-openssl genrsa $KEYSIZE -nodes > privkey.pem
+openssl genrsa $KEYSIZE > privkey.pem
 
 # Generate a "CA" certificate.
 SUBJECT=signer openssl req -config openssl.cnf -new -x509 -extensions exts_ca \


### PR DESCRIPTION
Apparently openssl never recognized this option, but previously didn't
complain about it.  Not using DES is the default, so it's safe to
remove.  This fixes make-certs.sh to run on openssl-1.1.0h.