### PR TITLE
Disable canonicalization in ccselect tests

### DIFF
--- a/src/tests/gssapi/t_ccselect.py
+++ b/src/tests/gssapi/t_ccselect.py
@@ -24,10 +24,13 @@
 
 from k5test import *
 
-# Create two independent realms (no cross-realm TGTs).
-r1 = K5Realm(create_user=False)
-r2 = K5Realm(create_user=False, realm='KRBTEST2.COM', portbase=62000,
-             testdir=os.path.join(r1.testdir, 'r2'))
+# Create two independent realms (no cross-realm TGTs).  For the
+# fallback realm tests we need to control the precise server hostname,
+# so turn off DNS canonicalization.
+conf = {'libdefaults': {'dns_canonicalize_hostname': 'false'}}
+r1 = K5Realm(create_user=False, krb5_conf=conf)
+r2 = K5Realm(create_user=False, krb5_conf=conf, realm='KRBTEST2.COM',
+             portbase=62000, testdir=os.path.join(r1.testdir, 'r2'))
 
 host1 = 'p:' + r1.host_princ
 host2 = 'p:' + r2.host_princ


### PR DESCRIPTION
[Noticed while migrating my dev environment to an Ubuntu 18.04 VM where "localhost" canonicalizes to "localhost6.localdomain6".]

DNS canonicalization can interfere with the fallback tests by changing
"localhost" to have multiple components, or (less likely) changing the
parent domain of foo.krbtest.com or foo.krbtest2.com.