### PR TITLE
Fix free of auth context memory replay cache

### DIFF
--- a/src/lib/krb5/krb/auth_con.c
+++ b/src/lib/krb5/krb/auth_con.c
@@ -77,8 +77,8 @@ krb5_auth_con_free(krb5_context context, krb5_auth_context auth_context)
         free(auth_context->permitted_etypes);
     if (auth_context->ad_context)
         krb5_authdata_context_free(context, auth_context->ad_context);
-    free(auth_context);
     k5_memrcache_free(context, auth_context->memrcache);
+    free(auth_context);
     return 0;
 }
 

--- a/src/lib/krb5/rcache/t_memrcache.c
+++ b/src/lib/krb5/rcache/t_memrcache.c
@@ -77,5 +77,6 @@ main()
     assert(e != NULL && K5_TAILQ_NEXT(e, links) == NULL);
     k5_memrcache_free(context, mrc);
 
+    krb5_free_context(context);
     return 0;
 }


### PR DESCRIPTION
This was an unusually bad botch.  asan would have caught it, but I didn't run it against the memory replay cache code.  Coverity caught it.
