### PR TITLE
zap.so is required when unit tests are not compiled with clang or gcc

### DIFF
--- a/src/util/support/Makefile.in
+++ b/src/util/support/Makefile.in
@@ -203,7 +203,7 @@ libkrb5support.exports: $(srcdir)/libkrb5support-fixed.exports Makefile
 ##DOS##	$(RM) libkrb5support.exports
 ##DOS##	$(MV) new-exports libkrb5support.exports
 
-T_K5BUF_OBJS= t_k5buf.o k5buf.o $(PRINTF_ST_OBJ)
+T_K5BUF_OBJS= t_k5buf.o k5buf.o $(PRINTF_ST_OBJ) zap.o
 
 t_k5buf: $(T_K5BUF_OBJS)
 	$(CC_LINK) -o t_k5buf $(T_K5BUF_OBJS)
@@ -223,7 +223,7 @@ path_win.o: $(srcdir)/path.c
 t_base64: t_base64.o base64.o
 	$(CC_LINK) -o $@ t_base64.o base64.o
 
-T_JSON_OBJS= t_json.o json.o base64.o k5buf.o $(PRINTF_ST_OBJ)
+T_JSON_OBJS= t_json.o json.o base64.o k5buf.o $(PRINTF_ST_OBJ) zap.o
 
 t_json: $(T_JSON_OBJS)
 	$(CC_LINK) -o $@ $(T_JSON_OBJS)
@@ -240,7 +240,7 @@ t_unal: t_unal.o
 t_utf8: t_utf8.o utf8.o
 	$(CC_LINK) -o t_utf8 t_utf8.o utf8.o
 
-T_UTF16_OBJS= t_utf16.o utf8_conv.o utf8.o k5buf.o $(PRINTF_ST_OBJ)
+T_UTF16_OBJS= t_utf16.o utf8_conv.o utf8.o k5buf.o $(PRINTF_ST_OBJ) zap.o
 
 t_utf16: $(T_UTF16_OBJS)
 	$(CC_LINK) -o $@ $(T_UTF16_OBJS)


### PR DESCRIPTION
k5-platform.h does not pick up memset() for zap() when unit tests
are being built by Solaris/developer studio. In this case we
must link with zap.so explicitly.

not sure if proposed change in this pull request is what we
also want to have for gcc & clang