### PR TITLE
Add flag to disable encrypted timestamp on client

### DIFF
--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -476,6 +476,16 @@ following tags may be specified in the realm's subsection:
     (for example, when converting ``rcmd.hostname`` to
     ``host/hostname.domain``).
 
+**disable_encrypted_timestamp**
+    If this flag is true, the client will not perform encrypted
+    timestamp preauthentication if requested by the KDC.  Setting this
+    flag can help to prevent dictionary attacks by active attackers,
+    if the realm's KDCs support SPAKE preauthentication or if initial
+    authentication always uses another mechanism or always uses FAST.
+    This flag persists across client referrals during initial
+    authentication.  This flag does not prevent the KDC from offering
+    encrypted timestamp.  New in release 1.17.
+
 **http_anchors**
     When KDCs and kpasswd servers are accessed through HTTPS proxies, this tag
     can be used to specify the location of the CA certificate which should be

--- a/doc/admin/spake.rst
+++ b/doc/admin/spake.rst
@@ -30,6 +30,14 @@ principal entries, as you would for any preauthentication mechanism::
 Clients which do not implement SPAKE preauthentication will fall back
 to encrypted timestamp.
 
+An active attacker can force a fallback to encrypted timestamp by
+modifying the initial KDC response, defeating the protection against
+dictionary attacks.  To prevent this fallback on clients which do
+implement SPAKE preauthentication, set the
+**disable_encrypted_timestamp** variable to ``true`` in the
+:ref:`realms` subsection for realms whose KDCs offer SPAKE
+preauthentication.
+
 By default, SPAKE preauthentication requires an extra network round
 trip to the KDC during initial authentication.  If most of the clients
 in a realm support SPAKE, this extra round trip can be eliminated

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -203,6 +203,7 @@ typedef unsigned char   u_char;
 #define KRB5_CONF_DES_CRC_SESSION_SUPPORTED    "des_crc_session_supported"
 #define KRB5_CONF_DICT_FILE                    "dict_file"
 #define KRB5_CONF_DISABLE                      "disable"
+#define KRB5_CONF_DISABLE_ENCRYPTED_TIMESTAMP  "disable_encrypted_timestamp"
 #define KRB5_CONF_DISABLE_LAST_SUCCESS         "disable_last_success"
 #define KRB5_CONF_DISABLE_LOCKOUT              "disable_lockout"
 #define KRB5_CONF_DNS_CANONICALIZE_HOSTNAME    "dns_canonicalize_hostname"

--- a/src/include/k5-trace.h
+++ b/src/include/k5-trace.h
@@ -299,6 +299,8 @@ void krb5int_trace(krb5_context context, const char *fmt, ...);
 #define TRACE_PREAUTH_ENC_TS(c, sec, usec, plain, enc)                  \
     TRACE(c, "Encrypted timestamp (for {long}.{int}): plain {hexdata}, " \
           "encrypted {hexdata}", (long) sec, (int) usec, plain, enc)
+#define TRACE_PREAUTH_ENC_TS_DISABLED(c)                                \
+    TRACE(c, "Ignoring encrypted timestamp because it is disabled")
 #define TRACE_PREAUTH_ETYPE_INFO(c, etype, salt, s2kparams)          \
     TRACE(c, "Selected etype info: etype {etype}, salt \"{data}\", " \
           "params \"{data}\"", etype, salt, s2kparams)

--- a/src/lib/krb5/krb/init_creds_ctx.h
+++ b/src/lib/krb5/krb/init_creds_ctx.h
@@ -61,6 +61,7 @@ struct _krb5_init_creds_context {
     krb5_boolean info_pa_permitted;
     krb5_boolean restarted;
     krb5_boolean fallback_disabled;
+    krb5_boolean encts_disabled;
     struct krb5_responder_context_st rctx;
     krb5_preauthtype selected_preauth_type;
     krb5_preauthtype allowed_preauth_type;

--- a/src/lib/krb5/krb/preauth_encts.c
+++ b/src/lib/krb5/krb/preauth_encts.c
@@ -28,6 +28,7 @@
 #include <k5-int.h>
 #include <krb5/clpreauth_plugin.h>
 #include "int-proto.h"
+#include "init_creds_ctx.h"
 
 static krb5_error_code
 encts_prep_questions(krb5_context context, krb5_clpreauth_moddata moddata,
@@ -38,7 +39,10 @@ encts_prep_questions(krb5_context context, krb5_clpreauth_moddata moddata,
                      krb5_data *encoded_previous_request,
                      krb5_pa_data *pa_data)
 {
-    cb->need_as_key(context, rock);
+    krb5_init_creds_context ctx = (krb5_init_creds_context)rock;
+
+    if (!ctx->encts_disabled)
+        cb->need_as_key(context, rock);
     return 0;
 }
 
@@ -51,6 +55,7 @@ encts_process(krb5_context context, krb5_clpreauth_moddata moddata,
               krb5_prompter_fct prompter, void *prompter_data,
               krb5_pa_data ***out_padata)
 {
+    krb5_init_creds_context ctx = (krb5_init_creds_context)rock;
     krb5_error_code ret;
     krb5_pa_enc_ts pa_enc;
     krb5_data *ts = NULL, *enc_ts = NULL;
@@ -59,6 +64,13 @@ encts_process(krb5_context context, krb5_clpreauth_moddata moddata,
     krb5_keyblock *as_key;
 
     enc_data.ciphertext = empty_data();
+
+    if (ctx->encts_disabled) {
+        TRACE_PREAUTH_ENC_TS_DISABLED(context);
+        k5_setmsg(context, KRB5_PREAUTH_FAILED,
+                  _("Encrypted timestamp is disabled"));
+        return KRB5_PREAUTH_FAILED;
+    }
 
     ret = cb->get_as_key(context, rock, &as_key);
     if (ret)


### PR DESCRIPTION
More at: http://krbdev.mit.edu/rt/Ticket/Display.html?id=8655

I decided to go with the simplest approach: a flag named disable_encrypted_timestamp to disable that one preauth mech on the client (not the KDC, since the necessary criteria for disabling it on the KDC are different).  Disabling SAM-2 on the client doesn't help as the KDC begins with a dictionary-attackable ciphertext in the client long-term key.  After thinking about various scenarios, disabling encrypted challenge doesn't seem necessary, whereas I can imagine a deployment wanting to disable encrypted timestamp because legitimate preauth (in that hypothetical deployment) will always use FAST.