### PR TITLE
- getpwnam_r() tests must use compile time options detected by ax_pth…

### DIFF
--- a/src/configure.in
+++ b/src/configure.in
@@ -576,6 +576,10 @@ fi
 ])
 
 
+# PTHREAD_CFLAGS changes which variant of these functions is declared
+# on Solaris 11, so use it for these tests.
+old_CFLAGS=$CFLAGS
+CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
 AC_CHECK_FUNC(getpwnam_r,ac_cv_func_getpwnam_r=yes,ac_cv_func_getpwnam_r=no)
 AC_CHECK_FUNC(getpwuid_r,ac_cv_func_getpwuid_r=yes,ac_cv_func_getpwuid_r=no)
 if test "$ac_cv_func_getpwnam_r" = yes; then
@@ -625,6 +629,7 @@ if test "$ac_cv_func_getpwnam_r" = yes; then
     fi
   fi
 fi
+CFLAGS=$old_CFLAGS
 
 if test "$ac_cv_func_getpwnam_r" = no && test "$ac_cv_func_getpwuid_r" = yes; then
   # Actually, we could do this check, and the corresponding checks


### PR DESCRIPTION
…read

I hit this corner case when building kerberos 1.16.1 on Solaris 11.3.
There are two types of getpwnam_r() functions available on S11.3

non-standard one, which looks as follow:
       struct passwd *getpwnam_r(const char *name, struct passwd *pwd,
            char *buffer, int buflen);
    Kerberos build detects it as 'GETPWNAM_R_4_ARGS' kind. Which is the exact
    case of 'som Solaris releases':
        getpwnam_r exists but takes only 4 arguments (e.g., POSIX draft 6
        implementations like some Solaris releases).])

standard one, which confirms to POSIX.1c:
       int getpwnam_r(const char *name, struct passwd *pwd, char *buffer,
            size_t bufsize, struct passwd **result);

The situation on S11.3 is unfortunate in sense that non-standard one
is a default option. In order to select POSIX.1c confirmant, one has
to be explicit and hint compiler as follows.
       cc [ flag...] file... -D_POSIX_PTHREAD_SEMANTICS [ library... ]

Solaris is unfortune because kerberos autoconf uses ax_pthread.m4 to detect
a Posix thread implementation. In case of Solaris the ax_pthread.m4
suggests _POSIX_PTHREAD_SEMANTICS compile time option to build kerberos
sources. However the information on using _POSIX_PTHREAD_SEMANTICS
is not conveyed to test, which determines getpwnam_r() variant.

So in case of Solaris 11.3 autoconf detects it should use
_POSIX_PTHREAD_SEMANTICS. Then it examines a variant of getpwnam_r().  autoconf
does not pass _POSIX_PTHREAD_SEMANTICS flag to compiler, when it compiles tests
for getpwnam_r() detection, thus it finds out GETPWNAM_R_4_ARGS kind of
getpwnam_r() is available and generates makefiles accordingly.

when building kerberos later (doing make) the k5-platform.h includes
pwd.h and gets compiled with _POSIX_PTHREAD_SEMANTICS flag, which is
inconsistent to autoconf test done earlier. The compilation fails
with error as follows:

/ws/on11update-tools/SUNWspro/sunstudio12.1/bin/cc -KPIC -DSHARED -DHAVE_CONFIG_H -DHAS_STDARG -DLIBDIR=\"/usr/lib\" -I../../include -I/scratch/anedvedi/userland.krb5/components/krb5/krb5-1.16.1/src/include -I.  -DKRB5_DEPRECATED=1 -DKRB5_PRIVATE -I/usr/include/openldap -m32 -xO4 -xchip=pentium -xregs=no%frameptr    -mt   -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -KPIC -DPIC -errtags=yes -errwarn=%all -errwarn=no%E_STATEMENT_NOT_REACHED -errwarn=no%E_NO_IMPLICIT_DECL_ALLOWED -errwarn=no%E_EMPTY_TRANSLATION_UNIT -errwarn=no%E_EMPTY_INITIALIZER -errwarn=no%E_EMPTY_DECLARATION -errwarn=no%E_ENUM_VAL_OVERFLOWS_INT_MAX -errwarn=no%E_INIT_SIGN_EXTEND -errwarn=no%E_ASSIGNMENT_TYPE_MISMATCH -errtags=yes -errwarn=E_BAD_PTR_INT_COMBINATION,E_BAD_PTR_INT_COMB_ARG,E_PTR_TO_VOID_IN_ARITHMETIC,E_NO_IMPLICIT_DECL_ALLOWED,E_ATTRIBUTE_PARAM_UNDEFINED -D_POSIX_PTHREAD_SEMANTICS -mt  -c /scratch/anedvedi/userland.krb5/components/krb5/krb5-1.16.1/src/util/profile/prof_file.c -o prof_file.so.o && mv -f prof_file.so.o prof_file.so
"/scratch/anedvedi/userland.krb5/components/krb5/krb5-1.16.1/src/util/profile/prof_file.c", line 228: prototype mismatch: 4 args passed, 5 expected
"/scratch/anedvedi/userland.krb5/components/krb5/krb5-1.16.1/src/util/profile/prof_file.c", line 228: improper pointer/integer combination: op "=" (E_BAD_PTR_INT_COMBINATION)
cc: acomp failed for /scratch/anedvedi/userland.krb5/components/krb5/krb5-1.16.1/src/util/profile/prof_file.c
make[3]: *** [prof_file.so] Error 1

221 #ifdef HAVE_PWD_H
222         if (home_env == NULL) {
223             uid_t uid;
224             struct passwd *pw, pwx;
225             char pwbuf[BUFSIZ];
226
227             uid = getuid();
228             if (!k5_getpwuid_r(uid, &pwx, pwbuf, sizeof(pwbuf), &pw)
229                 && pw != NULL && pw->pw_dir[0] != 0)
230                 home_env = pw->pw_dir;
231         }
232 #endif