### PR TITLE
Fix: test if login is needed, OR possible, to determine whether to call pkinit_login().

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -3855,8 +3855,8 @@ pkinit_open_session(krb5_context context,
     pkiDebug("open_session: slotid %d (%lu of %d)\n", (int)cctx->slotid,
              i + 1, (int) count);
 
-    /* Login if needed */
-    if (tinfo.flags & CKF_LOGIN_REQUIRED) {
+    /* Login if needed, or possible. */
+    if (tinfo.flags & (CKF_LOGIN_REQUIRED | CKF_PROTECTED_AUTHENTICATION_PATH)) {
         if (cctx->p11_module_name != NULL) {
             if (cctx->slotid != PK_NOSLOT) {
                 if (asprintf(&p11name,


### PR DESCRIPTION
To support ANTS IAS-ECC middleware module `libiaspkcs11.so`, we must test only whether the "PIN pad is present" flag, and not the "login required" flag, since `libiaspkcs11.so` doesn't set it.

[](https://ants.gouv.fr/Les-solutions/Identite-numerique2/Technologie-cartes-IAS-ECC/Pilote-carte-middleware)


The modules `libiaspkcs11.so` and `opensc-pkcs11.so` behave quite differently.

Of notable difference, is the absence of the login required flag with `libiaspkcs11.so`, which prevents the pkinit kerberos plugin to perform the pinpad login.

```
B/1:24:19[pjb@L0231342 :0.0 tmp]$ pkcs11-tool --module=/usr/local/lib/libiaspkcs11.so --list-slots
Available slots:
Slot 0 (0x1): Leo v2 (8288830623) 00 00
  token label        : ECC MI
  token manufacturer :
  token model        : ECC MI
  token flags        : PIN pad present, rng, token initialized, PIN initialized, readonly
  hardware version   : 1.0
  firmware version   : 1.0
  serial num         : 4938720064285
  pin min/max        : 4/32


B/1:24:19[pjb@L0231342 :0.0 tmp]$ pkcs11-tool --module=/usr/local/lib/opensc-pkcs11.so --list-slots --list-slots
Available slots:
Slot 0 (0x0): XIRING Leo v2 (8288830623) 00 00
  token label        : PIN Global (ECC MI)
  token manufacturer :
  token model        : PKCS#15
  token flags        : login required, PIN pad present, rng, token initialized, PIN initialized
  hardware version   : 0.0
  firmware version   : 0.0
  serial num         : 004938720064285F
  pin min/max        : 4/4
Slot 1 (0x1): XIRING Leo v2 (8288830623) 00 00
  token label        : PIN de Signature (ECC MI)
  token manufacturer :
  token model        : PKCS#15
  token flags        : login required, PIN pad present, rng, token initialized, PIN initialized
  hardware version   : 0.0
  firmware version   : 0.0
  serial num         : 004938720064285F
  pin min/max        : 6/6
Using slot 0 with a present token (0x0)
B/1:24:19[pjb@L0231342 :0.0 tmp]$
```


