### PR TITLE
Escape curly braces in def-check.pl regexes

### DIFF
--- a/src/util/def-check.pl
+++ b/src/util/def-check.pl
@@ -62,7 +62,7 @@ while (! $h->eof()) {
         next LINE;
     }
     s/#.*$//;
-    if (/^} *$/) {
+    if (/^\} *$/) {
         next LINE;
     }
     # strip comments
@@ -86,18 +86,18 @@ while (! $h->eof()) {
     if (/^[ \t]*$/) {
         next LINE;
     }
-    if (/^ *extern "C" {/) {
+    if (/^ *extern "C" \{/) {
         next LINE;
     }
     s/KRB5_ATTR_DEPRECATED//;
     # elide struct definitions
   Struct1:
-    if (/{[^}]*}/) {
-	s/{[^}]*}/ /g;
+    if (/\{[^}]*\}/) {
+	s/\{[^}]*\}/ /g;
 	goto Struct1;
     }
     # multi-line defs
-    if (/{/) {
+    if (/\{/) {
 	$_ .= "\n";
 	$len1 = length;
 	$_ .= $h->getline();


### PR DESCRIPTION
[Fixes one of the Windows build issues mentioned in ticket 8672, but I believe we run def-check.pl on all platforms in enable-maintainer-mode so this would eventually crop up on Unix-like platforms as well.  I checked the other perl scripts in the source tree and none of them appeared to have the same problem.  Only line 89 actually causes an error, as Perl doesn't complain about open-braces in the first position (they can't introduce a quantifier there as there is nothing to quantify) or close-braces anywhere.]

Recent versions of Perl issue a warning or error when an unescaped
open curly brace is used in a position where it might introduce a
quantifier in a regular expression.  Escape all regexp literal curly
braces in dep-check.pl.
