### PR TITLE
include autoconf.h in gss-server.c

### DIFF
--- a/src/appl/gss-sample/gss-server.c
+++ b/src/appl/gss-sample/gss-server.c
@@ -44,6 +44,8 @@
  * or implied warranty.
  */
 
+#include <autoconf.h>
+
 #include <stdio.h>
 #ifdef _WIN32
 #include <windows.h>


### PR DESCRIPTION
gss-server.c fails to build on macOS 10.14 without including autoconf.h, as it's missing a definition for close() (aliased from closesocket()), which is defined in unistd.h. HAVE_UNISTD_H requires autoconf.h.