### PR TITLE
Always honor desired_name in gss_add_cred()

### DIFF
--- a/src/lib/gssapi/mechglue/g_acquire_cred.c
+++ b/src/lib/gssapi/mechglue/g_acquire_cred.c
@@ -502,22 +502,20 @@ gss_add_cred_from(minor_status, input_cred_handle,
 	    return (status);
     }
 
-    /* for default credentials we will use GSS_C_NO_NAME */
-    if (input_cred_handle != GSS_C_NO_CREDENTIAL ||
-        cred_store != GSS_C_NO_CRED_STORE) {
-	/* may need to create a mechanism specific name */
-	if (desired_name) {
-	    union_name = (gss_union_name_t)desired_name;
-	    if (union_name->mech_type &&
-		g_OID_equal(union_name->mech_type, selected_mech))
-		internal_name = union_name->mech_name;
-	    else {
-		if (gssint_import_internal_name(minor_status, selected_mech,
-						union_name, &allocated_name) !=
-		    GSS_S_COMPLETE)
-		    return (GSS_S_BAD_NAME);
-		internal_name = allocated_name;
+    /* We may need to create a mechanism specific name. */
+    if (desired_name != GSS_C_NO_NAME) {
+	union_name = (gss_union_name_t)desired_name;
+	if (union_name->mech_type &&
+	    g_OID_equal(union_name->mech_type, selected_mech)) {
+	    internal_name = union_name->mech_name;
+	} else {
+	    if (gssint_import_internal_name(minor_status, selected_mech,
+					    union_name, &allocated_name) !=
+		GSS_S_COMPLETE) {
+		status = GSS_S_BAD_NAME;
+		goto errout;
 	    }
+	    internal_name = allocated_name;
 	}
     }
 

--- a/src/tests/gssapi/t_add_cred.c
+++ b/src/tests/gssapi/t_add_cred.c
@@ -48,6 +48,7 @@ main()
     OM_uint32 minor, major;
     gss_cred_id_t cred1, cred2;
     gss_cred_usage_t usage;
+    gss_name_t name;
 
     /* Check that we get the expected error if we pass neither an input nor an
      * output cred handle. */
@@ -55,6 +56,15 @@ main()
                          &mech_krb5, GSS_C_INITIATE, GSS_C_INDEFINITE,
                          GSS_C_INDEFINITE, NULL, NULL, NULL, NULL);
     assert(major == (GSS_S_CALL_INACCESSIBLE_WRITE | GSS_S_NO_CRED));
+
+    /* Regression test for #8737: make sure that desired_name is honored when
+     * creating a credential by passing in a non-matching name. */
+    name = import_name("p:does/not/match@WRONG_REALM");
+    major = gss_add_cred(&minor, GSS_C_NO_CREDENTIAL, name, &mech_krb5,
+                         GSS_C_INITIATE, GSS_C_INDEFINITE, GSS_C_INDEFINITE,
+                         &cred1, NULL, NULL, NULL);
+    assert(major == GSS_S_CRED_UNAVAIL);
+    gss_release_name(&minor, &name);
 
     /* Create cred1 with a krb5 initiator cred by passing an output handle but
      * no input handle. */


### PR DESCRIPTION
Remove the conditionalization around the desired_name processing in
gss_add_cred_from(), so that we always honor the requested name.
