### PR TITLE
Document necessary delay in master key rolllover

### DIFF
--- a/doc/admin/database.rst
+++ b/doc/admin/database.rst
@@ -535,6 +535,10 @@ availability.  To roll over the master key, follow these steps:
    use unlocked iteration; this variant will take longer, but will
    keep the database available to the KDC and kadmind while it runs.
 
+#. Wait until the above changes have propagated to all replica KDCs
+   and until all running KDC and kadmind processes have serviced
+   requests using updated principal entries.
+
 #. On the master KDC, run ``kdb5_util purge_mkeys`` to clean up the
    old master key.
 


### PR DESCRIPTION
[None of the code fixes for issue 8744 are easy, but documenting it is trivial and should largely address the problem.]

During master key rollover, if the old master key is purged
immediately after updating principal encryption, running processes may
not successfully update their in-memory copies of the master key.
Document that the administrator should delay purging the master key
until after propagation and some daemon activity.
