### PR TITLE
Add kvno option for user-to-user

### DIFF
--- a/doc/user/user_commands/kvno.rst
+++ b/doc/user/user_commands/kvno.rst
@@ -14,6 +14,7 @@ SYNOPSIS
 [**-P**]
 [**-S** *sname*]
 [**-U** *for_user*]
+[**--u2u** *ccache*]
 *service1 service2* ...
 
 
@@ -62,6 +63,12 @@ OPTIONS
     acquire a ticket on behalf of *for_user*.  If constrained
     delegation is not requested, the service name must match the
     credentials cache client principal.
+
+**--u2u** *ccache*
+    Requests a user-to-user ticket.  *ccache* must contain a local
+    krbtgt ticket for the server principal.  The reported version
+    number will typically be 0, as the resulting ticket is not
+    encrypted in the server's long-term key.
 
 
 ENVIRONMENT

--- a/src/appl/user_user/t_user2user.py
+++ b/src/appl/user_user/t_user2user.py
@@ -4,12 +4,6 @@ from k5test import *
 debug_compiled=1
 
 for realm in multipass_realms():
-    # Verify that -allow_svr denies regular TGS requests, but allows
-    # user-to-user TGS requests.
-    realm.run([kadminl, 'modprinc', '-allow_svr', realm.user_princ])
-    realm.run([kvno, realm.user_princ], expected_code=1,
-               expected_msg='Server principal valid for user2user only')
-
     if debug_compiled == 0:
         realm.start_in_inetd(['./uuserver', 'uuserver'], port=9999)
     else:

--- a/src/tests/Makefile.in
+++ b/src/tests/Makefile.in
@@ -176,6 +176,7 @@ check-pytests: unlockiter
 	$(RUNPYTEST) $(srcdir)/t_certauth.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_y2038.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_kdcpolicy.py $(PYTESTFLAGS)
+	$(RUNPYTEST) $(srcdir)/t_u2u.py $(PYTESTFLAGS)
 
 clean:
 	$(RM) adata etinfo forward gcred hist hooks hrealm icinterleave icred

--- a/src/tests/t_u2u.py
+++ b/src/tests/t_u2u.py
@@ -1,0 +1,27 @@
+from k5test import *
+
+realm = K5Realm(create_host=False)
+
+# Create a second user principal and get tickets for it.
+u2u_ccache = 'FILE:' + os.path.join(realm.testdir, 'ccu2u')
+realm.addprinc('alice', password('alice'))
+realm.kinit('alice', password('alice'), ['-c', u2u_ccache])
+
+# Verify that -allow_dup_skey denies u2u requests.
+realm.run([kadminl, 'modprinc', '-allow_dup_skey', 'alice'])
+realm.run([kvno, '--u2u', u2u_ccache, 'alice'], expected_code=1,
+          expected_msg='KDC policy rejects request')
+realm.run([kadminl, 'modprinc', '+allow_dup_skey', 'alice'])
+
+# Verify that -allow_svr denies regular TGS requests, but allows
+# user-to-user TGS requests.
+realm.run([kadminl, 'modprinc', '-allow_svr', 'alice'])
+realm.run([kvno, 'alice'], expected_code=1,
+          expected_msg='Server principal valid for user2user only')
+realm.run([kvno, '--u2u', u2u_ccache, 'alice'], expected_msg='kvno = 0')
+realm.run([kadminl, 'modprinc', '+allow_svr', 'alice'])
+
+# Try u2u against the client user.
+realm.run([kvno, '--u2u', realm.ccache, realm.user_princ])
+
+realm.run([klist])


### PR DESCRIPTION
[Will allow a proper test for #823.  Some subtleties:

* The server name has to match the u2u ccache default principal, which means we don't strictly need it to be given as an argument.  But deducing the server name from the u2u ccache would be awkward as it would break code symmetry with the other use cases.

* In principle we could decrypt the returned ticket using the session key from the u2u ccache, but there is no libkrb5 interface like krb5_server_decrypt_ticket_keytab() for doing so.

* At the protocol level, I don't see any reason why the second ticket can't be encrypted in a cross-realm TGT, although I can't think of any reason to do so and our KDC implementation doesn't allow it.  This kvno option only looks for a local TGT.

* I considered adding long options --enctype, --cache, keytab, --server, and --quiet from Heimdal at the same time, but decided that should be in a separate commit which might encompass other commands.  I'm also not immediately sure how to document long option aliases, or if it's okay to leave it undocumented.]

Add a --u2u option to kvno, with an argument to specify a credential
cache containing a krbtgt for the server principal.  Move the
-allow_svr test from appl/user_to_user to a new test script and add
additional tests.  Suggested by Chris Hecker.
