### PR TITLE
Check distclean target in Travis build

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,0 +1,11 @@
+cd src
+autoreconf
+./configure --enable-maintainer-mode --with-ldap
+make $MAKEVARS
+make check
+make distclean
+# Check for files unexpectedly not removed by make distclean.
+rm -rf autom4te.cache configure include/autoconf.h.in
+if [ -n "$(git ls-files -o)" ]; then
+  exit 1
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ before_install:
   - sudo make install
   - cd ../..
 
-script: cd src && autoreconf && ./configure --enable-maintainer-mode --with-ldap && make $MAKEVARS && make check
+script: sh -ex .travis-ci.sh


### PR DESCRIPTION
[The name ``.travis-ci.sh`` is cribbed from the ocaml repository, found by googling for "travis.yml sh ex".]

Move the build commands to a shell script, run with the -e flag so any
failure causes the script to exit.  In the script, verify that "make
distclean" removes everything produced by "make" and "make check".