### PR TITLE
Match ccache functions in krb5.h with export list

### DIFF
--- a/doc/appdev/h5l_mit_apidiff.rst
+++ b/doc/appdev/h5l_mit_apidiff.rst
@@ -19,10 +19,7 @@ Differences between Heimdal and MIT Kerberos API
   :c:func:`krb5_auth_con_setsendsubkey()`  H5l: Not implemented as of version 1.3.3
   :c:func:`krb5_cc_set_config()`           MIT: Before version 1.10 it was assumed that
                                            the last argument *data* is ALWAYS non-zero.
-  :c:func:`krb5_cccol_last_change_time()`  H5l takes 3 arguments: krb5_context context,
-                                           const char \*type, krb5_timestamp \*change_time
-                                           MIT takes two arguments: krb5_context context,
-                                           krb5_timestamp \*change_time
+  :c:func:`krb5_cccol_last_change_time()`  MIT: not implemented
   :c:func:`krb5_set_default_realm()`       H5l: Caches the computed default realm context
                                            field.  If the second argument is NULL,
                                            it tries to retrieve it from libdefaults or DNS.

--- a/doc/appdev/refs/api/index.rst
+++ b/doc/appdev/refs/api/index.rst
@@ -157,8 +157,6 @@ Rarely used public interfaces
    krb5_cc_get_config.rst
    krb5_cc_get_flags.rst
    krb5_cc_get_full_name.rst
-   krb5_cc_last_change_time.rst
-   krb5_cc_lock.rst
    krb5_cc_move.rst
    krb5_cc_next_cred.rst
    krb5_cc_remove_cred.rst
@@ -171,14 +169,10 @@ Rarely used public interfaces
    krb5_cc_store_cred.rst
    krb5_cc_support_switch.rst
    krb5_cc_switch.rst
-   krb5_cc_unlock.rst
    krb5_cccol_cursor_free.rst
    krb5_cccol_cursor_new.rst
    krb5_cccol_cursor_next.rst
    krb5_cccol_have_content.rst
-   krb5_cccol_last_change_time.rst
-   krb5_cccol_lock.rst
-   krb5_cccol_unlock.rst
    krb5_clear_error_message.rst
    krb5_check_clockskew.rst
    krb5_copy_addresses.rst

--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -2611,45 +2611,6 @@ krb5_error_code KRB5_CALLCONV
 krb5_cc_move(krb5_context context, krb5_ccache src, krb5_ccache dst);
 
 /**
- * Return a timestamp of the last modification to a credential cache.
- *
- * @param [in]  context         Library context
- * @param [in]  ccache          Credential cache handle
- * @param [out] change_time     The last change time of @a ccache
- *
- * If an error occurs, @a change_time is set to 0.
- */
-krb5_error_code KRB5_CALLCONV
-krb5_cc_last_change_time(krb5_context context, krb5_ccache ccache,
-                         krb5_timestamp *change_time);
-
-/**
- * Lock a credential cache.
- *
- * @param [in]  context         Library context
- * @param [in]  ccache          Credential cache handle
- *
- * Use krb5_cc_unlock() to unlock the lock.
- *
- * @retval 0 Success; otherwise - Kerberos error codes
- */
-krb5_error_code KRB5_CALLCONV
-krb5_cc_lock(krb5_context context, krb5_ccache ccache);
-
-/**
- * Unlock a credential cache.
- *
- * @param [in]  context         Library context
- * @param [in]  ccache          Credential cache handle
- *
- * This function unlocks the @a ccache locked by krb5_cc_lock().
- *
- * @retval 0 Success; otherwise - Kerberos error codes
- */
-krb5_error_code KRB5_CALLCONV
-krb5_cc_unlock(krb5_context context, krb5_ccache ccache);
-
-/**
  * Prepare to iterate over the collection of known credential caches.
  *
  * @param [in]  context         Library context
@@ -2713,52 +2674,6 @@ krb5_cccol_cursor_free(krb5_context context, krb5_cccol_cursor *cursor);
  */
 krb5_error_code KRB5_CALLCONV
 krb5_cccol_have_content(krb5_context context);
