### PR TITLE
Define missing posix socket error: EAFNOSUPPORT

### DIFF
--- a/src/include/port-sockets.h
+++ b/src/include/port-sockets.h
@@ -72,6 +72,9 @@ typedef WSABUF sg_buf;
 #ifndef ETIMEDOUT
 #define ETIMEDOUT WSAETIMEDOUT
 #endif
+#ifndef EAFNOSUPPORT
+#define EAFNOSUPPORT WSAEAFNOSUPPORT
+#endif
 
 /* Translate posix_error to its Winsock counterpart and set the last Winsock
  * error to the result. */


### PR DESCRIPTION
Windows build (vs2008) (some old SDK?) fails with:
```
if not . == . echo .  1>>new-exports 
	..\..\config\rm.bat libkrb5support.exports
	ren new-exports libkrb5support.exports
	cl    -I.\..\..\include -I.\..\..\include\krb5 -I..\..\windows\include -DWSHELPER=1 -DKRB5_DNS_LOOKUP=1 -DWIN32_LEAN_AND_MEAN -DKRB5_DEPRECATED=1 -DKRB5_PRIVATE -D_CRT_SECURE_NO_DEPRECATE -DUSE_LEASH=1  /Os /MD -nologo /EHsc /W3 -Fdobj\AMD64\rel\\ -FD  -Foobj\AMD64\rel\\ -c ...
threads.c
.\..\..\include\port-sockets.h(98) : error C2065: 'EAFNOSUPPORT' : undeclared identifier
.\..\..\include\port-sockets.h(98) : error C2051: case expression not constant
.\..\..\include\port-sockets.h(134) : error C2065: 'EAFNOSUPPORT' : undeclared identifier
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\BIN\amd64\cl.EXE"' : return code '0x2'
Stop.
NMAKE : fatal error U1077: 'for' : return code '0x1'
Stop.
NMAKE : fatal error U1077: 'for' : return code '0x1'
Stop.
```