### PR TITLE
Use Visual Studio 2017 in appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,27 @@
+image: Visual Studio 2017
+
 build_script:
-  - call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86
   - mkdir C:\kfw
   - set KRB_INSTALL_DIR=C:\kfw
-  - set CPU=i386
-  - set NO_LEASH=1
-  - set
   - cd %APPVEYOR_BUILD_FOLDER%\src
+  - set PATH=%PATH%;%wix%bin
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+  - set CPU=i386
+  - set
   - nmake -f Makefile.in prep-windows
   - nmake
   - nmake install
+  - cd windows\installer\wix
+  - nmake
+  - rename kfw.msi kfw32.msi
+  - cd ..\..\..
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
   - set CPU=AMD64
-  - setenv /x64
+  - set
   - nmake clean
   - nmake
   - nmake install
+  - cd windows\installer\wix
+  - nmake clean
+  - nmake
+  - rename kfw.msi kfw64.msi


### PR DESCRIPTION
Update appveyor.yml to build all of the Windows code including Leash
and the installers, using VS2017.

[Additional context for the PR:]

This change gives us much better compile-time coverage of the Windows code, which will let us avoid mistakes like the one we fixed in commit b1367abb2e2ff14446371155cb7e23a29b76aa87.  But this change is largely motivated by the SPAKE code; the edwards25519.c code borrowed from BoringSSL compiles without change in VS2017 but requires significant churn in VS2010 / SDK 7, which does not allow mixed declarations and code in C.  I will try to figure out where the cutoff point is for that (i.e. whether VS2013 and VS2015 can also build the edwards25519 code), in order to update the windows README when we add the SPAKE code.

With this update I am essentially committing to using VS2017 to build the next KfW release.  I think that's okay, as VS2017 output can run back as far as Windows XP (further than we care about) according to Microsoft.
