### PR TITLE
Fix minor leaks in principal conversions

### DIFF
--- a/src/lib/krb5/krb/conv_princ.c
+++ b/src/lib/krb5/krb/conv_princ.c
@@ -239,8 +239,10 @@ krb5_524_conv_principal(krb5_context context, krb5_const_principal princ,
             realm[compo->length] = '\0';
         } else {
             tmp_realm_len =  strlen(tmp_realm);
-            if (tmp_realm_len > REALM_SZ - 1)
+            if (tmp_realm_len > REALM_SZ - 1) {
+                profile_release_string(tmp_realm);
                 return KRB5_INVALID_PRINCIPAL;
+            }
             strncpy(realm, tmp_realm, tmp_realm_len);
             realm[tmp_realm_len] = '\0';
             profile_release_string(tmp_realm);
@@ -332,7 +334,7 @@ krb5_425_conv_principal(krb5_context context, const char *name,
                 buf[sizeof(buf) - 1] = '\0';
                 retval = krb5_get_realm_domain(context, realm, &domain);
                 if (retval)
-                    return retval;
+                    goto cleanup;
                 if (domain) {
                     for (cp = domain; *cp; cp++)
                         if (isupper((unsigned char) (*cp)))
@@ -349,6 +351,7 @@ krb5_425_conv_principal(krb5_context context, const char *name,
 not_service:
     retval = krb5_build_principal(context, princ, strlen(realm), realm, name,
                                   instance, NULL);
+cleanup:
     if (iterator) profile_iterator_free (&iterator);
     if (full_name) profile_free_list(full_name);
     if (v4realms) profile_free_list(v4realms);


### PR DESCRIPTION
In krb5_524_conv_principal(), if the realm we read from the profile is
too long for the result buffer, free the profile value before
returning.

In krb5_425_conv_principal(), if krb5_get_realm_domain() fails, still
free any leftover allocated data using a cleanup label.  The only one
that could be left over is dummy_value which we could address easily
enough within the loop, but we shouldn't sidestep the cleanup code.
