### PR TITLE
Implement krb5_cc_remove_cred for remaining types

### DIFF
--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -2485,8 +2485,10 @@ krb5_cc_get_principal(krb5_context context, krb5_ccache cache,
  *
  * krb5_cc_end_seq_get() must be called to complete the retrieve operation.
  *
- * @note If @a cache is modified between the time of the call to this function
- * and the time of the final krb5_cc_end_seq_get(), the results are undefined.
+ * @note If the cache represented by @a cache is modified between the time of
+ * the call to this function and the time of the final krb5_cc_end_seq_get(),
+ * these changes may not be reflected in the results of krb5_cc_next_cred()
+ * calls.
  *
  * @retval 0  Success; otherwise - Kerberos error codes
  */


### PR DESCRIPTION
Previously, only KCM and MSLA implemented credential removal.  Add
support for MEMORY and FILE (and therefore DIR), matching Heimdal's
implementations.  Also add a new implementation for KEYRING.