### PR TITLE
Windows spake support

### DIFF
--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -328,7 +328,8 @@ The libdefaults section may contain any of the following relations:
 **plugin_base_dir**
     If set, determines the base directory where krb5 plugins are
     located.  The default value is the ``krb5/plugins`` subdirectory
-    of the krb5 library directory.
+    of the krb5 library directory.  This relation is subject to
+    parameter expansion (see below) in release 1.17 and later.
 
 **preferred_preauth_types**
     This allows you to set the preferred preauthentication types which

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -31,7 +31,7 @@ SUBDIRS=util include lib \
 	plugins/tls/k5tls \
 	kdc kadmin slave clients appl tests \
 	config-files build-tools man doc @po@
-WINSUBDIRS=include util lib ccapi windows clients appl
+WINSUBDIRS=include util lib ccapi windows clients appl plugins\preauth\spake
 BUILDTOP=$(REL).
 
 SRCS =  
@@ -153,7 +153,8 @@ WINMAKEFILES=Makefile \
 	util\wshelper\Makefile \
 	windows\Makefile windows\lib\Makefile windows\ms2mit\Makefile \
 	windows\kfwlogon\Makefile windows\leashdll\Makefile \
-	windows\leash\Makefile windows\leash\htmlhelp\Makefile
+	windows\leash\Makefile windows\leash\htmlhelp\Makefile \
+	plugins\preauth\spake\Makefile
 
 ##DOS##Makefile-windows: $(MKFDEP) $(WINMAKEFILES)
 
@@ -278,6 +279,8 @@ WINMAKEFILES=Makefile \
 ##DOS##windows\leash\Makefile: windows\leash\Makefile.in $(MKFDEP)
 ##DOS##	$(WCONFIG) config < $@.in > $@
 ##DOS##windows\leash\htmlhelp\Makefile: windows\leash\htmlhelp\Makefile.in $(MKFDEP)
+##DOS##	$(WCONFIG) config < $@.in > $@
+##DOS##plugins\preauth\spake\Makefile: plugins\preauth\spake\Makefile.in $(MKFDEP)
 ##DOS##	$(WCONFIG) config < $@.in > $@
 
 clean-windows:: Makefile-windows
@@ -430,6 +433,8 @@ install-windows:
 	@if not exist "$(KRB_INSTALL_DIR)\include\gssapi\$(NULL)" @mkdir "$(KRB_INSTALL_DIR)\include\gssapi"
 	@if not exist "$(KRB_INSTALL_DIR)\lib\$(NULL)" @mkdir "$(KRB_INSTALL_DIR)\lib"
 	@if not exist "$(KRB_INSTALL_DIR)\bin\$(NULL)" @mkdir "$(KRB_INSTALL_DIR)\bin"
+	@if not exist "$(KRB_INSTALL_DIR)\bin\plugins\$(NULL)" @mkdir "$(KRB_INSTALL_DIR)\bin\plugins"
+	@if not exist "$(KRB_INSTALL_DIR)\bin\plugins\preauth\$(NULL)" @mkdir "$(KRB_INSTALL_DIR)\bin\plugins\preauth"
 	copy include\krb5.h "$(KRB_INSTALL_DIR)\include\."
 	copy include\krb5\krb5.h "$(KRB_INSTALL_DIR)\include\krb5\."
 	copy include\win-mac.h "$(KRB_INSTALL_DIR)\include\."
@@ -485,6 +490,8 @@ install-windows:
 	$(INSTALLDBGSYMS) clients\kdeltkt\$(OUTPRE)kdeltkt.pdb "$(KRB_INSTALL_DIR)\bin\."
 	$(INSTALLDBGSYMS) clients\kpasswd\$(OUTPRE)kpasswd.pdb "$(KRB_INSTALL_DIR)\bin\."
 	$(INSTALLDBGSYMS) clients\kswitch\$(OUTPRE)kswitch.pdb "$(KRB_INSTALL_DIR)\bin\."
+	copy plugins\preauth\spake\$(OUTPRE)$(SPAKELIB).dll "$(KRB_INSTALL_DIR)\bin\plugins\preauth\."
+	$(INSTALLDBGSYMS) plugins\preauth\spake\$(OUTPRE)$(SPAKELIB).pdb "$(KRB_INSTALL_DIR)\bin\plugins\preauth\."
 
 check-prerecurse: runenv.py
 	$(RM) $(SKIPTESTS)

