### PR TITLE
Check more time function results

### DIFF
--- a/src/lib/kadm5/logger.c
+++ b/src/lib/kadm5/logger.c
@@ -638,6 +638,7 @@ klog_vsyslog(int priority, const char *format, va_list arglist)
     time_t      now;
 #ifdef  HAVE_STRFTIME
     size_t      soff;
+    struct tm  *tm;
 #else
     char       *r;
 #endif
@@ -657,7 +658,10 @@ klog_vsyslog(int priority, const char *format, va_list arglist)
     /*
      * Format the date: mon dd hh:mm:ss
      */
-    soff = strftime(outbuf, sizeof(outbuf), "%b %d %H:%M:%S", localtime(&now));
+    tm = localtime(&now);
+    if (tm == NULL)
+        return(-1);
+    soff = strftime(outbuf, sizeof(outbuf), "%b %d %H:%M:%S", tm);
     if (soff > 0)
         cp += soff;
     else

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
@@ -1748,13 +1748,15 @@ getstringtime(krb5_timestamp epochtime)
     char                *strtime=NULL;
     time_t              posixtime = ts2tt(epochtime);
 
-    strtime = calloc (50, 1);
-    if (strtime == NULL)
-        return NULL;
-
     if (gmtime_r(&posixtime, &tme) == NULL)
         return NULL;
 
-    strftime(strtime, 50, "%Y%m%d%H%M%SZ", &tme);
+    strtime = calloc(50, 1);
+    if (strtime == NULL)
+        return NULL;
+    if (strftime(strtime, 50, "%Y%m%d%H%M%SZ", &tme) == 0) {
+        free(strtime);
+        return NULL;
+    }
     return strtime;
 }


### PR DESCRIPTION
[Coverity pointed out a couple more of these that I had missed.]

In logger.c:klog_vsyslog(), check the return value of localtime().  In
ldap_principal2.c:getstringtime(), check the strftime() result and
don't leak strtime on error.
