### PR TITLE
Remove unnecessary NULL-check in mk_priv.c

### DIFF
--- a/src/lib/krb5/krb/mk_priv.c
+++ b/src/lib/krb5/krb/mk_priv.c
@@ -94,10 +94,8 @@ create_krbpriv(krb5_context context, const krb5_data *userdata,
 cleanup:
     zapfree(privmsg.enc_part.ciphertext.data,
             privmsg.enc_part.ciphertext.length);
-    if (der_encpart != NULL) {
-        zap(der_encpart->data, der_encpart->length);
-        krb5_free_data(context, der_encpart);
-    }
+    zap(der_encpart->data, der_encpart->length);
+    krb5_free_data(context, der_encpart);
     return ret;
 }
 


### PR DESCRIPTION
encode_krb5_enc_priv_part() will initialize der_encpart on success, so
it can never be NULL at cleanup-time.  Reported by Coverity.