### PR TITLE
Disable stdin buffering in libss dummy readline

### DIFF
--- a/src/util/ss/listen.c
+++ b/src/util/ss/listen.c
@@ -33,6 +33,9 @@ static char *readline(const char *prompt)
     struct termios termbuf;
     char input[BUFSIZ];
 
+    /* Make sure we don't buffer anything beyond the line read. */
+    setvbuf(stdin, 0, _IONBF, 0);
+
     if (tcgetattr(STDIN_FILENO, &termbuf) == 0) {
         termbuf.c_lflag |= ICANON|ISIG|ECHO;
         tcsetattr(STDIN_FILENO, TCSANOW, &termbuf);


### PR DESCRIPTION
readline() is careful not to read more bytes from fd 0 than it has to.
Do the same in the dummy libss readline() by disabling stdin
buffering.
