### PR TITLE
Remove LDAP osa_princ_ent_rec XDR functions

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -621,8 +621,6 @@ OTHEREXCLUDES = \
 	lib/krb5/unicode \
 	plugins/kdb/db2/libdb2 \
 	plugins/kdb/db2/pol_xdr.c \
-	plugins/kdb/ldap/libkdb_ldap/princ_xdr.c \
-	plugins/kdb/ldap/libkdb_ldap/princ_xdr.h \
 	plugins/preauth/pkinit/pkcs11.h \
 	plugins/preauth/pkinit/pkinit_accessor.h \
 	plugins/preauth/pkinit/pkinit_crypto.h \

--- a/src/plugins/kdb/ldap/deps
+++ b/src/plugins/kdb/ldap/deps
@@ -3,22 +3,25 @@
 #
 ldap_exp.so ldap_exp.po $(OUTPRE)ldap_exp.$(OBJEXT): \
   $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/gssapi/gssapi.h \
-  $(BUILDTOP)/include/gssrpc/types.h $(BUILDTOP)/include/krb5/krb5.h \
-  $(BUILDTOP)/include/osconf.h $(BUILDTOP)/include/profile.h \
-  $(COM_ERR_DEPS) $(srcdir)/../../../lib/kdb/kdb5.h $(srcdir)/libkdb_ldap/kdb_ldap.h \
-  $(srcdir)/libkdb_ldap/ldap_krbcontainer.h $(srcdir)/libkdb_ldap/ldap_principal.h \
-  $(srcdir)/libkdb_ldap/ldap_pwd_policy.h $(srcdir)/libkdb_ldap/ldap_realm.h \
-  $(srcdir)/libkdb_ldap/ldap_tkt_policy.h $(srcdir)/libkdb_ldap/princ_xdr.h \
-  $(top_srcdir)/include/gssrpc/auth.h $(top_srcdir)/include/gssrpc/auth_gss.h \
-  $(top_srcdir)/include/gssrpc/auth_unix.h $(top_srcdir)/include/gssrpc/clnt.h \
-  $(top_srcdir)/include/gssrpc/rename.h $(top_srcdir)/include/gssrpc/rpc.h \
-  $(top_srcdir)/include/gssrpc/rpc_msg.h $(top_srcdir)/include/gssrpc/svc.h \
-  $(top_srcdir)/include/gssrpc/svc_auth.h $(top_srcdir)/include/gssrpc/xdr.h \
-  $(top_srcdir)/include/k5-buf.h $(top_srcdir)/include/k5-err.h \
-  $(top_srcdir)/include/k5-gmt_mktime.h $(top_srcdir)/include/k5-int-pkinit.h \
-  $(top_srcdir)/include/k5-int.h $(top_srcdir)/include/k5-platform.h \
-  $(top_srcdir)/include/k5-plugin.h $(top_srcdir)/include/k5-thread.h \
-  $(top_srcdir)/include/k5-trace.h $(top_srcdir)/include/kdb.h \
-  $(top_srcdir)/include/krb5.h $(top_srcdir)/include/krb5/authdata_plugin.h \
-  $(top_srcdir)/include/krb5/plugin.h $(top_srcdir)/include/port-sockets.h \
-  $(top_srcdir)/include/socket-utils.h ldap_exp.c
+  $(BUILDTOP)/include/gssrpc/types.h $(BUILDTOP)/include/kadm5/admin.h \
+  $(BUILDTOP)/include/kadm5/admin_internal.h $(BUILDTOP)/include/kadm5/chpass_util_strings.h \
+  $(BUILDTOP)/include/kadm5/kadm_err.h $(BUILDTOP)/include/kadm5/server_internal.h \
+  $(BUILDTOP)/include/krb5/krb5.h $(BUILDTOP)/include/osconf.h \
+  $(BUILDTOP)/include/profile.h $(COM_ERR_DEPS) $(srcdir)/../../../lib/kdb/kdb5.h \
+  $(srcdir)/libkdb_ldap/kdb_ldap.h $(srcdir)/libkdb_ldap/ldap_krbcontainer.h \
+  $(srcdir)/libkdb_ldap/ldap_principal.h $(srcdir)/libkdb_ldap/ldap_pwd_policy.h \
+  $(srcdir)/libkdb_ldap/ldap_realm.h $(srcdir)/libkdb_ldap/ldap_tkt_policy.h \
+  $(srcdir)/libkdb_ldap/princ_xdr.h $(top_srcdir)/include/gssrpc/auth.h \
+  $(top_srcdir)/include/gssrpc/auth_gss.h $(top_srcdir)/include/gssrpc/auth_unix.h \
+  $(top_srcdir)/include/gssrpc/clnt.h $(top_srcdir)/include/gssrpc/rename.h \
+  $(top_srcdir)/include/gssrpc/rpc.h $(top_srcdir)/include/gssrpc/rpc_msg.h \
+  $(top_srcdir)/include/gssrpc/svc.h $(top_srcdir)/include/gssrpc/svc_auth.h \
+  $(top_srcdir)/include/gssrpc/xdr.h $(top_srcdir)/include/k5-buf.h \
+  $(top_srcdir)/include/k5-err.h $(top_srcdir)/include/k5-gmt_mktime.h \
+  $(top_srcdir)/include/k5-int-pkinit.h $(top_srcdir)/include/k5-int.h \
+  $(top_srcdir)/include/k5-platform.h $(top_srcdir)/include/k5-plugin.h \
+  $(top_srcdir)/include/k5-thread.h $(top_srcdir)/include/k5-trace.h \
+  $(top_srcdir)/include/kdb.h $(top_srcdir)/include/krb5.h \
+  $(top_srcdir)/include/krb5/authdata_plugin.h $(top_srcdir)/include/krb5/plugin.h \
+  $(top_srcdir)/include/port-sockets.h $(top_srcdir)/include/socket-utils.h \
+  ldap_exp.c

