### PR TITLE
Document aliases for enterprise get_principal

### DIFF
--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -1018,9 +1018,10 @@ typedef struct _kdb_vftabl {
      *     requested; also set by the admin interface.  Determines whether the
      *     module should return in-realm aliases.
      *
-     * A module can return in-realm aliases if KRB5_KDB_FLAG_ALIAS_OK is set.
-     * To return an in-realm alias, fill in a different value for
-     * entries->princ than the one requested.
+     * A module can return in-realm aliases if KRB5_KDB_FLAG_ALIAS_OK is set,
+     * or if search_for->type is KRB5_NT_ENTERPRISE_PRINCIPAL.  To return an
+     * in-realm alias, fill in a different value for entries->princ than the
+     * one requested.
      *
      * A module can return out-of-realm referrals if KRB5_KDB_FLAG_CANONICALIZE
      * is set.  For AS request clients (KRB5_KDB_FLAG_CLIENT_REFERRALS_ONLY is


### PR DESCRIPTION
[As noted in PR #857, the alternative here is to change kdc_process_s4u2self_req() to pass ALIAS_OKAY to get_principal when looking up the requested client principal.  We always use the client's requested name for the ticket, so there probably wouldn't be any harm in that.]

Enterprise principals are always aliases.  In most contexts when we
see them we pass KRB5_KDB_FLAG_ALIAS_OK to the KDB module's
get_principal method, but for S4U2Proxy clients we currently do not.
Document that a KDB module may return an alias for enterprise
principals regardless of flags.
