### PR TITLE
Extend waiting time from 10s to 30s

### DIFF
--- a/src/appl/gss-sample/gss-misc.c
+++ b/src/appl/gss-sample/gss-misc.c
@@ -115,7 +115,7 @@ read_all(int fildes, void *data, unsigned int nbyte)
 
     FD_ZERO(&rfds);
     FD_SET(fildes, &rfds);
-    tv.tv_sec = 10;
+    tv.tv_sec = 300;
     tv.tv_usec = 0;
 
     for (ptr = buf; nbyte; ptr += ret, nbyte -= ret) {


### PR DESCRIPTION
There are some GSS mechanisms (such as GSS EAP - RFC 7055) where User interaction is required and 10s is too little to allow users to eg. select the identity they want to use or type their password.