--- a/src/config/win-pre.in
+++ b/src/config/win-pre.in
@@ -201,6 +201,7 @@ SLIB=$(BUILDTOP)\lib\$(OUTPRE)k5sprt32.lib
 GLIB=$(BUILDTOP)\lib\$(OUTPRE)gssapi32.lib
 DLIB=wshelp32
 CCLIB=krbcc32
+SPAKELIB=spake32
 WLIB=
 
 !if  ("$(CPU)" == "IA64" ) || ("$(CPU)" == "AMD64" ) || ("$(CPU)" == "ALPHA64" )
@@ -212,6 +213,7 @@ SLIB=$(BUILDTOP)\lib\$(OUTPRE)k5sprt64.lib
 GLIB=$(BUILDTOP)\lib\$(OUTPRE)gssapi64.lib
 DLIB=wshelp64
 CCLIB=krbcc64
+SPAKELIB=spake64
 WLIB=
 
 !endif

--- a/src/include/osconf.hin
+++ b/src/include/osconf.hin
@@ -55,8 +55,19 @@
 #endif
 #endif /* _WINDOWS  */
 
+#ifdef _WIN32
+#define DEFAULT_PLUGIN_BASE_DIR "%{LIBDIR}\\plugins"
+#else
 #define DEFAULT_PLUGIN_BASE_DIR "@LIBDIR/krb5/plugins"
+#endif
+
+#if defined(_WIN64)
+#define PLUGIN_EXT              "64.dll"
+#elif defined(_WIN32)
+#define PLUGIN_EXT              "32.dll"
+#else
 #define PLUGIN_EXT              "@DYNOBJEXT"
+#endif
 
 #define KDC_DIR                 "@LOCALSTATEDIR/krb5kdc"
 #define KDC_RUN_DIR             "@RUNSTATEDIR/krb5kdc"

--- a/src/lib/krb5/krb/init_ctx.c
+++ b/src/lib/krb5/krb/init_ctx.c
@@ -145,6 +145,7 @@ krb5_init_context_profile(profile_t profile, krb5_flags flags,
     } seed_data;
     krb5_data seed;
     int tmp;
+    char *plugin_dir = NULL;
 
     /* Verify some assumptions.  If the assumptions hold and the
        compiler is optimizing, this should result in no code being
@@ -261,8 +262,9 @@ krb5_init_context_profile(profile_t profile, krb5_flags flags,
 
     retval = profile_get_string(ctx->profile, KRB5_CONF_LIBDEFAULTS,
                                 KRB5_CONF_PLUGIN_BASE_DIR, 0,
-                                DEFAULT_PLUGIN_BASE_DIR,
-                                &ctx->plugin_base_dir);
+                                DEFAULT_PLUGIN_BASE_DIR, &plugin_dir);
+    if (!retval)
+        retval = k5_expand_path_tokens(ctx, plugin_dir, &ctx->plugin_base_dir);
     if (retval) {
         TRACE_PROFILE_ERR(ctx, KRB5_CONF_PLUGIN_BASE_DIR,
                           KRB5_CONF_LIBDEFAULTS, retval);
@@ -288,9 +290,10 @@ krb5_init_context_profile(profile_t profile, krb5_flags flags,
     (void)profile_get_string(ctx->profile, KRB5_CONF_LIBDEFAULTS,
                              KRB5_CONF_ERR_FMT, NULL, NULL, &ctx->err_fmt);
     *context_out = ctx;
-    return 0;
+    ctx = NULL;
 
 cleanup:
+    profile_release_string(plugin_dir);
     krb5_free_context(ctx);
     return retval;
 }

--- a/src/lib/krb5/krb/plugin.c
+++ b/src/lib/krb5/krb/plugin.c
@@ -473,14 +473,18 @@ k5_plugin_register_dyn(krb5_context context, int interface_id,
 {
     krb5_error_code ret;
     struct plugin_interface *interface = get_interface(context, interface_id);
-    char *path;
+    char *fname, *path;
 
     /* Disallow registering plugins after load. */
     if (interface == NULL || interface->configured)
         return EINVAL;
 
-    if (asprintf(&path, "%s/%s%s", modsubdir, modname, PLUGIN_EXT) < 0)
+    if (asprintf(&fname, "%s%s", modname, PLUGIN_EXT) < 0)
         return ENOMEM;
+    ret = k5_path_join(modsubdir, fname, &path);
+    free(fname);
+    if (ret)
+        return ret;
     ret = register_module(context, interface, modname, path, NULL);
     free(path);
     return ret;

