### PR TITLE
Fix minor leak in kdb5_util purge_mkeys

### DIFF
--- a/src/kadmin/dbutil/kdb5_mkey.c
+++ b/src/kadmin/dbutil/kdb5_mkey.c
@@ -1297,7 +1297,7 @@ kdb5_purge_mkeys(int argc, char *argv[])
         com_err(progname, retval,
                 _("while updating mkey_aux data for master principal entry"));
         exit_status++;
-        return;
+        goto cleanup_return;
     }
 
     if ((retval = krb5_timeofday(util_context, &now))) {


### PR DESCRIPTION
In kdb5_purge_mkeys(), if krb5_dbe_update_mkey_aux() fails, use the
cleanup label to free any allocated memory instead of returning
immediately.  Reported by Bean Zhang.