-
-/**
- * Return a timestamp of the last modification of any known credential cache.
- *
- * @param [in]  context         Library context
- * @param [out] change_time     Last modification timestamp
- *
- * This function returns the most recent modification time of any known
- * credential cache, ignoring any caches which cannot supply a last
- * modification time.
- *
- * If there are no known credential caches, @a change_time is set to 0.
- *
- * @retval 0 Success; otherwise - Kerberos error codes
- */
-krb5_error_code KRB5_CALLCONV
-krb5_cccol_last_change_time(krb5_context context, krb5_timestamp *change_time);
-
-/**
- * Acquire a global lock for credential caches.
- *
- * @param [in]  context         Library context
- *
- * This function locks the global credential cache collection, ensuring
- * that no ccaches are added to or removed from it until the collection
- * lock is released.
- *
- * Use krb5_cccol_unlock() to unlock the lock.
- *
- * @retval 0 Success; otherwise - Kerberos error codes
- */
-
-krb5_error_code KRB5_CALLCONV
-krb5_cccol_lock(krb5_context context);
-
-/**
- * Release a global lock for credential caches.
- *
- * @param [in]  context         Library context
- *
- * This function unlocks the lock from krb5_cccol_lock().
- *
- * @retval 0 Success; otherwise - Kerberos error codes
- */
-krb5_error_code KRB5_CALLCONV
-krb5_cccol_unlock(krb5_context context);
 
 /**
  * Create a new credential cache of the specified type with a unique name.

--- a/src/lib/krb5/ccache/cc-int.h
+++ b/src/lib/krb5/ccache/cc-int.h
@@ -114,6 +114,18 @@ extern krb5_error_code KRB5_CALLCONV krb5_stdccv3_context_unlock
 (krb5_context context);
 #endif
 
+krb5_error_code
+k5_cc_lock(krb5_context context, krb5_ccache ccache);
+
+krb5_error_code
+k5_cc_unlock(krb5_context context, krb5_ccache ccache);
+
+krb5_error_code
+k5_cccol_lock(krb5_context context);
+
+krb5_error_code
+k5_cccol_unlock(krb5_context context);
+
 void
 k5_cc_mutex_force_unlock(k5_cc_mutex *m);
 
@@ -200,8 +212,6 @@ struct _krb5_cc_ops {
                                                    krb5_cc_ptcursor *);
     krb5_error_code (KRB5_CALLCONV *move)(krb5_context, krb5_ccache,
                                           krb5_ccache);
-    krb5_error_code (KRB5_CALLCONV *lastchange)(krb5_context,
-                                                krb5_ccache, krb5_timestamp *);
     krb5_error_code (KRB5_CALLCONV *wasdefault)(krb5_context, krb5_ccache,
                                                 krb5_timestamp *);
     krb5_error_code (KRB5_CALLCONV *lock)(krb5_context, krb5_ccache);

--- a/src/lib/krb5/ccache/cc_dir.c
+++ b/src/lib/krb5/ccache/cc_dir.c
@@ -692,15 +692,6 @@ dcc_ptcursor_free(krb5_context context, krb5_cc_ptcursor *cursor)
 }
 
 static krb5_error_code KRB5_CALLCONV
-dcc_lastchange(krb5_context context, krb5_ccache cache,
-               krb5_timestamp *time_out)
-{
-    dcc_data *data = cache->data;
-
-    return krb5_fcc_ops.lastchange(context, data->fcc, time_out);
-}
-
-static krb5_error_code KRB5_CALLCONV
 dcc_lock(krb5_context context, krb5_ccache cache)
 {
     dcc_data *data = cache->data;
@@ -762,7 +753,6 @@ const krb5_cc_ops krb5_dcc_ops = {
     dcc_ptcursor_next,
     dcc_ptcursor_free,
     NULL, /* move */
-    dcc_lastchange,
     NULL, /* wasdefault */
     dcc_lock,
     dcc_unlock,

--- a/src/lib/krb5/ccache/cc_file.c
+++ b/src/lib/krb5/ccache/cc_file.c
@@ -1099,29 +1099,6 @@ fcc_ptcursor_free(krb5_context context, krb5_cc_ptcursor *cursor)
     return 0;
 }
 
-/* Get the cache file's last modification time. */
-static krb5_error_code KRB5_CALLCONV
-fcc_last_change_time(krb5_context context, krb5_ccache id,
-                     krb5_timestamp *change_time)
-{
-    krb5_error_code ret = 0;
-    fcc_data *data = id->data;
-    struct stat buf;
-
-    *change_time = 0;
-
-    k5_cc_mutex_lock(context, &data->lock);
-
-    if (stat(data->filename, &buf) == -1)
-        ret = interpret_errno(context, errno);
-    else
-        *change_time = (krb5_timestamp)buf.st_mtime;
-
-    k5_cc_mutex_unlock(context, &data->lock);
-
-    return set_errmsg_filename(context, ret, data->filename);
-}
-
 /* Lock the cache handle against other threads.  (This does not lock the cache
  * file against other processes.) */
 static krb5_error_code KRB5_CALLCONV
