### PR TITLE
Fix some omissions in make clean

### DIFF
--- a/src/lib/krb5/krb/Makefile.in
+++ b/src/lib/krb5/krb/Makefile.in
@@ -529,7 +529,7 @@ clean:
 	$(OUTPRE)t_response_items$(EXEEXT) \
 	$(OUTPRE)t_response_items.$(OBJEXT) \
 	$(OUTPRE)t_sname_match$(EXEEXT) $(OUTPRE)t_sname_match.$(OBJEXT) \
-	$(OUTPRE)t_valid_times$(EXEEXT) $(OUTPRE)t_valid_times.$(OBJECT) \
+	$(OUTPRE)t_valid_times$(EXEEXT) $(OUTPRE)t_valid_times.$(OBJEXT) \
 	$(OUTPRE)t_parse_host_string$(EXEEXT) \
 	$(OUTPRE)t_parse_host_string.$(OBJEXT)
 

--- a/src/plugins/preauth/spake/Makefile.in
+++ b/src/plugins/preauth/spake/Makefile.in
@@ -43,6 +43,9 @@ all-unix: all-liblinks
 install-unix: install-libs
 clean-unix:: clean-liblinks clean-libs clean-libobjs
 
+clean:
+	$(RM) t_vectors t_vectors.o $(STLIBOBJS)
+
 check-unix: t_vectors
 	$(RUN_TEST_LOCAL_CONF) ./t_vectors
 


### PR DESCRIPTION
I also looked into modifying travis.yml to detect future omissions in make clean.  I got as far as:

    git ls-files -o -x Makefile -x "*.pc" -x config.log -x config.status -x autoconf.h -x krb5-config

which we would then have to check for non-empty output.  The various -x options could be replaced with -X filename if we wanted to add a file containing the patterns.  Integrating that into the .travis.yml script (which is a long sequence of "a && b && ..." because travis doesn't abort on error) seems a bit messy.
