### PR TITLE
Allow referrals for S4U2Self requests

### DIFF
--- a/src/kdc/do_tgs_req.c
+++ b/src/kdc/do_tgs_req.c
@@ -269,6 +269,8 @@ process_tgs_req(krb5_kdc_req *request, krb5_data *pkt,
     errcode = kdc_process_s4u2self_req(kdc_active_realm,
                                        request,
                                        header_enc_tkt->client,
+                                       header_ticket->server,
+                                       is_referral,
                                        server,
                                        subkey,
                                        header_enc_tkt->session,
@@ -288,16 +290,8 @@ process_tgs_req(krb5_kdc_req *request, krb5_data *pkt,
 
     if (errcode)
         goto cleanup;
-    if (s4u_x509_user != NULL) {
+    if (s4u_x509_user != NULL)
         setflag(c_flags, KRB5_KDB_FLAG_PROTOCOL_TRANSITION);
-        if (is_referral) {
-            /* The requesting server appears to no longer exist, and we found
-             * a referral instead.  Treat this as a server lookup failure. */
-            errcode = KRB5KDC_ERR_S_PRINCIPAL_UNKNOWN;
-            status = "LOOKING_UP_SERVER";
-            goto cleanup;
-        }
-    }
 
     /* Deal with user-to-user and constrained delegation */
     errcode = decrypt_2ndtkt(kdc_active_realm, request, c_flags,

--- a/src/kdc/kdc_util.h
+++ b/src/kdc/kdc_util.h
@@ -269,6 +269,8 @@ krb5_error_code
 kdc_process_s4u2self_req (kdc_realm_t *kdc_active_realm,
                           krb5_kdc_req *request,
                           krb5_const_principal client_princ,
+                          krb5_const_principal header_srv_princ,
+                          krb5_boolean issuing_referral,
                           const krb5_db_entry *server,
                           krb5_keyblock *tgs_subkey,
                           krb5_keyblock *tgs_session,


### PR DESCRIPTION
as needed for cross realm protocol-transition to work.
See MS-SFU 3.2.5.1.1 for details.

This has been previously explicitly disabled in order
to preserve old behaviour which seem like a bug.

See discussion at:
http://mailman.mit.edu/pipermail/krbdev/2018-September/012992.html