### PR TITLE
Fix misleading indentation in clnt_udp.c

### DIFF
--- a/src/lib/rpc/clnt_udp.c
+++ b/src/lib/rpc/clnt_udp.c
@@ -196,7 +196,7 @@ clntudp_bufcreate(
 	}
 	if (connect(*sockp, (struct sockaddr *)raddr, sizeof(*raddr)) < 0)
 	     goto fooy;
-	     cu->cu_llen = sizeof(cu->cu_laddr);
+	cu->cu_llen = sizeof(cu->cu_laddr);
 	if (getsockname(*sockp, (struct sockaddr *)&cu->cu_laddr, &cu->cu_llen) < 0)
 	     goto fooy;
 


### PR DESCRIPTION
gcc warns that the `if` statement doesn't guard the length
assignment, which is true.  However, it wouldn't make sense for the
length assignment to be guarded by the `if` clause anyway, since the
previous statement is a `goto`.  De-indent for clarity.