### PR TITLE
Process profile includedir in sorted order

### DIFF
--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -60,7 +60,9 @@ alphanumeric characters, dashes, or underscores.  Starting in release
 1.15, files with names ending in ".conf" are also included, unless the
 name begins with ".".  Included profile files are syntactically
 independent of their parents, so each included file must begin with a
-section header.
+section header.  Starting in release 1.17, files are read in
+alphanumeric order; in previous releases, they may be read in any
+order.
 
 The krb5.conf file can specify that configuration should be obtained
 from a loadable module, rather than the file itself, using the

--- a/src/include/k5-platform.h
+++ b/src/include/k5-platform.h
@@ -44,6 +44,8 @@
  * + constant time memory comparison
  * + path manipulation
  * + _, N_, dgettext, bindtextdomain (for localization)
+ * + getopt_long
+ * + fetching filenames from a directory
  */
 
 #ifndef K5_PLATFORM_H
@@ -1147,5 +1149,10 @@ extern int k5_getopt_long(int nargc, char **nargv, char *options,
                           struct option *long_options, int *index);
 #define getopt_long k5_getopt_long
 #endif /* HAVE_GETOPT_LONG */
+
+/* Set *fnames_out to a null-terminated list of filenames within dirname,
+ * sorted according to strcmp().  Return 0 on success, or ENOENT/ENOMEM. */
+int k5_dir_filenames(const char *dirname, char ***fnames_out);
+void k5_free_filenames(char **fnames);
 
 #endif /* K5_PLATFORM_H */

--- a/src/util/profile/prof_parse.c
+++ b/src/util/profile/prof_parse.c
@@ -246,59 +246,22 @@ static int valid_name(const char *filename)
  * Include files within dirname.  Only files with names ending in ".conf", or
  * consisting entirely of alphanumeric characters, dashes, and underscores are
  * included.  This restriction avoids including editor backup files, .rpmsave
