### PR TITLE
Fix getdate.y compatability with POSIX yacc

### DIFF
--- a/src/kadmin/cli/getdate.y
+++ b/src/kadmin/cli/getdate.y
@@ -176,8 +176,9 @@ static time_t	yyRelSeconds;
 
 %}
 
-/* Mute shift/reduce warning as per header comment. */
-%expect 4
+/* This would mute the shift/reduce warnings as per header comment; however,
+ * it relies on bison extensions. */
+/* %expect 4 */
 
 %union {
     time_t		Number;


### PR DESCRIPTION
Commit 28fd0a934cdc7b3b42ce213c6d334d4edf1ab591 muted a warning from bison
about shift/reduce conflicts in the grammer.  However, the extension for
suppressing the warning is bison-only.  Revert that portion of the change and
live with the warning rather than adding additional conditionalization.
Reported by Michael Osipov.