### PR TITLE
imporomper initialization breaks compilation on Solaris

### DIFF
--- a/src/configure.in
+++ b/src/configure.in
@@ -842,6 +842,10 @@ AC_CHECK_TYPES([struct rt_msghdr], , , [
 #include <net/route.h>
 ])
 
+# Tests for 64-bit edwards25519 code.
+AC_CHECK_SIZEOF([size_t])
+AC_CHECK_TYPES([__int128_t, __uint128_t])
+
 # stuff for util/profile
 
 # AC_KRB5_TCL already done

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
@@ -628,7 +628,7 @@ update_ldap_mod_auth_ind(krb5_context context, krb5_db_entry *entry,
     int i = 0;
     krb5_error_code ret;
     char *auth_ind = NULL;
-    char *strval[10] = {};
+    char *strval[10] = { 0 };
     char *ai, *ai_save = NULL;
     int sv_num = sizeof(strval) / sizeof(*strval);
 

--- a/src/plugins/preauth/spake/edwards25519.c
+++ b/src/plugins/preauth/spake/edwards25519.c
@@ -101,17 +101,10 @@
 #pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
 #endif
 
-/*
- * These preprocessor conditionals are derived the BoringSSL
- * include/openssl/base.h (OPENSSL_64_BIT) and crypto/internal.h
- * (BORINGSSL_HAS_UINT128).
- */
-#if defined(__x86_64) || defined(_M_AMD64) || defined(_M_X64) || defined(__aarch64__) || ((defined(__PPC64__) || defined(__powerpc64__)) && defined(_LITTLE_ENDIAN)) || defined(__mips__) && defined(__LP64__)
-#if !defined(_MSC_VER) || defined(__clang__)
+#if SIZEOF_SIZE_T >= 8 && defined(HAVE___INT128_T) && defined(HAVE___UINT128_T)
 #define BORINGSSL_CURVE25519_64BIT
 typedef __int128_t int128_t;
 typedef __uint128_t uint128_t;
-#endif
 #endif
 
 #ifndef EDWARDS25519_ASSERTS

--- a/src/plugins/preauth/spake/util.c
+++ b/src/plugins/preauth/spake/util.c
@@ -78,6 +78,7 @@ update_thash(krb5_context context, groupstate *gstate, int32_t group,
     krb5_error_code ret;
     size_t hashlen;
     krb5_data dlist[3];
+    const krb5_data empty = empty_data();
 
     if (thash->length == 0) {
         /* Initialize the transcript hash to all zeros. */
@@ -91,8 +92,8 @@ update_thash(krb5_context context, groupstate *gstate, int32_t group,
 
     /* Set up the data array and hash it with the group's hash function. */
     dlist[0] = *thash;
-    dlist[1] = (data1 != NULL) ? *data1 : empty_data();
-    dlist[2] = (data2 != NULL) ? *data2 : empty_data();
+    dlist[1] = (data1 != NULL) ? *data1 : empty;
+    dlist[2] = (data2 != NULL) ? *data2 : empty;
     return group_hash(context, gstate, group, dlist, 3,
                       (uint8_t *)thash->data);
 }

--- a/src/util/support/Makefile.in
+++ b/src/util/support/Makefile.in
@@ -203,7 +203,7 @@ libkrb5support.exports: $(srcdir)/libkrb5support-fixed.exports Makefile
 ##DOS##	$(RM) libkrb5support.exports
 ##DOS##	$(MV) new-exports libkrb5support.exports
 
-T_K5BUF_OBJS= t_k5buf.o k5buf.o $(PRINTF_ST_OBJ)
+T_K5BUF_OBJS= t_k5buf.o k5buf.o zap.o $(PRINTF_ST_OBJ)
 
 t_k5buf: $(T_K5BUF_OBJS)
 	$(CC_LINK) -o t_k5buf $(T_K5BUF_OBJS)
@@ -223,7 +223,7 @@ path_win.o: $(srcdir)/path.c
 t_base64: t_base64.o base64.o
 	$(CC_LINK) -o $@ t_base64.o base64.o
 
-T_JSON_OBJS= t_json.o json.o base64.o k5buf.o $(PRINTF_ST_OBJ)
+T_JSON_OBJS= t_json.o json.o base64.o k5buf.o zap.o $(PRINTF_ST_OBJ)
 
 t_json: $(T_JSON_OBJS)
 	$(CC_LINK) -o $@ $(T_JSON_OBJS)
@@ -240,7 +240,7 @@ t_unal: t_unal.o
 t_utf8: t_utf8.o utf8.o
 	$(CC_LINK) -o t_utf8 t_utf8.o utf8.o
 
-T_UTF16_OBJS= t_utf16.o utf8_conv.o utf8.o k5buf.o $(PRINTF_ST_OBJ)
+T_UTF16_OBJS= t_utf16.o utf8_conv.o utf8.o k5buf.o zap.o $(PRINTF_ST_OBJ)
 
 t_utf16: $(T_UTF16_OBJS)
 	$(CC_LINK) -o $@ $(T_UTF16_OBJS)


### PR DESCRIPTION
gcc we use on Solaris complains about empty initialization. This small patch
makes it happy.

I gave a try to krb5-1.17-beta2