### PR TITLE
Fix double-close in ksu's get_authorized_princ_names

### DIFF
--- a/src/clients/ksu/heuristic.c
+++ b/src/clients/ksu/heuristic.c
@@ -266,7 +266,6 @@ get_authorized_princ_names(luser, cmd, princ_list)
 
     retval = list_union(k5login_list, k5users_filt_list, &combined_list);
     if (retval){
-        close_time(k5users_flag,users_fp, k5login_flag,login_fp);
         return retval;
     }
     *princ_list = combined_list;


### PR DESCRIPTION
if list_union fails, then close_time will attempt to fclose users_fp
and login_fp a second time.  However, the only way this can occur is
via an allocation failure in list_union, which being of fixed size is
highly unlikely.

This was originally introduced in
be95b52c2d0c21b1fe92f9f90166fc2fa8eecc95, meaning it has been present
in every krb5 release since 1.1.