### PR TITLE
Clean up Windows build CPU detection

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,6 @@ build_script:
   - cd %APPVEYOR_BUILD_FOLDER%\src
   - set PATH=%PATH%;%wix%bin
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
-  - set CPU=i386
   - set
   - nmake -f Makefile.in prep-windows
   - nmake
@@ -16,7 +15,6 @@ build_script:
   - rename kfw.msi kfw32.msi
   - cd ..\..\..
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-  - set CPU=AMD64
   - set
   - nmake clean
   - nmake

--- a/src/config/win-pre.in
+++ b/src/config/win-pre.in
@@ -34,6 +34,13 @@ CPU=i386
 !if ( "$(CPU)" != "i386" ) && ( "$(CPU)" != "ALPHA" ) && ( "$(CPU)" != "ALPHA64" ) && ( "$(CPU)" != "IA64" ) && ( "$(CPU)" != "AMD64" )
 !error Must specify CPU environment variable ( CPU=i386, CPU=ALPHA, CPU=ALPHA64,CPU=IA64, CPU=AMD64)
 !endif
+
+!if  ("$(CPU)" == "IA64" ) || ("$(CPU)" == "AMD64" ) || ("$(CPU)" == "ALPHA64" )
+BITS=64
+!else
+BITS=32
+!endif
+
 #
 # End of figuring out CPU
 #
@@ -114,7 +121,7 @@ CPPFLAGS=-I$(top_srcdir)\include -I$(top_srcdir)\include\krb5 $(DNSFLAGS) -DWIN3
 CCOPTS=-nologo /EHsc /W3 $(PDB_OPTS) $(DLL_FILE_DEF)
 LOPTS=-nologo -incremental:no -manifest
 
-!if  ("$(CPU)" == "IA64" ) || ("$(CPU)" == "AMD64" ) || ("$(CPU)" == "ALPHA64" )
+!if  ("$(BITS)" == "64" )
 ENTRYPOINT=_DllMainCRTStartup
 !else
 ENTRYPOINT=_DllMainCRTStartup@12
@@ -176,28 +183,13 @@ PERL=perl
 WCONFIG_EXE=$(BUILDTOP)\$(OUTPRE)wconfig.exe
 WCONFIG=$(WCONFIG_EXE:.exe=) $(WCONFIG_FLAGS)
 
-CLIB=$(BUILDTOP)\lib\$(OUTPRE)comerr32.lib
-PLIB=$(BUILDTOP)\lib\$(OUTPRE)xpprof32.lib
-KLIB=$(BUILDTOP)\lib\$(OUTPRE)krb5_32.lib
-K4LIB=$(BUILDTOP)\lib\$(OUTPRE)krb4_32.lib
-SLIB=$(BUILDTOP)\lib\$(OUTPRE)k5sprt32.lib
-GLIB=$(BUILDTOP)\lib\$(OUTPRE)gssapi32.lib
-CCLIB=krbcc32
-SPAKELIB=spake32
-WLIB=
-
-!if  ("$(CPU)" == "IA64" ) || ("$(CPU)" == "AMD64" ) || ("$(CPU)" == "ALPHA64" )
-CLIB=$(BUILDTOP)\lib\$(OUTPRE)comerr64.lib
-PLIB=$(BUILDTOP)\lib\$(OUTPRE)xpprof64.lib
-KLIB=$(BUILDTOP)\lib\$(OUTPRE)krb5_64.lib
-K4LIB=$(BUILDTOP)\lib\$(OUTPRE)krb4_64.lib
-SLIB=$(BUILDTOP)\lib\$(OUTPRE)k5sprt64.lib
-GLIB=$(BUILDTOP)\lib\$(OUTPRE)gssapi64.lib
-CCLIB=krbcc64
-SPAKELIB=spake64
-WLIB=
-
-!endif
+CLIB=$(BUILDTOP)\lib\$(OUTPRE)comerr$(BITS).lib
+PLIB=$(BUILDTOP)\lib\$(OUTPRE)xpprof$(BITS).lib
+KLIB=$(BUILDTOP)\lib\$(OUTPRE)krb5_$(BITS).lib
+SLIB=$(BUILDTOP)\lib\$(OUTPRE)k5sprt$(BITS).lib
+GLIB=$(BUILDTOP)\lib\$(OUTPRE)gssapi$(BITS).lib
+CCLIB=krbcc$(BITS)
+SPAKELIB=spake$(BITS)
 
 KRB4_INCLUDES=-I$(BUILDTOP)/include/kerberosIV
 

--- a/src/lib/Makefile.in
+++ b/src/lib/Makefile.in
@@ -28,11 +28,7 @@ clean-windows::
 
 
 
-##WIN32##!if  ("$(CPU)" == "IA64" ) || ("$(CPU)" == "AMD64" ) || ("$(CPU)" == "ALPHA64" )
-##WIN32##SLIBS = $(BUILDTOP)\util\support\$(OUTPRE)k5sprt64.lib
-##WIN32##!else
-##WIN32##SLIBS = $(BUILDTOP)\util\support\$(OUTPRE)k5sprt32.lib
-##WIN32##!endif
+##WIN32##SLIBS = $(BUILDTOP)\util\support\$(OUTPRE)k5sprt$(BITS).lib
 ##WIN32##CLIBS = $(BUILDTOP)\util\et\$(OUTPRE)comerr.lib
 ##WIN32##PLIBS = $(BUILDTOP)\util\profile\$(OUTPRE)profile.lib
 ##WIN32##KLIBS = krb5\$(OUTPRE)krb5.lib crypto\$(OUTPRE)crypto.lib \

--- a/src/windows/README
+++ b/src/windows/README
@@ -90,26 +90,24 @@ In a 32-bit command shell:
  4) nmake [NODEBUG=1]                   # Build the sources
  5) nmake install [NODEBUG=1]           # Copy headers, libs, executables
  6) cd windows\installer\wix            # Go to where the installer source is
- 7) set CPU=i386                        # Specify 32-bit target
- 8) nmake [NODEBUG=1]                   # Build the installer
- 9) rename kfw.msi kfw32.msi            # Save the 32-bit installer
+ 7) nmake [NODEBUG=1]                   # Build the installer
+ 8) rename kfw.msi kfw32.msi            # Save the 32-bit installer
 
 In a 64-bit command shell:
 
-10) set PATH=%PATH%;"%WindowsSdkVerBinPath%"\x86  # To get uicc.exe
-11) set KRB_INSTALL_DIR=\path\to\dir    # Where bin/include/lib lives
-12) cd xxx\src                          # Go to where source lives
-13) nmake clean                         # Clean up the 32-bit objects
-14) nmake [NODEBUG=1]                   # Build the sources for 64-bit
-15) nmake install [NODEBUG=1]           # Copy 64-bit lib/executables
-16) cd windows\installer\wix            # Back to the installer source
-17) set CPU=AMD64                       # Specify 64-bit target
-18) nmake clean                         # Remove 32-bit leavings
-19) nmake [NODEBUG=1]                   # Build the 64-bit installer
-20) rename kfw.msi kfw64.msi            # And name it usefully
+ 9) set PATH=%PATH%;"%WindowsSdkVerBinPath%"\x86  # To get uicc.exe
+10) set KRB_INSTALL_DIR=\path\to\dir    # Where bin/include/lib lives
+11) cd xxx\src                          # Go to where source lives
+12) nmake clean                         # Clean up the 32-bit objects
+13) nmake [NODEBUG=1]                   # Build the sources for 64-bit
+14) nmake install [NODEBUG=1]           # Copy 64-bit lib/executables
+15) cd windows\installer\wix            # Back to the installer source
+16) nmake clean                         # Remove 32-bit leavings
+17) nmake [NODEBUG=1]                   # Build the 64-bit installer
+18) rename kfw.msi kfw64.msi            # And name it usefully
 