--- a/src/plugins/kdb/ldap/libkdb_ldap/deps
+++ b/src/plugins/kdb/ldap/libkdb_ldap/deps
@@ -36,9 +36,11 @@ kdb_ldap_conn.so kdb_ldap_conn.po $(OUTPRE)kdb_ldap_conn.$(OBJEXT): \
   ldap_main.h ldap_misc.h ldap_realm.h ldap_service_stash.h
 ldap_realm.so ldap_realm.po $(OUTPRE)ldap_realm.$(OBJEXT): \
   $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/gssapi/gssapi.h \
-  $(BUILDTOP)/include/gssrpc/types.h $(BUILDTOP)/include/krb5/krb5.h \
-  $(BUILDTOP)/include/osconf.h $(BUILDTOP)/include/profile.h \
-  $(COM_ERR_DEPS) $(top_srcdir)/include/gssrpc/auth.h \
+  $(BUILDTOP)/include/gssrpc/types.h $(BUILDTOP)/include/kadm5/admin.h \
+  $(BUILDTOP)/include/kadm5/admin_internal.h $(BUILDTOP)/include/kadm5/chpass_util_strings.h \
+  $(BUILDTOP)/include/kadm5/kadm_err.h $(BUILDTOP)/include/kadm5/server_internal.h \
+  $(BUILDTOP)/include/krb5/krb5.h $(BUILDTOP)/include/osconf.h \
+  $(BUILDTOP)/include/profile.h $(COM_ERR_DEPS) $(top_srcdir)/include/gssrpc/auth.h \
   $(top_srcdir)/include/gssrpc/auth_gss.h $(top_srcdir)/include/gssrpc/auth_unix.h \
   $(top_srcdir)/include/gssrpc/clnt.h $(top_srcdir)/include/gssrpc/rename.h \
   $(top_srcdir)/include/gssrpc/rpc.h $(top_srcdir)/include/gssrpc/rpc_msg.h \
@@ -57,9 +59,11 @@ ldap_realm.so ldap_realm.po $(OUTPRE)ldap_realm.$(OBJEXT): \
   ldap_tkt_policy.h princ_xdr.h
 ldap_create.so ldap_create.po $(OUTPRE)ldap_create.$(OBJEXT): \
   $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/gssapi/gssapi.h \
