### PR TITLE
Check public_oid in gss_export_cred()

### DIFF
--- a/src/lib/gssapi/mechglue/g_export_cred.c
+++ b/src/lib/gssapi/mechglue/g_export_cred.c
@@ -81,7 +81,7 @@ gss_export_cred(OM_uint32 * minor_status, gss_cred_id_t cred_handle,
         mech_oid = &cred->mechs_array[i];
         public_oid = gssint_get_public_oid(mech_oid);
         mech = gssint_get_mechanism(mech_oid);
-        if (mech == NULL) {
+        if (public_oid == GSS_C_NO_OID || mech == NULL) {
             status = GSS_S_DEFECTIVE_CREDENTIAL;
             goto error;
         }


### PR DESCRIPTION
In gss_export_cred(), check the gssint_get_public_oid() result as well
as the gssint_get_mechanism() result.  There are probably no cases
where the former returns NULL and the latter does not, but it is easy
to be more obviously correct.  Reported by Bean Zhang.