### PR TITLE
Stop matching u2u credentials on regular searches

### DIFF
--- a/src/lib/krb5/ccache/cc_retr.c
+++ b/src/lib/krb5/ccache/cc_retr.c
@@ -164,6 +164,11 @@ pref (krb5_enctype my_ktype, int nktypes, krb5_enctype *ktypes)
 krb5_boolean
 krb5int_cc_creds_match_request(krb5_context context, krb5_flags whichfields, krb5_creds *mcreds, krb5_creds *creds)
 {
+    /* Only match a user-to-user credential if explicitly asked for, since the
+     * ticket won't work as a regular service ticket. */
+    if (! set(KRB5_TC_MATCH_IS_SKEY) && creds->is_skey)
+        return FALSE;
+
     if (((set(KRB5_TC_MATCH_SRV_NAMEONLY) &&
           srvname_match(context, mcreds, creds)) ||
          standard_fields_match(context, mcreds, creds))

--- a/src/lib/krb5/ccache/cc_retr.c
+++ b/src/lib/krb5/ccache/cc_retr.c
@@ -30,9 +30,6 @@
 
 #define KRB5_OK 0
 
-#define set(bits) (whichfields & bits)
-#define flags_match(a,b) (((a) & (b)) == (a))
-
 static int
 times_match_exact(const krb5_ticket_times *t1, const krb5_ticket_times *t2)
 {
@@ -58,30 +55,21 @@ times_match(const krb5_ticket_times *t1, const krb5_ticket_times *t2)
 }
 
 static krb5_boolean
-standard_fields_match(krb5_context context, const krb5_creds *mcreds, const krb5_creds *creds)
+princs_match(krb5_context context, krb5_flags whichfields,
+             const krb5_creds *mcreds, const krb5_creds *creds)
 {
-    return (krb5_principal_compare(context, mcreds->client,creds->client)
-            && krb5_principal_compare(context, mcreds->server,creds->server));
-}
+    krb5_principal_data princ;
 
-/* only match the server name portion, not the server realm portion */
-
-static krb5_boolean
-srvname_match(krb5_context context, const krb5_creds *mcreds, const krb5_creds *creds)
-{
-    krb5_boolean retval;
-    krb5_principal_data p1, p2;
-
-    retval = krb5_principal_compare(context, mcreds->client,creds->client);
-    if (retval != TRUE)
-        return retval;
-    /*
-     * Hack to ignore the server realm for the purposes of the compare.
-     */
-    p1 = *mcreds->server;
-    p2 = *creds->server;
-    p1.realm = p2.realm;
-    return krb5_principal_compare(context, &p1, &p2);
+    if (!krb5_principal_compare(context, mcreds->client, creds->client))
+        return FALSE;
+    if (whichfields & KRB5_TC_MATCH_SRV_NAMEONLY) {
+        /* Ignore the server realm. */
+        princ = *mcreds->server;
+        princ.realm = creds->server->realm;
+        return krb5_principal_compare(context, &princ, creds->server);
+    } else {
+        return krb5_principal_compare(context, mcreds->server, creds->server);
+    }
 }
 
 static krb5_boolean
@@ -162,42 +150,47 @@ pref (krb5_enctype my_ktype, int nktypes, krb5_enctype *ktypes)
  */
 
 krb5_boolean
-krb5int_cc_creds_match_request(krb5_context context, krb5_flags whichfields, krb5_creds *mcreds, krb5_creds *creds)
+krb5int_cc_creds_match_request(krb5_context context, krb5_flags whichfields,
+                               krb5_creds *mcreds, krb5_creds *creds)
 {
-    /* Only match a user-to-user credential if explicitly asked for, since the
-     * ticket won't work as a regular service ticket. */
-    if (! set(KRB5_TC_MATCH_IS_SKEY) && creds->is_skey)
+    krb5_boolean is_skey;
+
+    if (!princs_match(context, whichfields, mcreds, creds))
         return FALSE;
 
-    if (((set(KRB5_TC_MATCH_SRV_NAMEONLY) &&
-          srvname_match(context, mcreds, creds)) ||
-         standard_fields_match(context, mcreds, creds))
-        &&
-        (! set(KRB5_TC_MATCH_IS_SKEY) ||
-         mcreds->is_skey == creds->is_skey)
-        &&
-        (! set(KRB5_TC_MATCH_FLAGS_EXACT) ||
-         mcreds->ticket_flags == creds->ticket_flags)
-        &&
-        (! set(KRB5_TC_MATCH_FLAGS) ||
-         flags_match(mcreds->ticket_flags, creds->ticket_flags))
-        &&
-        (! set(KRB5_TC_MATCH_TIMES_EXACT) ||
-         times_match_exact(&mcreds->times, &creds->times))
-        &&
-        (! set(KRB5_TC_MATCH_TIMES) ||
-         times_match(&mcreds->times, &creds->times))
-        &&
-        ( ! set(KRB5_TC_MATCH_AUTHDATA) ||
-          authdata_match(mcreds->authdata, creds->authdata))
-        &&
-        (! set(KRB5_TC_MATCH_2ND_TKT) ||
-         data_match (&mcreds->second_ticket, &creds->second_ticket))
-        &&
-        ((! set(KRB5_TC_MATCH_KTYPE))||
-         (mcreds->keyblock.enctype == creds->keyblock.enctype)))
-        return TRUE;
-    return FALSE;
+    /* Only match a user-to-user credential if explicitly asked for, since the
+     * ticket won't work as a regular service ticket. */
+    is_skey = (whichfields & KRB5_TC_MATCH_IS_SKEY) ? mcreds->is_skey : FALSE;
+    if (creds->is_skey != is_skey)
+        return FALSE;
+
+    if ((whichfields & KRB5_TC_MATCH_FLAGS_EXACT) &&
+        mcreds->ticket_flags != creds->ticket_flags)
+        return FALSE;
+    if ((whichfields & KRB5_TC_MATCH_FLAGS) &&
+        (creds->ticket_flags & mcreds->ticket_flags) != mcreds->ticket_flags)
+        return FALSE;
+
+    if ((whichfields & KRB5_TC_MATCH_TIMES_EXACT) &&
+        !times_match_exact(&mcreds->times, &creds->times))
+        return FALSE;
+    if ((whichfields & KRB5_TC_MATCH_TIMES) &&
+        !times_match(&mcreds->times, &creds->times))
+        return FALSE;
+
+    if ((whichfields & KRB5_TC_MATCH_AUTHDATA) &&
+        !authdata_match(mcreds->authdata, creds->authdata))
+        return FALSE;
+
+    if ((whichfields & KRB5_TC_MATCH_2ND_TKT) &&
+        !data_match(&mcreds->second_ticket, &creds->second_ticket))
+        return FALSE;
+
+    if ((whichfields & KRB5_TC_MATCH_KTYPE) &&
+        mcreds->keyblock.enctype != creds->keyblock.enctype)
+        return FALSE;
+
+    return TRUE;
 }
 
 static krb5_error_code

--- a/src/tests/t_u2u.py
+++ b/src/tests/t_u2u.py
@@ -21,7 +21,15 @@ realm.run([kvno, 'alice'], expected_code=1,
 realm.run([kvno, '--u2u', u2u_ccache, 'alice'], expected_msg='kvno = 0')
 realm.run([kadminl, 'modprinc', '+allow_svr', 'alice'])
 
+# Verify that normal lookups ignore the user-to-user ticket.
+realm.run([kvno, 'alice'], expected_msg='kvno = 1')
+out = realm.run([klist])
+if out.count('alice@KRBTEST.COM') != 2:
+    fail('expected two alice tickets after regular kvno')
+
 # Try u2u against the client user.
 realm.run([kvno, '--u2u', realm.ccache, realm.user_princ])
 
 realm.run([klist])
+
+success('user-to-user tests')


### PR DESCRIPTION
Here is my fix for ticket 8718.  Review it commit-by-commit as the third commit is a style fix (the second commit is minimal but leaves the function in an awkward state).

Chris Hecker recently floated the idea of a kvno option to get user-to-user creds; if we had that, we could write a test case for this fix.  So there is a chance I will defer merging this until he or I implements that kvno option.