-  $(BUILDTOP)/include/gssrpc/types.h $(BUILDTOP)/include/krb5/krb5.h \
-  $(BUILDTOP)/include/osconf.h $(BUILDTOP)/include/profile.h \
-  $(COM_ERR_DEPS) $(top_srcdir)/include/gssrpc/auth.h \
+  $(BUILDTOP)/include/gssrpc/types.h $(BUILDTOP)/include/kadm5/admin.h \
+  $(BUILDTOP)/include/kadm5/admin_internal.h $(BUILDTOP)/include/kadm5/chpass_util_strings.h \
+  $(BUILDTOP)/include/kadm5/kadm_err.h $(BUILDTOP)/include/kadm5/server_internal.h \
+  $(BUILDTOP)/include/krb5/krb5.h $(BUILDTOP)/include/osconf.h \
+  $(BUILDTOP)/include/profile.h $(COM_ERR_DEPS) $(top_srcdir)/include/gssrpc/auth.h \
   $(top_srcdir)/include/gssrpc/auth_gss.h $(top_srcdir)/include/gssrpc/auth_unix.h \
   $(top_srcdir)/include/gssrpc/clnt.h $(top_srcdir)/include/gssrpc/rename.h \
   $(top_srcdir)/include/gssrpc/rpc.h $(top_srcdir)/include/gssrpc/rpc_msg.h \
@@ -91,9 +95,11 @@ ldap_krbcontainer.so ldap_krbcontainer.po $(OUTPRE)ldap_krbcontainer.$(OBJEXT): 
   ldap_krbcontainer.h ldap_main.h ldap_misc.h ldap_realm.h
 ldap_principal.so ldap_principal.po $(OUTPRE)ldap_principal.$(OBJEXT): \
   $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/gssapi/gssapi.h \
-  $(BUILDTOP)/include/gssrpc/types.h $(BUILDTOP)/include/krb5/krb5.h \
-  $(BUILDTOP)/include/osconf.h $(BUILDTOP)/include/profile.h \
-  $(COM_ERR_DEPS) $(top_srcdir)/include/gssrpc/auth.h \
+  $(BUILDTOP)/include/gssrpc/types.h $(BUILDTOP)/include/kadm5/admin.h \
+  $(BUILDTOP)/include/kadm5/admin_internal.h $(BUILDTOP)/include/kadm5/chpass_util_strings.h \
+  $(BUILDTOP)/include/kadm5/kadm_err.h $(BUILDTOP)/include/kadm5/server_internal.h \
+  $(BUILDTOP)/include/krb5/krb5.h $(BUILDTOP)/include/osconf.h \
+  $(BUILDTOP)/include/profile.h $(COM_ERR_DEPS) $(top_srcdir)/include/gssrpc/auth.h \
   $(top_srcdir)/include/gssrpc/auth_gss.h $(top_srcdir)/include/gssrpc/auth_unix.h \
   $(top_srcdir)/include/gssrpc/clnt.h $(top_srcdir)/include/gssrpc/rename.h \
   $(top_srcdir)/include/gssrpc/rpc.h $(top_srcdir)/include/gssrpc/rpc_msg.h \
@@ -113,7 +119,8 @@ ldap_principal.so ldap_principal.po $(OUTPRE)ldap_principal.$(OBJEXT): \
 ldap_principal2.so ldap_principal2.po $(OUTPRE)ldap_principal2.$(OBJEXT): \
   $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/gssapi/gssapi.h \
   $(BUILDTOP)/include/gssrpc/types.h $(BUILDTOP)/include/kadm5/admin.h \
-  $(BUILDTOP)/include/kadm5/chpass_util_strings.h $(BUILDTOP)/include/kadm5/kadm_err.h \
+  $(BUILDTOP)/include/kadm5/admin_internal.h $(BUILDTOP)/include/kadm5/chpass_util_strings.h \
+  $(BUILDTOP)/include/kadm5/kadm_err.h $(BUILDTOP)/include/kadm5/server_internal.h \
   $(BUILDTOP)/include/krb5/krb5.h $(BUILDTOP)/include/osconf.h \
   $(BUILDTOP)/include/profile.h $(COM_ERR_DEPS) $(top_srcdir)/include/gssrpc/auth.h \
   $(top_srcdir)/include/gssrpc/auth_gss.h $(top_srcdir)/include/gssrpc/auth_unix.h \
