### PR TITLE
SPNEGO: Pass mechanism error token status to application

### DIFF
--- a/src/lib/gssapi/spnego/gssapiP_spnego.h
+++ b/src/lib/gssapi/spnego/gssapiP_spnego.h
@@ -21,7 +21,7 @@ extern "C" {
 #define	ACCEPT_INCOMPLETE 1
 #define	REJECT 2
 #define REQUEST_MIC 3
-#define	ACCEPT_DEFECTIVE_TOKEN 0xffffffffUL
+#define	UNSPECIFIED 0xffffffffUL
 
 /*
  * constants for der encoding/decoding routines.

--- a/src/tests/gssapi/t_err.c
+++ b/src/tests/gssapi/t_err.c
@@ -74,11 +74,16 @@ main(int argc, char *argv[])
     gss_buffer_desc itok, atok;
     gss_ctx_id_t ictx = GSS_C_NO_CONTEXT, actx = GSS_C_NO_CONTEXT;
 
-    if (argc != 2) {
-        fprintf(stderr, "Usage: %s targetname\n", argv[0]);
+    argv++;
+    if (*argv != NULL && strcmp(*argv, "--spnego") == 0) {
+        mech = &mech_spnego;
+        argv++;
+    }
+    if (*argv == NULL || argv[1] != NULL) {
+        fprintf(stderr, "Usage: t_err targetname\n");
         return 1;
     }
-    tname = import_name(argv[1]);
+    tname = import_name(*argv);
 
     /* Get the initial context token. */
     flags = GSS_C_REPLAY_FLAG | GSS_C_SEQUENCE_FLAG | GSS_C_MUTUAL_FLAG;

--- a/src/tests/gssapi/t_gssapi.py
+++ b/src/tests/gssapi/t_gssapi.py
@@ -178,6 +178,7 @@ if krb5_mech not in out or spnego_mech not in out:
 # Test that accept_sec_context can produce an error token and
 # init_sec_context can interpret it.
 realm.run(['./t_err', 'p:' + realm.host_princ])
+realm.run(['./t_err', '--spnego', 'p:' + realm.host_princ])
 
 # Test the GSS_KRB5_CRED_NO_CI_FLAGS_X cred option.
 realm.run(['./t_ciflags', 'p:' + realm.host_princ])


### PR DESCRIPTION
Fixes an issue where if a SPNEGO initiator receives a `NegTokenResp` where `negState` is `reject`, it will immediately return to the caller, rather than processing any (mechanism-specific) context error tokens from the acceptor.

NB: still checking I have read RFC4178 correctly and it is OK to return a `responseToken` with a reject response.