### PR TITLE
Fix freeing string with secret without zapping memory

### DIFF
--- a/src/lib/crypto/krb/s2k_rc4.c
+++ b/src/lib/crypto/krb/s2k_rc4.c
@@ -25,7 +25,7 @@ krb5int_arcfour_string_to_key(const struct krb5_keytypes *ktp,
     if (utf8 == NULL)
         return err;
     err = k5_utf8_to_utf16le(utf8, &copystr, &copystrlen);
-    free(utf8);
+    zapfree(utf8, string->length);
     if (err)
         return err;
 


### PR DESCRIPTION
If you call krb5_c_string_to_key with an encryption type of ENCTYPE_ARCFOUR_HMAC, you will filter down to this function with a password in the "string" input. This password is copied into utf8 and freed without being zeroed. You then end up with a plaintext password floating through unallocated memory.