- * files, and the like.
+ * files, and the like.  Files are processed in alphanumeric order.
  */
 static errcode_t parse_include_dir(const char *dirname,
                                    struct profile_node *root_section)
 {
-#ifdef _WIN32
-    char *wildcard = NULL, *pathname;
-    WIN32_FIND_DATA ffd;
-    HANDLE handle;
     errcode_t retval = 0;
+    char **fnames, *pathname;
+    int i;
 
-    if (asprintf(&wildcard, "%s\\*", dirname) < 0)
-        return ENOMEM;
-
-    handle = FindFirstFile(wildcard, &ffd);
-    if (handle == INVALID_HANDLE_VALUE) {
-        retval = PROF_FAIL_INCLUDE_DIR;
-        goto cleanup;
-    }
-
-    do {
-        if (!valid_name(ffd.cFileName))
-            continue;
-        if (asprintf(&pathname, "%s\\%s", dirname, ffd.cFileName) < 0) {
-            retval = ENOMEM;
-            break;
-        }
-        retval = parse_include_file(pathname, root_section);
-        free(pathname);
-        if (retval)
-            break;
-    } while (FindNextFile(handle, &ffd) != 0);
-
-    FindClose(handle);
-
-cleanup:
-    free(wildcard);
-    return retval;
-
-#else /* not _WIN32 */
-
-    DIR     *dir;
-    char    *pathname;
-    errcode_t retval = 0;
-    struct dirent *ent;
-
-    dir = opendir(dirname);
-    if (dir == NULL)
+    if (k5_dir_filenames(dirname, &fnames) != 0)
         return PROF_FAIL_INCLUDE_DIR;
-    while ((ent = readdir(dir)) != NULL) {
-        if (!valid_name(ent->d_name))
+
+    for (i = 0; fnames != NULL && fnames[i] != NULL; i++) {
+        if (!valid_name(fnames[i]))
             continue;
-        if (asprintf(&pathname, "%s/%s", dirname, ent->d_name) < 0) {
+        if (asprintf(&pathname, "%s/%s", dirname, fnames[i]) < 0) {
             retval = ENOMEM;
             break;
         }
@@ -307,9 +270,8 @@ cleanup:
         if (retval)
             break;
     }
-    closedir(dir);
+    k5_free_filenames(fnames);
     return retval;
-#endif /* not _WIN32 */
 }
 
 static errcode_t parse_line(char *line, struct parse_state *state,

--- a/src/util/support/Makefile.in
+++ b/src/util/support/Makefile.in
@@ -84,6 +84,7 @@ STLIBOBJS= \
 	hex.o \
 	bcmp.o \
 	strerror_r.o \
+	dir_filenames.o \
 	$(GETTIMEOFDAY_ST_OBJ) \
 	$(IPC_ST_OBJ) \
 	$(STRLCPY_ST_OBJ) \
@@ -110,6 +111,7 @@ LIBOBJS= \
 	$(OUTPRE)hex.$(OBJEXT) \
 	$(OUTPRE)bcmp.$(OBJEXT) \
 	$(OUTPRE)strerror_r.$(OBJEXT) \
+	$(OUTPRE)dir_filenames.$(OBJEXT) \
 	$(GETTIMEOFDAY_OBJ) \
 	$(IPC_OBJ) \
 	$(STRLCPY_OBJ) \
@@ -146,6 +148,7 @@ SRCS=\
 	$(srcdir)/hex.c \
 	$(srcdir)/bcmp.c \
 	$(srcdir)/strerror_r.c \
+	$(srcdir)/dir_filenames.c \
 	$(srcdir)/t_utf8.c \
 	$(srcdir)/t_utf16.c \
 	$(srcdir)/getopt.c \

--- a/src/util/support/dir_filenames.c
+++ b/src/util/support/dir_filenames.c
@@ -1,0 +1,135 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* util/support/dir_filenames.c - fetch filenames in a directory */
+/*
+ * Copyright (C) 2018 by the Massachusetts Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "k5-platform.h"
+
+void
+k5_free_filenames(char **fnames)
+{
+    char **fn;
+
+    for (fn = fnames; fn != NULL && *fn != NULL; fn++)
+        free(*fn);
+    free(fnames);
+}
+
+/* Resize the filename list and add a name. */
+static int
+add_filename(char ***fnames, int *n_fnames, const char *name)
+{
+    char **newlist;
+
+    newlist = realloc(*fnames, (*n_fnames + 2) * sizeof(*newlist));
+    if (newlist == NULL)
+        return ENOMEM;
+    *fnames = newlist;
+    newlist[*n_fnames] = strdup(name);
+    if (newlist[*n_fnames] == NULL)
+        return ENOMEM;
+    (*n_fnames)++;
+    newlist[*n_fnames] = NULL;
+    return 0;
+}
+
+static int
+compare_with_strcmp(const void *a, const void *b)
+{
+    return strcmp(*(char **)a, *(char **)b);
+}
+
+#ifdef _WIN32
+
+int
+k5_dir_filenames(const char *dirname, char ***fnames_out)
+{
+    char *wildcard;
+    WIN32_FIND_DATA ffd;
+    HANDLE handle;
+    char **fnames = NULL;
+    int n_fnames = 0;
+
+    *fnames_out = NULL;
+
+    if (asprintf(&wildcard, "%s\\*", dirname) < 0)
+        return ENOMEM;
+    handle = FindFirstFile(wildcard, &ffd);
+    free(wildcard);
+    if (handle == INVALID_HANDLE_VALUE)
+        return ENOENT;
+
+    do {
+        if (add_filename(&fnames, &n_fnames, &ffd.cFileName) != 0) {
+            k5_free_filenames(fnames);
+            FindClose(handle);
+            return ENOMEM;
+        }
+    } while (FindNextFile(handle, &ffd) != 0);
+
+    FindClose(handle);
+    qsort(fnames, n_fnames, sizeof(*fnames), compare_with_strcmp);
+    *fnames_out = fnames;
+    return 0;
+}
+
+#else /* _WIN32 */
+
+#include <dirent.h>
+
+int
+k5_dir_filenames(const char *dirname, char ***fnames_out)
+{
+    DIR *dir;
+    struct dirent *ent;
+    char **fnames = NULL;
+    int n_fnames = 0;
+
+    *fnames_out = NULL;
+
+    dir = opendir(dirname);
+    if (dir == NULL)
+        return ENOENT;
+
+    while ((ent = readdir(dir)) != NULL) {
+        if (add_filename(&fnames, &n_fnames, ent->d_name) != 0) {
+            k5_free_filenames(fnames);
+            closedir(dir);
+            return ENOMEM;
+        }
+    }
+
+    closedir(dir);
+    qsort(fnames, n_fnames, sizeof(*fnames), compare_with_strcmp);
+    *fnames_out = fnames;
+    return 0;
+}
+
+#endif /* not _WIN32 */

--- a/src/util/support/libkrb5support-fixed.exports
+++ b/src/util/support/libkrb5support-fixed.exports
@@ -58,6 +58,8 @@ k5_path_split
 k5_strerror_r
 k5_utf8_to_utf16le
 k5_utf16le_to_utf8
+k5_dir_filenames
+k5_free_filenames
 krb5int_key_register
 krb5int_key_delete
 krb5int_getspecific


### PR DESCRIPTION
This PR supersedes #724 using a new helper function to handle Windows.

k5_dir_filenames() is not especially general--it could be inefficient for large directories because it does a realloc() per entry, sorting with strcmp() isn't always desirable, and consumers could be interested in other dirent fields.  (For instance, when sorting for display purposes, using strcoll() to respect the locale would be better.  But if the goal is to have a predictable order, as it is in this case, strcmp() seems better.)  But we can always change it later.