### PR TITLE
Don't include all MEMORY ccaches in collection

### DIFF
--- a/src/lib/krb5/ccache/t_cccol.py
+++ b/src/lib/krb5/ccache/t_cccol.py
@@ -100,10 +100,11 @@ if test_keyring:
 mark('MEMORY cursor')
 mfoo = 'MEMORY:foo'
 mbar = 'MEMORY:bar'
-cursor_test('filemem', [fccname, mfoo, mbar], [fccname, mfoo, mbar])
-cursor_test('dirmem', [dccname, mfoo], [duser, dalice, dbob, mfoo])
+cursor_test('filemem', [fccname, mfoo], [fccname])
+cursor_test('dirmem', [dccname, mfoo], [duser, dalice, dbob])
+cursor_test('mem', [mfoo, mbar], [mfoo])
 if test_keyring:
-    cursor_test('keyringmem', [krccname, mfoo], [kruser, kralice, krbob, mfoo])
+    cursor_test('keyringmem', [krccname, mfoo], [kruser, kralice, krbob])
 
 # Test krb5_cccol_have_content.
 mark('krb5_cccol_have_content')


### PR DESCRIPTION
[This is preliminary to using a hash table for memory ccache resolution, which I've gotten a request for.]

In the MEMORY ccache implementation, only yield a cache in the
per-type cursor if it is the context default cache, matching the
behavior of FILE after commit 45360c9688ca963f75a2480f2cf818424fc3dc7b
(ticket 6955).
