### PR TITLE
Log a message when non-root ksu authorization fails

### DIFF
--- a/src/clients/ksu/main.c
+++ b/src/clients/ksu/main.c
@@ -414,6 +414,16 @@ main (argc, argv)
     if (hp){
         if (gb_err) fprintf(stderr, "%s", gb_err);
         fprintf(stderr, _("account %s: authorization failed\n"), target_user);
+
+        if (cmd != NULL) {
+            syslog(LOG_WARNING,
+                   "Account %s: authorization for %s for execution of %s failed",
+                   target_user, source_user, cmd);
+        } else {
+            syslog(LOG_WARNING, "Account %s: authorization of %s failed",
+                   target_user, source_user);
+        }
+
         exit(1);
     }
 


### PR DESCRIPTION
If non-root user attempts to ksu but is denied by policy, log to
syslog at LOG_WARNING in keeping with other failure messages.

ticket: 8270