### PR TITLE
Explicitly look for python2 in configure.in

### DIFF
--- a/src/appl/gss-sample/t_gss_sample.py
+++ b/src/appl/gss-sample/t_gss_sample.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 # Copyright (C) 2010 by the Massachusetts Institute of Technology.
 # All rights reserved.
 #

--- a/src/appl/user_user/t_user2user.py
+++ b/src/appl/user_user/t_user2user.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # If uuserver is not compiled under -DDEBUG, then set to 0

--- a/src/configure.in
+++ b/src/configure.in
@@ -1100,13 +1100,16 @@ fi
 AC_SUBST(HAVE_RUNTEST)
 
 # For Python tests.
-AC_CHECK_PROG(PYTHON,python,python)
+AC_CHECK_PROG(PYTHON,python2,python2)
+if text x"$PYTHON" = x; then
+	AC_CHECK_PROG(PYTHON,python,python)
+fi
 HAVE_PYTHON=no
 if test x"$PYTHON" != x; then
 	# k5test.py requires python 2.4 (for the subprocess module).
 	# Some code needs python 2.5 (for syntax like conditional expressions).
-	vercheck="import sys;sys.exit((sys.hexversion < 0x2050000) and 1 or 0)"
-	if python -c "$vercheck"; then
+	wantver="(sys.hexversion >= 0x2050000 and sys.hexversion < 0x3000000)"
+	if "$PYTHON" -c "import sys; sys.exit(not $wantver and 1 or 0)"; then
 		HAVE_PYTHON=yes
 	fi
 fi

--- a/src/kadmin/dbutil/t_tdumputil.py
+++ b/src/kadmin/dbutil/t_tdumputil.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 from k5test import *
 from subprocess import *
 

--- a/src/kdc/t_bigreply.py
+++ b/src/kdc/t_bigreply.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # Set the maximum UDP reply size very low, so that all replies go

--- a/src/kdc/t_emptytgt.py
+++ b/src/kdc/t_emptytgt.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 realm = K5Realm(create_host=False)

--- a/src/kdc/t_workers.py
+++ b/src/kdc/t_workers.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 realm = K5Realm(start_kdc=False, create_host=False)

--- a/src/lib/kdb/t_stringattr.py
+++ b/src/lib/kdb/t_stringattr.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 realm = K5Realm(create_kdb=False)

--- a/src/lib/krad/t_daemon.py
+++ b/src/lib/krad/t_daemon.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-#
 # Copyright 2013 Red Hat, Inc.  All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/src/lib/krb5/ccache/t_cccol.py
+++ b/src/lib/krb5/ccache/t_cccol.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 realm = K5Realm(create_kdb=False)

--- a/src/lib/krb5/krb/t_expire_warn.py
+++ b/src/lib/krb5/krb/t_expire_warn.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 # Copyright (C) 2010 by the Massachusetts Institute of Technology.
 # All rights reserved.
 #

--- a/src/lib/krb5/krb/t_in_ccache_patypes.py
+++ b/src/lib/krb5/krb/t_in_ccache_patypes.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 # Copyright (C) 2010,2012 by the Massachusetts Institute of Technology.
 # All rights reserved.
 #

--- a/src/lib/krb5/krb/t_vfy_increds.py
+++ b/src/lib/krb5/krb/t_vfy_increds.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 # Copyright (C) 2011 by the Massachusetts Institute of Technology.
 # All rights reserved.
 #

