### PR TITLE
Fix 64-bit Windows socket write error handling

### DIFF
--- a/src/include/port-sockets.h
+++ b/src/include/port-sockets.h
@@ -40,8 +40,9 @@ typedef WSABUF sg_buf;
  */
 /* WSASend returns 0 or SOCKET_ERROR.  */
 #define SOCKET_WRITEV_TEMP DWORD
-#define SOCKET_WRITEV(FD, SG, LEN, TMP)                         \
-    (WSASend((FD), (SG), (LEN), &(TMP), 0, 0, 0) ? -1 : (TMP))
+#define SOCKET_WRITEV(FD, SG, LEN, TMP)                 \
+    (WSASend((FD), (SG), (LEN), &(TMP), 0, 0, 0) ?      \
+     (ssize_t)-1 : (ssize_t)(TMP))
 
 #define SHUTDOWN_READ   SD_RECEIVE
 #define SHUTDOWN_WRITE  SD_SEND

--- a/src/lib/krb5/os/net_write.c
+++ b/src/lib/krb5/os/net_write.c
@@ -47,7 +47,7 @@ krb5_net_write(krb5_context context, int fd, const char *buf, int len)
 int
 krb5int_net_writev(krb5_context context, int fd, sg_buf *sgp, int nsg)
 {
-    int cc, len = 0;
+    ssize_t cc, len = 0;
     SOCKET_WRITEV_TEMP tmp;
 
     while (nsg > 0) {


### PR DESCRIPTION
Add casts to ensure that the result type of SOCKET_WRITEV() on Windows
can represent -1.  Otherwise it will be treated as 2^32-1 when cast to
ssize_t on 64-bit Windows.
