### PR TITLE
Allow u2u requests when KRB5_KDB_DISALLOW_SVR is set

### DIFF
--- a/doc/admin/admin_commands/kadmin_local.rst
+++ b/doc/admin/admin_commands/kadmin_local.rst
@@ -297,8 +297,9 @@ Options:
 
 {-\|+}\ **allow_dup_skey**
     **-allow_dup_skey** disables user-to-user authentication for this
-    principal by prohibiting this principal from obtaining a session
-    key for another user.  **+allow_dup_skey** clears this flag.
+    principal by prohibiting others from obtaining a service ticket
+    encrypted in this principal's TGT session key.
+    **+allow_dup_skey** clears this flag.
 
 {-\|+}\ **requires_preauth**
     **+requires_preauth** requires this principal to preauthenticate
@@ -325,7 +326,9 @@ Options:
 
 {-\|+}\ **allow_svr**
     **-allow_svr** prohibits the issuance of service tickets for this
-    principal.  **+allow_svr** clears this flag.
+    principal.  In release 1.17 and later, user-to-user service
+    tickets are still allowed unless the **-allow_dup_skey** flag is
+    also set.  **+allow_svr** clears this flag.
 
 {-\|+}\ **allow_tgs_req**
     **-allow_tgs_req** specifies that a Ticket-Granting Service (TGS)

--- a/doc/admin/conf_files/kdc_conf.rst
+++ b/doc/admin/conf_files/kdc_conf.rst
@@ -134,9 +134,8 @@ The following tags may be specified in a [realms] subsection:
         the principal within this realm.
 
     **dup-skey**
-        Enabling this flag allows the principal to obtain a session
-        key for another user, permitting user-to-user authentication
-        for this principal.
+        Enabling this flag allows the KDC to issue user-to-user
+        service tickets for this principal.
 
     **forwardable**
         Enabling this flag allows the principal to obtain forwardable
@@ -193,7 +192,9 @@ The following tags may be specified in a [realms] subsection:
 
     **service**
         Enabling this flag allows the the KDC to issue service tickets
-        for this principal.
+        for this principal.  In release 1.17 and later, user-to-user
+        service tickets are still allowed if the **dup-skey** flag is
+        set.
 
     **tgt-based**
         Enabling this flag allows a principal to obtain tickets based

--- a/src/appl/user_user/t_user2user.py
+++ b/src/appl/user_user/t_user2user.py
@@ -4,6 +4,12 @@ from k5test import *
 debug_compiled=1
 
 for realm in multipass_realms():
+    # Verify that -allow_svr denies regular TGS requests, but allows
+    # user-to-user TGS requests.
+    realm.run([kadminl, 'modprinc', '-allow_svr', realm.user_princ])
+    realm.run([kvno, realm.user_princ], expected_code=1,
+               expected_msg='Server principal valid for user2user only')
+
     if debug_compiled == 0:
         realm.start_in_inetd(['./uuserver', 'uuserver'], port=9999)
     else:

--- a/src/kdc/tgs_policy.c
+++ b/src/kdc/tgs_policy.c
@@ -146,7 +146,8 @@ check_tgs_svc_deny_all(krb5_kdc_req *req, krb5_db_entry server,
         *status = "SERVER LOCKED OUT";
         return KDC_ERR_S_PRINCIPAL_UNKNOWN;
     }
-    if (server.attributes & KRB5_KDB_DISALLOW_SVR) {
+    if ((server.attributes & KRB5_KDB_DISALLOW_SVR) &&
+        !(req->kdc_options & KDC_OPT_ENC_TKT_IN_SKEY)) {
         *status = "SERVER NOT ALLOWED";
         return KDC_ERR_MUST_USE_USER2USER;
     }


### PR DESCRIPTION
Here is the change to allow u2u tickets with -allow_svr.  As briefly discussed on the krbdev list, this trues up the code and the error message (the KDC errors for u2u requests with KDC_ERR_MUST_USE_USER2USER, which is confusing).  I also found an old bug for this issue while searching, so I've added that link below.

I've been testing this change in production for years on 1.9, and just recently ported it to the latest code.

One question: should I make the same check in check_tgs_svc_deny_all()?  It looks like it, but I never had to in my testing...I'm not exactly sure what that code is for, it looks like some kind of policy check function table?  It'd be a trivial fix to make obviously.

The other place KRB5_KDB_DISALLOW_SVR is checked is in kdc_get_server_key(), but there's no krb5_kdc_req passed to that function, so I'm not sure how you'd check for KDC_OPT_ENC_TKT_IN_SKEY if it was necessary there.

Thanks, let me know what you think,
Chris


-------

When checking KRB5_KDB_DISALLOW_SVR, also check if it is a u2u request so the KDC_ERR_MUST_USE_USER2USER error message is correct.  In other words, we can still issue u2u tickets for princs that aren't allowed to be normal services.

This fixes Ticket #2641 "KRB5_KDB_DISALLOW_SVR flag unnecessarily prevents User2User"
http://krbdev.mit.edu/rt/Ticket/Display.html?id=2641