### PR TITLE
let autoconf decide whether particular compier supports 128bit integers

### DIFF
--- a/src/configure.in
+++ b/src/configure.in
@@ -851,7 +851,8 @@ AC_SUBST(DO_TCL)
 
 # types libdb2 wants
 
-AC_CHECK_TYPES([ssize_t, u_char, u_int, u_long, u_int8_t, u_int16_t, u_int32_t, int8_t, int16_t, int32_t])
+AC_CHECK_TYPES([ssize_t, u_char, u_int, u_long, u_int8_t, u_int16_t, u_int32_t,
+int8_t, int16_t, int32_t, __int128_t, __uint128_t])
 
 # Some libdb2 test programs want a shell that supports functions.
 FCTSH=false

--- a/src/plugins/preauth/spake/edwards25519.c
+++ b/src/plugins/preauth/spake/edwards25519.c
@@ -107,7 +107,10 @@
  * (BORINGSSL_HAS_UINT128).
  */
 #if defined(__x86_64) || defined(_M_AMD64) || defined(_M_X64) || defined(__aarch64__) || ((defined(__PPC64__) || defined(__powerpc64__)) && defined(_LITTLE_ENDIAN)) || defined(__mips__) && defined(__LP64__)
-#if !defined(_MSC_VER) || defined(__clang__)
+/*
+ * Not all compilers provide 128bit integer types.
+ */
+#if defined(HAVE___INT128_T) && defined(HAVE___UINT128_T)
 #define BORINGSSL_CURVE25519_64BIT
 typedef __int128_t int128_t;
 typedef __uint128_t uint128_t;


### PR DESCRIPTION
This is yet another take on int128_t. The simple change does right thing for Solaris Studio and gcc.