### PR TITLE
enctype logging updates

### DIFF
--- a/src/clients/klist/klist.c
+++ b/src/clients/klist/klist.c
@@ -571,11 +571,17 @@ static char *
 etype_string(krb5_enctype enctype)
 {
     static char buf[100];
-    krb5_error_code ret;
+    char *bp = buf;
+    size_t deplen, buflen = sizeof(buf);
 
-    ret = krb5_enctype_to_name(enctype, FALSE, buf, sizeof(buf));
-    if (ret)
-        snprintf(buf, sizeof(buf), "etype %d", enctype);
+    if (krb5int_c_deprecated_enctype(enctype)) {
+        deplen = strlcpy(bp, "DEPRECATED:", buflen);
+        buflen -= deplen;
+        bp += deplen;
+    }
+
+    if (krb5_enctype_to_name(enctype, FALSE, bp, buflen))
+        snprintf(bp, buflen, "etype %d", enctype);
     return buf;
 }
 

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -2082,6 +2082,7 @@ krb5_get_tgs_ktypes(krb5_context, krb5_const_principal, krb5_enctype **);
 krb5_boolean krb5_is_permitted_enctype(krb5_context, krb5_enctype);
 
 krb5_boolean KRB5_CALLCONV krb5int_c_weak_enctype(krb5_enctype);
