### PR TITLE
Update many documentation links to https

### DIFF
--- a/doc/about.rst
+++ b/doc/about.rst
@@ -6,7 +6,7 @@ towards improving the MIT KC documentation content.  If you are an experienced
 Kerberos developer and/or administrator, please consider sharing your knowledge
 and experience with the Kerberos Community.  You can suggest your own topic or
 write about any of the topics listed
-`here <http://k5wiki.kerberos.org/wiki/Projects/Documentation_Tasks>`__.
+`here <https://k5wiki.kerberos.org/wiki/Projects/Documentation_Tasks>`__.
 
 If you have any questions, comments, or suggestions on the existing documents,
 please send your feedback via email to krb5-bugs@mit.edu. The HTML version of
@@ -22,7 +22,7 @@ unified in a central form.  Man pages, HTML documentation, and PDF
 documents are compiled from reStructuredText sources, and the application
 developer documentation incorporates Doxygen markup from the source
 tree.  This project was undertaken along the outline described
-`here <http://k5wiki.kerberos.org/wiki/Projects/Kerberos_Documentation>`__.
+`here <https://k5wiki.kerberos.org/wiki/Projects/Kerberos_Documentation>`__.
 
 Previous versions of Kerberos 5 attempted to maintain separate documentation
 in the texinfo format, with separate groff manual pages.  Having the API

--- a/doc/admin/conf_ldap.rst
+++ b/doc/admin/conf_ldap.rst
@@ -18,7 +18,7 @@ Configuring Kerberos with OpenLDAP back-end
           certificate location in *slapd.conf* file.
 
           Refer to the following link for more information:
-          http://www.openldap.org/doc/admin23/tls.html
+          https://www.openldap.org/doc/admin23/tls.html
 
     B. Setting up SSL on OpenLDAP client:
 

--- a/doc/appdev/gssapi.rst
+++ b/doc/appdev/gssapi.rst
@@ -627,11 +627,11 @@ gss_get_mic_iov_length and gss_get_mic_iov::
         handle_error(major, minor);
 
 
-.. _gss_accept_sec_context: http://tools.ietf.org/html/rfc2744.html#section-5.1
-.. _gss_acquire_cred: http://tools.ietf.org/html/rfc2744.html#section-5.2
-.. _gss_export_name: http://tools.ietf.org/html/rfc2744.html#section-5.13
-.. _gss_get_name_attribute: http://tools.ietf.org/html/6680.html#section-7.5
-.. _gss_import_name: http://tools.ietf.org/html/rfc2744.html#section-5.16
-.. _gss_init_sec_context: http://tools.ietf.org/html/rfc2744.html#section-5.19
-.. _gss_inquire_name: http://tools.ietf.org/html/rfc6680.txt#section-7.4
-.. _gss_inquire_cred: http://tools.ietf.org/html/rfc2744.html#section-5.21
+.. _gss_accept_sec_context: https://tools.ietf.org/html/rfc2744.html#section-5.1
+.. _gss_acquire_cred: https://tools.ietf.org/html/rfc2744.html#section-5.2
+.. _gss_export_name: https://tools.ietf.org/html/rfc2744.html#section-5.13
+.. _gss_get_name_attribute: https://tools.ietf.org/html/6680.html#section-7.5
+.. _gss_import_name: https://tools.ietf.org/html/rfc2744.html#section-5.16
+.. _gss_init_sec_context: https://tools.ietf.org/html/rfc2744.html#section-5.19
+.. _gss_inquire_name: https://tools.ietf.org/html/rfc6680.txt#section-7.4
+.. _gss_inquire_cred: https://tools.ietf.org/html/rfc2744.html#section-5.21

--- a/doc/build/doing_build.rst
+++ b/doc/build/doing_build.rst
@@ -123,7 +123,7 @@ by ``make check``.  These tests require manual setup and teardown of
 support infrastructure which is not easily automated, or require
 excessive resources for ordinary use.  The procedure for running
 the manual tests is documented at
-http://k5wiki.kerberos.org/wiki/Manual_Testing.
+https://k5wiki.kerberos.org/wiki/Manual_Testing.
 
 
 Cleaning up the build

--- a/doc/build_this.rst
+++ b/doc/build_this.rst
@@ -3,8 +3,8 @@ How to build this documentation from the source
 
 Pre-requisites for a simple build, or to update man pages:
 
