### PR TITLE
Suppress krb5_cc_start_seq_get() popups in Leash

### DIFF
--- a/src/windows/leash/KrbListTickets.cpp
+++ b/src/windows/leash/KrbListTickets.cpp
@@ -222,7 +222,8 @@ do_ccache(krb5_context ctx,
     }
     code = pkrb5_cc_start_seq_get(ctx, cache, &cur);
     if (code) {
-        functionName = "krb5_cc_start_seq_get";
+        // MSLSA errors here if no TGT is found; suppress error message box
+        code = 0;
         goto cleanup;
     }
     if (*ticketInfoTail)


### PR DESCRIPTION
[This relates to reports from a couple of users at MIT.  Ordinarily I like to have a better understanding of problems before patching around them, but in this case I can't easily investigate further.]

Under some circumstances (perhaps related to a February Windows 10
update), Leash can get past the krb5_cc_get_principal() step when
processing an empty MSLSA ccache, and get a KRB5_CC_NOMATCH error from
krb5_cc_start_seq_get().  Do not display a modal error dialog if this
happens.
