### PR TITLE
Fix spurious errors from kcmio_unix_socket_write

### DIFF
--- a/src/lib/krb5/ccache/cc_kcm.c
+++ b/src/lib/krb5/ccache/cc_kcm.c
@@ -308,8 +308,9 @@ kcmio_unix_socket_write(krb5_context context, struct kcmio *io, void *request,
 
     for (;;) {
         ret = krb5int_net_writev(context, io->fd, sg, 2);
-        if (ret < 0)
-            ret = errno;
+        if (ret >= 0)
+            return 0;
+        ret = errno;
         if (ret != EPIPE || reconnected)
             return ret;
 
@@ -327,8 +328,6 @@ kcmio_unix_socket_write(krb5_context context, struct kcmio *io, void *request,
             return ret;
         reconnected = TRUE;
     }
-
-    return ret;
 }
 
 /* Read a KCM reply: 4-byte big-endian length, 4-byte big-endian status code,


### PR DESCRIPTION
Commit 33634a940166d0b21c3105bab8dcf5550fbbd678 accidentally changed
the return value from kcmio_unix_socket_write to be the result of the
write call.  Most commonly this resulted in it returning 8, which led
to many commands failing; for instance:

kinit: Exec format error while getting default ccache

tags: pullup
target_version: 1.17-next