### PR TITLE
Properly size #ifdef in k5_cccol_lock()

### DIFF
--- a/src/lib/krb5/ccache/ccbase.c
+++ b/src/lib/krb5/ccache/ccbase.c
@@ -511,7 +511,6 @@ k5_cccol_lock(krb5_context context)
 #endif
 #ifdef USE_CCAPI_V3
     ret = krb5_stdccv3_context_lock(context);
-#endif
     if (ret) {
         k5_cc_mutex_unlock(context, &krb5int_mcc_mutex);
         k5_cc_mutex_unlock(context, &krb5int_cc_file_mutex);
@@ -519,6 +518,7 @@ k5_cccol_lock(krb5_context context)
         k5_cc_mutex_unlock(context, &cccol_lock);
         return ret;
     }
+#endif
     k5_mutex_unlock(&cc_typelist_lock);
     return ret;
 }


### PR DESCRIPTION
The cleanup code only could get executed in the USE_CCAPI_V3 case, so
move it inside that block.  Reported by Coverity.