### PR TITLE
Check return values of time functions

### DIFF
--- a/src/kadmin/cli/kadmin.c
+++ b/src/kadmin/cli/kadmin.c
@@ -138,7 +138,7 @@ strdur(time_t duration)
     return out;
 }
 
-static char *
+static const char *
 strdate(krb5_timestamp when)
 {
     struct tm *tm;
@@ -146,7 +146,9 @@ strdate(krb5_timestamp when)
     time_t lcltim = ts2tt(when);
 
     tm = localtime(&lcltim);
-    strftime(out, sizeof(out), "%a %b %d %H:%M:%S %Z %Y", tm);
+    if (tm == NULL ||
+        strftime(out, sizeof(out), "%a %b %d %H:%M:%S %Z %Y", tm) == 0)
+        strlcpy(out, "(error)", sizeof(out));
     return out;
 }
 

--- a/src/kadmin/dbutil/kdb5_mkey.c
+++ b/src/kadmin/dbutil/kdb5_mkey.c
@@ -40,14 +40,17 @@ extern kadm5_config_params global_params;
 extern krb5_context util_context;
 extern time_t get_date(char *);
 
-static char *strdate(krb5_timestamp when)
+static const char *
+strdate(krb5_timestamp when)
 {
     struct tm *tm;
     static char out[40];
     time_t lcltim = ts2tt(when);
 
     tm = localtime(&lcltim);
-    strftime(out, sizeof(out), "%a %b %d %H:%M:%S %Z %Y", tm);
+    if (tm == NULL ||
+        strftime(out, sizeof(out), "%a %b %d %H:%M:%S %Z %Y", tm) == 0)
+        strlcpy(out, "(error)", sizeof(out));
     return out;
 }
 

--- a/src/kadmin/ktutil/ktutil.c
+++ b/src/kadmin/ktutil/ktutil.c
@@ -249,7 +249,6 @@ void ktutil_list(argc, argv)
             time_t tstamp;
 
             tstamp = lp->entry->timestamp;
-            (void) localtime(&tstamp);
             lp->entry->timestamp = tstamp;
             fill = ' ';
             if (!krb5_timestamp_to_sfstring((krb5_timestamp)lp->entry->

--- a/src/kadmin/server/misc.c
+++ b/src/kadmin/server/misc.c
@@ -95,6 +95,8 @@ check_min_life(void *server_handle, krb5_principal principal,
                 until = princ.last_pwd_change + pol.pw_min_life;
 
                 time_string = ctime(&until);
+                if (time_string == NULL)
+                    time_string = "(error)";
                 errstr = error_message(CHPASS_UTIL_PASSWORD_TOO_SOON);
 
                 if (strlen(errstr) + strlen(time_string) < msg_len) {

--- a/src/lib/kadm5/chpass_util.c
+++ b/src/lib/kadm5/chpass_util.c
@@ -217,7 +217,9 @@ kadm5_ret_t _kadm5_chpass_principal_util(void *server_handle,
         until = ts_incr(princ_ent.last_pwd_change, policy_ent.pw_min_life);
 
         time_string = ctime(&until);
-        if (*(ptr = &time_string[strlen(time_string)-1]) == '\n')
+        if (time_string == NULL)
+            time_string = "(error)";
+        else if (*(ptr = &time_string[strlen(time_string)-1]) == '\n')
             *ptr = '\0';
 
         snprintf(msg_ret, msg_len, string_text(CHPASS_UTIL_PASSWORD_TOO_SOON),

--- a/src/lib/kadm5/logger.c
+++ b/src/lib/kadm5/logger.c
@@ -638,7 +638,9 @@ klog_vsyslog(int priority, const char *format, va_list arglist)
     time_t      now;
 #ifdef  HAVE_STRFTIME
     size_t      soff;
-#endif  /* HAVE_STRFTIME */
+#else
+    char       *r;
+#endif
 
     /*
      * Format a syslog-esque message of the format:
@@ -667,7 +669,10 @@ klog_vsyslog(int priority, const char *format, va_list arglist)
      *  dow mon dd hh:mm:ss tzs yyyy\n
      *  012345678901234567890123456789
      */
-    strncpy(outbuf, ctime(&now) + 4, 15);
+    r = ctime(&now);
+    if (r == NULL)
+        return(-1);
+    strncpy(outbuf, r + 4, 15);
     cp += 15;
 #endif  /* HAVE_STRFTIME */
 #ifdef VERBOSE_LOGS

--- a/src/lib/krb5/krb/str_conv.c
+++ b/src/lib/krb5/krb/str_conv.c
@@ -212,11 +212,8 @@ krb5_timestamp_to_string(krb5_timestamp timestamp, char *buffer, size_t buflen)
     const char *fmt = "%c"; /* This is to get around gcc -Wall warning that
                                the year returned might be two digits */
 
-#ifdef HAVE_LOCALTIME_R
-    (void) localtime_r(&timestamp2, &tmbuf);
-#else
-    memcpy(&tmbuf, localtime(&timestamp2), sizeof(tmbuf));
-#endif
+    if (localtime_r(&timestamp2, &tmbuf) == NULL)
+        return(ENOMEM);
     ret = strftime(buffer, buflen, fmt, &tmbuf);
     if (ret == 0 || ret == buflen)
         return(ENOMEM);
@@ -246,11 +243,9 @@ krb5_timestamp_to_sfstring(krb5_timestamp timestamp, char *buffer, size_t buflen
     static const unsigned int sftime_format_table_nents =
         sizeof(sftime_format_table)/sizeof(sftime_format_table[0]);
 
-#ifdef HAVE_LOCALTIME_R
     tmp = localtime_r(&timestamp2, &tmbuf);
-#else
-    memcpy((tmp = &tmbuf), localtime(&timestamp2), sizeof(tmbuf));
-#endif
+    if (tmp == NULL)
+        return errno;
     ndone = 0;
     for (i=0; i<sftime_format_table_nents; i++) {
         if ((ndone = strftime(buffer, buflen, sftime_format_table[i], tmp)))

--- a/src/slave/kproplog.c
+++ b/src/slave/kproplog.c
@@ -71,13 +71,15 @@ print_flags(unsigned int flags)
 }
 
 /* ctime() for uint32_t* */
-static char *
+static const char *
 ctime_uint32(uint32_t *time32)
 {
     time_t tmp;
+    const char *r;
 
     tmp = *time32;
-    return ctime(&tmp);
+    r = ctime(&tmp);
+    return (r == NULL) ? "(error)" : r;
 }
 
 /* Display time information. */


### PR DESCRIPTION
Where ctime(), localtime(), or localtime_r() is used, check for
failure even if it is unlikely (reported by Bean Zhang).  Constify the
strdate() return type in kdb5_mkey.c and the ctime_uint32() return
type in kproplog.c.  Use localtime_r() unconditionally in str_conv.c
as there is already a wrapper in that file for the case where the
platform doesn't have it.  Remove an inoperative localtime() call in
ktutil.c.