@@ -149,7 +156,8 @@ ldap_pwd_policy.so ldap_pwd_policy.po $(OUTPRE)ldap_pwd_policy.$(OBJEXT): \
 ldap_misc.so ldap_misc.po $(OUTPRE)ldap_misc.$(OBJEXT): \
   $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/gssapi/gssapi.h \
   $(BUILDTOP)/include/gssrpc/types.h $(BUILDTOP)/include/kadm5/admin.h \
-  $(BUILDTOP)/include/kadm5/chpass_util_strings.h $(BUILDTOP)/include/kadm5/kadm_err.h \
+  $(BUILDTOP)/include/kadm5/admin_internal.h $(BUILDTOP)/include/kadm5/chpass_util_strings.h \
+  $(BUILDTOP)/include/kadm5/kadm_err.h $(BUILDTOP)/include/kadm5/server_internal.h \
   $(BUILDTOP)/include/krb5/krb5.h $(BUILDTOP)/include/osconf.h \
   $(BUILDTOP)/include/profile.h $(COM_ERR_DEPS) $(top_srcdir)/include/gssrpc/auth.h \
   $(top_srcdir)/include/gssrpc/auth_gss.h $(top_srcdir)/include/gssrpc/auth_unix.h \
@@ -198,7 +206,8 @@ ldap_tkt_policy.so ldap_tkt_policy.po $(OUTPRE)ldap_tkt_policy.$(OBJEXT): \
 princ_xdr.so princ_xdr.po $(OUTPRE)princ_xdr.$(OBJEXT): \
   $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/gssapi/gssapi.h \
   $(BUILDTOP)/include/gssrpc/types.h $(BUILDTOP)/include/kadm5/admin.h \
-  $(BUILDTOP)/include/kadm5/chpass_util_strings.h $(BUILDTOP)/include/kadm5/kadm_err.h \
+  $(BUILDTOP)/include/kadm5/admin_internal.h $(BUILDTOP)/include/kadm5/chpass_util_strings.h \
+  $(BUILDTOP)/include/kadm5/kadm_err.h $(BUILDTOP)/include/kadm5/server_internal.h \
   $(BUILDTOP)/include/krb5/krb5.h $(BUILDTOP)/include/osconf.h \
   $(BUILDTOP)/include/profile.h $(COM_ERR_DEPS) $(top_srcdir)/include/gssrpc/auth.h \
   $(top_srcdir)/include/gssrpc/auth_gss.h $(top_srcdir)/include/gssrpc/auth_unix.h \
@@ -246,8 +255,9 @@ ldap_err.so ldap_err.po $(OUTPRE)ldap_err.$(OBJEXT): \
   ldap_err.c ldap_err.h
 lockout.so lockout.po $(OUTPRE)lockout.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
   $(BUILDTOP)/include/gssapi/gssapi.h $(BUILDTOP)/include/gssrpc/types.h \
-  $(BUILDTOP)/include/kadm5/admin.h $(BUILDTOP)/include/kadm5/chpass_util_strings.h \
-  $(BUILDTOP)/include/kadm5/kadm_err.h $(BUILDTOP)/include/krb5/krb5.h \
+  $(BUILDTOP)/include/kadm5/admin.h $(BUILDTOP)/include/kadm5/admin_internal.h \
+  $(BUILDTOP)/include/kadm5/chpass_util_strings.h $(BUILDTOP)/include/kadm5/kadm_err.h \
+  $(BUILDTOP)/include/kadm5/server_internal.h $(BUILDTOP)/include/krb5/krb5.h \
   $(BUILDTOP)/include/osconf.h $(BUILDTOP)/include/profile.h \
   $(COM_ERR_DEPS) $(top_srcdir)/include/gssrpc/auth.h \
   $(top_srcdir)/include/gssrpc/auth_gss.h $(top_srcdir)/include/gssrpc/auth_unix.h \

