### PR TITLE
Add option to build without libkeyutils

### DIFF
--- a/doc/build/options2configure.rst
+++ b/doc/build/options2configure.rst
@@ -387,6 +387,10 @@ Optional packages
     ``--without-krb5-config`` to disable the use of krb5-config and
     use the usual built-in defaults.
 
+**-**\ **-without-keyutils**
+    Build without libkeyutils support.  This disables the KEYRING
+    credential cache type.
+
 
 Examples
 --------

--- a/src/aclocal.m4
+++ b/src/aclocal.m4
@@ -93,8 +93,6 @@ KRB5_LIB_PARAMS
 KRB5_AC_INITFINI
 KRB5_AC_ENABLE_THREADS
 KRB5_AC_FIND_DLOPEN
-KRB5_AC_KEYRING_CCACHE
-KRB5_AC_PERSISTENT_KEYRING
 ])dnl
 
 dnl Maintainer mode, akin to what automake provides, 'cept we don't
@@ -1677,23 +1675,3 @@ if test "$with_ldap" = yes; then
   OPENLDAP_PLUGIN=yes
 fi
 ])dnl
-dnl
-dnl If libkeyutils exists (on Linux) include it and use keyring ccache
-AC_DEFUN(KRB5_AC_KEYRING_CCACHE,[
-  AC_CHECK_HEADERS([keyutils.h],
-    AC_CHECK_LIB(keyutils, add_key, 
-      [dnl Pre-reqs were found
-       AC_DEFINE(USE_KEYRING_CCACHE, 1, [Define if the keyring ccache should be enabled])
-       LIBS="-lkeyutils $LIBS"
-      ]))
-])dnl
-dnl
-dnl If libkeyutils supports persistent keyrings, use them
-AC_DEFUN(KRB5_AC_PERSISTENT_KEYRING,[
-  AC_CHECK_HEADERS([keyutils.h],
-    AC_CHECK_LIB(keyutils, keyctl_get_persistent,
-      [AC_DEFINE(HAVE_PERSISTENT_KEYRING, 1,
-                 [Define if persistent keyrings are supported])
-      ]))
-])dnl
-dnl

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -323,6 +323,27 @@ AC_SUBST(TLS_IMPL)
 AC_SUBST(TLS_IMPL_CFLAGS)
 AC_SUBST(TLS_IMPL_LIBS)
 
+AC_ARG_WITH([keyutils],
+AC_HELP_STRING([--without-keyutils],[do not link with libkeyutils]),
+            [], [with_keyutils=check])
+if test "$with_keyutils" != no; then
+  have_keyutils=false
+  AC_CHECK_HEADERS([keyutils.h],
+    AC_CHECK_LIB(keyutils, add_key, [have_keyutils=true]))
+  if test "$have_keyutils" = true; then
+    AC_DEFINE(USE_KEYRING_CCACHE, 1,
+              [Define if the keyring ccache should be enabled])
+    LIBS="-lkeyutils $LIBS"
+    # If libkeyutils supports persistent keyrings, use them.
+    AC_CHECK_LIB(keyutils, keyctl_get_persistent,
+      [AC_DEFINE(HAVE_PERSISTENT_KEYRING, 1,
+                 [Define if persistent keyrings are supported])
+      ])
+  elif test "$with_keyutils" = yes; then
+    AC_MSG_ERROR([libkeyutils not found])
+  fi
+fi
+
 # The SPAKE preauth plugin currently supports edwards25519 natively,
 # and can support three NIST groups using OpenSSL.
 HAVE_SPAKE_OPENSSL=no


### PR DESCRIPTION
- There are instances where it is advantageous to be able to
  turn off the keyring ccache feature when compiling on Linux.
  This patch adds --disable-keyring-ccache as an option to
  the configure script.

Signed-off-by: Robert Marshall <rmarshall@gitlab.com>