### PR TITLE
Always pass tgt-client principal to sign_authdata

### DIFF
--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -1018,9 +1018,9 @@ typedef struct _kdb_vftabl {
      *     requested; also set by the admin interface.  Determines whether the
      *     module should return in-realm aliases.
      *
-     * A module can return in-realm aliases if KRB5_KDB_FLAG_ALIAS_OK is set,
-     * or if search_for->type is KRB5_NT_ENTERPRISE_PRINCIPAL.  To return an
-     * in-realm alias, fill in a different value for entries->princ than the
+     * A module can lookup a principal by alias name if it so desires, but can
+     * only return in-realm aliases if KRB5_KDB_FLAG_ALIAS_OK is set. To return
+     * an in-realm alias, fill in a different value for entries->princ than the
      * one requested.
      *
      * A module can return out-of-realm referrals if KRB5_KDB_FLAG_CANONICALIZE

--- a/src/kdc/do_as_req.c
+++ b/src/kdc/do_as_req.c
@@ -589,9 +589,11 @@ process_as_req(krb5_kdc_req *request, krb5_data *req_pkt,
      * Note that according to the referrals draft we should
      * always canonicalize enterprise principal names.
      */
-    if (isflagset(state->request->kdc_options, KDC_OPT_CANONICALIZE) ||
-        state->request->client->type == KRB5_NT_ENTERPRISE_PRINCIPAL) {
+    if (isflagset(state->request->kdc_options, KDC_OPT_CANONICALIZE)) {
         setflag(state->c_flags, KRB5_KDB_FLAG_CANONICALIZE);
+        setflag(state->c_flags, KRB5_KDB_FLAG_ALIAS_OK);
+    }
+    if (state->request->client->type == KRB5_NT_ENTERPRISE_PRINCIPAL) {
         setflag(state->c_flags, KRB5_KDB_FLAG_ALIAS_OK);
     }
     if (include_pac_p(kdc_context, state->request)) {

--- a/src/kdc/kdc_authdata.c
+++ b/src/kdc/kdc_authdata.c
@@ -361,7 +361,7 @@ fetch_kdb_authdata(krb5_context context, unsigned int flags,
      * not be changed until the final hop.
      */
     if (isflagset(flags, KRB5_KDB_FLAG_PROTOCOL_TRANSITION))
-        actual_client = for_user_princ;
+        actual_client = client == NULL ? for_user_princ : enc_tkt_req->client;
     else
         actual_client = enc_tkt_reply->client;
 

--- a/src/plugins/kdb/test/kdb_test.c
+++ b/src/plugins/kdb/test/kdb_test.c
@@ -502,8 +502,8 @@ mkauthdata(krb5_context context, krb5_const_principal princ,
     ad = ealloc(sizeof(*ad));
     ad->magic = KV5M_AUTHDATA;
     ad->ad_type = TEST_AD_TYPE;
-    ad->length = sizeof(prefix) + strlen(princ_str) + 3;
-    data = (char *)ealloc(ad->length);
+    ad->length = sizeof(prefix) + strlen(princ_str) + 2;
+    data = (char *)ealloc(ad->length + 1);
 
     strcpy(data, prefix);
     if (princ->type == KRB5_NT_ENTERPRISE_PRINCIPAL)
@@ -541,7 +541,8 @@ test_sign_authdata(krb5_context context, unsigned int flags,
     if (!(flags & KRB5_KDB_FLAG_CLIENT_REFERRALS_ONLY)) {
         check(krb5_find_authdata(context, tgt_auth_data, NULL,
                                  TEST_AD_TYPE, &testad));
-        if (testad == NULL || testad[0] == NULL)
+      if (testad != NULL) {
+        if (testad[0] == NULL)
             abort();
 
         for (i = 0; testad[i]; i++)
@@ -560,6 +561,7 @@ test_sign_authdata(krb5_context context, unsigned int flags,
             ad = mkauthdata(context, client ? client->princ :
                             client_princ, sign_realm);
         }
+      }
     }
 
     list = ealloc(2 * sizeof(*list));

--- a/src/tests/gssapi/t_s4u.py
+++ b/src/tests/gssapi/t_s4u.py
@@ -208,8 +208,8 @@ msgs = ('Getting initial credentials for enterprise\\@abc@SREALM',
         '/Generic preauthentication failure',
         'Getting credentials enterprise\\@abc@UREALM -> user@SREALM',
         'TGS reply is for enterprise\@abc@UREALM -> user@SREALM')
-#r1.run(['./t_s4u', 'e:enterprise@abc@NOREALM', '-', r1.keytab],
-#       expected_trace=msgs)
+r1.run(['./t_s4u', 'e:enterprise@abc@NOREALM', '-', r1.keytab],
+       expected_trace=msgs)
 
 r1.stop()
 r2.stop()

--- a/src/tests/gssapi/t_s4u.py
+++ b/src/tests/gssapi/t_s4u.py
@@ -208,8 +208,8 @@ msgs = ('Getting initial credentials for enterprise\\@abc@SREALM',
         '/Generic preauthentication failure',
         'Getting credentials enterprise\\@abc@UREALM -> user@SREALM',
         'TGS reply is for enterprise\@abc@UREALM -> user@SREALM')
-r1.run(['./t_s4u', 'e:enterprise@abc@NOREALM', '-', r1.keytab],
-       expected_trace=msgs)
+#r1.run(['./t_s4u', 'e:enterprise@abc@NOREALM', '-', r1.keytab],
+#       expected_trace=msgs)
 
 r1.stop()
 r2.stop()


### PR DESCRIPTION
to allows a plugin handling s4u2self request, to verify the PAC from the TGT and to generate a new one for the impersonate principal in case the latter is from local realm.

We have discussed it back then, and while relevant section in MS-SFU (3.2.5.x) is ambiguous to me,  Windows KDC seem to require the PAC to exist (which implies that it verifies it), as the following fails with err_c_principal_unknown (works fine if I omit the -U).

`$ echo -n pwd | kinit apache@ACME.COM --no-request-pac && kvno
-Uuser@abc@ACME.COM apache@ACME.COM`

I've tested this prove-of-concept change with Samba plugin patched accordingly, in cross realm trust with WIndows KDC (both ways): https://github.com/iboukris/samba/commit/610afde8cf9efabe24768aa58183f5349e660df5

I've also consulted on samba-technical and got the same feedback that we should verify it.
CC @cryptomilk @abbra