--- a/src/lib/krb5_32.def
+++ b/src/lib/krb5_32.def
@@ -473,3 +473,14 @@ EXPORTS
 
 ; new in 1.16
 	k5_enctype_to_ssf				@438 ; PRIVATE GSSAPI
+
+; new in 1.17
+; private symbols used by SPAKE client module
+	profile_get_string				@439 ; PRIVATE
+	profile_release_string				@440 ; PRIVATE
+	k5_sha256					@441 ; PRIVATE
+	krb5_encrypt_helper				@442 ; PRIVATE
+	encode_krb5_spake_factor			@443 ; PRIVATE
+	encode_krb5_pa_spake				@444 ; PRIVATE
+	decode_krb5_pa_spake				@445 ; PRIVATE
+	k5_free_pa_spake				@446 ; PRIVATE

--- a/src/plugins/preauth/spake/Makefile.in
+++ b/src/plugins/preauth/spake/Makefile.in
@@ -13,6 +13,8 @@ RELDIR=../plugins/preauth/spake
 SHLIB_EXPDEPS=$(KRB5_BASE_DEPLIBS)
 SHLIB_EXPLIBS=$(KRB5_BASE_LIBS) $(SPAKE_OPENSSL_LIBS)
 
+WINLIBS = $(SLIB) $(KLIB) $(CLIB)
+
 STLIBOBJS=util.o iana.o groups.o openssl.o edwards25519.o \
 	spake_client.o spake_kdc.o
 
@@ -25,6 +27,15 @@ SRCS= \
 	$(srcdir)/spake_client.c \
 	$(srcdir)/spake_kdc.c
 
+# Don't include spake_kdc.c in the Windows object list since we don't
+# need it.
+OBJS=	$(OUTPRE)util.$(OBJEXT) \
+	$(OUTPRE)iana.$(OBJEXT) \
+	$(OUTPRE)groups.$(OBJEXT) \
+	$(OUTPRE)openssl.$(OBJEXT) \
+	$(OUTPRE)edwards25519.$(OBJEXT) \
+	$(OUTPRE)spake_client.$(OBJEXT)
+
 t_vectors: t_vectors.o $(STLIBOBJS) $(SHLIB_EXPDEPS)
 	$(CC_LINK) -o $@ t_vectors.o $(STLIBOBJS) $(SHLIB_EXPLIBS)
 
@@ -34,6 +45,13 @@ clean-unix:: clean-liblinks clean-libs clean-libobjs
 
 check-unix: t_vectors
 	$(RUN_TEST_LOCAL_CONF) ./t_vectors
+
+all-windows: $(OUTPRE)$(SPAKELIB).dll
+clean-windows::
+	$(RM) $(OUTPRE)$(SPAKELIB).dll
+
+$(OUTPRE)$(SPAKELIB).dll: spake.def $(OBJS)
+	link /dll $(LOPTS) -def:spake.def -out:$*.dll $(OBJS) $(WINLIBS)
 
 @libnover_frag@
 @libobj_frag@

--- a/src/plugins/preauth/spake/spake.def
+++ b/src/plugins/preauth/spake/spake.def
@@ -1,0 +1,3 @@
+EXPORTS
+
+	clpreauth_spake_initvt

--- a/src/windows/README
+++ b/src/windows/README
@@ -8,13 +8,13 @@ MIT Kerberos Ticket Manager application.
 
 To build Kerberos 5 on Windows, you will need the following:
 
-* A version of Visual Studio which includes the Microsoft Foundation
-  Classes libraries.  These instructions will work for Visual Studio
-  2017 Community or Professional, both of which include the MFC
-  libraries if the "Visual C++ MFC" checkbox is selected after
-  enabling the "Desktop development with C++" workload.  If you do not
-  plan to build the graphical ticket manager application, the MFC
-  libraries are not required.
+* A version of Visual Studio (at least 2013) which includes the
+  Microsoft Foundation Classes libraries.  These instructions will
+  work for Visual Studio 2017 Community or Professional, both of which
+  include the MFC libraries if the "Visual C++ MFC" checkbox is
+  selected after enabling the "Desktop development with C++" workload.
+  If you do not plan to build the graphical ticket manager
+  application, the MFC libraries are not required.
 
 * A version of Perl.
 
@@ -112,17 +112,9 @@ Step 10 may be skipped if uicc is already in your command-line path
 (try running "uicc" to see if you get a usage message or a not-found
 error), or if you are not building the graphical ticket manager.
 
