### PR TITLE
Make krb5kdc -p affect TCP ports

### DIFF
--- a/doc/admin/admin_commands/krb5kdc.rst
+++ b/doc/admin/admin_commands/krb5kdc.rst
@@ -57,12 +57,12 @@ The **-P** *pid_file* option tells the KDC to write its PID into
 the KDC is still running and to allow init scripts to stop the correct
 process.
 
-The **-p** *portnum* option specifies the default UDP port numbers
-which the KDC should listen on for Kerberos version 5 requests, as a
-comma-separated list.  This value overrides the UDP port numbers
-specified in the :ref:`kdcdefaults` section of :ref:`kdc.conf(5)`, but
-may be overridden by realm-specific values.  If no value is given from
-any source, the default port is 88.
+The **-p** *portnum* option specifies the default UDP and TCP port
+numbers which the KDC should listen on for Kerberos version 5
+requests, as a comma-separated list.  This value overrides the port
+numbers specified in the :ref:`kdcdefaults` section of
+:ref:`kdc.conf(5)`, but may be overridden by realm-specific values.
+If no value is given from any source, the default port is 88.
 
 The **-w** *numworkers* option tells the KDC to fork *numworkers*
 processes to listen to the KDC ports and process requests in parallel.

--- a/src/kdc/main.c
+++ b/src/kdc/main.c
@@ -782,19 +782,15 @@ initialize_realms(krb5_context kcontext, int argc, char **argv,
             pid_file = optarg;
             break;
         case 'p':
-            if (def_udp_listen)
-                free(def_udp_listen);
+            free(def_udp_listen);
+            free(def_tcp_listen);
             def_udp_listen = strdup(optarg);
-            if (!def_udp_listen) {
+            def_tcp_listen = strdup(optarg);
+            if (def_udp_listen == NULL || def_tcp_listen == NULL) {
                 fprintf(stderr, _(" KDC cannot initialize. Not enough "
                                   "memory\n"));
                 exit(1);
             }
-#if 0 /* not yet */
-            if (default_tcp_ports)
-                free(default_tcp_ports);
-            default_tcp_ports = strdup(optarg);
-#endif
             break;
         case 'T':
             time_offset = atoi(optarg);


### PR DESCRIPTION
Now that the KDC listens for TCP connections by default (ticket 6731),
the "-p" flag should affect both UDP and TCP default listening ports.
