### PR TITLE
Address some optimized-out memset() calls

### DIFF
--- a/src/clients/ksu/krb_auth_su.c
+++ b/src/clients/ksu/krb_auth_su.c
@@ -183,21 +183,19 @@ krb5_boolean ksu_get_tgt_via_passwd(context, client, options, zero_password,
     if (code ) {
         com_err(prog_name, code, _("while reading password for '%s'\n"),
                 client_name);
-        memset(password, 0, sizeof(password));
         return (FALSE);
     }
 
     if ( pwsize == 0) {
         fprintf(stderr, _("No password given\n"));
         *zero_password = TRUE;
-        memset(password, 0, sizeof(password));
         return (FALSE);
     }
 
     code = krb5_get_init_creds_password(context, &creds, client, password,
                                         krb5_prompter_posix, NULL, 0, NULL,
                                         options);
-    memset(password, 0, sizeof(password));
+    zap(password, sizeof(password));
 
 
     if (code) {

--- a/src/lib/gssapi/krb5/iakerb.c
+++ b/src/lib/gssapi/krb5/iakerb.c
@@ -262,7 +262,6 @@ iakerb_make_token(iakerb_ctx_id_t ctx,
     /*
      * Assemble the IAKERB-HEADER from the realm and cookie
      */
-    memset(&iah, 0, sizeof(iah));
     iah.target_realm = *realm;
     iah.cookie = cookie;
 

--- a/src/lib/kadm5/srv/svr_principal.c
+++ b/src/lib/kadm5/srv/svr_principal.c
@@ -2093,14 +2093,8 @@ static int decrypt_key_data(krb5_context context,
         ret = krb5_dbe_decrypt_key_data(context, NULL, &key_data[i], &keys[i],
                                         NULL);
         if (ret) {
-            for (; i >= 0; i--) {
-                if (keys[i].contents) {
-                    memset (keys[i].contents, 0, keys[i].length);
-                    free( keys[i].contents );
-                }
-            }
-
-            memset(keys, 0, n_key_data*sizeof(krb5_keyblock));
+            for (; i >= 0; i--)
+                krb5_free_keyblock_contents(context, &keys[i]);
             free(keys);
             return ret;
         }

--- a/src/lib/krb5/asn.1/asn1_k_encode.c
+++ b/src/lib/krb5/asn.1/asn1_k_encode.c
@@ -528,7 +528,6 @@ decode_kdc_req_body(const taginfo *t, const uint8_t *asn1, size_t len,
         if (ret) {
             free_kdc_req_body(b);
             free(h.server_realm.data);
-            memset(&h, 0, sizeof(h));
             return ret;
         }
         b->server->realm = h.server_realm;


### PR DESCRIPTION
Ilja Van Sprundel reported a list of memset() calls which gcc
optimizes out.  In krb_auth_su.c, use zap() to clear the password, and
remove two memset() calls when there is no password to clear.  In
iakerb.c, remove an unnecessary memset() before setting the only two
fields of the IAKERB header structure.  In svr_principal.c, use
krb5_free_key_keyblock_contents() instead of hand-freeing key data.
In asn1_k_encode.c, remove an unnecessary memset() of the kdc_req_hack
shell before returning.