-Visual Studio 2012 provides only a single command prompt.  Within this
-prompt, use "vcvarsall.bat x86" and "vcvarsall.bat amd64" to switch to
-32-bit and 64-bit mode.
-
-With Visual Studio 2010, it is necessary to separately install the
-Windows SDK version 7.1 and use the Microsoft Windows SDK -> Windows
-SDK X.Y Command Prompt menu item.  Within this command prompt, run
-"setenv /x86" and "setenv /x64" to switch to 32-bit and 64-bit mode.
-Also include the "/release" option if building with NODEBUG.  If you
-are building with NO_LEASH=1, Visual Studio 2010 itself is not
-necessary; Windows SDK version 7.1 alone is sufficient.
+Visual Studio 2013 and 2015 provide only a single command prompt.
+Within this prompt, use "vcvarsall.bat x86" and "vcvarsall.bat amd64"
+to switch to 32-bit and 64-bit mode.
 
 
 Running Kerberos 5 Apps:

--- a/src/windows/installer/wix/config.wxi
+++ b/src/windows/installer/wix/config.wxi
@@ -39,6 +39,7 @@
         <?error CPU is not set ?>
     <?endif?>
     <?define BinDir="$(env.KRB_INSTALL_DIR)\bin\"?>
+    <?define PreauthDir=$(env.KRB_INSTALL_DIR)\bin\plugins\preauth?>
     <?define LibDir="$(env.KRB_INSTALL_DIR)\lib\"?>
     <?define InstallerVersion="450"?>
     <?if $(env.CPU) = "i386"?>

--- a/src/windows/installer/wix/config.wxi
+++ b/src/windows/installer/wix/config.wxi
@@ -55,6 +55,10 @@
         <?define VCVer="100"?>
     <?elseif $(env.VISUALSTUDIOVERSION) = "11.0"?>
         <?define VCVer="110"?>
+    <?elseif $(env.VISUALSTUDIOVERSION) = "12.0"?>
+        <?define VCVer="120"?>
+    <?elseif $(env.VISUALSTUDIOVERSION) = "14.0"?>
+        <?define VCVer="140"?>
     <?elseif $(env.VISUALSTUDIOVERSION) = "15.0"?>
         <?define VCVer="141"?>
     <?else?>

--- a/src/windows/installer/wix/features.wxi
+++ b/src/windows/installer/wix/features.wxi
@@ -51,6 +51,7 @@
                     Level="$(var.DebugSymLowLevel)" 
                     Title="!(loc.StrKerberosClientDebugTitle)">
                     <ComponentRef Id="cmf_bin_debug"/>
+                    <ComponentRef Id="cmf_preauth_debug"/>
 		    <ComponentRef Id="cmp_ClientSystemDebug"/>
                     <?include runtime_debug.wxi?>
 	        </Feature>
@@ -64,6 +65,7 @@
           <ComponentRef Id="cmf_leashw64_dll" />
           <ComponentRef Id="cmf_wshelp64_dll" />
           <ComponentRef Id="cmf_xpprof64_dll" />
+          <ComponentRef Id="cmf_spake64_dll" />
        <?endif?>
 
             <ComponentRef Id="cmf_comerr32_dll" />
@@ -86,6 +88,7 @@
             <ComponentRef Id="cmf_mit2ms_exe" />
             <ComponentRef Id="cmf_wshelp32_dll" />
             <ComponentRef Id="cmf_xpprof32_dll" />
+            <ComponentRef Id="cmf_spake32_dll" />
 
             <ComponentRef Id="cmf_leashw32_dll" />
 

--- a/src/windows/installer/wix/files.wxi
+++ b/src/windows/installer/wix/files.wxi
@@ -346,6 +346,27 @@
                     </Component>
                 <?endif?>
 
