### PR TITLE
asan fixes

### DIFF
--- a/src/lib/krb5/krb/t_valid_times.c
+++ b/src/lib/krb5/krb/t_valid_times.c
@@ -105,5 +105,7 @@ main()
     ret = krb5int_validate_times(context, &times);
     assert(ret == KRB5KRB_AP_ERR_TKT_EXPIRED);
 
+    krb5_free_context(context);
+
     return 0;
 }

--- a/src/util/profile/prof_test1
+++ b/src/util/profile/prof_test1
@@ -360,6 +360,7 @@ proc test10 {} {
 	puts stderr "Error: test10: Did not find expected chores."
 	exit 1
     }
+    profile_release $p
 }
 
 test1

--- a/src/util/profile/profile_tcl.c
+++ b/src/util/profile/profile_tcl.c
@@ -2234,6 +2234,7 @@ _wrap_profile_get_string(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, i
     char *s = (arg6 && *arg6) ? *arg6 : "";
     Tcl_ListObjAppendElement(interp, Tcl_GetObjResult(interp),
       Tcl_NewStringObj(s, strlen(s)));
+    profile_release_string(s);
   }
   if (alloc2 == SWIG_NEWOBJ) free((char*)buf2);
   if (alloc3 == SWIG_NEWOBJ) free((char*)buf3);


### PR DESCRIPTION
A new dev machine means a new version of clang, which means new things detected by clang.  One of these is a harmless-in-practice memory bug in krb5_read_password() which has been present since 2004: if prompt2 is given, k5prompt.reply is pointed at a krb5_data object inside an inner scope, and then `k5prompt.reply->length`` is referenced just after that object goes out of scope.  Since there are no new stack allocations in the interim, it works.  I didn't make the fix minimal since there's no need to backport it.
