### PR TITLE
Fix memory leak in 'none' replay cache type

### DIFF
--- a/src/lib/krb5/rcache/rc_none.c
+++ b/src/lib/krb5/rcache/rc_none.c
@@ -50,6 +50,7 @@ krb5_rc_none_noargs(krb5_context ctx, krb5_rcache rc)
 static krb5_error_code KRB5_CALLCONV
 krb5_rc_none_close(krb5_context ctx, krb5_rcache rc)
 {
+    k5_mutex_destroy(&rc->lock);
     free (rc);
     return 0;
 }


### PR DESCRIPTION
Commit 0f06098e2ab419d02e89a1ca6bc9f2828f6bdb1e fixed part of a memory
leak in the 'none' replay cache type by freeing the outer container,
but we also need to free the mutex.

[ghudson@mit.edu: wrote commit message]