--- a/src/lib/krb5/os/t_discover_uri.py
+++ b/src/lib/krb5/os/t_discover_uri.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 entries = ('URI _kerberos.TEST krb5srv::kkdcp:https://kdc1 1 1\n',

--- a/src/tests/gssapi/t_authind.py
+++ b/src/tests/gssapi/t_authind.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # Test authentication indicators.  Load the test preauth module so we

--- a/src/tests/gssapi/t_ccselect.py
+++ b/src/tests/gssapi/t_ccselect.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 # Copyright (C) 2011 by the Massachusetts Institute of Technology.
 # All rights reserved.
 

--- a/src/tests/gssapi/t_client_keytab.py
+++ b/src/tests/gssapi/t_client_keytab.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # Set up a basic realm and a client keytab containing two user principals.

--- a/src/tests/gssapi/t_enctypes.py
+++ b/src/tests/gssapi/t_enctypes.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # Define some convenience abbreviations for enctypes we will see in

--- a/src/tests/gssapi/t_export_cred.py
+++ b/src/tests/gssapi/t_export_cred.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # Test gss_export_cred and gss_import_cred for initiator creds,

--- a/src/tests/gssapi/t_gssapi.py
+++ b/src/tests/gssapi/t_gssapi.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # Test krb5 negotiation under SPNEGO for all enctype configurations.  Also

--- a/src/tests/gssapi/t_s4u.py
+++ b/src/tests/gssapi/t_s4u.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 realm = K5Realm(create_host=False, get_creds=False)

--- a/src/tests/jsonwalker.py
+++ b/src/tests/jsonwalker.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 import sys
 try:
     import cjson

--- a/src/tests/t_audit.py
+++ b/src/tests/t_audit.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 conf = {'plugins': {'audit': {

--- a/src/tests/t_authdata.py
+++ b/src/tests/t_authdata.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # Load the sample KDC authdata module.

--- a/src/tests/t_bogus_kdc_req.py
+++ b/src/tests/t_bogus_kdc_req.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 import base64
 import socket
 from k5test import *

--- a/src/tests/t_ccache.py
+++ b/src/tests/t_ccache.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 # Copyright (C) 2011 by the Massachusetts Institute of Technology.
 # All rights reserved.
 

--- a/src/tests/t_certauth.py
+++ b/src/tests/t_certauth.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # Skip this test if pkinit wasn't built.

--- a/src/tests/t_changepw.py
+++ b/src/tests/t_changepw.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # This file is intended to cover any password-changing mechanism.  For

--- a/src/tests/t_crossrealm.py
+++ b/src/tests/t_crossrealm.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 # Copyright (C) 2011 by the Massachusetts Institute of Technology.
 # All rights reserved.
 #

--- a/src/tests/t_cve-2012-1014.py
+++ b/src/tests/t_cve-2012-1014.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 import base64
 import socket
 from k5test import *

--- a/src/tests/t_cve-2012-1015.py
+++ b/src/tests/t_cve-2012-1015.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 import base64
 import socket
 from k5test import *

--- a/src/tests/t_cve-2013-1416.py
+++ b/src/tests/t_cve-2013-1416.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 from k5test import *
 
 realm = K5Realm()

--- a/src/tests/t_cve-2013-1417.py
+++ b/src/tests/t_cve-2013-1417.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 from k5test import *
 
 realm = K5Realm(realm='TEST')

--- a/src/tests/t_dump.py
+++ b/src/tests/t_dump.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 from filecmp import cmp
 

--- a/src/tests/t_errmsg.py
+++ b/src/tests/t_errmsg.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 realm = K5Realm(create_kdb=False)

--- a/src/tests/t_etype_info.py
+++ b/src/tests/t_etype_info.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 supported_enctypes = 'aes128-cts des3-cbc-sha1 rc4-hmac des-cbc-crc:afs3'

--- a/src/tests/t_general.py
+++ b/src/tests/t_general.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 for realm in multipass_realms(create_host=False):

--- a/src/tests/t_hooks.py
+++ b/src/tests/t_hooks.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # Test that KDC send and recv hooks work correctly.

--- a/src/tests/t_hostrealm.py
+++ b/src/tests/t_hostrealm.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 plugin = os.path.join(buildtop, "plugins", "hostrealm", "test",

--- a/src/tests/t_iprop.py
+++ b/src/tests/t_iprop.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 import os
 import re
 

--- a/src/tests/t_kadm5_auth.py
+++ b/src/tests/t_kadm5_auth.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # Create a realm with the welcomer and bouncer kadm5_auth test modules

--- a/src/tests/t_kadm5_hook.py
+++ b/src/tests/t_kadm5_hook.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 plugin = os.path.join(buildtop, "plugins", "kadm5_hook", "test",

--- a/src/tests/t_kadmin_acl.py
+++ b/src/tests/t_kadmin_acl.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 import os
 

--- a/src/tests/t_kadmin_parsing.py
+++ b/src/tests/t_kadmin_parsing.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # This file contains tests for kadmin command parsing.  Principal

--- a/src/tests/t_kdb.py
+++ b/src/tests/t_kdb.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 import time
 from itertools import imap

--- a/src/tests/t_kdb_locking.py
+++ b/src/tests/t_kdb_locking.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 # This is a regression test for
 # https://bugzilla.redhat.com/show_bug.cgi?id=586032 .
 #

--- a/src/tests/t_kdc_log.py
+++ b/src/tests/t_kdc_log.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 from k5test import *
 
 # Make a TGS request with an expired ticket.

--- a/src/tests/t_kdcpolicy.py
+++ b/src/tests/t_kdcpolicy.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 from datetime import datetime
 import re

--- a/src/tests/t_keydata.py
+++ b/src/tests/t_keydata.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 realm = K5Realm(create_user=False, create_host=False)

--- a/src/tests/t_keyrollover.py
+++ b/src/tests/t_keyrollover.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 rollover_krb5_conf = {'libdefaults': {'allow_weak_crypto': 'true'}}

--- a/src/tests/t_keytab.py
+++ b/src/tests/t_keytab.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 for realm in multipass_realms(create_user=False):

--- a/src/tests/t_kprop.py
+++ b/src/tests/t_kprop.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 conf_slave = {'dbmodules': {'db': {'database_name': '$testdir/db.slave'}}}

--- a/src/tests/t_localauth.py
+++ b/src/tests/t_localauth.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # Unfortunately, we can't reliably test the k5login module.  We can control

--- a/src/tests/t_mkey.py
+++ b/src/tests/t_mkey.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 import random
 import re

--- a/src/tests/t_otp.py
+++ b/src/tests/t_otp.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-#
 # Author: Nathaniel McCallum <npmccallum@redhat.com>
 #
 # Copyright (c) 2013 Red Hat, Inc.

--- a/src/tests/t_pkinit.py
+++ b/src/tests/t_pkinit.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # Skip this test if pkinit wasn't built.

--- a/src/tests/t_policy.py
+++ b/src/tests/t_policy.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 import re
 

--- a/src/tests/t_preauth.py
+++ b/src/tests/t_preauth.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # Test that the kdcpreauth client_keyblock() callback matches the key

--- a/src/tests/t_princflags.py
+++ b/src/tests/t_princflags.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 from princflags import *
 import re

--- a/src/tests/t_proxy.py
+++ b/src/tests/t_proxy.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # Skip this test if we're missing proxy functionality or parts of the proxy.
@@ -62,7 +61,8 @@ def start_proxy(realm, keycertpem):
     conf.write('kpasswd = kpasswd://localhost:%d\n' % (realm.portbase + 2))
     conf.close()
     realm.env['KDCPROXY_CONFIG'] = proxy_conf_path
-    cmd = [proxy_exec_path, str(realm.server_port()), keycertpem]
+    cmd = [sys.executable, proxy_exec_path, str(realm.server_port()),
+           keycertpem]
     return realm.start_server(cmd, sentinel='proxy server ready')
 
 # Fail: untrusted issuer and hostname doesn't match.

--- a/src/tests/t_pwqual.py
+++ b/src/tests/t_pwqual.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 plugin = os.path.join(buildtop, "plugins", "pwqual", "test", "pwqual_test.so")

--- a/src/tests/t_rdreq.py
+++ b/src/tests/t_rdreq.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 conf = {'realms': {'$realm': {'supported_enctypes': 'aes256-cts aes128-cts'}}}

--- a/src/tests/t_referral.py
+++ b/src/tests/t_referral.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # Create a pair of realms, where KRBTEST1.COM can authenticate to

--- a/src/tests/t_renew.py
+++ b/src/tests/t_renew.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 from datetime import datetime
 import re

--- a/src/tests/t_renprinc.py
+++ b/src/tests/t_renprinc.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 # Copyright (C) 2011 by the Massachusetts Institute of Technology.
 # All rights reserved.
 

--- a/src/tests/t_salt.py
+++ b/src/tests/t_salt.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 import re
 

--- a/src/tests/t_sesskeynego.py
+++ b/src/tests/t_sesskeynego.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 import re
 

--- a/src/tests/t_skew.py
+++ b/src/tests/t_skew.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # Create a realm with the KDC one hour in the past.

--- a/src/tests/t_sn2princ.py
+++ b/src/tests/t_sn2princ.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 offline = (len(args) > 0 and args[0] != "no")

--- a/src/tests/t_spake.py
+++ b/src/tests/t_spake.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # The name and number of each supported SPAKE group.

--- a/src/tests/t_stringattr.py
+++ b/src/tests/t_stringattr.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 # Copyright (C) 2011 by the Massachusetts Institute of Technology.
 # All rights reserved.
 

--- a/src/tests/t_tabdump.py
+++ b/src/tests/t_tabdump.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 import csv

--- a/src/tests/t_unlockiter.py
+++ b/src/tests/t_unlockiter.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # Default KDB iteration is locked.  Expect write lock failure unless

--- a/src/tests/t_y2038.py
+++ b/src/tests/t_y2038.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 from k5test import *
 
 # These tests will become much less important after the y2038 boundary

--- a/src/util/paste-kdcproxy.py
+++ b/src/util/paste-kdcproxy.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import kdcproxy
 from paste import httpserver
 import os


### PR DESCRIPTION
The executable "python" has traditionally been Python 2, but is
becoming more ambiguous as operating systems transition towards Python
3.  Look for "python2" in the path in preference to "python", and
check that what we found isn't Python 3.

Remove the "#!/usr/bin/python" headers at the start of Python test
scripts since we run them explicitly under python, not as executables.
Execute paste-kdcproxy.py via sys.executable in t_proxy.py so that it
doesn't need a #!/usr/bin/python header.  .
