### PR TITLE
zapfreedata

### DIFF
--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -666,6 +666,16 @@ zapfreestr(void *str)
     }
 }
 
+/* Convenience function: zap and free krb5_data pointer if it is non-NULL. */
+static inline void
+zapfreedata(krb5_data *data)
+{
+    if (data != NULL) {
+        zapfree(data->data, data->length);
+        free(data);
+    }
+}
+
 /*
  * Combine two keys (normally used by the hardware preauth mechanism)
  */

--- a/src/lib/krb5/krb/mk_cred.c
+++ b/src/lib/krb5/krb/mk_cred.c
@@ -59,8 +59,7 @@ encrypt_credencpart(krb5_context context, krb5_cred_enc_part *encpart,
     ret = k5_encrypt_keyhelper(context, key, KRB5_KEYUSAGE_KRB_CRED_ENCPART,
                                der_enccred, encdata_out);
 
-    zap(der_enccred->data, der_enccred->length);
-    krb5_free_data(context, der_enccred);
+    zapfreedata(der_enccred);
     return ret;
 }
 
@@ -208,10 +207,7 @@ cleanup:
     krb5_free_data_contents(context, &enc.ciphertext);
     free(lstorage.contents);
     free(rstorage.contents);
-    if (der_krbcred != NULL) {
-        zap(der_krbcred->data, der_krbcred->length);
-        krb5_free_data(context, der_krbcred);
-    }
+    zapfreedata(der_krbcred);
     return ret;
 }
 

--- a/src/lib/krb5/krb/mk_priv.c
+++ b/src/lib/krb5/krb/mk_priv.c
@@ -50,7 +50,7 @@ create_krbpriv(krb5_context context, const krb5_data *userdata,
     krb5_error_code ret;
     krb5_priv privmsg;
     krb5_priv_enc_part encpart;
-    krb5_data *der_encpart, *der_krbpriv;
+    krb5_data *der_encpart = NULL, *der_krbpriv;
     size_t enclen;
 
     memset(&privmsg, 0, sizeof(privmsg));
@@ -97,10 +97,7 @@ create_krbpriv(krb5_context context, const krb5_data *userdata,
 cleanup:
     zapfree(privmsg.enc_part.ciphertext.data,
             privmsg.enc_part.ciphertext.length);
-    if (der_encpart != NULL) {
-        zap(der_encpart->data, der_encpart->length);
-        krb5_free_data(context, der_encpart);
-    }
+    zapfreedata(der_encpart);
     return ret;
 }
 

--- a/src/lib/krb5/krb/mk_safe.c
+++ b/src/lib/krb5/krb/mk_safe.c
@@ -78,8 +78,7 @@ create_krbsafe(krb5_context context, const krb5_data *userdata, krb5_key key,
     ret = krb5_k_make_checksum(context, sumtype, key,
                                KRB5_KEYUSAGE_KRB_SAFE_CKSUM, der_krbsafe,
                                &safe_checksum);
-    zap(der_krbsafe->data, der_krbsafe->length);
-    krb5_free_data(context, der_krbsafe);
+    zapfreedata(der_krbsafe);
     if (ret)
         return ret;
 

--- a/src/lib/krb5/krb/rd_safe.c
+++ b/src/lib/krb5/krb/rd_safe.c
@@ -117,10 +117,7 @@ read_krbsafe(krb5_context context, krb5_auth_context ac,
     safe_cksum = NULL;
 
 cleanup:
-    if (der_zerosafe != NULL) {
-        zap(der_zerosafe->data, der_zerosafe->length);
-        krb5_free_data(context, der_zerosafe);
-    }
+    zapfreedata(der_zerosafe);
     krb5_free_data(context, safe_body);
     krb5_free_safe(context, krbsafe);
     krb5_free_checksum(context, safe_cksum);


### PR DESCRIPTION
This feels a bit niche (only five uses, all in the libkrb5 message-handling code) but it seems like a reasonable helper to have on principal.  The proximal motivation is to squelch the Coverity false positive referred to in PR #900.