-* Sphinx 1.0.4 or higher (See http://sphinx.pocoo.org) with the autodoc
-  extension installed.
+* Sphinx 1.0.4 or higher (See http://www.sphinx-doc.org) with the
+  autodoc extension installed.
 
 Additional prerequisites to include the API reference based on Doxygen
 markup:

--- a/doc/mitK5features.rst
+++ b/doc/mitK5features.rst
@@ -10,7 +10,7 @@
 MIT Kerberos features
 =====================
 
-http://web.mit.edu/kerberos
+https://web.mit.edu/kerberos
 
 
 Quick facts
@@ -19,8 +19,8 @@ Quick facts
 License - :ref:`mitK5license`
 
 Releases:
-    - Latest stable: http://web.mit.edu/kerberos/krb5-1.16/
-    - Supported: http://web.mit.edu/kerberos/krb5-1.15/
+    - Latest stable: https://web.mit.edu/kerberos/krb5-1.16/
+    - Supported: https://web.mit.edu/kerberos/krb5-1.15/
     - Release cycle: 9 -- 12 months
 
 Supported platforms \/ OS distributions:
@@ -31,7 +31,7 @@ Supported platforms \/ OS distributions:
 
 Crypto backends:
     - builtin - MIT Kerberos native crypto library
-    - OpenSSL (1.0\+) - http://www.openssl.org
+    - OpenSSL (1.0\+) - https://www.openssl.org
 
 Database backends: LDAP, DB2, LMDB
 
@@ -85,7 +85,7 @@ Starting from release 1.8:
 Feature list
 ------------
 
-For more information on the specific project see http://k5wiki.kerberos.org/wiki/Projects
+For more information on the specific project see https://k5wiki.kerberos.org/wiki/Projects
 
 Release 1.7
  -   Credentials delegation                   :rfc:`5896`
@@ -96,9 +96,9 @@ Release 1.7
 Release 1.8
  -   Anonymous PKINIT         :rfc:`6112` :ref:`anonymous_pkinit`
  -   Constrained delegation
- -   IAKERB                   http://tools.ietf.org/html/draft-ietf-krb-wg-iakerb-02
+ -   IAKERB                   https://tools.ietf.org/html/draft-ietf-krb-wg-iakerb-02
  -   Heimdal bridge plugin for KDC backend
- -   GSS-API S4U extensions   http://msdn.microsoft.com/en-us/library/cc246071
+ -   GSS-API S4U extensions   https://msdn.microsoft.com/en-us/library/cc246071
  -   GSS-API naming extensions                            :rfc:`6680`
  -   GSS-API extensions for storing delegated credentials :rfc:`5588`
 
@@ -132,20 +132,20 @@ Release 1.12
  -   Plugin to control krb5_aname_to_localname and krb5_kuserok behavior   :ref:`localauth_plugin`
  -   Plugin to control hostname-to-realm mappings and the default realm    :ref:`hostrealm_plugin`
  -   GSSAPI extensions for constructing MIC tokens using IOV lists         :ref:`gssapi_mic_token`
- -   Principal may refer to nonexistent policies `Policy Refcount project <http://k5wiki.kerberos.org/wiki/Projects/Policy_refcount_elimination>`_
- -   Support for having no long-term keys for a principal `Principals Without Keys project <http://k5wiki.kerberos.org/wiki/Projects/Principals_without_keys>`_
+ -   Principal may refer to nonexistent policies `Policy Refcount project <https://k5wiki.kerberos.org/wiki/Projects/Policy_refcount_elimination>`_
+ -   Support for having no long-term keys for a principal `Principals Without Keys project <https://k5wiki.kerberos.org/wiki/Projects/Principals_without_keys>`_
  -   Collection support to the KEYRING credential cache type on Linux :ref:`ccache_definition`
  -   FAST OTP preauthentication module for the KDC which uses RADIUS to validate OTP token values :ref:`otp_preauth`
- -   Experimental Audit plugin for KDC processing `Audit project <http://k5wiki.kerberos.org/wiki/Projects/Audit>`_
+ -   Experimental Audit plugin for KDC processing `Audit project <https://k5wiki.kerberos.org/wiki/Projects/Audit>`_
 
 Release 1.13
 
  -   Add support for accessing KDCs via an HTTPS proxy server using
      the `MS-KKDCP
-     <http://msdn.microsoft.com/en-us/library/hh553774.aspx>`_
+     <https://msdn.microsoft.com/en-us/library/hh553774.aspx>`_
      protocol.
  -   Add support for `hierarchical incremental propagation
-     <http://k5wiki.kerberos.org/wiki/Projects/Hierarchical_iprop>`_,
+     <https://k5wiki.kerberos.org/wiki/Projects/Hierarchical_iprop>`_,
      where slaves can act as intermediates between an upstream master
      and other downstream slaves.
  -   Add support for configuring GSS mechanisms using
@@ -153,12 +153,12 @@ Release 1.13
      ``/etc/gss/mech``.
  -   Add support to the LDAP KDB module for `binding to the LDAP
      server using SASL
-     <http://k5wiki.kerberos.org/wiki/Projects/LDAP_SASL_support>`_.
+     <https://k5wiki.kerberos.org/wiki/Projects/LDAP_SASL_support>`_.
  -   The KDC listens for TCP connections by default.
  -   Fix a minor key disclosure vulnerability where using the
      "keepold" option to the kadmin randkey operation could return the
      old keys. `[CVE-2014-5351]
-     <http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-5351>`_
+     <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-5351>`_
  -   Add client support for the Kerberos Cache Manager protocol. If
      the host is running a Heimdal kcm daemon, caches served by the
      daemon can be accessed with the KCM: cache type.
@@ -407,12 +407,12 @@ Release 1.16
 - PKINIT with FAST on client   (release 1.10)     :rfc:`6113`
 - PKINIT                                          :rfc:`4556`
 - FX-COOKIE                                       :rfc:`6113#section-5.2`
-- S4U-X509-USER                (release 1.8)      http://msdn.microsoft.com/en-us/library/cc246091
+- S4U-X509-USER                (release 1.8)      https://msdn.microsoft.com/en-us/library/cc246091
 - OTP                          (release 1.12)     :ref:`otp_preauth`
 
 `PRNG`
 
 - modularity       (release 1.9)
 - Yarrow PRNG      (release < 1.10)
-- Fortuna PRNG     (release 1.9)       http://www.schneier.com/book-practical.html
+- Fortuna PRNG     (release 1.9)       https://www.schneier.com/book-practical.html
 - OS PRNG          (release 1.10)      OS's native PRNG

--- a/doc/notice.rst
+++ b/doc/notice.rst
@@ -39,7 +39,7 @@ nationals of those countries.
 
 Documentation components of this software distribution are licensed
 under a Creative Commons Attribution-ShareAlike 3.0 Unported License.
-(http://creativecommons.org/licenses/by-sa/3.0/)
+(https://creativecommons.org/licenses/by-sa/3.0/)
 
 Individual source code files are copyright MIT, Cygnus Support,
 Novell, OpenVision Technologies, Oracle, Red Hat, Sun Microsystems,

--- a/doc/plugindev/general.rst
+++ b/doc/plugindev/general.rst
@@ -114,5 +114,5 @@ types, the logged message does not include the usual header for some
 output types, and the severity for syslog outputs is configured as
 part of the logging specification, defaulting to error severity.)
 
-.. _automake: http://www.gnu.org/software/automake/
-.. _libtool: http://www.gnu.org/software/libtool/
+.. _automake: https://www.gnu.org/software/automake/
+.. _libtool: https://www.gnu.org/software/libtool/

--- a/doc/resources.rst
+++ b/doc/resources.rst
@@ -7,10 +7,10 @@ Mailing lists
 * kerberos@mit.edu is a community resource for discussion and
   questions about MIT krb5 and other Kerberos implementations.  To
   subscribe to the list, please follow the instructions at
-  http://mailman.mit.edu/mailman/listinfo/kerberos.
+  https://mailman.mit.edu/mailman/listinfo/kerberos.
 * krbdev@mit.edu is the primary list for developers of MIT Kerberos.
   To subscribe to the list, please follow the instructions at
-  http://mailman.mit.edu/mailman/listinfo/krbdev.
+  https://mailman.mit.edu/mailman/listinfo/krbdev.
 * krb5-bugs@mit.edu is notified when a ticket is created or updated.
   This list helps track bugs and feature requests.
   In addition, this list is used to track documentation criticism
@@ -31,23 +31,23 @@ resource for general Kerberos discussion and support.
 The main IRC channel for MIT Kerberos development is `#krbdev` on
 freenode.
 
-For more information about freenode, see http://freenode.net/.
+For more information about freenode, see https://freenode.net/.
 
 
 Archives
 --------
 
-* The archive http://mailman.mit.edu/pipermail/kerberos/ contains past
-  postings from the `kerberos@mit.edu` list.
+* The archive https://mailman.mit.edu/pipermail/kerberos/ contains
+  past postings from the `kerberos@mit.edu` list.
 
-* The http://mailman.mit.edu/pipermail/krbdev/ contains past
-  postings from the `krbdev@mit.edu` list.
+* The https://mailman.mit.edu/pipermail/krbdev/ contains past postings
+  from the `krbdev@mit.edu` list.
 
 
 Wiki
 ----
 
-The wiki at http://k5wiki.kerberos.org/ contains useful information
+The wiki at https://k5wiki.kerberos.org/ contains useful information
 for developers working on the MIT Kerberos source code.  Some of the
 information on the wiki may be useful for advanced users or system
 administrators.
@@ -55,6 +55,6 @@ administrators.
 Web pages
 ---------
 
-* http://web.mit.edu/kerberos/ is the MIT Kerberos software web page.
+* https://web.mit.edu/kerberos/ is the MIT Kerberos software web page.
 
-* http://kerberos.org/ is the MIT Kerberos Consortium web page.
+* https://kerberos.org/ is the MIT Kerberos Consortium web page.


### PR DESCRIPTION
[web.mit.edu is supposed to change to not require client certs for https in two days.  I will not merge this until that cutover has finished.]

Use secure URLs in the documentation where possible.  The Sphinx web
site does not appear to have a valid server cert, but does have a more
official URL.
