### PR TITLE
Check mech cred in gss_inquire_cred_by_mech()

### DIFF
--- a/src/lib/gssapi/mechglue/g_inq_cred.c
+++ b/src/lib/gssapi/mechglue/g_inq_cred.c
@@ -197,6 +197,8 @@ gss_inquire_cred_by_mech(minor_status, cred_handle, mech_type, name,
 
     union_cred = (gss_union_cred_t) cred_handle;
     mech_cred = gssint_get_mechanism_cred(union_cred, selected_mech);
+    if (cred_handle != GSS_C_NO_CREDENTIAL && mech_cred == GSS_C_NO_CREDENTIAL)
+	return (GSS_S_NO_CRED);
 
     public_mech = gssint_get_public_oid(selected_mech);
     status = mech->gss_inquire_cred_by_mech(minor_status,


### PR DESCRIPTION
[Discovered while working on gss_add_cred() fixes, because I want to use gss_inquire_cred_by_mech() with non-present mechs in the test cases.  RFC 2744 doesn't say anything explicit about what this behavior should be, but our behavior is clearly wrong.  The Solaris mechglue returns GSS_S_DEFECTIVE_CREDENTIAL in this case, but I decided to be consistent with Heimdal.]

If gss_inquire_cred_by_mech() is called with a mechanism and there is
no corresponding mechanism credential in the union cred, return
GSS_S_NO_CRED (as Heimdal does) instead of interrogating the mechanism
about the default credential.
