### PR TITLE
k5-platform: Avoid allocating a register for protecting memset()

### DIFF
--- a/src/configure.in
+++ b/src/configure.in
@@ -421,7 +421,7 @@ AC_PROG_LEX
 AC_C_CONST
 AC_HEADER_DIRENT
 AC_FUNC_STRERROR_R
-AC_CHECK_FUNCS(strdup setvbuf seteuid setresuid setreuid setegid setresgid setregid setsid flock fchmod chmod strptime geteuid setenv unsetenv getenv gmtime_r localtime_r bswap16 bswap64 mkstemp getusershell access getcwd srand48 srand srandom stat strchr strerror timegm)
+AC_CHECK_FUNCS(strdup setvbuf seteuid setresuid setreuid setegid setresgid setregid setsid flock fchmod chmod strptime geteuid setenv unsetenv getenv gmtime_r localtime_r bswap16 bswap64 mkstemp getusershell access getcwd srand48 srand srandom stat strchr strerror timegm explicit_bzero explicit_memset)
 
 AC_CHECK_FUNC(mkstemp,
 [MKSTEMP_ST_OBJ=

--- a/src/include/k5-platform.h
+++ b/src/include/k5-platform.h
@@ -1023,6 +1023,10 @@ static inline void zap(void *ptr, size_t len)
     if (len > 0)
         memset_s(ptr, len, 0, len);
 }
+#elif defined(HAVE_EXPLICIT_BZERO)
+# define zap(ptr, len) explicit_bzero(ptr, len)
+#elif defined(HAVE_EXPLICIT_MEMSET)
+# define zap(ptr, len) explicit_memset(ptr, 0, len)
 #elif defined(__GNUC__) || defined(__clang__)
 /*
  * Use an asm statement which declares a memory clobber to force the memset to
@@ -1032,7 +1036,7 @@ static inline void zap(void *ptr, size_t len)
 {
     if (len > 0)
         memset(ptr, 0, len);
-    __asm__ __volatile__("" : : "r" (ptr) : "memory");
+    __asm__ __volatile__("" : : "g" (ptr) : "memory");
 }
 #else
 /*


### PR DESCRIPTION
See https://bugs.llvm.org/show_bug.cgi?id=15495