-Step 10 may be skipped if uicc is already in your command-line path
-(try running "uicc" to see if you get a usage message or a not-found
+Step 9 may be skipped if uicc is already in the command-line path (try
+running "uicc" to see if you get a usage message or a not-found
 error), or if you are not building the graphical ticket manager.
 
 Visual Studio 2013 and 2015 provide only a single command prompt.

--- a/src/windows/installer/wix/Makefile
+++ b/src/windows/installer/wix/Makefile
@@ -35,10 +35,22 @@ WIXINCLUDES= \
 
 CUSTOMDLL=custom\custom.dll
 
+!if !defined(CPU) || "$(CPU)" == ""
+CPU=$(PROCESSOR_ARCHITECTURE)
+!endif # CPU
+
+!if ( "$(CPU)" == "X86" ) || ( "$(CPU)" == "x86" ) || ( "$(CPU)" == "i386" )
+WIXARCH = x86
+!elseif ( "$(CPU)" == "AMD64" )
+WIXARCH = x64
+!else
+!error "Architecture $(CPU) not supported by installer"
+!endif
+
 all: $(MSIFILE)
 
 $(OBJFILE): kfw.wxs $(WIXINCLUDES)
-	$(CANDLE) -out $@ kfw.wxs \
+	$(CANDLE) -arch $(WIXARCH) -out $@ kfw.wxs \
 		"-dDate=%DATE%" \
 		"-dTime=%TIME%" \
 		-dBuildLang=$(LANG)

--- a/src/windows/installer/wix/config.wxi
+++ b/src/windows/installer/wix/config.wxi
@@ -35,22 +35,10 @@
     <?endif?>
 
     <!-- Build type specifications -->
-    <?ifndef env.CPU?>
-        <?error CPU is not set ?>
-    <?endif?>
     <?define BinDir="$(env.KRB_INSTALL_DIR)\bin\"?>
     <?define PreauthDir=$(env.KRB_INSTALL_DIR)\bin\plugins\preauth?>
     <?define LibDir="$(env.KRB_INSTALL_DIR)\lib\"?>
     <?define InstallerVersion="450"?>
-    <?if $(env.CPU) = "i386"?>
-        <?define Platform="Intel"?>
-        <?define Win64="no"?>
-    <?elseif $(env.CPU) = "AMD64"?>
-        <?define Platform="x64"?>
-        <?define Win64="yes"?>
-    <?else?>
-        <?error Unknown build type?>
-    <?endif?>
     <?ifndef env.VISUALSTUDIOVERSION?>
         <?define VCVer="100"?>
     <?elseif $(env.VISUALSTUDIOVERSION) = "11.0"?>

--- a/src/windows/installer/wix/features.wxi
+++ b/src/windows/installer/wix/features.wxi
@@ -56,7 +56,7 @@
                     <?include runtime_debug.wxi?>
 	        </Feature>
 	    <?endif?>
-      <?if $(var.Platform)="x64"?>
+      <?if $(sys.BUILDARCH)="x64"?>
           <ComponentRef Id="cmf_comerr64_dll" />
           <ComponentRef Id="cmf_gssapi64_dll" />
           <ComponentRef Id="cmf_k5sprt64_dll" />
@@ -146,7 +146,7 @@
             Level="130" 
             Title="!(loc.KerberosSDKTitle)">
             
-        <?if $(var.Platform) = "Intel" ?>
+        <?if $(sys.BUILDARCH) = "x86" ?>
             <ComponentRef Id="cmp_dirlib_i386" />
         <?else?>
             <ComponentRef Id="cmp_dirlib_amd64" />
@@ -169,10 +169,6 @@
             Level="30" 
             Title="!(loc.KerberosDocTitle)">
 
-<!--            <?if $(var.Platform) = "Intel"?>
-                    <ComponentRef Id="efl_leash_userdoc_pdf" />
-            <?endif?> -->
-            
             <ComponentRef Id="rcm_common" />
             <ComponentRef Id="rcm_docs" />
         </Feature>

--- a/src/windows/installer/wix/files.wxi
+++ b/src/windows/installer/wix/files.wxi
@@ -35,7 +35,7 @@
   <Directory Id="TARGETDIR" Name="SourceDir">
     <Directory Id="DesktopFolder" Name="Desktop"/>
     <Directory Id="$(var.PISystemFolder)" SourceName="System">
-        <Component Win64="$(var.Win64)" Id="cmf_kfwlogon_DLL" Guid="$(var.cmf_kfwlogon_DLL_guid)">
+        <Component Id="cmf_kfwlogon_DLL" Guid="$(var.cmf_kfwlogon_DLL_guid)">
             <File Id="filekfwlogon_DLL" Name="kfwlogon.dll" KeyPath="yes" DiskId="1" Source="$(var.BinDir)kfwlogon.dll" />
             <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows NT\CurrentVersion\WinLogon\Notify\MIT_KFW" Action="createAndRemoveOnUninstall">
                 <RegistryValue Name="Asynchronous" Type="integer" Value="0" />
@@ -51,11 +51,11 @@
             <RegistryValue Name="Name" Type="string" Value="MIT Kerberos"/>
           </RegistryKey>
          </Component>
-         <Component Win64="$(var.Win64)" Id="cmf_kfwcpcc_EXE" Guid="$(var.cmf_kfwcpcc_EXE_guid)">
+         <Component Id="cmf_kfwcpcc_EXE" Guid="$(var.cmf_kfwcpcc_EXE_guid)">
              <File Id="filekfwcpcc_EXE"  Name="kfwcpcc.exe"  DiskId="1" Source="$(var.BinDir)kfwcpcc.exe" />
          </Component>
      <?ifdef DebugSyms?>
-         <Component Win64="$(var.Win64)" Id="cmp_ClientSystemDebug" Guid="$(var.cmp_ClientSystemDebug_guid)">
+         <Component Id="cmp_ClientSystemDebug" Guid="$(var.cmp_ClientSystemDebug_guid)">
 		<File Id="filekfwlogon_PDB" Name="kfwlogon.pdb" KeyPath="yes" DiskId="1" Source="$(var.BinDir)kfwlogon.pdb" />
 		<File Id="filekfwcpcc_PDB" Name="kfwcpcc.pdb" DiskId="1" Source="$(var.BinDir)kfwcpcc.pdb" />
          </Component>
@@ -67,76 +67,76 @@
                 <Directory Id="dirbin" Name="bin" FileSource="$(var.BinDir)">
                 
 		    <!-- Kerberos V options -->
-		    <Component Win64="$(var.Win64)" Id="rcm_krb5_1" Guid="$(var.rcm_krb5_1_guid)" DiskId="1">
+		    <Component Id="rcm_krb5_1" Guid="$(var.rcm_krb5_1_guid)" DiskId="1">
 			<RegistryValue Id="reg_krb5_1" Root="HKLM" Key="Software\MIT\kerberos5" Name="config" Type="string" Value="[KRB5CONFIG]" KeyPath="yes" />
 		    	<Condition>KRB5CONFIG</Condition>
 		    </Component>
-		    <Component Win64="$(var.Win64)" Id="rcm_krb5_2" Guid="$(var.rcm_krb5_2_guid)" DiskId="1">
+		    <Component Id="rcm_krb5_2" Guid="$(var.rcm_krb5_2_guid)" DiskId="1">
 			<RegistryValue Id="reg_krb5_2" Root="HKLM" Key="Software\MIT\kerberos5" Name="ccname" Type="string" Value="[KRB5CCNAME]" KeyPath="yes" />
 		    	<Condition>KRB5CCNAME</Condition>
 		    </Component>
-		    <Component Win64="$(var.Win64)" Id="rcm_krb5_3" Guid="$(var.rcm_krb5_3_guid)" DiskId="1">
+		    <Component Id="rcm_krb5_3" Guid="$(var.rcm_krb5_3_guid)" DiskId="1">
 			<RegistryValue Id="reg_krb5_3" Root="HKLM" Key="Software\MIT\kerberos5" Name="PreserveInitialTicketIdentity" Type="integer" Value="[KRB5PRESERVEIDENTITY]" KeyPath="yes" />
 		    	<Condition>KRB5PRESERVEIDENTITY</Condition>
 		    </Component>
                 
-                    <Component Win64="$(var.Win64)" Id="cmf_comerr32_dll" Guid="$(var.cmf_comerr32_dll_guid)" DiskId="1">
+                    <Component Id="cmf_comerr32_dll" Guid="$(var.cmf_comerr32_dll_guid)" DiskId="1">
 	                    <File Id="fil_comerr32_dll" Name="$(var.cmf_comerr32_dll_name)" KeyPath="yes" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_gss_client_exe" Guid="$(var.cmf_gss_client_exe_guid)" DiskId="1">
+                    <Component Id="cmf_gss_client_exe" Guid="$(var.cmf_gss_client_exe_guid)" DiskId="1">
 	                    <File Id="fil_gss_client_exe" Name="gss-client.exe" KeyPath="yes" />
 	                    <RegistryKey Id="reg_ts_gss_client_0" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\gss-client" Action="createAndRemoveOnUninstall" />
 	                    <RegistryValue Id="reg_ts_gss_client_1" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\gss-client" Name="Flags" Type="integer" Value="1032" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_gss_server_exe" Guid="$(var.cmf_gss_server_exe_guid)" DiskId="1">
+                    <Component Id="cmf_gss_server_exe" Guid="$(var.cmf_gss_server_exe_guid)" DiskId="1">
 	                    <File Id="fil_gss_server_exe" Name="gss-server.exe" KeyPath="yes" />
 	                    <RegistryKey Id="reg_ts_gss_server_0" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\gss-server" Action="createAndRemoveOnUninstall" />
 	                    <RegistryValue Id="reg_ts_gss_server_1" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\gss-server" Name="Flags" Type="integer" Value="1032" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_gssapi32_dll" Guid="$(var.cmf_gssapi32_dll_guid)" DiskId="1">
+                    <Component Id="cmf_gssapi32_dll" Guid="$(var.cmf_gssapi32_dll_guid)" DiskId="1">
 	                    <File Id="fil_gssapi32_dll" Name="$(var.cmf_gssapi32_dll_name)" KeyPath="yes" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_kdestroy_exe" Guid="$(var.cmf_kdestroy_exe_guid)" DiskId="1">
+                    <Component Id="cmf_kdestroy_exe" Guid="$(var.cmf_kdestroy_exe_guid)" DiskId="1">
 	                    <File Id="fil_kdestroy_exe" Name="kdestroy.exe" KeyPath="yes" />
 	                    <RegistryKey Id="reg_ts_kdestroy_0" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\kdestroy" Action="createAndRemoveOnUninstall" />
 	                    <RegistryValue Id="reg_ts_kdestroy_1" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\kdestroy" Name="Flags" Type="integer" Value="1032" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_kcpytkt_exe" Guid="$(var.cmf_kcpytkt_exe_guid)" DiskId="1">
+                    <Component Id="cmf_kcpytkt_exe" Guid="$(var.cmf_kcpytkt_exe_guid)" DiskId="1">
 	                    <File Id="fil_kcpytkt_exe" Name="kcpytkt.exe" KeyPath="yes" />
 	                    <RegistryKey Id="reg_ts_kcpytkt_0" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\kcpytkt" Action="createAndRemoveOnUninstall" />
 	                    <RegistryValue Id="reg_ts_kcpytkt_1" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\kcpytkt" Name="Flags" Type="integer" Value="1032" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_kdeltkt_exe" Guid="$(var.cmf_kdeltkt_exe_guid)" DiskId="1">
+                    <Component Id="cmf_kdeltkt_exe" Guid="$(var.cmf_kdeltkt_exe_guid)" DiskId="1">
 	                    <File Id="fil_kdeltkt_exe" Name="kdeltkt.exe" KeyPath="yes" />
 	                    <RegistryKey Id="reg_ts_kdeltkt_0" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\kdeltkt" Action="createAndRemoveOnUninstall" />
 	                    <RegistryValue Id="reg_ts_kdeltkt_1" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\kdeltkt" Name="Flags" Type="integer" Value="1032" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_kinit_exe" Guid="$(var.cmf_kinit_exe_guid)" DiskId="1">
+                    <Component Id="cmf_kinit_exe" Guid="$(var.cmf_kinit_exe_guid)" DiskId="1">
 	                    <File Id="fil_kinit_exe" Name="kinit.exe" KeyPath="yes" />
 	                    <RegistryKey Id="reg_ts_kinit_0" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\kinit" Action="createAndRemoveOnUninstall" />
 	                    <RegistryValue Id="reg_ts_kinit_1" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\kinit" Name="Flags" Type="integer" Value="1032" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_klist_exe" Guid="$(var.cmf_klist_exe_guid)" DiskId="1">
+                    <Component Id="cmf_klist_exe" Guid="$(var.cmf_klist_exe_guid)" DiskId="1">
 	                    <File Id="fil_klist_exe" Name="klist.exe" KeyPath="yes" />
 	                    <RegistryKey Id="reg_ts_klist_0" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\klist" Action="createAndRemoveOnUninstall" />
 	                    <RegistryValue Id="reg_ts_klist_1" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\klist" Name="Flags" Type="integer" Value="1032" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_kpasswd_exe" Guid="$(var.cmf_kpasswd_exe_guid)" DiskId="1">
+                    <Component Id="cmf_kpasswd_exe" Guid="$(var.cmf_kpasswd_exe_guid)" DiskId="1">
 	                    <File Id="fil_kpasswd_exe" Name="kpasswd.exe" KeyPath="yes" />
 	                    <RegistryKey Id="reg_ts_kpasswd_0" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\kpasswd" Action="createAndRemoveOnUninstall" />
 	                    <RegistryValue Id="reg_ts_kpasswd_1" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\kpasswd" Name="Flags" Type="integer" Value="1032" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_kswitch_exe" Guid="$(var.cmf_kswitch_exe_guid)" DiskId="1">
+                    <Component Id="cmf_kswitch_exe" Guid="$(var.cmf_kswitch_exe_guid)" DiskId="1">
                       <File Id="fil_kswitch_exe" Name="kswitch.exe" KeyPath="yes" />
                       <RegistryKey Id="reg_ts_kswitch_0" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\kswitch" Action="createAndRemoveOnUninstall" />
                       <RegistryValue Id="reg_ts_kswitch_1" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\kswitch" Name="Flags" Type="integer" Value="1032" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_kvno_exe" Guid="$(var.cmf_kvno_exe_guid)" DiskId="1">
+                    <Component Id="cmf_kvno_exe" Guid="$(var.cmf_kvno_exe_guid)" DiskId="1">
 	                    <File Id="fil_kvno_exe" Name="kvno.exe" KeyPath="yes" />
 	                    <RegistryKey Id="reg_ts_kvno_0" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\kvno" Action="createAndRemoveOnUninstall" />
 	                    <RegistryValue Id="reg_ts_kvno_1" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\kvno" Name="Flags" Type="integer" Value="1032" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_krb5_32_dll" Guid="$(var.cmf_krb5_32_dll_guid)" DiskId="1">
+                    <Component Id="cmf_krb5_32_dll" Guid="$(var.cmf_krb5_32_dll_guid)" DiskId="1">
 	                    <File Id="fil_krb5_32_dll" Name="$(var.cmf_krb5_32_dll_name)" KeyPath="yes" />
 	                    <Environment Id="env_kclient_path" Action="set" Name="PATH" Part="last" System="yes" Value="[KERBEROSDIR]bin" />
 	                    <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Control\Lsa\Kerberos\Domains\ATHENA.MIT.EDU">
@@ -153,158 +153,158 @@
 	                      </RegistryValue>
 	                    </RegistryKey>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_k5sprt32_dll" Guid="$(var.cmf_k5sprt32_dll_guid)" DiskId="1">
+                    <Component Id="cmf_k5sprt32_dll" Guid="$(var.cmf_k5sprt32_dll_guid)" DiskId="1">
 	                    <File Id="fil_k5sprt32_dll" Name="$(var.cmf_k5sprt32_dll_name)" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_krbcc32_dll" Guid="$(var.cmf_krbcc32_dll_guid)" DiskId="1">
+                    <Component Id="cmf_krbcc32_dll" Guid="$(var.cmf_krbcc32_dll_guid)" DiskId="1">
 	                    <File Id="fil_krbcc32_dll" Name="$(var.cmf_krbcc32_dll_name)" KeyPath="yes" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_ccapiserver_exe" Guid="$(var.cmf_ccapiserver_exe_guid)" DiskId="1">
+                    <Component Id="cmf_ccapiserver_exe" Guid="$(var.cmf_ccapiserver_exe_guid)" DiskId="1">
 	                    <File Id="fil_ccapiserver_exe" Name="$(var.cmf_ccapiserver_exe_name)" KeyPath="yes" />
 	                    <RegistryKey Id="reg_ts_krbcc32s_0" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\ccapiserver" Action="createAndRemoveOnUninstall" />
 	                    <RegistryValue Id="reg_ts_krbcc32s_1" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\ccapiserver" Name="Flags" Type="integer" Value="1032" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_leash_exe" Guid="$(var.cmf_leash_exe_guid)" DiskId="1">
+                    <Component Id="cmf_leash_exe" Guid="$(var.cmf_leash_exe_guid)" DiskId="1">
                       <File Id="fil_leash_exe" Name="MIT Kerberos.exe" KeyPath="yes">
                       </File>
                       <RegistryKey Id="reg_ts_leash32_0" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\leash32" Action="createAndRemoveOnUninstall" />
 	                    <RegistryValue Id="reg_ts_leash32_1" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\leash32" Name="Flags" Type="integer" Value="1032" />
                     </Component>
 
-<!--                    <Component Win64="$(var.Win64)" Id="csc_leash32_exe" Guid="$(var.csc_leash32_exe_guid)" DiskId="1">
+<!--                    <Component Id="csc_leash32_exe" Guid="$(var.csc_leash32_exe_guid)" DiskId="1">
                         <CreateFolder Directory="dirShortcut" />
                         <Condition>USELEASH</Condition>
                     </Component> -->
 
                     <!-- Leash32 configuration -->
-                    <Component Win64="$(var.Win64)" Id="rcm_leash_2" Guid="$(var.rcm_leash_2_guid)" DiskId="1">
+                    <Component Id="rcm_leash_2" Guid="$(var.rcm_leash_2_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leash_2" Root="HKLM" Key="Software\MIT\Leash32\Settings" Name="createmissingconfig" Type="integer" Value="[LEASHCREATEMISSINGCONFIG]" KeyPath="yes"/>
 	                    <Condition>LEASHCREATEMISSINGCONFIG</Condition>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="rcm_leash_3" Guid="$(var.rcm_leash_3_guid)" DiskId="1">
+                    <Component Id="rcm_leash_3" Guid="$(var.rcm_leash_3_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leash_3" Root="HKLM" Key="Software\MIT\Leash32\Settings" Name="AutoRenewTickets" Type="integer" Value="[LEASHAUTORENEWTICKETS]" KeyPath="yes"/>
 	                    <Condition>LEASHAUTORENEWTICKETS</Condition>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="rcm_leash_6" Guid="$(var.rcm_leash_6_guid)" DiskId="1">
+                    <Component Id="rcm_leash_6" Guid="$(var.rcm_leash_6_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leash_6" Root="HKLM" Key="Software\MIT\Leash" Name="MsLsaImport" Type="integer" Value="[LEASHMSLSAIMPORT]" KeyPath="yes"/>
 	                    <Condition>LEASHMSLSAIMPORT</Condition>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="csc_LeashStartup" Guid="$(var.csc_LeashStartup_guid)" DiskId="1">
+                    <Component Id="csc_LeashStartup" Guid="$(var.csc_LeashStartup_guid)" DiskId="1">
                         <RegistryValue Id="reg_sc_leash_marker" Root="HKCU" Key="$(var.KfwRegRoot)\Client\$(var.VersionString)" Name="LeashAutoStart" Type="integer" Value="1" KeyPath="yes" />
                         <Shortcut Id="sc_leash_exe_startup" Advertise="no" Directory="StartupFolder" Name="MIT Kerberos.lnk" Arguments="[LEASHAUTOINIT]" Target="[dirbin]MIT Kerberos.exe" Show="minimized" />
                     </Component>
 
-                    <Component Win64="$(var.Win64)" Id="cmf_leash32_chm" Guid="$(var.cmf_leash32_chm_guid)" DiskId="1">
+                    <Component Id="cmf_leash32_chm" Guid="$(var.cmf_leash32_chm_guid)" DiskId="1">
 	                    <File Id="fil_leash32_chm" Name="MIT Kerberos.chm" KeyPath="yes" />
                     </Component>
                     
-                    <Component Win64="$(var.Win64)" Id="cmf_leashw32_dll" Guid="$(var.cmf_leashw32_dll_guid)" DiskId="1">
+                    <Component Id="cmf_leashw32_dll" Guid="$(var.cmf_leashw32_dll_guid)" DiskId="1">
 	                    <File Id="fil_leashw32_dll" Name="$(var.cmf_leashw32_dll_name)" KeyPath="yes" />
                     </Component>
                     
                     <!-- Leash DLL configuration -->
-                    <Component Win64="$(var.Win64)" Id="rcm_leashdll_1" Guid="$(var.rcm_leashdll_1_guid)" DiskId="1">
+                    <Component Id="rcm_leashdll_1" Guid="$(var.rcm_leashdll_1_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leashdll_1" Root="HKLM" Key="Software\MIT\Leash" Name="lifetime" Type="integer" Value="[LEASHLIFETIME]" KeyPath="yes"/>
 	                    <Condition>LEASHLIFETIME</Condition>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="rcm_leashdll_2" Guid="$(var.rcm_leashdll_2_guid)" DiskId="1">
+                    <Component Id="rcm_leashdll_2" Guid="$(var.rcm_leashdll_2_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leashdll_2" Root="HKLM" Key="Software\MIT\Leash" Name="renew_till" Type="integer" Value="[LEASHRENEWTILL]" KeyPath="yes"/>
 	                    <Condition>LEASHRENEWTILL</Condition>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="rcm_leashdll_3" Guid="$(var.rcm_leashdll_3_guid)" DiskId="1">
+                    <Component Id="rcm_leashdll_3" Guid="$(var.rcm_leashdll_3_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leashdll_3" Root="HKLM" Key="Software\MIT\Leash" Name="renewable" Type="integer" Value="[LEASHRENEWABLE]" KeyPath="yes"/>
 	                    <Condition>LEASHRENEWABLE</Condition>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="rcm_leashdll_4" Guid="$(var.rcm_leashdll_4_guid)" DiskId="1">
+                    <Component Id="rcm_leashdll_4" Guid="$(var.rcm_leashdll_4_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leashdll_4" Root="HKLM" Key="Software\MIT\Leash" Name="forwardable" Type="integer" Value="[LEASHFORWARDABLE]" KeyPath="yes"/>
 	                    <Condition>LEASHFORWARDABLE</Condition>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="rcm_leashdll_5" Guid="$(var.rcm_leashdll_5_guid)" DiskId="1">
+                    <Component Id="rcm_leashdll_5" Guid="$(var.rcm_leashdll_5_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leashdll_5" Root="HKLM" Key="Software\MIT\Leash" Name="noaddresses" Type="integer" Value="[LEASHNOADDRESSES]" KeyPath="yes"/>
 	                    <Condition>LEASHNOADDRESSES</Condition>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="rcm_leashdll_6" Guid="$(var.rcm_leashdll_6_guid)" DiskId="1">
+                    <Component Id="rcm_leashdll_6" Guid="$(var.rcm_leashdll_6_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leashdll_6" Root="HKLM" Key="Software\MIT\Leash" Name="proxiable" Type="integer" Value="[LEASHPROXIABLE]" KeyPath="yes"/>
 	                    <Condition>LEASHPROXIABLE</Condition>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="rcm_leashdll_7" Guid="$(var.rcm_leashdll_7_guid)" DiskId="1">
+                    <Component Id="rcm_leashdll_7" Guid="$(var.rcm_leashdll_7_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leashdll_7" Root="HKLM" Key="Software\MIT\Leash" Name="publicip" Type="integer" Value="[LEASHPUBLICIP]" KeyPath="yes"/>
 	                    <Condition>LEASHPUBLICIP</Condition>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="rcm_leashdll_9" Guid="$(var.rcm_leashdll_9_guid)" DiskId="1">
+                    <Component Id="rcm_leashdll_9" Guid="$(var.rcm_leashdll_9_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leashdll_9" Root="HKLM" Key="Software\MIT\Leash" Name="hide_kinit_options" Type="integer" Value="[LEASHHIDEKINITOPTIONS]" KeyPath="yes"/>
 	                    <Condition>LEASHHIDEKINITOPTIONS</Condition>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="rcm_leashdll_10" Guid="$(var.rcm_leashdll_10_guid)" DiskId="1">
+                    <Component Id="rcm_leashdll_10" Guid="$(var.rcm_leashdll_10_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leashdll_10" Root="HKLM" Key="Software\MIT\Leash" Name="life_min" Type="integer" Value="[LEASHLIFEMIN]" KeyPath="yes"/>
 	                    <Condition>LEASHLIFEMIN</Condition>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="rcm_leashdll_11" Guid="$(var.rcm_leashdll_11_guid)" DiskId="1">
+                    <Component Id="rcm_leashdll_11" Guid="$(var.rcm_leashdll_11_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leashdll_11" Root="HKLM" Key="Software\MIT\Leash" Name="life_max" Type="integer" Value="[LEASHLIFEMAX]" KeyPath="yes"/>
 	                    <Condition>LEASHLIFEMAX</Condition>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="rcm_leashdll_12" Guid="$(var.rcm_leashdll_12_guid)" DiskId="1">
+                    <Component Id="rcm_leashdll_12" Guid="$(var.rcm_leashdll_12_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leashdll_12" Root="HKLM" Key="Software\MIT\Leash" Name="renew_min" Type="integer" Value="[LEASHRENEWMIN]" KeyPath="yes"/>
 	                    <Condition>LEASHRENEWMIN</Condition>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="rcm_leashdll_13" Guid="$(var.rcm_leashdll_13_guid)" DiskId="1">
+                    <Component Id="rcm_leashdll_13" Guid="$(var.rcm_leashdll_13_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leashdll_13" Root="HKLM" Key="Software\MIT\Leash" Name="renew_max" Type="integer" Value="[LEASHRENEWMAX]" KeyPath="yes"/>
 	                    <Condition>LEASHRENEWMAX</Condition>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="rcm_leashdll_15" Guid="$(var.rcm_leashdll_15_guid)" DiskId="1">
+                    <Component Id="rcm_leashdll_15" Guid="$(var.rcm_leashdll_15_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leashdll_15" Root="HKLM" Key="Software\MIT\Leash32\Settings" Name="uppercaserealm" Type="integer" Value="[LEASHUPPERCASEREALM]" KeyPath="yes"/>
 	                    <Condition>LEASHUPPERCASEREALM</Condition>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="rcm_leashdll_16" Guid="$(var.rcm_leashdll_16_guid)" DiskId="1">
+                    <Component Id="rcm_leashdll_16" Guid="$(var.rcm_leashdll_16_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leashdll_16" Root="HKLM" Key="Software\MIT\Leash32\Settings" Name="timehost" Type="string" Value="[LEASHTIMEHOST]" KeyPath="yes"/>
 	                    <Condition>LEASHTIMEHOST</Condition>
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="rcm_leashdll_17" Guid="$(var.rcm_leashdll_17_guid)" DiskId="1">
+                    <Component Id="rcm_leashdll_17" Guid="$(var.rcm_leashdll_17_guid)" DiskId="1">
 	                    <RegistryValue Id="reg_leashdll_17" Root="HKLM" Key="Software\MIT\Leash" Name="preserve_kinit_options" Type="integer" Value="[LEASHPRESERVEKINITOPTIONS]" KeyPath="yes"/>
 	                    <Condition>LEASHPRESERVEKINITOPTIONS</Condition>
                     </Component>
                     
-                    <Component Win64="$(var.Win64)" Id="cmf_ms2mit_exe" Guid="$(var.cmf_ms2mit_exe_guid)" DiskId="1">
+                    <Component Id="cmf_ms2mit_exe" Guid="$(var.cmf_ms2mit_exe_guid)" DiskId="1">
 	                    <File Id="fil_ms2mit_exe" Name="ms2mit.exe" KeyPath="yes" />
 	                    <RegistryKey Id="reg_ts_ms2mit_0" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\ms2mit" Action="createAndRemoveOnUninstall" />
 	                    <RegistryValue Id="reg_ts_ms2mit_1" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\ms2mit" Name="Flags" Type="integer" Value="1032" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_mit2ms_exe" Guid="$(var.cmf_mit2ms_exe_guid)" DiskId="1">
+                    <Component Id="cmf_mit2ms_exe" Guid="$(var.cmf_mit2ms_exe_guid)" DiskId="1">
 	                    <File Id="fil_mit2ms_exe" Name="mit2ms.exe" KeyPath="yes" />
 	                    <RegistryKey Id="reg_ts_mit2ms_0" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\mit2ms" Action="createAndRemoveOnUninstall" />
 	                    <RegistryValue Id="reg_ts_mit2ms_1" Root="HKLM" Key="Software\Microsoft\Windows NT\CurrentVersion\Terminal Server\Compatibility\Applications\mit2ms" Name="Flags" Type="integer" Value="1032" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_xpprof32_dll" Guid="$(var.cmf_xpprof32_dll_guid)" DiskId="1">
+                    <Component Id="cmf_xpprof32_dll" Guid="$(var.cmf_xpprof32_dll_guid)" DiskId="1">
 	                    <File Id="fil_xpprof32_dll" Name="$(var.cmf_xpprof32_dll_name)" KeyPath="yes" />
                     </Component>
-                  <?if $(var.Platform) = "x64"?>
-                    <Component Win64="$(var.Win64)" Id="cmf_krb5_64_dll" Guid="$(var.cmf_krb5_64_dll_guid)" DiskId="1">
+                  <?if $(sys.BUILDARCH) = "x64"?>
+                    <Component Id="cmf_krb5_64_dll" Guid="$(var.cmf_krb5_64_dll_guid)" DiskId="1">
                       <File Id="fil_krb5_64_dll" Name="$(var.cmf_krb5_64_dll_name)" KeyPath="yes" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_k5sprt64_dll" Guid="$(var.cmf_k5sprt64_dll_guid)" DiskId="1">
+                    <Component Id="cmf_k5sprt64_dll" Guid="$(var.cmf_k5sprt64_dll_guid)" DiskId="1">
                       <File Id="fil_k5sprt64_dll" Name="$(var.cmf_k5sprt64_dll_name)" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_krbcc64_dll" Guid="$(var.cmf_krbcc64_dll_guid)" DiskId="1">
+                    <Component Id="cmf_krbcc64_dll" Guid="$(var.cmf_krbcc64_dll_guid)" DiskId="1">
                       <File Id="fil_krbcc64_dll" Name="$(var.cmf_krbcc64_dll_name)" KeyPath="yes" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_gssapi64_dll" Guid="$(var.cmf_gssapi64_dll_guid)" DiskId="1">
+                    <Component Id="cmf_gssapi64_dll" Guid="$(var.cmf_gssapi64_dll_guid)" DiskId="1">
                       <File Id="fil_gssapi64_dll" Name="$(var.cmf_gssapi64_dll_name)" KeyPath="yes" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_comerr64_dll" Guid="$(var.cmf_comerr64_dll_guid)" DiskId="1">
+                    <Component Id="cmf_comerr64_dll" Guid="$(var.cmf_comerr64_dll_guid)" DiskId="1">
                       <File Id="fil_comerr64_dll" Name="$(var.cmf_comerr64_dll_name)" KeyPath="yes" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_leashw64_dll" Guid="$(var.cmf_leashw64_dll_guid)" DiskId="1">
+                    <Component Id="cmf_leashw64_dll" Guid="$(var.cmf_leashw64_dll_guid)" DiskId="1">
                       <File Id="fil_leashw64_dll" Name="$(var.cmf_leashw64_dll_name)" KeyPath="yes" />
                     </Component>
-                    <Component Win64="$(var.Win64)" Id="cmf_xpprof64_dll" Guid="$(var.cmf_xpprof64_dll_guid)" DiskId="1">
+                    <Component Id="cmf_xpprof64_dll" Guid="$(var.cmf_xpprof64_dll_guid)" DiskId="1">
                       <File Id="fil_xpprof64_dll" Name="$(var.cmf_xpprof64_dll_name)" KeyPath="yes" />
                     </Component>
                   <?endif?>
 
                   <!-- Debug symbols -->
                 <?ifdef DebugSyms?>
-                    <Component Win64="$(var.Win64)" Id="cmf_bin_debug" Guid="$(var.cmf_bin_debug_guid)" DiskId="1">
-                        <?if $(var.Platform) = "Intel" ?>
+                    <Component Id="cmf_bin_debug" Guid="$(var.cmf_bin_debug_guid)" DiskId="1">
+                        <?if $(sys.BUILDARCH) = "x86" ?>
 	                    <File Id="fil_comerr32_pdb" Name="comerr32.pdb" />
 	                    <File Id="fil_gssapi32_pdb" Name="gssapi32.pdb" />
 	                    <File Id="fil_krb5_32_pdb" Name="krb5_32.pdb" KeyPath="yes" />
@@ -340,17 +340,17 @@
 
                   <Directory Id="dirplugins" Name="plugins">
                     <Directory Id="dirpreauth" Name="preauth" FileSource="$(var.PreauthDir)">
-                      <Component Win64="$(var.Win64)" Id="cmf_spake32_dll" Guid="$(var.cmf_spake32_dll_guid)" DiskId="1">
+                      <Component Id="cmf_spake32_dll" Guid="$(var.cmf_spake32_dll_guid)" DiskId="1">
                         <File Id="fil_spake32_dll" Name="$(var.cmf_spake32_dll_name)" KeyPath="yes" />
                       </Component>
-                      <?if $(var.Platform) = "x64"?>
-                        <Component Win64="$(var.Win64)" Id="cmf_spake64_dll" Guid="$(var.cmf_spake64_dll_guid)" DiskId="1">
+                      <?if $(sys.BUILDARCH) = "x64"?>
+                        <Component Id="cmf_spake64_dll" Guid="$(var.cmf_spake64_dll_guid)" DiskId="1">
                           <File Id="fil_spake64_dll" Name="$(var.cmf_spake64_dll_name)" KeyPath="yes" />
                         </Component>
                       <?endif?>
                       <?ifdef DebugSyms?>
-                        <Component Win64="$(var.Win64)" Id="cmf_preauth_debug" Guid="$(var.cmf_preauth_debug_guid)" DiskId="1">
-                          <?if $(var.Platform) = "Intel" ?>
+                        <Component Id="cmf_preauth_debug" Guid="$(var.cmf_preauth_debug_guid)" DiskId="1">
+                          <?if $(sys.BUILDARCH) = "x86" ?>
                             <File Id="fil_spake32_pdb" Name="spake32.pdb" />
                           <?else?>
                             <File Id="fil_spake32_pdb" Name="spake64.pdb" />
@@ -363,7 +363,7 @@
                 
                 <Directory Id="dirinc" Name="include" FileSource="$(var.IncDir)">
                         <Directory Id="dirinc_krb5_gssapi" Name="gssapi" FileSource="$(var.IncDir)gssapi\">
-                            <Component Win64="$(var.Win64)" Id="cmp_dirinc_krb5_gssapi" Guid="BD3C190B-1EBB-4d14-81DD-B2000DC4EAC7" DiskId="1">
+                            <Component Id="cmp_dirinc_krb5_gssapi" Guid="BD3C190B-1EBB-4d14-81DD-B2000DC4EAC7" DiskId="1">
                                 <File Id="fil_gssapi_h" Name="gssapi.h" KeyPath="yes" />
                                 <File Id="fil_gssapi_ext_h" Name="gssapi_ext.h" />
                                 <File Id="fil_gssapi_generic_h" Name="gssapi_generic.h" />
@@ -371,11 +371,11 @@
                             </Component>
                         </Directory>
                         <Directory Id="dirinc_krb5_krb5" Name="krb5" FileSource="$(var.IncDir)krb5\">
-                            <Component Win64="$(var.Win64)" Id="cmp_dirinc_krb5_krb5" Guid="D1E4E3D8-EF04-4DD6-B01E-F87876509869" DiskId="1">
+                            <Component Id="cmp_dirinc_krb5_krb5" Guid="D1E4E3D8-EF04-4DD6-B01E-F87876509869" DiskId="1">
                                 <File Id="fil_krb5_h_inc" Name="krb5.h" KeyPath="yes" />
                             </Component>
                         </Directory>
-                        <Component Win64="$(var.Win64)" Id="cmp_dirinc_krb5" Guid="7FD8008B-2F46-4613-8A09-989F643258F1" DiskId="1">
+                        <Component Id="cmp_dirinc_krb5" Guid="7FD8008B-2F46-4613-8A09-989F643258F1" DiskId="1">
                             <File Id="fil_com_err_.h" Name="com_err.h" />
                             <File Id="fil_krb5_.h" Name="krb5.h" KeyPath="yes" />
                             <File Id="fil_profile_.h" Name="profile.h" />
@@ -383,15 +383,15 @@
                         </Component>
                     <Directory Id="dirinc_windows" Name="windows" FileSource="$(var.SrcDir)windows\include\">
 <!-- TODO: CredentialCache.h?
-                        <Component Win64="$(var.Win64)" Id="cmp_dirinc_krbcc" Guid="2CE4B708-7D45-41e4-8A53-BF2D78451A81" DiskId="1">
+                        <Component Id="cmp_dirinc_krbcc" Guid="2CE4B708-7D45-41e4-8A53-BF2D78451A81" DiskId="1">
                             <File Id="fil_cacheapi_h" Name="cacheapi.h" KeyPath="yes" />
                         </Component> -->
-                        <Component Win64="$(var.Win64)" Id="cmp_dirinc_leash" Guid="FCF269AB-D9BC-49bd-B9F3-D6EA9697D8D7" DiskId="1">
+                        <Component Id="cmp_dirinc_leash" Guid="FCF269AB-D9BC-49bd-B9F3-D6EA9697D8D7" DiskId="1">
                             <File Id="fil_leasherr_h" Name="leasherr.h" />
                             <File Id="fil_leashinfo_h" Name="leashinfo.h" />
                             <File Id="fil_leashwin_h" Name="leashwin.h" KeyPath="yes" />
                         </Component>
-                        <Component Win64="$(var.Win64)" Id="cmp_dirinc_loadfuncs" Guid="C8E59D05-4502-498b-A107-1DF65C3A27D3" DiskId="1">
+                        <Component Id="cmp_dirinc_loadfuncs" Guid="C8E59D05-4502-498b-A107-1DF65C3A27D3" DiskId="1">
                             <File Id="fil_loadfuncs_com_err_h" Name="loadfuncs-com_err.h" />
                             <File Id="fil_loadfuncs_krb5_h" Name="loadfuncs-krb5.h" />
                             <File Id="fil_loadfuncs_leash_h" Name="loadfuncs-leash.h" />
@@ -404,9 +404,9 @@
                 </Directory>
                 
                 <Directory Id="dirlib" Name="lib" FileSource="$(var.LibDir)">
-                   <?if $(var.Platform) = "Intel" ?>
+                   <?if $(sys.BUILDARCH) = "x86" ?>
                     <Directory Id="dirlib_i386" Name="i386" FileSource="$(var.LibDir)">
-                        <Component Win64="$(var.Win64)" Id="cmp_dirlib_i386" Guid="CFEE3ED4-92D4-49e1-BB78-8BCBC60C3E57" DiskId="1">
+                        <Component Id="cmp_dirlib_i386" Guid="CFEE3ED4-92D4-49e1-BB78-8BCBC60C3E57" DiskId="1">
                             <File Id="fil_comerr32_lib" Name="comerr32.lib" />
                             <File Id="fil_gssapi32_lib" Name="gssapi32.lib" />
                             <File Id="fil_krb5_32_lib" Name="krb5_32.lib" KeyPath="yes" />
@@ -416,9 +416,9 @@
                         </Component>
                     </Directory>
                     <?endif?>
-                    <?if $(var.Platform) = "x64" ?>
+                    <?if $(sys.BUILDARCH) = "x64" ?>
                     <Directory Id="dirlib_amd64" Name="amd64" FileSource="$(var.LibDir)">
-                        <Component Win64="$(var.Win64)" Id="cmp_dirlib_amd64" Guid="F9A54201-FFD6-4a45-B021-276D9F6C40A2" DiskId="1">
+                        <Component Id="cmp_dirlib_amd64" Guid="F9A54201-FFD6-4a45-B021-276D9F6C40A2" DiskId="1">
                             <File Id="fil_comerr64_lib" Name="comerr64.lib" />
                             <File Id="fil_gssapi64_lib" Name="gssapi64.lib" />
                             <File Id="fil_krb5_64_lib" Name="krb5_64.lib" KeyPath="yes" />
@@ -429,25 +429,13 @@
                     </Directory>
                     <?endif?>
                 </Directory>
-                
-<!--                <Directory Id="dirdoc" Name="doc" FileSource="$(var.DocDir)">
-                <?if $(var.Platform) = "Intel" ?>
-                    <Component Win64="$(var.Win64)" Id="efl_leash_userdoc_pdf" Guid="68FB24DD-5EC2-4db1-AD42-5B9DDEC247C5" DiskId="1">
-                        <File Id="fil_leash_userdoc_pdf" Name="leash_userdoc.pdf" KeyPath="yes">
-			    <Shortcut Id="sc_leash_userdoc_pdf" Advertise="no" Directory="dirShortcut" Name="Leash User Documentation.lnk" />
-                        </File>
-                        <Condition>USELEASH</Condition>
-                    </Component>
-                <?endif?>
-                </Directory> -->
-
             </Directory> <!-- /Kerberos -->
         </Directory> <!-- /MIT -->
     </Directory> <!-- /Program Files -->
     <Directory Id="CommonAppDataFolder" Name="CommonAppDataFolder">
       <Directory Id="APPDATAMITDIR" Name="MIT">
         <Directory Id="APPDATAKERBEROS5DIR" Name="Kerberos5">
-          <Component Win64="$(var.Win64)" Id="cmf_krb5_ini" Guid="C1AF0670-BBF1-4AA6-B2A6-6C8B1584A1F4" NeverOverwrite="yes" Permanent="yes" DiskId="1">
+          <Component Id="cmf_krb5_ini" Guid="C1AF0670-BBF1-4AA6-B2A6-6C8B1584A1F4" NeverOverwrite="yes" Permanent="yes" DiskId="1">
             <File Id="fil_krb5_ini" Name="krb5.ini" Source="$(var.ConfigDir)krb5.ini" KeyPath="yes" />
             <CreateFolder/>
           </Component>
@@ -463,7 +451,7 @@
     <Directory Id="StartupFolder">
     </Directory>
     
-    <Component Win64="$(var.Win64)" Id="rcm_common" Guid="486D84B6-CCE5-4b95-B8E2-7DFBDB4CF9A2">
+    <Component Id="rcm_common" Guid="486D84B6-CCE5-4b95-B8E2-7DFBDB4CF9A2">
         <RegistryKey Id="reg_common0" Root="HKLM" Key="$(var.KfwRegRoot)" Action="createAndRemoveOnUninstall" />
         <RegistryValue Id="reg_common2" Root="HKLM" Key="$(var.KfwRegRoot)" Name="InstallDir" Type="string" Value="[KERBEROSDIR]" KeyPath="yes" />
     <?ifdef Debug?>
@@ -475,7 +463,7 @@
         <RemoveRegistryKey Id="reg_common7" Root="HKLM" Key="$(var.KfwRegRoot)\CurrentVersion" Action="removeOnInstall"/>
         <RemoveRegistryKey Id="reg_common8" Root="HKLM" Key="$(var.KfwRegRoot)\$(var.VersionString)" Action="removeOnInstall"/>
     <?endif?>
-    <?if $(var.Platform) = "x64"?>
+    <?if $(sys.BUILDARCH) = "x64"?>
         <RegistryKey Id="reg_common0_32" Root="HKLM" Key="$(var.KfwRegWow6432Root)" Action="createAndRemoveOnUninstall" />
         <!-- Cannot set KeyPath twice in one Component -->
         <RegistryValue Id="reg_common2_32" Root="HKLM" Key="$(var.KfwRegWow6432Root)" Name="InstallDir" Type="string" Value="[KERBEROSDIR]"/>
@@ -491,7 +479,7 @@
     <?endif?>
     </Component>
     
-    <Component Win64="$(var.Win64)" Id="rcm_client" Guid="901179B2-7369-43b1-ACF3-4C7F37482CC7">
+    <Component Id="rcm_client" Guid="901179B2-7369-43b1-ACF3-4C7F37482CC7">
         <RegistryKey Id="reg_client0" Root="HKLM" Key="$(var.KfwRegRoot)\Client" Action="createAndRemoveOnUninstall"/>
 
         <RegistryKey Id="reg_client1" Root="HKLM" Key="$(var.KfwRegRoot)\Client\CurrentVersion" Action="createAndRemoveOnUninstall"/>
@@ -515,7 +503,7 @@
         <RegistryValue Id="reg_client20" Root="HKLM" Key="$(var.KfwRegRoot)\Client\$(var.VersionString)" Name="PatchLevel" Type="integer" Value="$(var.VersionPatch)" />
     </Component>
 
-    <Component Win64="$(var.Win64)" Id="rcm_sdk" Guid="96AA90C7-8C60-4341-A15B-3DEDF29DA9F1">
+    <Component Id="rcm_sdk" Guid="96AA90C7-8C60-4341-A15B-3DEDF29DA9F1">
         <RegistryKey Id="reg_sdk0" Root="HKLM" Key="$(var.KfwRegRoot)\SDK" Action="createAndRemoveOnUninstall"/>
 
         <RegistryKey Id="reg_sdk1" Root="HKLM" Key="$(var.KfwRegRoot)\SDK\CurrentVersion" Action="createAndRemoveOnUninstall"/>
@@ -539,7 +527,7 @@
         <RegistryValue Id="reg_sdk20" Root="HKLM" Key="$(var.KfwRegRoot)\SDK\$(var.VersionString)" Name="PatchLevel" Type="integer" Value="$(var.VersionPatch)" />
     </Component>
     
-    <Component Win64="$(var.Win64)" Id="rcm_docs" Guid="C7EADA0F-8FF7-4e7b-9372-5553BDD5812F">
+    <Component Id="rcm_docs" Guid="C7EADA0F-8FF7-4e7b-9372-5553BDD5812F">
         <RegistryKey Id="reg_docs0" Root="HKLM" Key="$(var.KfwRegRoot)\Documentation" Action="createAndRemoveOnUninstall"/>
 
         <RegistryKey Id="reg_docs1" Root="HKLM" Key="$(var.KfwRegRoot)\Documentation\CurrentVersion" Action="createAndRemoveOnUninstall"/>
@@ -575,7 +563,7 @@
           <?define MM="$(env.CommonProgramFiles)/Merge Modules"?>
 	<?endif?>
       <?endif?>
-      <?if $(var.Platform) = "x64" ?>
+      <?if $(sys.BUILDARCH) = "x64" ?>
         <?ifndef Debug?>
           <Merge Id="MSVCRT$(var.VCVer)MEM64" DiskId="1" Language="0" SourceFile="$(var.MM)\Microsoft_VC$(var.VCVer)_CRT_x64.msm"/>
           <Merge Id="MSVCRT$(var.VCVer)MFC64" DiskId="1" Language="0" SourceFile="$(var.MM)\Microsoft_VC$(var.VCVer)_MFC_x64.msm"/>

--- a/src/windows/installer/wix/kfw.wxs
+++ b/src/windows/installer/wix/kfw.wxs
@@ -50,7 +50,6 @@
             Languages="$(var.Language)"
             Compressed="yes"
             SummaryCodepage="$(var.CodePage)"
-            Platforms="$(var.Platform)" 
             />
         
         <?include lang\ui_$(var.BuildLang).wxi?>
@@ -65,7 +64,7 @@
         <Condition Message="!(loc.OsVistaSP2)">(Not (VersionNT = 600)) Or (ServicePackLevel &gt;= 2)</Condition>
         <Condition Message="!(loc.CMNotSelected)">USELEASH Or USENETIDMGR</Condition>
         <Condition Message="!(loc.CMDupSelected)">Not (USELEASH And USENETIDMGR)</Condition>
-        <?if $(var.Platform) = "x64" ?>
+        <?if $(sys.BUILDARCH) = "x64" ?>
             <Condition Message="!(loc.StrPlatform64)">
                 <![CDATA[VersionNT64]]>
             </Condition>

--- a/src/windows/installer/wix/lang/config_1033.wxi
+++ b/src/windows/installer/wix/lang/config_1033.wxi
@@ -27,10 +27,10 @@
 <Include xmlns="http://schemas.microsoft.com/wix/2003/01/wi">
     
     <?define VersionString="$(var.VersionMajor).$(var.VersionMinor).$(var.VersionPatch)"?>
-    <?if $(var.Platform) = "x64" ?>
+    <?if $(sys.BUILDARCH) = "x64" ?>
         <?define BaseProductName="!(loc.ProductName64)"?>
         <?define BaseProductNameShort="!(loc.ProductNameShort64)"?>
-    <?elseif $(var.Platform) = "Intel" ?>
+    <?elseif $(sys.BUILDARCH) = "x86" ?>
         <?define BaseProductName="!(loc.ProductName)"?>
         <?define BaseProductNameShort="!(loc.ProductNameShort)"?>
     <?else?>

--- a/src/windows/installer/wix/platform.wxi
+++ b/src/windows/installer/wix/platform.wxi
@@ -18,7 +18,7 @@
   <?define cmf_xpprof32_dll_name="xpprof32.dll"?>
   <?define cmf_spake32_dll_guid="36A1695B-A2B4-4A93-8C35-733A121923D4"?>
   <?define cmf_spake32_dll_name="spake32.dll"?>
-  <?if $(var.Platform) = "x64" ?>
+  <?if $(sys.BUILDARCH) = "x64" ?>
         <?define UpgradeCode="6DA9CD86-6028-4852-8C94-452CAC229244"?>
         <?define PISystemFolder="System64Folder"?>
         <?define PIProgramFilesFolder="ProgramFiles64Folder"?>
@@ -104,7 +104,7 @@
         <?define cmf_krb5cred_en_us_dll_name="krb5cred_en_us.dll"?>
         <?define cmf_bin_debug_guid="F3432C85-89D9-4bd6-BD82-4ED49A118338"?>
         <?define cmf_preauth_debug_guid="53491A4E-CB96-44D9-9B92-4ADF37C3A2D6"?>
-<?elseif $(var.Platform) = "Intel"?>
+<?elseif $(sys.BUILDARCH) = "x86"?>
         <?define UpgradeCode="61211594-AAA1-4A98-A299-757326763CC7"?>
         <?define PISystemFolder="SystemFolder"?>
         <?define PIProgramFilesFolder="ProgramFilesFolder"?>

--- a/src/windows/installer/wix/runtime.wxi
+++ b/src/windows/installer/wix/runtime.wxi
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0"?> 
 <Include>
     <?ifdef CL1600 ?>
-      <?if $(var.Platform) = "x64" ?>
+      <?if $(sys.BUILDARCH) = "x64" ?>
         <MergeRef Id="MSVCRT$(var.VCVer)MEM64"/>
         <MergeRef Id="MSVCRT$(var.VCVer)MFC64"/>
         <MergeRef Id="MSVCRT$(var.VCVer)MFL64"/>

--- a/src/windows/leash/Makefile.in
+++ b/src/windows/leash/Makefile.in
@@ -43,7 +43,7 @@ DEFINES = $(DEFINES) -DDBG
 
 ##### Linker
 LINK	= link
-LIBS	= $(GLIB) $(CLIB) $(WLIB)
+LIBS	= $(GLIB) $(CLIB)
 SYSLIBS	= kernel32.lib Iphlpapi.lib ws2_32.lib user32.lib gdi32.lib comdlg32.lib comctl32.lib version.lib
 LFLAGS	= /nologo $(LOPTS)
 

--- a/src/windows/leashdll/Makefile.in
+++ b/src/windows/leashdll/Makefile.in
@@ -1,12 +1,6 @@
 BUILDTOP=..\..
 
-DLL_NAME=leashw32
-
-# Use 64-bit DLL_NAME and DEF_FILE on 64-bit platforms
-!if ("$(CPU)" == "IA64") || ("$(CPU)" == "AMD64") || ("$(CPU)" == "ALPHA64")
-DLL_NAME=leashw64
-!endif
-
+DLL_NAME=leashw$(BITS)
 DEF_FILE=leashw32.def
 
 OBJS=	$(OUTPRE)krb5routines.$(OBJEXT) \


### PR DESCRIPTION
In the main build, set a variable BITS based on the detected CPU type,
and use it in library name expansions rather than repeatedly checking
for the same three 64-bit architectures.  Also remove an unused
variable WLIB, formerly used to name the winsock library.

In the installer build, detect the CPU type in the makefile and pass
it to candle with the -arch option.  This sets $(sys.BUILDARCH) in wix
scripts and also sets the default value of Win64 in components so we
don't have to set it for each one.

Update the build instructions and appveyor.yml to reflect that the
builder no longer needs to set CPU.
