### PR TITLE
Update doxygen-RST bridge to Python 3

### DIFF
--- a/doc/tools/docmodel.py
+++ b/doc/tools/docmodel.py
@@ -201,7 +201,6 @@ class DocModel(object):
 
     def __repr__(self):
         obj = getattr(self,self.category)
-        print type(obj)
         return str(obj)
 
     def signature(self):
@@ -236,8 +235,8 @@ class DocModelTest(DocModel):
         self.test_save()
 
     def test_print(self):
-        print 'testing'
-        print self
+        print('testing')
+        print(self)
 
 
     def test_save(self):

--- a/doc/tools/doxybuilder_funcs.py
+++ b/doc/tools/doxybuilder_funcs.py
@@ -93,7 +93,7 @@ class DocNode(object):
 
         return '\n'.join(result)
 
-class DoxyContenHandler(object, ContentHandler):
+class DoxyContenHandler(ContentHandler):
     def __init__(self, builder):
         self.builder = builder
         self.counters = defaultdict(int)
@@ -242,7 +242,7 @@ class DoxyFuncs(XML2AST):
                            'description': p_descr}
             parameters.append(param_descr)
         result = Function(**function_descr)
-        print >> self.tmp, result
+        print(result, file=self.tmp)
 
         return function_descr
 

--- a/doc/tools/doxybuilder_types.py
+++ b/doc/tools/doxybuilder_types.py
@@ -358,7 +358,7 @@ class DoxyBuilderTypes(DoxyTypes):
         result = self.run(filename, include=['typedef'])
         target_dir = '%s/types' % (self.target_dir)
         if not os.path.exists(target_dir):
-            os.makedirs(target_dir, 0755)
+            os.makedirs(target_dir, 0o755)
         for t in result:
             obj = DocModel(**t)
             self.save(obj, self.templates, target_dir)
@@ -369,7 +369,7 @@ class DoxyBuilderTypes(DoxyTypes):
         result = self.run(filename, include=['define'])
         target_dir = '%s/macros' % (self.target_dir)
         if not os.path.exists(target_dir):
-            os.makedirs(target_dir, 0755)
+            os.makedirs(target_dir, 0o755)
         for t in result:
             obj = DocModel(**t)
             tmpl = {'composite': 'define_document.tmpl'}

--- a/src/doc/Makefile.in
+++ b/src/doc/Makefile.in
@@ -48,7 +48,7 @@ html: composite
 
 # Dummy target for use in an unconfigured source tree.
 htmlsrc:
-	$(MAKE) -f Makefile.in srcdir=. top_srcdir=.. PYTHON=python html clean
+	$(MAKE) -f Makefile.in srcdir=. top_srcdir=.. PYTHON=python3 html clean
 
 # Create HTML documentation in html_subst suitable for
 # installation by an OS package, with substitutions for configured


### PR DESCRIPTION
[Commit a7c6d98480f1e33454173f88381921472d72f80a updated the doc build to work with python3-sphinx, but the code that translates from Doxygen XML output to RST was still in Python 2, so "make html" in a build tree fails now that we look for Python 3 in configure.in.

The Python 3 version of the Cheetah templating engine is not present in Ubuntu before 18.10, so I grabbed it with pip for now.  Given the resources, we might consider moving to Mako or not using a template engine, but I don't have immediate plans to do either.]

Also remove a debugging print from DocModel.__repr__.
