### PR TITLE
Fix name of .pdb file in ccapi/test/Makefile.in

### DIFF
--- a/src/ccapi/test/Makefile.in
+++ b/src/ccapi/test/Makefile.in
@@ -151,7 +151,7 @@ build-tests: $(TEST_NAMES)
 
 $(TEST_NAMES):
     @echo DBG: $@
-    $(CC) $(ALL_CFLAGS) -Fe$(TESTDIR)$(S)$@.exe -Fd$(OBJDIR)$(S)$@.obj $@.c $(OBJECTS) $(LIBS)
+    $(CC) $(ALL_CFLAGS) -Fe$(TESTDIR)$(S)$@.exe -Fd$(OBJDIR)$(S)$@.pdb $@.c $(OBJECTS) $(LIBS)
 # Clean .obj from .:
     $(RM) $@.$(OBJEXT)
 ##-- These two rules build each element of the list.


### PR DESCRIPTION
A few days ago, something changed about the appveyor build image (probably a MSVC update) which caused our builds to start failing with:

```
	cl   /I..\.. /I..\..\include /I..\..\include\krb5   -I..\..\util\et /I. -I..\..\CCAPI\COMMON -I..\..\CCAPI\LIB -I.\..\..\include -I.\..\..\include\krb5 -DKRB5_DNS_LOOKUP=1 -DWIN32_LEAN_AND_MEAN -DKRB5_DEPRECATED=1 -DKRB5_PRIVATE -D_CRT_SECURE_NO_DEPRECATE -DUSE_LEASH=1 -DDEBUG -D_CRTDBG_MAP_ALLOC  /EHsc -D_CRTAPI1=_cdecl -D_CRTAPI2=_cdecl -DWINVER=0x0501  -D_WIN32_WINNT=0x0501 -D_CRT_SECURE_NO_WARNINGS /Od /Zi /MDd -nologo /EHsc /W3 -Fdobj\AMD64\dbg\\ -FD  -Fe.\ccapi_test\tests\test_cc_ccache_iterator_next.exe -Fd.\ccapi_intermediates\test_cc_ccache_iterator_next.obj test_cc_ccache_iterator_next.c obj\AMD64\dbg\test_ccapi_ccache.obj  obj\AMD64\dbg\test_ccapi_check.obj  obj\AMD64\dbg\test_ccapi_constants.obj  obj\AMD64\dbg\test_ccapi_context.obj  obj\AMD64\dbg\test_ccapi_v2.obj  obj\AMD64\dbg\test_ccapi_globals.obj  obj\AMD64\dbg\test_ccapi_iterators.obj  obj\AMD64\dbg\test_ccapi_log.obj  obj\AMD64\dbg\test_ccapi_util.obj ..\..\lib\obj\AMD64\dbg\comerr64.lib ..\..\lib\obj\AMD64\dbg\k5sprt64.lib advapi32.lib rpcrt4.lib user32.lib ws2_32.lib krbcc64.lib
cl : Command line warning D9025 : overriding '/Fdobj\AMD64\dbg\\' with '/Fd.\ccapi_intermediates\test_cc_ccache_iterator_next.obj'
test_cc_ccache_iterator_next.c
test_cc_ccache_iterator_next.c(13): warning C4013: 'check_cc_ccache_iterator_next' undefined; assuming extern returning int
C:\projects\krb5\src\ccapi\test\test_cc_ccache_iterator_next.c : fatal error C1083: Cannot open compiler generated file: 'C:\projects\krb5\src\ccapi\test\test_cc_ccache_iterator_next.obj': Permission denied
NMAKE : fatal error U1077: '"C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.15.26726\bin\HostX64\x64\cl.EXE"' : return code '0x1'
```

Compared to a successful build, all of the lines up to the error message are the same, so us specifying -Fd twice is nothing new (the first one comes via ALL_CFLAGS from PDB_OPTS in win-pre.in and would be hard to elide).  However, -Fd specifies where the .pdb file should go, not the .obj file; correcting that fixes the build failure.  Doc reference:

https://docs.microsoft.com/en-us/cpp/build/reference/fd-program-database-file-name

A few unknowns that I don't plan to resolve at this time:

* Why does a PDB file in ccapi\test\ccapi_intermediates\test_cc_ccache_iterator_next.obj conflict with creating an object file at ccapi\test\test_cc_ccache_iterator_next.obj with this version of the compiler?

* Why does ccapi/test/Makefile.in need to specify a special location for the PDB files? What's wrong with the usual obj\AMD64\dbg or whatever?

* We also pass -FD in PDB_OPTS.  Does this do anything useful?  https://docs.microsoft.com/en-us/cpp/build/reference/fd-ide-minimal-rebuild suggests that it doesn't.

---

The -Fd cl option specifies the location of the program database
filename, which should have the extension .pdb.  Using a .obj
extension causes a build failure with MSVC version 14.15.26726.