+                  <Directory Id="dirplugins" Name="plugins">
+                    <Directory Id="dirpreauth" Name="preauth" FileSource="$(var.PreauthDir)">
+                      <Component Win64="$(var.Win64)" Id="cmf_spake32_dll" Guid="$(var.cmf_spake32_dll_guid)" DiskId="1">
+                        <File Id="fil_spake32_dll" Name="$(var.cmf_spake32_dll_name)" KeyPath="yes" />
+                      </Component>
+                      <?if $(var.Platform) = "x64"?>
+                        <Component Win64="$(var.Win64)" Id="cmf_spake64_dll" Guid="$(var.cmf_spake64_dll_guid)" DiskId="1">
+                          <File Id="fil_spake64_dll" Name="$(var.cmf_spake64_dll_name)" KeyPath="yes" />
+                        </Component>
+                      <?endif?>
+                      <?ifdef DebugSyms?>
+                        <Component Win64="$(var.Win64)" Id="cmf_preauth_debug" Guid="$(var.cmf_preauth_debug_guid)" DiskId="1">
+                          <?if $(var.Platform) = "Intel" ?>
+                            <File Id="fil_spake32_pdb" Name="spake32.pdb" />
+                          <?else?>
+                            <File Id="fil_spake32_pdb" Name="spake64.pdb" />
+                          <?endif?>
+                        </Component>
+                      <?endif?>
+                    </Directory> <!-- /preauth -->
+                  </Directory> <!-- /plugins -->
                 </Directory> <!-- /bin -->
                 
                 <Directory Id="dirinc" Name="include" FileSource="$(var.IncDir)">

--- a/src/windows/installer/wix/platform.wxi
+++ b/src/windows/installer/wix/platform.wxi
@@ -18,6 +18,8 @@
   <?define cmf_wshelp32_dll_name="wshelp32.dll"?>
   <?define cmf_xpprof32_dll_guid="A7DF8BAF-7188-4C24-89FB-C8EB51571FD2"?>
   <?define cmf_xpprof32_dll_name="xpprof32.dll"?>
+  <?define cmf_spake32_dll_guid="36A1695B-A2B4-4A93-8C35-733A121923D4"?>
+  <?define cmf_spake32_dll_name="spake32.dll"?>
   <?if $(var.Platform) = "x64" ?>
         <?define UpgradeCode="6DA9CD86-6028-4852-8C94-452CAC229244"?>
         <?define PISystemFolder="System64Folder"?>
@@ -95,6 +97,8 @@
         <?define cmf_wshelp64_dll_name="wshelp64.dll"?>
         <?define cmf_xpprof64_dll_guid="B1112677-50A4-4430-846B-F824C859E3DF"?>
         <?define cmf_xpprof64_dll_name="xpprof64.dll"?>
+        <?define cmf_spake64_dll_guid="0E97B52A-EC8E-494C-BF5D-83AAACFEFDBA"?>
+        <?define cmf_spake64_dll_name="spake64.dll"?>
         <?define cmf_nidmgr32_dll_guid="8538212A-9BD5-4d62-BF29-36D853385F0A"?>
         <?define cmf_nidmgr32_dll_name="nidmgr64.dll"?>
         <?define cmf_nidmgr32_dll_w2k_guid="01655D48-C596-48f8-A0C3-5DB3FC833444"?>
@@ -103,6 +107,7 @@
         <?define cmf_krb5cred_en_us_dll_guid="223B7E9D-290F-40b8-89B3-F8337A8E082D"?>
         <?define cmf_krb5cred_en_us_dll_name="krb5cred_en_us.dll"?>
         <?define cmf_bin_debug_guid="F3432C85-89D9-4bd6-BD82-4ED49A118338"?>
+        <?define cmf_preauth_debug_guid="53491A4E-CB96-44D9-9B92-4ADF37C3A2D6"?>
 <?elseif $(var.Platform) = "Intel"?>
         <?define UpgradeCode="61211594-AAA1-4A98-A299-757326763CC7"?>
         <?define PISystemFolder="SystemFolder"?>
@@ -169,6 +174,7 @@
         <?define cmf_krb5cred_en_us_dll_guid="EA9ABE05-A85B-43BB-8741-50D3C3128632"?>
         <?define cmf_krb5cred_en_us_dll_name="krb5cred_en_us.dll"?>
         <?define cmf_bin_debug_guid="C8468854-8261-4781-8119-A612636841E3"?>
+        <?define cmf_preauth_debug_guid="169C0A38-EB79-4AA9-B78B-998B55084ECD"?>
 <?else?>
         <?error Unknown platform?>
 <?endif?>


### PR DESCRIPTION
The first commit makes plugin auto-registration work, under the assumptions that auto-registered preauth modules will be named "modname32.dll" and "modname64.dll" and will be located in bin/plugins/preauth.  (bin because that's where the DLLs get installed.)

The second commit builds SPAKE for Windows without OpenSSL support, and adds it to "nmake install" and the installer.  Pleasantly, no code changes are required for VS2013 and later.  Some symbols are needed from libkrb5 that we don't yet export on Windows; I kept this list short by not building spake_kdc.c.

The third commit updates the README again to indicate that VS2013 or later is now required for the build, and adds support for VS2013 and VS2015 to the installer.