### PR TITLE
Fix Windows strerror_r() implementation

### DIFF
--- a/src/util/support/strerror_r.c
+++ b/src/util/support/strerror_r.c
@@ -46,6 +46,7 @@ k5_strerror_r(int errnum, char *buf, size_t buflen)
         errno = st;
         return -1;
     }
+    return 0;
 }
 
 #elif !defined(HAVE_STRERROR_R)


### PR DESCRIPTION
Commit 6351586a771e9a99e1e946cc9a0b6a87bbb14094 (ticket 7961)
introduced several variants of strerror_r().  The Windows one
contained a bug which made its return value undefined; fix that.
