### PR TITLE
Fix a typo in the kswitch man page

### DIFF
--- a/doc/user/user_commands/kswitch.rst
+++ b/doc/user/user_commands/kswitch.rst
@@ -53,4 +53,4 @@ FILES
 SEE ALSO
 --------
 
-:ref:`kinit(1)`, :ref:`kdestroy(1)`, :ref:`klist(1)`), kerberos(1)
+:ref:`kinit(1)`, :ref:`kdestroy(1)`, :ref:`klist(1)`, kerberos(1)


### PR DESCRIPTION
Fix a typo introduced by commit
fe44da52deea41483326debf2d9ad525f65e19f6.  Reported by Matthew
Krupcale.