+krb5_boolean KRB5_CALLCONV krb5int_c_deprecated_enctype(krb5_enctype);
 krb5_error_code k5_enctype_to_ssf(krb5_enctype enctype, unsigned int *ssf_out);
 
 krb5_error_code krb5_kdc_rep_decrypt_proc(krb5_context, const krb5_keyblock *,

--- a/src/kadmin/cli/kadmin.c
+++ b/src/kadmin/cli/kadmin.c
@@ -1451,12 +1451,16 @@ kadmin_getprinc(int argc, char *argv[])
         for (i = 0; i < dprinc.n_key_data; i++) {
             krb5_key_data *key_data = &dprinc.key_data[i];
             char enctype[BUFSIZ], salttype[BUFSIZ];
+            char *deprecated = "";
 
             if (krb5_enctype_to_name(key_data->key_data_type[0], FALSE,
                                      enctype, sizeof(enctype)))
                 snprintf(enctype, sizeof(enctype), _("<Encryption type 0x%x>"),
                          key_data->key_data_type[0]);
-            printf("Key: vno %d, %s", key_data->key_data_kvno, enctype);
+            if (krb5int_c_deprecated_enctype(key_data->key_data_type[0]))
+                deprecated = "DEPRECATED:";
+            printf("Key: vno %d, %s%s", key_data->key_data_kvno, deprecated,
+                   enctype);
             if (key_data->key_data_ver > 1 &&
                 key_data->key_data_type[1] != KRB5_KDB_SALTTYPE_NORMAL) {
                 if (krb5_salttype_to_string(key_data->key_data_type[1],

--- a/src/kdc/kdc_log.c
+++ b/src/kdc/kdc_log.c
@@ -65,7 +65,7 @@ log_as_req(krb5_context context,
 {
     const char *fromstring = 0;
     char fromstringbuf[70];
-    char ktypestr[128];
+    char *ktypestr = NULL;
     const char *cname2 = cname ? cname : "<unknown client>";
     const char *sname2 = sname ? sname : "<unknown server>";
 
@@ -74,26 +74,29 @@ log_as_req(krb5_context context,
                            fromstringbuf, sizeof(fromstringbuf));
     if (!fromstring)
         fromstring = "<unknown>";
-    ktypes2str(ktypestr, sizeof(ktypestr),
-               request->nktypes, request->ktype);
+
+    ktypestr = ktypes2str(request->ktype, request->nktypes);
 
     if (status == NULL) {
         /* success */
-        char rep_etypestr[128];
-        rep_etypes2str(rep_etypestr, sizeof(rep_etypestr), reply);
+        char *rep_etypestr = rep_etypes2str(reply);
         krb5_klog_syslog(LOG_INFO, _("AS_REQ (%s) %s: ISSUE: authtime %u, %s, "
                                      "%s for %s"),
-                         ktypestr, fromstring, (unsigned int)authtime,
-                         rep_etypestr, cname2, sname2);
+                         ktypestr ? ktypestr : "", fromstring,
+                         (unsigned int)authtime,
+                         rep_etypestr ? rep_etypestr : "", cname2, sname2);
+        free(rep_etypestr);
     } else {
         /* fail */
         krb5_klog_syslog(LOG_INFO, _("AS_REQ (%s) %s: %s: %s for %s%s%s"),
-                         ktypestr, fromstring, status,
-                         cname2, sname2, emsg ? ", " : "", emsg ? emsg : "");
+                         ktypestr ? ktypestr : "", fromstring, status, cname2,
+                         sname2, emsg ? ", " : "", emsg ? emsg : "");
     }
     krb5_db_audit_as_req(context, request,
                          local_addr->address, remote_addr->address,
                          client, server, authtime, errcode);
+
+    free(ktypestr);
 }
 
 /*
@@ -122,10 +125,9 @@ log_tgs_req(krb5_context ctx, const krb5_fulladdr *from,
             unsigned int c_flags,
             const char *status, krb5_error_code errcode, const char *emsg)
 {
-    char ktypestr[128];
+    char *ktypestr = NULL, *rep_etypestr = NULL;
     const char *fromstring = 0;
     char fromstringbuf[70];
-    char rep_etypestr[128];
     char *cname = NULL, *sname = NULL, *altcname = NULL;
     char *logcname = NULL, *logsname = NULL, *logaltcname = NULL;
 
@@ -134,11 +136,6 @@ log_tgs_req(krb5_context ctx, const krb5_fulladdr *from,
                            fromstringbuf, sizeof(fromstringbuf));
     if (!fromstring)
         fromstring = "<unknown>";
-    ktypes2str(ktypestr, sizeof(ktypestr), request->nktypes, request->ktype);
-    if (!errcode)
-        rep_etypes2str(rep_etypestr, sizeof(rep_etypestr), reply);
-    else
-        rep_etypestr[0] = 0;
 
     unparse_and_limit(ctx, cprinc, &cname);
     logcname = (cname != NULL) ? cname : "<unknown client>";
@@ -151,10 +148,14 @@ log_tgs_req(krb5_context ctx, const krb5_fulladdr *from,
        name (useful), and doesn't log ktypestr (probably not
        important).  */
     if (errcode != KRB5KDC_ERR_SERVER_NOMATCH) {
+        ktypestr = ktypes2str(request->ktype, request->nktypes);
+        rep_etypestr = rep_etypes2str(reply);
         krb5_klog_syslog(LOG_INFO, _("TGS_REQ (%s) %s: %s: authtime %u, %s%s "
                                      "%s for %s%s%s"),
-                         ktypestr, fromstring, status, (unsigned int)authtime,
-                         rep_etypestr, !errcode ? "," : "", logcname, logsname,
+                         ktypestr ? ktypestr : "", fromstring, status,
+                         (unsigned int)authtime,
+                         rep_etypestr ? rep_etypestr : "",
+                         !errcode ? "," : "", logcname, logsname,
                          errcode ? ", " : "", errcode ? emsg : "");
         if (isflagset(c_flags, KRB5_KDB_FLAG_PROTOCOL_TRANSITION))
             krb5_klog_syslog(LOG_INFO,
@@ -171,9 +172,8 @@ log_tgs_req(krb5_context ctx, const krb5_fulladdr *from,
                          fromstring, status, (unsigned int)authtime,
                          logcname, logsname, logaltcname);
 
-    /* OpenSolaris: audit_krb5kdc_tgs_req(...)  or
-       audit_krb5kdc_tgs_req_2ndtktmm(...) */
-
+    free(rep_etypestr);
+    free(ktypestr);
     krb5_free_unparsed_name(ctx, cname);
     krb5_free_unparsed_name(ctx, sname);
     krb5_free_unparsed_name(ctx, altcname);

--- a/src/kdc/kdc_util.c
+++ b/src/kdc/kdc_util.c
@@ -1060,10 +1060,19 @@ static krb5_error_code
 enctype_name(krb5_enctype ktype, char *buf, size_t buflen)
 {
     char *name;
+    size_t len;
 
     if (buflen == 0)
         return EINVAL;
     *buf = '\0'; /* ensure these are always valid C-strings */
+
+    if (krb5int_c_deprecated_enctype(ktype)) {
+        len = strlcpy(buf, "DEPRECATED:", buflen);
+        if (len >= buflen)
+            return ENOMEM;
+        buflen -= len;
+        buf += len;
+    }
 
     /* rfc4556 recommends that clients wishing to indicate support for these
      * pkinit algorithms include them in the etype field of the AS-REQ. */

--- a/src/kdc/kdc_util.h
+++ b/src/kdc/kdc_util.h
@@ -109,11 +109,9 @@ select_session_keytype (kdc_realm_t *kdc_active_realm,
 
 void limit_string (char *name);
 
-void
-ktypes2str(char *s, size_t len, int nktypes, krb5_enctype *ktype);
+char *ktypes2str(krb5_enctype *ktype, int nktypes);
 
-void
-rep_etypes2str(char *s, size_t len, krb5_kdc_rep *rep);
+char *rep_etypes2str(krb5_kdc_rep *rep);
 
 /* authind.c */
 krb5_boolean

--- a/src/kdc/main.c
+++ b/src/kdc/main.c
@@ -210,12 +210,23 @@ init_realm(kdc_realm_t * rdp, krb5_pointer aprof, char *realm,
     char                *svalue = NULL;
     const char          *hierarchy[4];
     krb5_kvno       mkvno = IGNORE_VNO;
+    char ename[32];
 
     memset(rdp, 0, sizeof(kdc_realm_t));
     if (!realm) {
         kret = EINVAL;
         goto whoops;
     }
+
+    if (def_enctype != ENCTYPE_UNKNOWN &&
+        krb5int_c_deprecated_enctype(def_enctype)) {
+        if (krb5_enctype_to_name(def_enctype, FALSE, ename, sizeof(ename)))
+            ename[0] = '\0';
+        fprintf(stderr,
+                _("Requested master password enctype %s in %s is DEPRECATED!"),
+                ename, realm);
+    }
+
     hierarchy[0] = KRB5_CONF_REALMS;
     hierarchy[1] = realm;
     hierarchy[3] = NULL;
@@ -368,6 +379,14 @@ init_realm(kdc_realm_t * rdp, krb5_pointer aprof, char *realm,
                 _("while fetching master key %s for realm %s"),
                 rdp->realm_mpname, realm);
         goto whoops;
+    }
+
+    if (krb5int_c_deprecated_enctype(rdp->realm_mkey.enctype)) {
+        if (krb5_enctype_to_name(rdp->realm_mkey.enctype, FALSE, ename,
+                                 sizeof(ename)))
+            ename[0] = '\0';
+        fprintf(stderr, _("Stash file %s uses DEPRECATED enctype %s!"),
+                rdp->realm_stash, ename);
     }
 
     if ((kret = krb5_db_fetch_mkey_list(rdp->realm_context, rdp->realm_mprinc,

--- a/src/kprop/kpropd.c
+++ b/src/kprop/kpropd.c
@@ -1270,7 +1270,8 @@ kerberos_authenticate(krb5_context context, int fd, krb5_principal *clientp,
             exit(1);
         }
 
-        retval = krb5_enctype_to_string(*etype, etypebuf, sizeof(etypebuf));
+        retval = krb5_enctype_to_name(*etype, FALSE, etypebuf,
+                                      sizeof(etypebuf));
         if (retval) {
             com_err(progname, retval, _("while unparsing ticket etype"));
             exit(1);

--- a/src/lib/crypto/krb/crypto_int.h
+++ b/src/lib/crypto/krb/crypto_int.h
@@ -114,7 +114,14 @@ struct krb5_keytypes {
     unsigned int ssf;
 };
 
-#define ETYPE_WEAK 1
+/*
+ * "Weak" means the enctype is believed to be vulnerable to practical attacks,
+ * and will be disabled unless allow_weak_crypto is set to true.  "Deprecated"
+ * means the enctype has been deprecated by the IETF, and affects display and
+ * logging.
+ */
+#define ETYPE_WEAK (1 << 0)
+#define ETYPE_DEPRECATED (1 << 1)
 
 extern const struct krb5_keytypes krb5int_enctypes_list[];
 extern const int krb5int_enctypes_length;

--- a/src/lib/crypto/krb/enctype_util.c
+++ b/src/lib/crypto/krb/enctype_util.c
@@ -51,6 +51,13 @@ krb5int_c_weak_enctype(krb5_enctype etype)
     return (ktp != NULL && (ktp->flags & ETYPE_WEAK) != 0);
 }
 
+krb5_boolean KRB5_CALLCONV
+krb5int_c_deprecated_enctype(krb5_enctype etype)
+{
+    const struct krb5_keytypes *ktp = find_enctype(etype);
+    return ktp != NULL && (ktp->flags & ETYPE_DEPRECATED) != 0;
+}
+
 krb5_error_code KRB5_CALLCONV
 krb5_c_enctype_compare(krb5_context context, krb5_enctype e1, krb5_enctype e2,
                        krb5_boolean *similar)

--- a/src/lib/crypto/krb/etypes.c
+++ b/src/lib/crypto/krb/etypes.c
@@ -33,6 +33,7 @@
    that the keytypes are all near each other.  I'd rather not make
    that assumption. */
 
+/* Deprecations come from RFC 6649 and RFC 8249. */
 const struct krb5_keytypes krb5int_enctypes_list[] = {
     { ENCTYPE_DES_CBC_CRC,
       "des-cbc-crc", { 0 }, "DES cbc mode with CRC-32",
@@ -42,7 +43,7 @@ const struct krb5_keytypes krb5int_enctypes_list[] = {
       krb5int_des_string_to_key, k5_rand2key_des,
       krb5int_des_prf,
       CKSUMTYPE_RSA_MD5_DES,
-      ETYPE_WEAK, 56 },
+      ETYPE_WEAK | ETYPE_DEPRECATED, 56 },
     { ENCTYPE_DES_CBC_MD4,
       "des-cbc-md4", { 0 }, "DES cbc mode with RSA-MD4",
       &krb5int_enc_des, &krb5int_hash_md4,
@@ -51,7 +52,7 @@ const struct krb5_keytypes krb5int_enctypes_list[] = {
       krb5int_des_string_to_key, k5_rand2key_des,
       krb5int_des_prf,
       CKSUMTYPE_RSA_MD4_DES,
-      ETYPE_WEAK, 56 },
+      ETYPE_WEAK | ETYPE_DEPRECATED, 56 },
     { ENCTYPE_DES_CBC_MD5,
       "des-cbc-md5", { "des" }, "DES cbc mode with RSA-MD5",
       &krb5int_enc_des, &krb5int_hash_md5,
@@ -60,7 +61,7 @@ const struct krb5_keytypes krb5int_enctypes_list[] = {
       krb5int_des_string_to_key, k5_rand2key_des,
       krb5int_des_prf,
       CKSUMTYPE_RSA_MD5_DES,
-      ETYPE_WEAK, 56 },
+      ETYPE_WEAK | ETYPE_DEPRECATED, 56 },
     { ENCTYPE_DES_CBC_RAW,
       "des-cbc-raw", { 0 }, "DES cbc mode raw",
       &krb5int_enc_des, NULL,
@@ -69,7 +70,7 @@ const struct krb5_keytypes krb5int_enctypes_list[] = {
       krb5int_des_string_to_key, k5_rand2key_des,
       krb5int_des_prf,
       0,
-      ETYPE_WEAK, 56 },
+      ETYPE_WEAK | ETYPE_DEPRECATED, 56 },
     { ENCTYPE_DES3_CBC_RAW,
       "des3-cbc-raw", { 0 }, "Triple DES cbc mode raw",
       &krb5int_enc_des3, NULL,
@@ -78,7 +79,7 @@ const struct krb5_keytypes krb5int_enctypes_list[] = {
       krb5int_dk_string_to_key, k5_rand2key_des3,
       NULL, /*PRF*/
       0,
-      ETYPE_WEAK, 112 },
+      ETYPE_WEAK | ETYPE_DEPRECATED, 112 },
 
     { ENCTYPE_DES3_CBC_SHA1,
       "des3-cbc-sha1", { "des3-hmac-sha1", "des3-cbc-sha1-kd" },
@@ -89,7 +90,7 @@ const struct krb5_keytypes krb5int_enctypes_list[] = {
       krb5int_dk_string_to_key, k5_rand2key_des3,
       krb5int_dk_prf,
       CKSUMTYPE_HMAC_SHA1_DES3,
-      0 /*flags*/, 112 },
+      ETYPE_DEPRECATED, 112 },
 
     { ENCTYPE_DES_HMAC_SHA1,
       "des-hmac-sha1", { 0 }, "DES with HMAC/sha1",
@@ -99,7 +100,7 @@ const struct krb5_keytypes krb5int_enctypes_list[] = {
       krb5int_dk_string_to_key, k5_rand2key_des,
       NULL, /*PRF*/
       0,
-      ETYPE_WEAK, 56 },
+      ETYPE_WEAK | ETYPE_DEPRECATED, 56 },
 
     /* rc4-hmac uses a 128-bit key, but due to weaknesses in the RC4 cipher, we
      * consider its strength degraded and assign it an SSF value of 64. */
@@ -113,7 +114,7 @@ const struct krb5_keytypes krb5int_enctypes_list[] = {
       krb5int_arcfour_decrypt, krb5int_arcfour_string_to_key,
       k5_rand2key_direct, krb5int_arcfour_prf,
       CKSUMTYPE_HMAC_MD5_ARCFOUR,
-      0 /*flags*/, 64 },
+      ETYPE_DEPRECATED, 64 },
     { ENCTYPE_ARCFOUR_HMAC_EXP,
       "arcfour-hmac-exp", { "rc4-hmac-exp", "arcfour-hmac-md5-exp" },
       "Exportable ArcFour with HMAC/md5",
@@ -124,7 +125,7 @@ const struct krb5_keytypes krb5int_enctypes_list[] = {
       krb5int_arcfour_decrypt, krb5int_arcfour_string_to_key,
       k5_rand2key_direct, krb5int_arcfour_prf,
       CKSUMTYPE_HMAC_MD5_ARCFOUR,
-      ETYPE_WEAK, 40
+      ETYPE_WEAK | ETYPE_DEPRECATED, 40
     },
 
     { ENCTYPE_AES128_CTS_HMAC_SHA1_96,

--- a/src/lib/crypto/libk5crypto.exports
+++ b/src/lib/crypto/libk5crypto.exports
@@ -109,3 +109,4 @@ k5_allow_weak_pbkdf2iter
 krb5_c_prfplus
 krb5_c_derive_prfplus
 k5_enctype_to_ssf
+krb5int_c_deprecated_enctype

--- a/src/lib/krb5/krb/rd_req_dec.c
+++ b/src/lib/krb5/krb/rd_req_dec.c
@@ -864,9 +864,8 @@ negotiate_etype(krb5_context context,
         if (permitted == FALSE) {
             char enctype_name[30];
 
-            if (krb5_enctype_to_string(desired_etypes[i],
-                                       enctype_name,
-                                       sizeof(enctype_name)) == 0)
+            if (krb5_enctype_to_name(desired_etypes[i], FALSE, enctype_name,
+                                     sizeof(enctype_name)) == 0)
                 k5_setmsg(context, KRB5_NOPERM_ETYPE,
                           _("Encryption type %s not permitted"), enctype_name);
             return KRB5_NOPERM_ETYPE;

--- a/src/lib/krb5_32.def
+++ b/src/lib/krb5_32.def
@@ -487,3 +487,6 @@ EXPORTS
 	encode_krb5_pa_spake				@444 ; PRIVATE
 	decode_krb5_pa_spake				@445 ; PRIVATE
 	k5_free_pa_spake				@446 ; PRIVATE
+
+; new in 1.18
+	krb5int_c_deprecated_enctype			@450 ; PRIVATE

--- a/src/tests/gssapi/t_enctypes.py
+++ b/src/tests/gssapi/t_enctypes.py
@@ -85,7 +85,8 @@ test('both aes128', 'aes128-cts', 'aes128-cts',
 # If only the acceptor constrains the permitted session enctypes to
 # aes128, subkey negotiation fails because the acceptor considers the
 # aes256 session key to be non-permitted.
-test_err('acc aes128', None, 'aes128-cts', 'Encryption type not permitted')
+test_err('acc aes128', None, 'aes128-cts',
+         'Encryption type aes256-cts-hmac-sha1-96 not permitted')
 
 # If the initiator constrains the permitted session enctypes to des3,
 # no acceptor subkey will be generated because we can't upgrade to a
@@ -128,7 +129,7 @@ test('upgrade init des3+rc4', 'des3 rc4', None,
 # is only for the sake of the kernel, since we could upgrade to an
 # aes128 subkey, but it's the current semantics.)
 test_err('upgrade acc aes128', None, 'aes128-cts',
-         'Encryption type ArcFour with HMAC/md5 not permitted')
+         'Encryption type arcfour-hmac not permitted')
 
 # If the acceptor permits rc4 but prefers aes128, it will negotiate an
 # upgrade to aes128.

--- a/src/tests/gssapi/t_enctypes.py
+++ b/src/tests/gssapi/t_enctypes.py
@@ -9,8 +9,11 @@ from k5test import *
 aes256 = 'aes256-cts-hmac-sha1-96'
 aes128 = 'aes128-cts-hmac-sha1-96'
 des3 = 'des3-cbc-sha1'
+d_des3 = 'DEPRECATED:des3-cbc-sha1'
 des3raw = 'des3-cbc-raw'
+d_des3raw = 'DEPRECATED:des3-cbc-raw'
 rc4 = 'arcfour-hmac'
+d_rc4 = 'DEPRECATED:arcfour-hmac'
 
 # These tests make assumptions about the default enctype lists, so set
 # them explicitly rather than relying on the library defaults.
@@ -92,7 +95,7 @@ test_err('acc aes128', None, 'aes128-cts',
 # no acceptor subkey will be generated because we can't upgrade to a
 # CFX enctype.
 test('init des3', 'des3', None,
-     tktenc=aes256, tktsession=des3,
+     tktenc=aes256, tktsession=d_des3,
      proto='rfc1964', isubkey=des3raw, asubkey=None)
 
 # Force the ticket session key to be rc4, so we can test some subkey
@@ -103,7 +106,7 @@ realm.run([kadminl, 'setstr', realm.host_princ, 'session_enctypes', 'rc4'])
 # [aes256 aes128 des3] and the acceptor should upgrade to an aes256
 # subkey.
 test('upgrade noargs', None, None,
-     tktenc=aes256, tktsession=rc4,
+     tktenc=aes256, tktsession=d_rc4,
      proto='cfx', isubkey=rc4, asubkey=aes256)
 
 # If the initiator won't permit rc4 as a session key, it won't be able
@@ -113,14 +116,14 @@ test_err('upgrade init aes', 'aes', None, 'no support for encryption type')
 # If the initiator permits rc4 but prefers aes128, it will send an
 # upgrade list of [aes128] and the acceptor will upgrade to aes128.
 test('upgrade init aes128+rc4', 'aes128-cts rc4', None,
-     tktenc=aes256, tktsession=rc4,
+     tktenc=aes256, tktsession=d_rc4,
      proto='cfx', isubkey=rc4, asubkey=aes128)
 
 # If the initiator permits rc4 but prefers des3, it will send an
 # upgrade list of [des3], but the acceptor won't generate a subkey
 # because des3 isn't a CFX enctype.
 test('upgrade init des3+rc4', 'des3 rc4', None,
-     tktenc=aes256, tktsession=rc4,
+     tktenc=aes256, tktsession=d_rc4,
      proto='rfc1964', isubkey=rc4, asubkey=None)
 
 # If the acceptor permits only aes128, subkey negotiation will fail
@@ -134,14 +137,14 @@ test_err('upgrade acc aes128', None, 'aes128-cts',
 # If the acceptor permits rc4 but prefers aes128, it will negotiate an
 # upgrade to aes128.
 test('upgrade acc aes128 rc4', None, 'aes128-cts rc4',
-     tktenc=aes256, tktsession=rc4,
+     tktenc=aes256, tktsession=d_rc4,
      proto='cfx', isubkey=rc4, asubkey=aes128)
 
 # In this test, the initiator and acceptor each prefer an AES enctype
 # to rc4, but they can't agree on which one, so no subkey is
 # generated.
 test('upgrade mismatch', 'aes128-cts rc4', 'aes256-cts rc4',
-     tktenc=aes256, tktsession=rc4,
+     tktenc=aes256, tktsession=d_rc4,
      proto='rfc1964', isubkey=rc4, asubkey=None)
 
 success('gss_krb5_set_allowable_enctypes tests')

--- a/src/tests/t_keyrollover.py
+++ b/src/tests/t_keyrollover.py
@@ -22,8 +22,9 @@ realm.run([kvno, princ1])
 realm.run([kadminl, 'purgekeys', realm.krbtgt_princ])
 # Make sure an old TGT fails after purging old TGS key.
 realm.run([kvno, princ2], expected_code=1)
-msg = 'krbtgt/%s@%s\n\tEtype (skey, tkt): des-cbc-crc, des-cbc-crc' % \
-    (realm.realm, realm.realm)
+ddes = "DEPRECATED:des-cbc-crc"
+msg = 'krbtgt/%s@%s\n\tEtype (skey, tkt): %s, %s' % \
+    (realm.realm, realm.realm, ddes, ddes)
 realm.run([klist, '-e'], expected_msg=msg)
 
 # Check that new key actually works.
@@ -48,7 +49,8 @@ realm.run([kadminl, 'cpw', '-randkey', '-keepold', '-e', 'aes256-cts',
            realm.krbtgt_princ])
 realm.run([kadminl, 'modprinc', '-kvno', '1', realm.krbtgt_princ])
 out = realm.run([kadminl, 'getprinc', realm.krbtgt_princ])
-if 'vno 1, aes256' not in out or 'vno 1, des3' not in out:
+if 'vno 1, aes256-cts' not in out or \
+   'vno 1, DEPRECATED:des3-cbc-sha1' not in out:
     fail('keyrollover: setup for TGS enctype test failed')
 # Now present the DES3 ticket to the KDC and make sure it's rejected.
 realm.run([kvno, realm.host_princ], expected_code=1)

--- a/src/tests/t_sesskeynego.py
+++ b/src/tests/t_sesskeynego.py
@@ -62,11 +62,11 @@ test_kvno(realm, 'aes128-cts-hmac-sha1-96', 'aes256-cts-hmac-sha1-96')
 # 3b: Negotiate rc4-hmac session key when principal only has aes256 long-term.
 realm.run([kadminl, 'setstr', 'server', 'session_enctypes',
            'rc4-hmac,aes128-cts,aes256-cts'])
-test_kvno(realm, 'arcfour-hmac', 'aes256-cts-hmac-sha1-96')
+test_kvno(realm, 'DEPRECATED:arcfour-hmac', 'aes256-cts-hmac-sha1-96')
 
 # 3c: Test des-cbc-crc default assumption.
 realm.run([kadminl, 'delstr', 'server', 'session_enctypes'])
-test_kvno(realm, 'des-cbc-crc', 'aes256-cts-hmac-sha1-96')
+test_kvno(realm, 'DEPRECATED:des-cbc-crc', 'aes256-cts-hmac-sha1-96')
 realm.stop()
 
 # Last go: test that we can disable the des-cbc-crc assumption


### PR DESCRIPTION
First commit augments the constants with their human-readable names.

Second commit augments that logging with all-caps information that the etype in question is deprecated.  I didn't mark the PKINIT etypes as deprecated because I couldn't find formal docs that they are, but am happy to change that.