### PR TITLE
Add ksu option for non-forwardable tickets

### DIFF
--- a/doc/user/user_commands/ksu.rst
+++ b/doc/user/user_commands/ksu.rst
@@ -12,7 +12,8 @@ SYNOPSIS
 [ **-c** *source_cache_name* ]
 [ **-k** ]
 [ **-r** time ]
-[ **-pf** ]
+[ **-p** | **-P**]
+[ **-f** | **-F**]
 [ **-l** *lifetime* ]
 [ **-z | Z** ]
 [ **-q** ]
@@ -247,7 +248,7 @@ OPTIONS
 
 Ticket granting ticket options:
 
-**-l** *lifetime* **-r** *time* **-pf**
+**-l** *lifetime* **-r** *time* **-p** **-P** **-f** **-F**
     The ticket granting ticket options only apply to the case where
     there are no appropriate tickets in the cache to authenticate the
     source user.  In this case if ksu is configured to prompt users
@@ -269,9 +270,19 @@ Ticket granting ticket options:
     specifies that the **proxiable** option should be requested for
     the ticket.
 
+**-P**
+    specifies that the **proxiable** option should not be requested
+    for the ticket, even if the default configuration is to ask for
+    proxiable tickets.
+
 **-f**
     option specifies that the **forwardable** option should be
     requested for the ticket.
+
+**-F**
+    option specifies that the **forwardable** option should not be
+    requested for the ticket, even if the default configuration is to
+    ask for forwardable tickets.
 
 **-e** *command* [*args* ...]
     ksu proceeds exactly the same as if it was invoked without the

--- a/src/clients/ksu/main.c
+++ b/src/clients/ksu/main.c
@@ -66,7 +66,7 @@ static krb5_error_code resolve_target_cache(krb5_context ksu_context,
 void usage (){
     fprintf(stderr,
             _("Usage: %s [target user] [-n principal] [-c source cachename] "
-              "[-k] [-r time] [-pf] [-l lifetime] [-zZ] [-q] "
+              "[-k] [-r time] [-p|-P] [-f|-F] [-l lifetime] [-zZ] [-q] "
               "[-e command [args... ] ] [-a [args... ] ]\n"), prog_name);
 }
 
@@ -189,7 +189,8 @@ main (argc, argv)
         com_err (prog_name, errno, _("while setting euid to source user"));
         exit (1);
     }
-    while(!done && ((option = getopt(pargc, pargv,"n:c:r:a:zZDfpkql:e:")) != -1)){
+    while (!done &&
+           (option = getopt(pargc, pargv,"n:c:r:a:zZDfFpPkql:e:")) != -1) {
         switch (option) {
         case 'r':
             if (strlen (optarg) >= 14)
@@ -217,8 +218,14 @@ main (argc, argv)
         case 'p':
             krb5_get_init_creds_opt_set_proxiable(options, 1);
             break;
+        case 'P':
+            krb5_get_init_creds_opt_set_proxiable(options, 0);
+            break;
         case 'f':
             krb5_get_init_creds_opt_set_forwardable(options, 1);
+            break;
+        case 'F':
+            krb5_get_init_creds_opt_set_forwardable(options, 0);
             break;
         case 'k':
             keep_target_cache =1;


### PR DESCRIPTION
Add ksu -F and -P options to explicitly not request forwardable and
proxiable tickets.
