### PR TITLE
Fix minor leak in localauth RULE handling

### DIFF
--- a/src/lib/krb5/os/localauth_rule.c
+++ b/src/lib/krb5/os/localauth_rule.c
@@ -146,7 +146,7 @@ aname_replacer(const char *string, const char **contextp, char **result)
 {
     krb5_error_code ret = 0;
     const char *cp, *ep, *tp;
-    char *current, *newstr, *rule = NULL, *repl = NULL;
+    char *newstr, *rule = NULL, *repl = NULL, *current = NULL;
     krb5_boolean doglobal;
 
     *result = NULL;
@@ -192,8 +192,10 @@ aname_replacer(const char *string, const char **contextp, char **result)
         current = newstr;
     }
     *result = current;
+    current = NULL;
 
 cleanup:
+    free(current);
     free(repl);
     free(rule);
     return ret;


### PR DESCRIPTION
In aname_replacer(), initialize current, null it when transferring
ownership to the caller, and free it on failure.  Otherwise it leaks
on failure.  Reported by Bean Zhang.