@@ -1217,7 +1194,6 @@ const krb5_cc_ops krb5_fcc_ops = {
     fcc_ptcursor_next,
     fcc_ptcursor_free,
     NULL, /* move */
-    fcc_last_change_time,
     NULL, /* wasdefault */
     fcc_lock,
     fcc_unlock,
@@ -1288,7 +1264,6 @@ const krb5_cc_ops krb5_cc_file_ops = {
     fcc_ptcursor_next,
     fcc_ptcursor_free,
     NULL, /* move */
-    fcc_last_change_time,
     NULL, /* wasdefault */
     fcc_lock,
     fcc_unlock,

--- a/src/lib/krb5/ccache/cc_mslsa.c
+++ b/src/lib/krb5/ccache/cc_mslsa.c
@@ -2203,7 +2203,6 @@ const krb5_cc_ops krb5_lcc_ops = {
     krb5_lcc_ptcursor_next,
     krb5_lcc_ptcursor_free,
     NULL, /* move */
-    NULL, /* lastchange */
     NULL, /* wasdefault */
     NULL, /* lock */
     NULL, /* unlock */

--- a/src/lib/krb5/ccache/ccapi/stdcc.c
+++ b/src/lib/krb5/ccache/ccapi/stdcc.c
@@ -92,7 +92,6 @@ krb5_cc_ops krb5_cc_stdcc_ops = {
     krb5_stdccv3_ptcursor_next,
     krb5_stdccv3_ptcursor_free,
     NULL, /* move */
-    krb5_stdccv3_last_change_time, /* lastchange */
     NULL, /* wasdefault */
     krb5_stdccv3_lock,
     krb5_stdccv3_unlock,
@@ -113,7 +112,6 @@ krb5_cc_ops krb5_cc_stdcc_ops = {
     krb5_stdcc_remove,
     krb5_stdcc_set_flags,
     krb5_stdcc_get_flags,
-    NULL,
     NULL,
     NULL,
     NULL,
@@ -1001,29 +999,6 @@ krb5_stdccv3_ptcursor_free(
         *cursor = NULL;
     }
     return 0;
-}
-
-krb5_error_code KRB5_CALLCONV krb5_stdccv3_last_change_time
-(krb5_context context, krb5_ccache id,
- krb5_timestamp *change_time)
-{
-    krb5_error_code err = 0;
-    stdccCacheDataPtr ccapi_data = id->data;
-    cc_time_t ccapi_change_time = 0;
-
-    *change_time = 0;
-
-    if (!err) {
-        err = stdccv3_setup(context, ccapi_data);
-    }
-    if (!err) {
-        err = cc_ccache_get_change_time (ccapi_data->NamedCache, &ccapi_change_time);
-    }
-    if (!err) {
-        *change_time = ccapi_change_time;
-    }
-
-    return cc_err_xlate (err);
 }
 
 krb5_error_code KRB5_CALLCONV krb5_stdccv3_lock

--- a/src/lib/krb5/ccache/ccapi/stdcc.h
+++ b/src/lib/krb5/ccache/ccapi/stdcc.h
@@ -102,10 +102,6 @@ krb5_error_code KRB5_CALLCONV krb5_stdccv3_ptcursor_next
 krb5_error_code KRB5_CALLCONV krb5_stdccv3_ptcursor_free
 (krb5_context context, krb5_cc_ptcursor *cursor);
 
-krb5_error_code KRB5_CALLCONV krb5_stdccv3_last_change_time
-(krb5_context context, krb5_ccache id,
- krb5_timestamp *change_time);
-
 krb5_error_code KRB5_CALLCONV krb5_stdccv3_lock
 (krb5_context, krb5_ccache id);
 

--- a/src/lib/krb5/ccache/ccbase.c
+++ b/src/lib/krb5/ccache/ccbase.c
@@ -355,14 +355,14 @@ krb5_cc_move(krb5_context context, krb5_ccache src, krb5_ccache dst)
     krb5_principal princ = NULL;
 
     TRACE_CC_MOVE(context, src, dst);
-    ret = krb5_cccol_lock(context);
+    ret = k5_cccol_lock(context);
     if (ret) {
         return ret;
     }
 
-    ret = krb5_cc_lock(context, src);
+    ret = k5_cc_lock(context, src);
     if (ret) {
-        krb5_cccol_unlock(context);
+        k5_cccol_unlock(context);
         return ret;
     }
 
@@ -371,22 +371,22 @@ krb5_cc_move(krb5_context context, krb5_ccache src, krb5_ccache dst)
         ret = krb5_cc_initialize(context, dst, princ);
     }
     if (ret) {
-        krb5_cc_unlock(context, src);
-        krb5_cccol_unlock(context);
+        k5_cc_unlock(context, src);
+        k5_cccol_unlock(context);
         return ret;
     }
 
-    ret = krb5_cc_lock(context, dst);
+    ret = k5_cc_lock(context, dst);
     if (!ret) {
         ret = krb5_cc_copy_creds(context, src, dst);
-        krb5_cc_unlock(context, dst);
+        k5_cc_unlock(context, dst);
     }
 
-    krb5_cc_unlock(context, src);
+    k5_cc_unlock(context, src);
     if (!ret) {
         ret = krb5_cc_destroy(context, src);
     }
-    krb5_cccol_unlock(context);
+    k5_cccol_unlock(context);
     if (princ) {
         krb5_free_principal(context, princ);
         princ = NULL;
@@ -497,8 +497,8 @@ k5_cc_mutex_force_unlock(k5_cc_mutex *m)
  * holds on to all pertype global locks as well as typelist lock
  */
 
-krb5_error_code KRB5_CALLCONV
-krb5_cccol_lock(krb5_context context)
+krb5_error_code
+k5_cccol_lock(krb5_context context)
 {
     krb5_error_code ret = 0;
 
@@ -523,8 +523,8 @@ krb5_cccol_lock(krb5_context context)
     return ret;
 }
 
-krb5_error_code KRB5_CALLCONV
-krb5_cccol_unlock(krb5_context context)
+krb5_error_code
+k5_cccol_unlock(krb5_context context)
 {
     krb5_error_code ret = 0;
 

--- a/src/lib/krb5/ccache/cccursor.c
+++ b/src/lib/krb5/ccache/cccursor.c
@@ -142,41 +142,6 @@ krb5_cccol_cursor_free(krb5_context context,
 }
 
 krb5_error_code KRB5_CALLCONV
-krb5_cccol_last_change_time(krb5_context context,
-                            krb5_timestamp *change_time)
-{
-    krb5_error_code ret = 0;
-    krb5_cccol_cursor c = NULL;
-    krb5_ccache ccache = NULL;
-    krb5_timestamp last_time = 0;
-    krb5_timestamp max_change_time = 0;
-
-    *change_time = 0;
-
-    ret = krb5_cccol_cursor_new(context, &c);
-
-    while (!ret) {
-        ret = krb5_cccol_cursor_next(context, c, &ccache);
-        if (ccache) {
-            ret = krb5_cc_last_change_time(context, ccache, &last_time);
-            if (!ret && ts_after(last_time, max_change_time)) {
-                max_change_time = last_time;
-            }
-            ret = 0;
-        }
-        else {
-            break;
-        }
-    }
-    *change_time = max_change_time;
-    return ret;
-}
-
-/*
- * krb5_cccol_lock and krb5_cccol_unlock are defined in ccbase.c
- */
-
-krb5_error_code KRB5_CALLCONV
 krb5_cc_cache_match(krb5_context context, krb5_principal client,
                     krb5_ccache *cache_out)
 {

--- a/src/lib/krb5/ccache/ccfns.c
+++ b/src/lib/krb5/ccache/ccfns.c
@@ -189,21 +189,14 @@ krb5_cc_get_type(krb5_context context, krb5_ccache cache)
     return cache->ops->prefix;
 }
 
-krb5_error_code KRB5_CALLCONV
-krb5_cc_last_change_time(krb5_context context, krb5_ccache ccache,
-                         krb5_timestamp *change_time)
-{
-    return ccache->ops->lastchange(context, ccache, change_time);
-}
-
-krb5_error_code KRB5_CALLCONV
-krb5_cc_lock(krb5_context context, krb5_ccache ccache)
+krb5_error_code
+k5_cc_lock(krb5_context context, krb5_ccache ccache)
 {
     return ccache->ops->lock(context, ccache);
 }
 
-krb5_error_code KRB5_CALLCONV
-krb5_cc_unlock(krb5_context context, krb5_ccache ccache)
+krb5_error_code
+k5_cc_unlock(krb5_context context, krb5_ccache ccache)
 {
     return ccache->ops->unlock(context, ccache);
 }


### PR DESCRIPTION
r20743 (part of 1.7) added new ccache functions to krb5.h, but not
either exports list.  Though ad5aa12f13aad7ec4cafcffeec4f2e84e56c9c78
exported krb5_cc_move, the rest remain unexported.

krb5_cc_lock, krb5_cc_unlock, krb5_cccol_lock, and krb5_cccol_unlock
are used internally, so remove them from krb5.h and rename k5_cc_lock,
k5_cc_unlock, k5_cccol_lock, and k5_cccol_unlock, respectively.

krb5_cccol_last_change_time is not used, so remove it.

krb5_cc_last_change_time is also not used, so remove it as well.
Update ccache interface to reflect removal.  Of particular note, this
function didn't behave as documented for MEMORY or KEYRING ccaches at
time of removal.

ticket: 7765