### PR TITLE
Fix minor leak in gssrpc UDP cache code

### DIFF
--- a/src/lib/rpc/svc_udp.c
+++ b/src/lib/rpc/svc_udp.c
@@ -479,6 +479,7 @@ cache_set(
 		newbuf = mem_alloc(su->su_iosz);
 		if (newbuf == NULL) {
 			CACHE_PERROR("cache_set: could not allocate new rpc_buffer");
+			free(victim);
 			return;
 		}
 	}


### PR DESCRIPTION
[I checked libtirpc and this bug was already fixed before their initial import into their git repository.  Solaris also has it fixed.]

In svc_udp.c:cache_set(), if victim is allocated successfully but
allocation for newbuf fails, free victim before returning.  Reported
by Bean Zhang.