--- a/src/plugins/kdb/ldap/libkdb_ldap/lockout.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/lockout.c
@@ -44,7 +44,6 @@ lookup_lockout_policy(krb5_context context,
     krb5_tl_data tl_data;
     krb5_error_code code;
     osa_princ_ent_rec adb;
-    XDR xdrs;
 
     *pw_max_fail = 0;
     *pw_failcnt_interval = 0;
@@ -74,9 +73,7 @@ lookup_lockout_policy(krb5_context context,
         krb5_db_free_policy(context, policy);
     }
 
-    xdrmem_create(&xdrs, NULL, 0, XDR_FREE);
-    ldap_xdr_osa_princ_ent_rec(&xdrs, &adb);
-    xdr_destroy(&xdrs);
+    ldap_osa_free_princ_ent(&adb);
 
     return 0;
 }

--- a/src/plugins/kdb/ldap/libkdb_ldap/princ_xdr.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/princ_xdr.c
@@ -1,174 +1,10 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+
 #include "kdb_ldap.h"
 #include "ldap_principal.h"
 #include "princ_xdr.h"
 #include <kadm5/admin.h>
-
-bool_t
-ldap_xdr_krb5_ui_2(XDR *xdrs, krb5_ui_2 *objp)
-{
-    unsigned int tmp;
-
-    tmp = (unsigned int) *objp;
-
-    if (!xdr_u_int(xdrs, &tmp))
-	return(FALSE);
-
-    *objp = (krb5_ui_2) tmp;
-    return(TRUE);
-}
-
-bool_t
-ldap_xdr_krb5_int16(XDR *xdrs, krb5_int16 *objp)
-{
-    int tmp;
-
-    tmp = (int) *objp;
-
-    if (!xdr_int(xdrs, &tmp))
-	return(FALSE);
-
-    *objp = (krb5_int16) tmp;
-    return(TRUE);
-}
-
-bool_t
-ldap_xdr_nullstring(XDR *xdrs, char **objp)
-{
-    u_int size;
-
-    if (xdrs->x_op == XDR_ENCODE) {
-	if (*objp == NULL)
-	    size = 0;
-	else
-	    size = strlen(*objp) + 1;
-    }
-    if (! xdr_u_int(xdrs, &size)) {
-	return FALSE;
-    }
-    switch (xdrs->x_op) {
-    case XDR_DECODE:
-	if (size == 0) {
-	    *objp = NULL;
-	    return TRUE;
-	} else if (*objp == NULL) {
-	    *objp = (char *) mem_alloc(size);
-	    if (*objp == NULL) {
-		/*errno = ENOMEM;*/
-		return FALSE;
-	    }
-	}
-	return (xdr_opaque(xdrs, *objp, size));
-
-    case XDR_ENCODE:
-	if (size != 0)
-	    return (xdr_opaque(xdrs, *objp, size));
-	return TRUE;
-
-    case XDR_FREE:
-	if (*objp != NULL)
-	    mem_free(*objp, size);
-	*objp = NULL;
-	return TRUE;
-    }
-    return FALSE;
-}
-
-bool_t
-ldap_xdr_krb5_kvno(XDR *xdrs, krb5_kvno *objp)
-{
-    unsigned char tmp;
-
-    tmp = '\0'; /* for purify, else xdr_u_char performs a umr */
-
-    if (xdrs->x_op == XDR_ENCODE)
-	tmp = (unsigned char) *objp;
-
-    if (!xdr_u_char(xdrs, &tmp))
-	return (FALSE);
-
-    if (xdrs->x_op == XDR_DECODE)
-	*objp = (krb5_kvno) tmp;
-    return (TRUE);
-}
-
-bool_t
-ldap_xdr_krb5_key_data(XDR *xdrs, krb5_key_data *objp)
-{
-    unsigned int tmp;
-
-    if (!ldap_xdr_krb5_int16(xdrs, &objp->key_data_ver))
-	return(FALSE);
-    if (!ldap_xdr_krb5_ui_2(xdrs, &objp->key_data_kvno))
-	return(FALSE);
-    if (!ldap_xdr_krb5_int16(xdrs, &objp->key_data_type[0]))
-	return(FALSE);
-    if (!ldap_xdr_krb5_int16(xdrs, &objp->key_data_type[1]))
-	return(FALSE);
-    if (!ldap_xdr_krb5_ui_2(xdrs, &objp->key_data_length[0]))
-	return(FALSE);
-    if (!ldap_xdr_krb5_ui_2(xdrs, &objp->key_data_length[1]))
-	return(FALSE);
-
-    tmp = (unsigned int) objp->key_data_length[0];
-    if (!xdr_bytes(xdrs, (char **) &objp->key_data_contents[0],
-		   &tmp, (unsigned int) ~0))
-	return FALSE;
-
-    tmp = (unsigned int) objp->key_data_length[1];
-    if (!xdr_bytes(xdrs, (char **) &objp->key_data_contents[1],
-		   &tmp, (unsigned int) ~0))
-	return FALSE;
-
-    /* don't need to copy tmp out, since key_data_length will be set
-       by the above encoding. */
-    return(TRUE);
-}
-
-bool_t
-ldap_xdr_osa_pw_hist_ent(XDR *xdrs, osa_pw_hist_ent *objp)
-{
-    if (!xdr_array(xdrs, (caddr_t *) &objp->key_data,
-		   (u_int *) &objp->n_key_data, (unsigned int) ~0,
-		   sizeof(krb5_key_data),
-		   ldap_xdr_krb5_key_data))
-	return (FALSE);
-    return (TRUE);
-}
-
-bool_t
-ldap_xdr_osa_princ_ent_rec(XDR *xdrs, osa_princ_ent_t objp)
-{
-    switch (xdrs->x_op) {
-    case XDR_ENCODE:
-	objp->version = OSA_ADB_PRINC_VERSION_1;
-	/* fall through */
-    case XDR_FREE:
-	if (!xdr_int(xdrs, &objp->version))
-	    return FALSE;
-	break;
-    case XDR_DECODE:
-	if (!xdr_int(xdrs, &objp->version))
-	    return FALSE;
-	if (objp->version != OSA_ADB_PRINC_VERSION_1)
-	    return FALSE;
-	break;
-    }
-
-    if (!ldap_xdr_nullstring(xdrs, &objp->policy))
-	return (FALSE);
-    if (!xdr_long(xdrs, &objp->aux_attributes))
-	return (FALSE);
-    if (!xdr_u_int(xdrs, &objp->old_key_next))
-	return (FALSE);
-    if (!ldap_xdr_krb5_kvno(xdrs, &objp->admin_history_kvno))
-	return (FALSE);
-    if (!xdr_array(xdrs, (caddr_t *) &objp->old_keys,
-		   (unsigned int *) &objp->old_key_len, (unsigned int) ~0,
-		   sizeof(osa_pw_hist_ent),
-		   ldap_xdr_osa_pw_hist_ent))
-	return (FALSE);
-    return (TRUE);
-}
+#include <kadm5/server_internal.h>
 
 void
 ldap_osa_free_princ_ent(osa_princ_ent_t val)
