### PR TITLE
Fix minor leak in k5_os_hostaddr()

### DIFF
--- a/src/lib/krb5/os/hostaddr.c
+++ b/src/lib/krb5/os/hostaddr.c
@@ -34,9 +34,9 @@ k5_os_hostaddr(krb5_context context, const char *name,
                krb5_address ***ret_addrs)
 {
     krb5_error_code     retval;
-    krb5_address        **addrs;
+    krb5_address        **addrs = NULL;
     int                 i, j, r;
-    struct addrinfo hints, *ai, *aip;
+    struct addrinfo hints, *ai = NULL, *aip;
 
     if (!name)
         return KRB5_ERR_BAD_HOSTNAME;
@@ -68,9 +68,9 @@ k5_os_hostaddr(krb5_context context, const char *name,
         }
     }
 
-    addrs = malloc ((i+1) * sizeof(*addrs));
-    if (!addrs)
-        return ENOMEM;
+    addrs = k5calloc(i + 1, sizeof(*addrs), &retval);
+    if (addrs == NULL)
+        goto errout;
 
     for (j = 0; j < i + 1; j++)
         addrs[j] = 0;


### PR DESCRIPTION
In k5_os_hostaddr(), if allocation of the result array fails, use the
cleanup handler so that the getaddrinfo() result is freed.  Also
initialize the pointers which are freed in the cleanup handler for
safety.  Reported by Bean Zhang.
