### PR TITLE
Rename configure.in to configure.ac

### DIFF
--- a/src/config/post.in
+++ b/src/config/post.in
@@ -181,7 +181,7 @@ Makefile: $(srcdir)/Makefile.in $(srcdir)/deps $(BUILDTOP)/config.status \
 $(BUILDTOP)/config.status: $(top_srcdir)/configure
 	(cd $(BUILDTOP) && $(SHELL) config.status --recheck)
 $(top_srcdir)/configure: @MAINT@ \
-		$(top_srcdir)/configure.in \
+		$(top_srcdir)/configure.ac \
 		$(top_srcdir)/patchlevel.h \
 		$(top_srcdir)/aclocal.m4
 	(cd $(top_srcdir) && \

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -916,7 +916,7 @@ ath_compat=compat,)
 AC_CHECK_PROG(have_RUNTEST,runtest,runtest)
 AC_CHECK_PROG(have_PERL,perl,perl)
 if test "$have_PERL" = perl -a "$have_RUNTEST" = runtest -a "$TCL_LIBS" != ""; then
- 	DO_TEST=ok
+	DO_TEST=ok
 fi
 AC_SUBST(DO_TEST)
 

--- a/src/include/Makefile.in
+++ b/src/include/Makefile.in
@@ -33,7 +33,7 @@ all-windows: autoconf.h $(BUILT_HEADERS) verify-calling-conventions-krb5
 all-unix: @MAINT@ verify-calling-conventions-krb5
 
 $(srcdir)/autoconf.h.in: @MAINT@ $(srcdir)/autoconf.stmp
-$(srcdir)/autoconf.stmp: $(top_srcdir)/configure.in $(top_srcdir)/aclocal.m4
+$(srcdir)/autoconf.stmp: $(top_srcdir)/configure.ac $(top_srcdir)/aclocal.m4
 	(cd $(top_srcdir) && $(AUTOHEADER) --include=$(CONFIG_RELTOPDIR) $(AUTOHEADERFLAGS))
 	touch $(srcdir)/autoconf.stmp
 

--- a/src/util/check-ac-syms
+++ b/src/util/check-ac-syms
@@ -3,9 +3,9 @@
 # args: srcdir srctop-from-srcdir header-path
 
 d=`pwd`
-head -1 $1/configure.in > config-in.tmp
+head -1 $1/configure.ac > config-in.tmp
 echo "AC_CONFIG_HEADER(fooconfig.h:$d/fooconfig-h.tmp)" >> config-in.tmp
-tail +2 $1/configure.in | grep -v AC_CONFIG_HEADER >> config-in.tmp
+tail +2 $1/configure.ac | grep -v AC_CONFIG_HEADER >> config-in.tmp
 mv -f config-in.tmp config-in.ac~
 
 if (cd $1 && autoheader --include=$2 $d/config-in.ac~) > /dev/null; then

--- a/src/util/getsyms
+++ b/src/util/getsyms
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Run this from the TOP of the source tree!
 M4=gm4
-configs=`find $1 -name configure.in -print|sort|sed -e 's@/configure.in@@'`
+configs=`find $1 -name configure.ac -print|sort|sed -e 's@/configure.ac@@'`
 for dir in $configs; do
 	syms=""
 	libs=""
@@ -10,7 +10,7 @@ for dir in $configs; do
 	funcs=""
 	AC_MACRODIR=./util/autoconf
 	# The following bits shamelessly stolen from autoheader.sh
-	eval "`$M4 -I$AC_MACRODIR autoheader.m4 $dir/configure.in|
+	eval "`$M4 -I$AC_MACRODIR autoheader.m4 $dir/configure.ac|
 		sed -n -e '
 		: again
 		/^@@@.*@@@$/s/^@@@\(.*\)@@@$/\1/p
@@ -41,7 +41,7 @@ for dir in $configs; do
 			done | sed 's/[^a-zA-Z0-9_]/_/g' | tr '[a-z]' '[A-Z]' | sed 's/^/HAVE_LIB/'`"
 	allsyms="$allsyms $libs"
 	fi
-	echo $dir/configure.in: $allsyms
+	echo $dir/configure.ac: $allsyms
 	allsyms="`echo $allsyms|tr ' ' '|'`"
 	files="$dir/*.[ch]"
 	if test ! "`echo $files`" = "$dir/"'*.[ch]'; then


### PR DESCRIPTION
autotools plans to drop support for the name configure.in.
(automake's NEWS file expresses plans to drop support for it in
autoconf 2.0; autoconf added a warning in commit
560f16b52d3d3db1536d9ca5b863ce9b1a5c9e35, indicating in the commit
message that support will be dropped in a future version.)
