### PR TITLE
Check strdup return in kadm5_get_config_params()

### DIFF
--- a/src/lib/kadm5/alt_prof.c
+++ b/src/lib/kadm5/alt_prof.c
@@ -526,8 +526,11 @@ krb5_error_code kadm5_get_config_params(krb5_context context,
 
     if (params_in->mask & KADM5_CONFIG_REALM) {
         lrealm = params.realm = strdup(params_in->realm);
-        if (params.realm != NULL)
-            params.mask |= KADM5_CONFIG_REALM;
+        if (params.realm == NULL) {
+            ret = ENOMEM;
+            goto cleanup;
+        }
+        params.mask |= KADM5_CONFIG_REALM;
     } else {
         ret = krb5_get_default_realm(context, &lrealm);
         if (ret)
@@ -730,6 +733,10 @@ krb5_error_code kadm5_get_config_params(krb5_context context,
             krb5_aprof_get_string(aprofile, hierarchy, TRUE, &svalue);
         if (svalue == NULL)
             svalue = strdup(KRB5_DEFAULT_SUPPORTED_ENCTYPES);
+        if (svalue == NULL) {
+            ret = ENOMEM;
+            goto cleanup;
+        }
 
         params.keysalts = NULL;
         params.num_keysalts = 0;


### PR DESCRIPTION
When copying the realm string, if strdup() returns NULL, fail out with
ENOMEM instead of pretending the realm wasn't specified.  When copying
KRB5_DEFAULT_SUPPORTED_ENCTYPES, if strdup() returns NULL, fail out
with ENOMEM instead of crashing.  Reported by Bean Zhang.