@@ -176,7 +12,7 @@ ldap_osa_free_princ_ent(osa_princ_ent_t val)
     XDR xdrs;
 
     xdrmem_create(&xdrs, NULL, 0, XDR_FREE);
-    ldap_xdr_osa_princ_ent_rec(&xdrs, val);
+    xdr_osa_princ_ent_rec(&xdrs, val);
     xdr_destroy(&xdrs);
 }
 
@@ -187,29 +23,28 @@ krb5_lookup_tl_kadm_data(krb5_tl_data *tl_data, osa_princ_ent_rec *princ_entry)
     XDR xdrs;
 
     xdrmem_create(&xdrs, (caddr_t)tl_data->tl_data_contents,
-		  tl_data->tl_data_length, XDR_DECODE);
-    if (! ldap_xdr_osa_princ_ent_rec(&xdrs, princ_entry)) {
-	xdr_destroy(&xdrs);
-	return(KADM5_XDR_FAILURE);
+                  tl_data->tl_data_length, XDR_DECODE);
+    if (!xdr_osa_princ_ent_rec(&xdrs, princ_entry)) {
+        xdr_destroy(&xdrs);
+        return KADM5_XDR_FAILURE;
     }
     xdr_destroy(&xdrs);
 
     return 0;
-
 }
 
 krb5_error_code
 krb5_update_tl_kadm_data(krb5_context context, krb5_db_entry *entry,
-			 osa_princ_ent_rec *princ_entry)
+                         osa_princ_ent_rec *princ_entry)
 {
     XDR xdrs;
     krb5_tl_data tl_data;
     krb5_error_code retval;
 
     xdralloc_create(&xdrs, XDR_ENCODE);
-    if (! ldap_xdr_osa_princ_ent_rec(&xdrs, princ_entry)) {
-	xdr_destroy(&xdrs);
-	return KADM5_XDR_FAILURE;
+    if (!xdr_osa_princ_ent_rec(&xdrs, princ_entry)) {
+        xdr_destroy(&xdrs);
+        return KADM5_XDR_FAILURE;
     }
     tl_data.tl_data_type = KRB5_TL_KADM_DATA;
     tl_data.tl_data_length = xdr_getpos(&xdrs);

--- a/src/plugins/kdb/ldap/libkdb_ldap/princ_xdr.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/princ_xdr.h
@@ -1,59 +1,18 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+
 #ifndef _PRINC_XDR_H
 #define _PRINC_XDR_H 1
 
-#include <sys/types.h>
 #include <krb5.h>
 #include <kdb.h>
-#include <gssrpc/rpc.h>
-
-#ifdef HAVE_MEMORY_H
-#include <memory.h>
-#endif
-
-#define OSA_ADB_PRINC_VERSION_1  0x12345C01
-#define KADM5_XDR_FAILURE                        (43787575L)
-
-typedef struct _osa_pw_hist_t {
-  int n_key_data;
-  krb5_key_data *key_data;
-} osa_pw_hist_ent, *osa_pw_hist_t;
-
-typedef struct _osa_princ_ent_t {
-  int                         version;
-  char                        *policy;
-  long                        aux_attributes;
-  unsigned int                old_key_len;
-  unsigned int                old_key_next;
-  krb5_kvno                   admin_history_kvno;
-  osa_pw_hist_ent             *old_keys;
-} osa_princ_ent_rec, *osa_princ_ent_t;
-
-bool_t
-ldap_xdr_krb5_ui_2(XDR *xdrs, krb5_ui_2 *objp);
-
-bool_t
-ldap_xdr_krb5_int16(XDR *xdrs, krb5_int16 *objp);
-
-bool_t
-ldap_xdr_nullstring(XDR *xdrs, char **objp);
-
-bool_t
-ldap_xdr_krb5_kvno(XDR *xdrs, krb5_kvno *objp);
-
-bool_t
-ldap_xdr_krb5_key_data(XDR *xdrs, krb5_key_data *objp);
-
-bool_t
-ldap_xdr_osa_pw_hist_ent(XDR *xdrs, osa_pw_hist_ent *objp);
-
-bool_t
-ldap_xdr_osa_princ_ent_rec(XDR *xdrs, osa_princ_ent_t objp);
+#include <kadm5/server_internal.h>
 
 void
 ldap_osa_free_princ_ent(osa_princ_ent_t val);
 
 krb5_error_code
-krb5_lookup_tl_kadm_data(krb5_tl_data *tl_data, osa_princ_ent_rec *princ_entry);
+krb5_lookup_tl_kadm_data(krb5_tl_data *tl_data,
+                         osa_princ_ent_rec *princ_entry);
 
 krb5_error_code
 krb5_update_tl_kadm_data(krb5_context context, krb5_db_entry *entry,


### PR DESCRIPTION
[Yang Xiao reported that the LDAP version of xdr_nullstring() didn't contain the same fix to check for terminating null bytes as the libkadm5srv version.  This doesn't manifest as a bug because we only call the LDAP version on marshalled tl-data values we created ourselves based on the normalized policy name and password history attributes.  But there's no reason to have the duplicate version of these marshalling functions at all, so here is a PR to get rid of them.]

The LDAP KDB module contained a duplicate set of functions to marshal
osa_princ_ent_ret structures, perhaps to avoid a circular dependency
on libkadm5srv before KDB modules were dynamically loaded.  We have
been using the libkadm5srv versions of those functions from the DB2
KDB module since release 1.8.  Use them from the LDAP KDB module as
well.

Since no rpcgen output remains in princ_xdr.c and princ_xdr.h, add
emacs mode lines for the krb5 C style to those files and make small
formatting adjustments to match.