### PR TITLE
Change dns_canonicalize_hostname profile option

### DIFF
--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -201,6 +201,10 @@ The libdefaults section may contain any of the following relations:
     means that short hostnames will not be canonicalized to
     fully-qualified hostnames.  The default value is true.
 
+    If this option is set to ``fallback`` (new in release 1.18), DNS
+    canonicalization will only be performed the server hostname is not
+    found with the original name when requesting credentials.
+
 **dns_lookup_kdc**
     Indicate whether DNS SRV records should be used to locate the KDCs
     and other servers for a realm, if they are not listed in the

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -1158,6 +1158,12 @@ k5_plugin_register_dyn(krb5_context context, int interface_id,
 void
 k5_plugin_free_context(krb5_context context);
 
+enum dns_canonhost {
+    CANONHOST_FALSE = 0,
+    CANONHOST_TRUE = 1,
+    CANONHOST_FALLBACK = 2
+};
+
 struct _kdb5_dal_handle;        /* private, in kdb5.h */
 typedef struct _kdb5_dal_handle kdb5_dal_handle;
 struct _kdb_log_context;
@@ -1221,7 +1227,7 @@ struct _krb5_context {
 
     krb5_boolean allow_weak_crypto;
     krb5_boolean ignore_acceptor_hostname;
-    krb5_boolean dns_canonicalize_hostname;
+    enum dns_canonhost dns_canonicalize_hostname;
 
     krb5_trace_callback trace_callback;
     void *trace_callback_data;

--- a/src/include/k5-trace.h
+++ b/src/include/k5-trace.h
@@ -191,6 +191,9 @@ void krb5int_trace(krb5_context context, const char *fmt, ...);
 #define TRACE_FAST_REQUIRED(c)                                  \
     TRACE(c, "Using FAST due to KRB5_FAST_REQUIRED flag")
 
+#define TRACE_GET_CREDS_FALLBACK(c, hostname)                           \
+    TRACE(c, "Falling back to canonicalized server hostname {str}", hostname)
+
 #define TRACE_GIC_PWD_CHANGED(c)                                \
     TRACE(c, "Getting initial TGT with changed password")
 #define TRACE_GIC_PWD_CHANGEPW(c, tries)                                \

--- a/src/lib/krb5/krb/t_copy_context.c
+++ b/src/lib/krb5/krb/t_copy_context.c
@@ -145,7 +145,7 @@ main(int argc, char **argv)
     ctx->udp_pref_limit = 2345;
     ctx->use_conf_ktypes = TRUE;
     ctx->ignore_acceptor_hostname = TRUE;
-    ctx->dns_canonicalize_hostname = FALSE;
+    ctx->dns_canonicalize_hostname = CANONHOST_FALSE;
     free(ctx->plugin_base_dir);
     check((ctx->plugin_base_dir = strdup("/a/b/c/d")) != NULL);
 

--- a/src/lib/krb5/os/os-proto.h
+++ b/src/lib/krb5/os/os-proto.h
@@ -83,6 +83,10 @@ struct sendto_callback_info {
     void *data;
 };
 
+krb5_error_code k5_expand_hostname(krb5_context context, const char *host,
+                                   krb5_boolean is_fallback,
+                                   char **canonhost_out);
+
 krb5_error_code k5_locate_server(krb5_context, const krb5_data *realm,
                                  struct serverlist *serverlist,
                                  enum locate_service_type svc,

--- a/src/tests/gcred.c
+++ b/src/tests/gcred.c
@@ -66,6 +66,7 @@ main(int argc, char **argv)
     krb5_principal client, server;
     krb5_ccache ccache;
     krb5_creds in_creds, *creds;
+    krb5_ticket *ticket;
     krb5_flags options = 0;
     char *name;
     int c;
@@ -102,9 +103,11 @@ main(int argc, char **argv)
     in_creds.client = client;
     in_creds.server = server;
     check(krb5_get_credentials(ctx, options, ccache, &in_creds, &creds));
-    check(krb5_unparse_name(ctx, creds->server, &name));
+    check(krb5_decode_ticket(&creds->ticket, &ticket));
+    check(krb5_unparse_name(ctx, ticket->server, &name));
     printf("%s\n", name);
 
+    krb5_free_ticket(ctx, ticket);
     krb5_free_unparsed_name(ctx, name);
     krb5_free_creds(ctx, creds);
     krb5_free_principal(ctx, client);

--- a/src/tests/t_sn2princ.py
+++ b/src/tests/t_sn2princ.py
@@ -7,10 +7,15 @@ conf = {'domain_realm': {'kerberos.org': 'R1',
                          'mit.edu': 'R3'}}
 no_rdns_conf = {'libdefaults': {'rdns': 'false'}}
 no_canon_conf = {'libdefaults': {'dns_canonicalize_hostname': 'false'}}
+fallback_canon_conf = {'libdefaults':
+                       {'rdns': 'false',
+                        'dns_canonicalize_hostname': 'fallback'}}
 
-realm = K5Realm(create_kdb=False, krb5_conf=conf)
+realm = K5Realm(realm='R1', create_host=False, krb5_conf=conf)
 no_rdns = realm.special_env('no_rdns', False, krb5_conf=no_rdns_conf)
 no_canon = realm.special_env('no_canon', False, krb5_conf=no_canon_conf)
+fallback_canon = realm.special_env('fallback_canon', False,
+                                   krb5_conf=fallback_canon_conf)
 
 def testbase(host, nametype, princhost, princrealm, env=None):
     # Run the sn2princ harness with a specified host and name type and
@@ -36,6 +41,10 @@ def testnr(host, princhost, princrealm):
 def testu(host, princhost, princrealm):
     # Test with the unknown name type.
     testbase(host, 'unknown', princhost, princrealm)
+
+def testfc(host, princhost, princrealm):
+    # Test with the host-based name type with canonicalization fallback.
+    testbase(host, 'srv-hst', princhost, princrealm, env=fallback_canon)
 
 # With the unknown principal type, we do not canonicalize or downcase,
 # but we do remove a trailing period and look up the realm.
@@ -70,6 +79,29 @@ if offline:
 # and reverse resolving to these names.
 oname = 'ptr-mismatch.kerberos.org'
 fname = 'www.kerberos.org'
+
+# Test fallback canonicalization krb5_sname_to_principal() results
+# (same as dns_canonicalize_hostname=false).
+mark('dns_canonicalize_host=fallback')
+testfc(oname, oname, 'R1')
+
+# Test fallback canonicalization in krb5_get_credentials().
+oprinc = 'host/' + oname
+fprinc = 'host/' + fname
+shutil.copy(realm.ccache, realm.ccache + '.save')
+realm.addprinc(fprinc)
+# oprinc doesn't exist, so we get the canonicalized fprinc as a fallback.
+msgs = ('Falling back to canonicalized server hostname ' + fname,)
+realm.run(['./gcred', 'srv-hst', oprinc], env=fallback_canon,
+          expected_msg=fprinc, expected_trace=msgs)
+realm.addprinc(oprinc)
+# oprinc now exists, but we still get the fprinc ticket from the cache.
+realm.run(['./gcred', 'srv-hst', oprinc], env=fallback_canon,
+          expected_msg=fprinc)
+# Without the cached result, we sould get oprinc in preference to fprinc.
+os.rename(realm.ccache + '.save', realm.ccache)
+realm.run(['./gcred', 'srv-hst', oprinc], env=fallback_canon,
+          expected_msg=oprinc)
 
 # Verify forward resolution before testing for it.
 try:


### PR DESCRIPTION
Turns it into a three-state that allows the value "fallback" on top
of the true/false booleans supported previously.

When the option is set to fallback we dealy canonicalization and attempt
it only in krb5_get_credentials() if the KDC responds that the requested
server principal name is unknown.