### PR TITLE
Implement resource-based-constrained-delegation support

### DIFF
--- a/doc/appdev/refs/api/index.rst
+++ b/doc/appdev/refs/api/index.rst
@@ -253,6 +253,7 @@ Rarely used public interfaces
    krb5_pac_sign_ext.rst
    krb5_pac_verify.rst
    krb5_pac_verify_ext.rst
+   krb5_pac_get_client_info.rst
    krb5_prepend_error_message.rst
    krb5_principal2salt.rst
    krb5_rd_cred.rst

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -559,6 +559,13 @@ typedef struct _krb5_secure_cookie {
     krb5_pa_data **data;
 } krb5_secure_cookie;
 
+typedef struct _krb5_pa_pac_options {
+    krb5_flags options;
+} krb5_pa_pac_options;
+
+/* In PAC options, indicates Resource-Based Constrained Delegation support. */
+#define KRB5_PA_PAC_OPTIONS_RBCD 0x10000000
+
 #include <stdlib.h>
 #include <string.h>
 
@@ -1536,6 +1543,9 @@ encode_utf8_strings(krb5_data *const *ut8fstrings, krb5_data **);
 krb5_error_code
 encode_krb5_secure_cookie(const krb5_secure_cookie *, krb5_data **);
 
+krb5_error_code
+encode_krb5_pa_pac_options(const krb5_pa_pac_options *, krb5_data **);
+
 /*************************************************************************
  * End of prototypes for krb5_encode.c
  *************************************************************************/
@@ -1717,6 +1727,9 @@ decode_utf8_strings(const krb5_data *, krb5_data ***);
 
 krb5_error_code
 decode_krb5_secure_cookie(const krb5_data *, krb5_secure_cookie **);
+
+krb5_error_code
+decode_krb5_pa_pac_options(const krb5_data *, krb5_pa_pac_options **);
 
 struct _krb5_key_data;          /* kdb.h */
 

--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -664,10 +664,12 @@ krb5_error_code krb5_db_sign_authdata(krb5_context kcontext,
                                       krb5_const_principal server_princ,
                                       krb5_db_entry *client,
                                       krb5_db_entry *server,
-                                      krb5_db_entry *krbtgt,
+                                      krb5_db_entry *header_server,
+                                      krb5_db_entry *local_tgt,
                                       krb5_keyblock *client_key,
                                       krb5_keyblock *server_key,
-                                      krb5_keyblock *krbtgt_key,
+                                      krb5_keyblock *header_key,
+                                      krb5_keyblock *local_tgt_key,
                                       krb5_keyblock *session_key,
                                       krb5_timestamp authtime,
                                       krb5_authdata **tgt_auth_data,
@@ -1303,10 +1305,11 @@ typedef struct _kdb_vftabl {
      *   server: The DB entry of the service principal, or of a cross-realm
      *     krbtgt principal in case of referral.
      *
-     *   krbtgt: For S4U2Proxy requests, the DB entry of the second ticket
-     *     server.  For other TGS requests, the DB entry of the header ticket
-     *     server.  For AS requests, the DB entry of the service principal;
-     *     this is usually a local krbtgt principal.
+     *   header_server: For S4U2Proxy requests, the DB entry of the second
+     *     ticket server.  For other TGS requests, the DB entry of the header
+     *     ticket server.  For AS requests, NULL.
+     *
+     *   local_tgt: the DB entry of the local krbtgt principal.
      *
      *   client_key: The reply key for the KDC request, before any FAST armor
      *     is applied.  For AS requests, this may be the client's long-term key
@@ -1315,10 +1318,11 @@ typedef struct _kdb_vftabl {
      *
      *   server_key: The server key used to encrypt the returned ticket.
      *
-     *   krbtgt_key: For S4U2Proxy requests, the key used to decrypt the second
-     *     ticket.  For other TGS requests, the key used to decrypt the header
-     *     ticket.  For AS requests, the server key used to encrypt the
-     *     returned ticket.
+     *   header_key: For S4U2Proxy requests, the key used to decrypt the second
+     *     ticket.  For TGS requests, the key used to decrypt the header
+     *     ticket.  For AS requests, NULL.
+     *
+     *   local_tgt_key: The decrypted first key of local_tgt.
      *
      *   session_key: The session key of the ticket being granted to the
      *     requestor.
@@ -1347,10 +1351,12 @@ typedef struct _kdb_vftabl {
                                      krb5_const_principal server_princ,
                                      krb5_db_entry *client,
                                      krb5_db_entry *server,
-                                     krb5_db_entry *krbtgt,
+                                     krb5_db_entry *header_server,
+                                     krb5_db_entry *local_tgt,
                                      krb5_keyblock *client_key,
                                      krb5_keyblock *server_key,
-                                     krb5_keyblock *krbtgt_key,
+                                     krb5_keyblock *header_key,
+                                     krb5_keyblock *local_tgt_key,
                                      krb5_keyblock *session_key,
                                      krb5_timestamp authtime,
                                      krb5_authdata **tgt_auth_data,

--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -1879,6 +1879,7 @@ krb5_verify_checksum(krb5_context context, krb5_cksumtype ctype,
 #define KRB5_ENCPADATA_REQ_ENC_PA_REP   149 /**< RFC 6806 */
 #define KRB5_PADATA_AS_FRESHNESS        150 /**< RFC 8070 */
 #define KRB5_PADATA_SPAKE               151
+#define KRB5_PADATA_PAC_OPTIONS         167 /**< MS-KILE and MS-SFU */
 
 #define KRB5_SAM_USE_SAD_AS_KEY         0x80000000
 #define KRB5_SAM_SEND_ENCRYPTED_SAD     0x40000000

--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -8338,6 +8338,28 @@ krb5_pac_sign_ext(krb5_context context, krb5_pac pac, krb5_timestamp authtime,
                   const krb5_keyblock *privsvr_key, krb5_boolean with_realm,
                   krb5_data *data);
 
+
+/*
+ * Read client information from a PAC.
+ *
+ * @param [in]  context         Library context
+ * @param [in]  pac             PAC handle
+ * @param [out] authtime_out    Authentication timestamp (NULL if not needed)
+ * @param [out] princname_out   Client account name
+ *
+ * Read the PAC_CLIENT_INFO buffer in @a pac.  Place the client account name as
+ * a string in @a princname_out.  If @a authtime_out is not NULL, place the
+ * initial authentication timestamp in @a authtime_out.
+ *
+ * @retval 0 on success, ENOENT if no PAC_CLIENT_INFO buffer is present in @a
+ * pac, ERANGE if the buffer contains invalid lengths.
+ *
+ * @version New in 1.18
+ */
+krb5_error_code KRB5_CALLCONV
+krb5_pac_get_client_info(krb5_context context, const krb5_pac pac,
+                         krb5_timestamp *authtime_out, char **princname_out);
+
 /**
  * Allow the appplication to override the profile's allow_weak_crypto setting.
  *

--- a/src/kdc/do_as_req.c
+++ b/src/kdc/do_as_req.c
@@ -299,7 +299,7 @@ finish_process_as_req(struct as_req_state *state, krb5_error_code errcode)
                               state->server, NULL, state->local_tgt,
                               &state->local_tgt_key, &state->client_keyblock,
                               &state->server_keyblock, NULL, state->req_pkt,
-                              state->request, NULL, NULL,
+                              state->request, NULL, NULL, NULL,
                               &state->auth_indicators, &state->enc_tkt_reply);
     if (errcode) {
         krb5_klog_syslog(LOG_INFO, _("AS_REQ : handle_authdata (%d)"),

--- a/src/kdc/kdc_preauth.c
+++ b/src/kdc/kdc_preauth.c
@@ -1642,6 +1642,12 @@ return_enc_padata(krb5_context context, krb5_data *req_pkt,
                                             &reply_encpart->enc_padata);
     if (code)
         goto cleanup;
+
+    code = kdc_add_pa_pac_options(context, request,
+                                  &reply_encpart->enc_padata);
+    if (code)
+        goto cleanup;
+
     /*Add potentially other enc_padata providers*/
 cleanup:
     return code;

--- a/src/kdc/kdc_util.h
+++ b/src/kdc/kdc_util.h
@@ -234,7 +234,8 @@ handle_authdata (krb5_context context,
                  krb5_keyblock *header_key,
                  krb5_data *req_pkt,
                  krb5_kdc_req *request,
-                 krb5_const_principal for_user_princ,
+                 krb5_const_principal altcprinc,
+                 void *ad_info,
                  krb5_enc_tkt_part *enc_tkt_request,
                  krb5_data ***auth_indicators,
                  krb5_enc_tkt_part *enc_tkt_reply);
@@ -283,11 +284,19 @@ kdc_make_s4u2self_rep (krb5_context context,
 
 krb5_error_code
 kdc_process_s4u2proxy_req (kdc_realm_t *kdc_active_realm,
+                           unsigned int flags,
                            krb5_kdc_req *request,
                            const krb5_enc_tkt_part *t2enc,
+                           krb5_db_entry *krbtgt,
+                           krb5_keyblock *krbtgt_key,
                            const krb5_db_entry *server,
+                           krb5_keyblock *server_key,
                            krb5_const_principal server_princ,
+                           const krb5_db_entry *proxy,
                            krb5_const_principal proxy_princ,
+                           void *ad_info,
+                           void **stkt_ad_info,
+                           krb5_principal *stkt_ad_client,
                            const char **status);
 
 krb5_error_code
@@ -420,6 +429,10 @@ kdc_add_pa_pac_options(krb5_context context, krb5_kdc_req *request,
 krb5_error_code
 kdc_get_pa_pac_options(krb5_context context, krb5_pa_data **in_padata,
                        krb5_pa_pac_options **pac_options_out);
+
+krb5_error_code
+kdc_get_pa_pac_rbcd(krb5_context context, krb5_pa_data **in_padata,
+                    krb5_boolean *supported);
 
 /* Information handle for kdcpreauth callbacks.  All pointers are aliases. */
 struct krb5_kdcpreauth_rock_st {

--- a/src/kdc/kdc_util.h
+++ b/src/kdc/kdc_util.h
@@ -413,6 +413,14 @@ kdc_fast_make_cookie(krb5_context context, struct kdc_request_state *state,
                      krb5_const_principal client_princ,
                      krb5_pa_data **cookie_out);
 
+krb5_error_code
+kdc_add_pa_pac_options(krb5_context context, krb5_kdc_req *request,
+                       krb5_pa_data ***out_enc_padata);
+
+krb5_error_code
+kdc_get_pa_pac_options(krb5_context context, krb5_pa_data **in_padata,
+                       krb5_pa_pac_options **pac_options_out);
+
 /* Information handle for kdcpreauth callbacks.  All pointers are aliases. */
 struct krb5_kdcpreauth_rock_st {
     krb5_kdc_req *request;

--- a/src/lib/gssapi/krb5/accept_sec_context.c
+++ b/src/lib/gssapi/krb5/accept_sec_context.c
@@ -945,8 +945,7 @@ kg_accept_krb5(minor_status, context_handle,
 
     if (delegated_cred_handle != NULL &&
         deleg_cred == NULL && /* no unconstrained delegation */
-        cred->usage == GSS_C_BOTH &&
-        (ticket->enc_part2->flags & TKT_FLG_FORWARDABLE)) {
+        cred->usage == GSS_C_BOTH) {
         /*
          * Now, we always fabricate a delegated credentials handle
          * containing the service ticket to ourselves, which can be

--- a/src/lib/gssapi/krb5/init_sec_context.c
+++ b/src/lib/gssapi/krb5/init_sec_context.c
@@ -129,6 +129,7 @@ static krb5_error_code get_credentials(context, cred, server, now,
     krb5_error_code     code;
     krb5_creds          in_creds, evidence_creds, mcreds, *result_creds = NULL;
     krb5_flags          flags = 0;
+    krb5_principal_data server_data;
 
     *out_creds = NULL;
 
@@ -139,8 +140,14 @@ static krb5_error_code get_credentials(context, cred, server, now,
 
     assert(cred->name != NULL);
 
+    /* Remove assumed realm from host-based S4U2Proxy requests as they must
+     * start in the client realm. */
+    server_data = *server->princ;
+    if (cred->impersonator != NULL && server_data.type == KRB5_NT_SRV_HST)
+        server_data.realm = empty_data();
+    in_creds.server = &server_data;
+
     in_creds.client = cred->name->princ;
-    in_creds.server = server->princ;
     in_creds.times.endtime = endtime;
     in_creds.authdata = NULL;
     in_creds.keyblock.enctype = 0;

--- a/src/lib/gssapi/krb5/init_sec_context.c
+++ b/src/lib/gssapi/krb5/init_sec_context.c
@@ -196,7 +196,6 @@ static krb5_error_code get_credentials(context, cred, server, now,
         if (code)
             goto cleanup;
 
-        assert(evidence_creds.ticket_flags & TKT_FLG_FORWARDABLE);
         in_creds.client = cred->impersonator;
         in_creds.second_ticket = evidence_creds.ticket;
         flags = KRB5_GC_CANONICALIZE | KRB5_GC_CONSTRAINED_DELEGATION;

--- a/src/lib/gssapi/krb5/s4u_gss_glue.c
+++ b/src/lib/gssapi/krb5/s4u_gss_glue.c
@@ -261,17 +261,9 @@ kg_compose_deleg_cred(OM_uint32 *minor_status,
     if (code != 0)
         goto cleanup;
 
-    /*
-     * Only return a "proxy" credential for use with constrained
-     * delegation if the subject credentials are forwardable.
-     * Submitting non-forwardable credentials to the KDC for use
-     * with constrained delegation will only return an error.
-     */
-    if (subject_creds->ticket_flags & TKT_FLG_FORWARDABLE) {
-        code = make_proxy_cred(context, cred, impersonator_cred);
-        if (code != 0)
-            goto cleanup;
-    }
+    code = make_proxy_cred(context, cred, impersonator_cred);
+    if (code != 0)
+        goto cleanup;
 
     code = krb5_cc_store_cred(context, cred->ccache, subject_creds);
     if (code != 0)

--- a/src/lib/kdb/kdb5.c
+++ b/src/lib/kdb/kdb5.c
@@ -2594,9 +2594,10 @@ krb5_error_code
 krb5_db_sign_authdata(krb5_context kcontext, unsigned int flags,
                       krb5_const_principal client_princ,
                       krb5_const_principal server_princ, krb5_db_entry *client,
-                      krb5_db_entry *server, krb5_db_entry *krbtgt,
-                      krb5_keyblock *client_key, krb5_keyblock *server_key,
-                      krb5_keyblock *krbtgt_key, krb5_keyblock *session_key,
+                      krb5_db_entry *server, krb5_db_entry *header_server,
+                      krb5_db_entry *local_tgt, krb5_keyblock *client_key,
+                      krb5_keyblock *server_key, krb5_keyblock *header_key,
+                      krb5_keyblock *local_tgt_key, krb5_keyblock *session_key,
                       krb5_timestamp authtime, krb5_authdata **tgt_auth_data,
                       void *ad_info, krb5_data ***auth_indicators,
                       krb5_authdata ***signed_auth_data)
@@ -2611,9 +2612,10 @@ krb5_db_sign_authdata(krb5_context kcontext, unsigned int flags,
     if (v->sign_authdata == NULL)
         return KRB5_PLUGIN_OP_NOTSUPP;
     return v->sign_authdata(kcontext, flags, client_princ, server_princ,
-                            client, server, krbtgt, client_key, server_key,
-                            krbtgt_key, session_key, authtime, tgt_auth_data,
-                            ad_info, auth_indicators, signed_auth_data);
+                            client, server, header_server, local_tgt,
+                            client_key, server_key, header_key, local_tgt_key,
+                            session_key, authtime, tgt_auth_data, ad_info,
+                            auth_indicators, signed_auth_data);
 }
 
 krb5_error_code

--- a/src/lib/kdb/libkdb5.exports
+++ b/src/lib/kdb/libkdb5.exports
@@ -3,6 +3,7 @@ krb5_db_open
 krb5_db_inited
 krb5_db_alloc
 krb5_db_free
+krb5_db_allowed_to_delegate_from
 krb5_db_audit_as_req
 krb5_db_check_allowed_to_delegate
 krb5_db_get_s4u_x509_principal
@@ -15,8 +16,10 @@ krb5_db_destroy
 krb5_db_fetch_mkey
 krb5_db_fetch_mkey_list
 krb5_db_fini
+krb5_db_free_authdata_info
 krb5_db_free_principal
 krb5_db_get_age
+krb5_db_get_authdata_info
 krb5_db_get_key_data_kvno
 krb5_db_get_context
 krb5_db_get_principal

--- a/src/lib/krb5/asn.1/asn1_k_encode.c
+++ b/src/lib/krb5/asn.1/asn1_k_encode.c
@@ -1732,6 +1732,28 @@ DEFSEQTYPE(secure_cookie, krb5_secure_cookie, secure_cookie_fields);
 MAKE_ENCODER(encode_krb5_secure_cookie, secure_cookie);
 MAKE_DECODER(decode_krb5_secure_cookie, secure_cookie);
 
+/*
+ * -- based on MS-KILE and MS-SFU
+ * PAC-OPTIONS-FLAGS ::= BIT STRING {
+ *     claims(0),
+ *     branch-aware(1),
+ *     forward-to-full-dc(2),
+ *     resource-based-constrained-delegation(3)
+ * }
+ *
+ * PA-PAC-OPTIONS ::= SEQUENCE {
+ *     flags [0] PAC-OPTIONS-FLAGS
+ * }
+ */
+DEFFIELD(pa_pac_options_0, krb5_pa_pac_options, options, 0, krb5_flags);
+static const struct atype_info *pa_pac_options_fields[] = {
+    &k5_atype_pa_pac_options_0
+};
+DEFSEQTYPE(pa_pac_options, krb5_pa_pac_options, pa_pac_options_fields);
+MAKE_ENCODER(encode_krb5_pa_pac_options, pa_pac_options);
+MAKE_DECODER(decode_krb5_pa_pac_options, pa_pac_options);
+
+
 DEFFIELD(spake_factor_0, krb5_spake_factor, type, 0, int32);
 DEFFIELD(spake_factor_1, krb5_spake_factor, data, 1, opt_ostring_data_ptr);
 static const struct atype_info *spake_factor_fields[] = {

--- a/src/lib/krb5/krb/gc_via_tkt.c
+++ b/src/lib/krb5/krb/gc_via_tkt.c
@@ -257,9 +257,12 @@ krb5int_process_tgs_reply(krb5_context context,
         /* Final hop, check whether KDC supports S4U2Self */
         if (krb5_principal_compare(context, dec_rep->client, in_cred->server))
             retval = KRB5KDC_ERR_PADATA_TYPE_NOSUPP;
-    } else if ((kdcoptions & KDC_OPT_CNAME_IN_ADDL_TKT) == 0) {
-        /* XXX for constrained delegation this check must be performed by caller
-         * as we don't have access to the key to decrypt the evidence ticket.
+    } else if ((kdcoptions & KDC_OPT_CNAME_IN_ADDL_TKT) == 0 ||
+               IS_TGS_PRINC(dec_rep->ticket->server)) {
+        /*
+         * For constrained delegation this check must be performed by caller,
+         * as we can't decrypt the evidence ticket.  However, if it is a
+         * referral the client should match the TGT client like normal.
          */
         if (!krb5_principal_compare(context, dec_rep->client, tkt->client))
             retval = KRB5_KDCREP_MODIFIED;

--- a/src/lib/krb5/krb/int-proto.h
+++ b/src/lib/krb5/krb/int-proto.h
@@ -376,4 +376,14 @@ krb5_error_code
 k5_get_etype_info(krb5_context context, krb5_init_creds_context ctx,
                   krb5_pa_data **padata);
 
+/*
+ * Make an S4U2Proxy (constrained delegation) request.  in_creds->client is the
+ * impersonator principal, and in_creds->second_ticket is the evidence
+ * ticket.
+ */
+krb5_error_code
+k5_get_proxy_cred_from_kdc(krb5_context context, krb5_flags options,
+                           krb5_ccache ccache, krb5_creds *in_creds,
+                           krb5_creds **out_creds);
+
 #endif /* KRB5_INT_FUNC_PROTO__ */

--- a/src/lib/krb5/krb/s4u_creds.c
+++ b/src/lib/krb5/krb/s4u_creds.c
@@ -725,6 +725,50 @@ cleanup:
     return code;
 }
 
+static krb5_error_code
+check_rbcd_support(krb5_context context, krb5_pa_data **padata)
+{
+    krb5_error_code code;
+    krb5_pa_data *pa;
+    krb5_pa_pac_options *pac_options;
+    krb5_data der_pac_options;
+
+    pa = krb5int_find_pa_data(context, padata, KRB5_PADATA_PAC_OPTIONS);
+    if (pa == NULL)
+        return KRB5KDC_ERR_PADATA_TYPE_NOSUPP;
+
+    der_pac_options = make_data(pa->contents, pa->length);
+    code = decode_krb5_pa_pac_options(&der_pac_options, &pac_options);
+    if (code)
+        return code;
+
+    if (!(pac_options->options & KRB5_PA_PAC_OPTIONS_RBCD))
+        code = KRB5KDC_ERR_PADATA_TYPE_NOSUPP;
+
+    free(pac_options);
+    return code;
+}
+
+static krb5_error_code
+add_rbcd_padata(krb5_context context, krb5_pa_data ***in_padata)
+{
+    krb5_error_code code;
+    krb5_pa_pac_options pac_options;
+    krb5_data *der_pac_options = NULL;
+
+    memset(&pac_options, 0, sizeof(pac_options));
+    pac_options.options |= KRB5_PA_PAC_OPTIONS_RBCD;
+
+    code = encode_krb5_pa_pac_options(&pac_options, &der_pac_options);
+    if (code)
+        return code;
+
+    code = k5_add_pa_data_from_data(in_padata, KRB5_PADATA_PAC_OPTIONS,
+                                    der_pac_options);
+    krb5_free_data(context, der_pac_options);
+    return code;
+}
+
 /* Set *tgt_out to a local TGT for the client realm retrieved from ccache. */
 static krb5_error_code
 get_client_tgt(krb5_context context, krb5_flags options, krb5_ccache ccache,
@@ -748,8 +792,11 @@ get_client_tgt(krb5_context context, krb5_flags options, krb5_ccache ccache,
     return code;
 }
 
-/* Copy req_server to *out_server.  If req_server has the referral realm, set
- * the realm of *out_server to realm. */
+/*
+ * Copy req_server to *out_server.  If req_server has the referral realm, set
+ * the realm of *out_server to realm.  Otherwise the S4U2Proxy request will
+ * fail unless the specified realm is the same as the TGT (or an alias to it).
+ */
 static krb5_error_code
 normalize_server_princ(krb5_context context, const krb5_data *realm,
                        krb5_principal req_server, krb5_principal *out_server)
@@ -776,14 +823,162 @@ normalize_server_princ(krb5_context context, const krb5_data *realm,
     return 0;
 }
 
+/* Return an error if server is present in referral_list. */
+static krb5_error_code
+check_referral_path(krb5_context context, krb5_principal server,
+                    krb5_creds **referral_list, int referral_count)
+{
+    int i;
+
+    for (i = 0; i < referral_count; i++) {
+        if (krb5_principal_compare(context, server, referral_list[i]->server))
+            return KRB5_KDC_UNREACH;
+    }
+    return 0;
+}
+
+/*
+ * Make TGS requests for in_creds using *tgt_inout, following referrals until
+ * the requested service ticket is issued.  Replace *tgt_inout with the final
+ * TGT used, or free it and set it to NULL on error.  Place the final creds
+ * received in *creds_out.
+ */
+static krb5_error_code
+chase_referrals(krb5_context context, krb5_creds *in_creds, krb5_flags kdcopt,
+                krb5_creds **tgt_inout, krb5_creds **creds_out)
+{
+    krb5_error_code code;
+    krb5_creds *referral_tgts[KRB5_REFERRAL_MAXHOPS] = { NULL };
+    krb5_creds mcreds, *tgt, *tkt = NULL;
+    krb5_principal_data server;
+    int referral_count = 0, i;
+
+    tgt = *tgt_inout;
+    *tgt_inout = NULL;
+    *creds_out = NULL;
+
+    mcreds = *in_creds;
+    server = *in_creds->server;
+    mcreds.server = &server;
+
+    for (referral_count = 0; referral_count < KRB5_REFERRAL_MAXHOPS;
+         referral_count++) {
+        code = krb5_get_cred_via_tkt(context, tgt, kdcopt, tgt->addresses,
+                                     &mcreds, &tkt);
+        if (code)
+            goto cleanup;
+
+        if (krb5_principal_compare_any_realm(context, mcreds.server,
+                                             tkt->server)) {
+            *creds_out = tkt;
+            *tgt_inout = tgt;
+            tkt = tgt = NULL;
+            goto cleanup;
+        }
+
+        if (!IS_TGS_PRINC(tkt->server)) {
+            code = KRB5KRB_AP_WRONG_PRINC;
+            goto cleanup;
+        }
+
+        if (data_eq(tgt->server->data[1], tkt->server->data[1])) {
+            code = KRB5_ERR_HOST_REALM_UNKNOWN;
+            goto cleanup;
+        }
+
+        code = check_referral_path(context, tkt->server, referral_tgts,
+                                   referral_count);
+        if (code)
+            goto cleanup;
+
+        referral_tgts[referral_count] = tgt;
+        tgt = tkt;
+        tkt = NULL;
+        server.realm = tgt->server->data[1];
+    }
+
+    /* Max hop count exceeded. */
+    code = KRB5_KDCREP_MODIFIED;
+
+cleanup:
+    for (i = 0; i < KRB5_REFERRAL_MAXHOPS; i++)
+        krb5_free_creds(context, referral_tgts[i]);
+    krb5_free_creds(context, tkt);
+    krb5_free_creds(context, tgt);
+    return code;
+}
+
+/*
+ * Make non-S4U2Proxy TGS requests for in_creds using *tgt_inout, following
+ * referrals until the requested service ticket is returned.  Discard the
+ * service ticket, but replace *tgt_inout with the final referral TGT.
+ */
+static krb5_error_code
+get_tgt_to_target_realm(krb5_context context, krb5_creds *in_creds,
+                        krb5_flags req_kdcopt, krb5_creds **tgt_inout)
+{
+    krb5_error_code code;
+    krb5_flags kdcopt;
+    krb5_creds mcreds, *out;
+
+    mcreds = *in_creds;
+    mcreds.second_ticket = empty_data();
+    kdcopt = FLAGS2OPTS((*tgt_inout)->ticket_flags) | req_kdcopt;
+
+    code = chase_referrals(context, &mcreds, kdcopt, tgt_inout, &out);
+    krb5_free_creds(context, out);
+
+    return code;
+}
+
+/*
+ * Make TGS requests for a cross-TGT to realm using *tgt_inout, following
+ * alternate TGS replies until the requested TGT is issued.  Replace *tgt_inout
+ * with the result.  Do nothing if *tgt_inout is already a cross-TGT for realm.
+ */
+static krb5_error_code
+get_target_realm_proxy_tgt(krb5_context context, const krb5_data *realm,
+                           krb5_flags req_kdcopt, krb5_creds **tgt_inout)
+{
+    krb5_error_code code;
+    krb5_creds mcreds, *out;
+    krb5_principal tgs;
+    krb5_flags flags;
+
+    if (data_eq(*realm, (*tgt_inout)->server->data[1]))
+        return 0;
+
+    code = krb5int_tgtname(context, realm, &(*tgt_inout)->server->data[1],
+                           &tgs);
+    if (code)
+        return code;
+
+    memset(&mcreds, 0, sizeof(mcreds));
+    mcreds.client = (*tgt_inout)->client;
+    mcreds.server = tgs;
+    flags = req_kdcopt | FLAGS2OPTS((*tgt_inout)->ticket_flags);
+
+    code = chase_referrals(context, &mcreds, flags, tgt_inout, &out);
+    krb5_free_principal(context, tgs);
+    if (code)
+        return code;
+
+    krb5_free_creds(context, *tgt_inout);
+    *tgt_inout = out;
+
+    return 0;
+}
+
 krb5_error_code
 k5_get_proxy_cred_from_kdc(krb5_context context, krb5_flags options,
                            krb5_ccache ccache, krb5_creds *in_creds,
                            krb5_creds **out_creds)
 {
     krb5_error_code code;
-    krb5_flags kdcopt, flags;
+    krb5_flags flags, req_kdcopt = 0;
     krb5_principal server = NULL;
+    krb5_pa_data **in_padata = NULL;
+    krb5_pa_data **enc_padata = NULL;
     krb5_creds mcreds, *tgt = NULL, *tkt = NULL;
 
     *out_creds = NULL;
@@ -803,27 +998,110 @@ k5_get_proxy_cred_from_kdc(krb5_context context, krb5_flags options,
     if (code)
         goto cleanup;
 
-    kdcopt = KDC_OPT_CNAME_IN_ADDL_TKT;
+    code = add_rbcd_padata(context, &in_padata);
+    if (code)
+        goto cleanup;
+
     if (options & KRB5_GC_CANONICALIZE)
-        kdcopt |= KDC_OPT_CANONICALIZE;
+        req_kdcopt |= KDC_OPT_CANONICALIZE;
     if (options & KRB5_GC_FORWARDABLE)
-        kdcopt |= KDC_OPT_FORWARDABLE;
+        req_kdcopt |= KDC_OPT_FORWARDABLE;
     if (options & KRB5_GC_NO_TRANSIT_CHECK)
-        kdcopt |= KDC_OPT_DISABLE_TRANSITED_CHECK;
+        req_kdcopt |= KDC_OPT_DISABLE_TRANSITED_CHECK;
 
     mcreds = *in_creds;
     mcreds.server = server;
 
-    flags = kdcopt | FLAGS2OPTS(tgt->ticket_flags);
+    flags = req_kdcopt | FLAGS2OPTS(tgt->ticket_flags) |
+        KDC_OPT_CNAME_IN_ADDL_TKT | KDC_OPT_CANONICALIZE;
     code = krb5_get_cred_via_tkt_ext(context, tgt, flags, tgt->addresses,
-                                     NULL, &mcreds, NULL, NULL, NULL, NULL,
-                                     &tkt, NULL);
+                                     in_padata, &mcreds, NULL, NULL, NULL,
+                                     &enc_padata, &tkt, NULL);
+
+    /*
+     * If the server principal name included a foreign realm which wasn't an
+     * alias for the local realm, the KDC won't be able to decrypt the TGT.
+     * Windows KDCs will return a BAD_INTEGRITY error in this case, while MIT
+     * KDCs will return S_PRINCIPAL_UNKNOWN.  We cannot distinguish the latter
+     * error from the service principal actually being unknown in the realm,
+     * but set a comprehensible error message for the BAD_INTEGRITY error.
+     */
+    if (code == KRB5KRB_AP_ERR_BAD_INTEGRITY &&
+        !krb5_realm_compare(context, in_creds->client, server)) {
+        k5_setmsg(context, code, _("Realm specified but S4U2Proxy must use "
+                                   "referral realm"));
+    }
+
     if (code)
         goto cleanup;
 
-    if (!krb5_principal_compare(context, server, tkt->server)) {
-        code = KRB5KRB_AP_WRONG_PRINC;
-        goto cleanup;
+    if (!krb5_principal_compare_any_realm(context, server, tkt->server)) {
+        /* Make sure we got a referral. */
+        if (!IS_TGS_PRINC(tkt->server)) {
+            code = KRB5KRB_AP_WRONG_PRINC;
+            goto cleanup;
+        }
+
+        /*
+         * Make sure the KDC supports S4U and resource-based constrained
+         * delegation; otherwise we might have gotten a regular TGT referral
+         * rather than a proxy TGT referral.
+         */
+        code = check_rbcd_support(context, enc_padata);
+        if (code)
+            goto cleanup;
+
+        krb5_free_pa_data(context, enc_padata);
+        enc_padata = NULL;
+
+        /*
+         * Replace tgt with a regular (not proxy) TGT to the target realm, by
+         * making a normal TGS request and following referrals.  Per [MS-SFU]
+         * 3.1.5.2.2, we need this TGT to make the final TGS request.
+         */
+        code = get_tgt_to_target_realm(context, &mcreds, req_kdcopt, &tgt);
+        if (code)
+            goto cleanup;
+
+        /*
+         * Replace tkt with a proxy TGT (meaning, one obtained using the
+         * referral TGT we got from the first S4U2Proxy request) to the target
+         * realm, if it isn't already one.
+         */
+        code = get_target_realm_proxy_tgt(context, &tgt->server->data[1],
+                                          req_kdcopt, &tkt);
+        if (code)
+            goto cleanup;
+
+        krb5_free_data_contents(context, &server->realm);
+        code = krb5int_copy_data_contents(context, &tgt->server->data[1],
+                                          &server->realm);
+        if (code)
+            goto cleanup;
+
+        /* Make an S4U2Proxy request to the target realm using the regular TGT,
+         * with the proxy TGT as the evidence ticket. */
+        mcreds.second_ticket = tkt->ticket;
+        tkt->ticket = empty_data();
+        krb5_free_creds(context, tkt);
+        tkt = NULL;
+        flags = req_kdcopt | FLAGS2OPTS(tgt->ticket_flags) |
+            KDC_OPT_CNAME_IN_ADDL_TKT | KDC_OPT_CANONICALIZE;
+        code = krb5_get_cred_via_tkt_ext(context, tgt, flags, tgt->addresses,
+                                         in_padata, &mcreds, NULL, NULL, NULL,
+                                         &enc_padata, &tkt, NULL);
+        free(mcreds.second_ticket.data);
+        if (code)
+            goto cleanup;
+
+        code = check_rbcd_support(context, enc_padata);
+        if (code)
+            goto cleanup;
+
+        if (!krb5_principal_compare(context, server, tkt->server)) {
+            code = KRB5KRB_AP_WRONG_PRINC;
+            goto cleanup;
+        }
     }
 
     if (!krb5_principal_compare(context, in_creds->server, tkt->server)) {
@@ -844,6 +1122,8 @@ cleanup:
     krb5_free_creds(context, tgt);
     krb5_free_creds(context, tkt);
     krb5_free_principal(context, server);
+    krb5_free_pa_data(context, in_padata);
+    krb5_free_pa_data(context, enc_padata);
     return code;
 }
 

--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -34,6 +34,7 @@ decode_krb5_pa_fx_fast_request
 decode_krb5_pa_otp_challenge
 decode_krb5_pa_otp_req
 decode_krb5_pa_otp_enc_req
+decode_krb5_pa_pac_options
 decode_krb5_pa_pac_req
 decode_krb5_pa_s4u_x509_user
 decode_krb5_pa_spake
@@ -86,6 +87,7 @@ encode_krb5_pa_fx_fast_reply
 encode_krb5_pa_otp_challenge
 encode_krb5_pa_otp_req
 encode_krb5_pa_otp_enc_req
+encode_krb5_pa_pac_options
 encode_krb5_pa_s4u_x509_user
 encode_krb5_pa_spake
 encode_krb5_padata_sequence

--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -498,6 +498,7 @@ krb5_pac_sign
 krb5_pac_sign_ext
 krb5_pac_verify
 krb5_pac_verify_ext
+krb5_pac_get_client_info
 krb5_parse_name
 krb5_parse_name_flags
 krb5_prepend_error_message

--- a/src/lib/krb5_32.def
+++ b/src/lib/krb5_32.def
@@ -488,3 +488,4 @@ EXPORTS
 
 ; new in 1.18
 	krb5int_c_deprecated_enctype			@450 ; PRIVATE
+	krb5_pac_get_client_info			@451

--- a/src/plugins/kdb/test/kdb_test.c
+++ b/src/plugins/kdb/test/kdb_test.c
@@ -57,8 +57,16 @@
  *                 }
  *             }
  *             delegation = {
+ *                 # Traditional constrained delegation; target_service
+ *                 # must be in the same realm.
  *                 intermediate_service = target_service
  *             }
+ *             rbcd = {
+ *                 # Resource-based constrained delegation;
+ *                 # intermediate_service may be in a different realm.
+ *                 target_service = intermediate_service
+ *             }
+ *             ad_type = mspac
  *         }
  *
  * Key values are generated using a hash of the kvno, enctype, salt type,
@@ -79,6 +87,9 @@
 #include <ctype.h>
 
 #define TEST_AD_TYPE -456
+
+#define IS_TGS_PRINC(p) ((p)->length == 2 &&                            \
+                         data_eq_string((p)->data[0], KRB5_TGS_NAME))
 
 typedef struct {
     void *profile;
@@ -543,6 +554,326 @@ test_encrypt_key_data(krb5_context context, const krb5_keyblock *mkey,
     return 0;
 }
 
+typedef struct {
+    char *pac_princ;
+    struct {
+        char *proxy_target;
+        char *impersonator;
+    } deleg_info;
+    krb5_boolean not_delegated;
+    krb5_pac pac;
+} pac_info;
+
+static void
+free_pac_info(krb5_context context, pac_info *info)
+{
+    if (info == NULL)
+        return;
+
+    free(info->pac_princ);
+    free(info->deleg_info.proxy_target);
+    free(info->deleg_info.impersonator);
+    krb5_pac_free(context, info->pac);
+    free(info);
+}
+
+/*
+ * Create a PAC object with a fake logon-info blob.  Instead of a real
+ * KERB_VALIDATION_INFO structure, store a byte indicating whether the
+ * USER_NOT_DELEGATED bit is set.
+ */
+static krb5_error_code
+create_pac(krb5_context context, krb5_boolean not_delegated, krb5_pac *pac_out)
+{
+    krb5_data data;
+    krb5_pac pac;
+    char nd;
+
+    nd = not_delegated ? 1 : 0;
+    data = make_data(&nd, 1);
+    check(krb5_pac_init(context, &pac));
+    check(krb5_pac_add_buffer(context, pac, KRB5_PAC_LOGON_INFO, &data));
+
+    *pac_out = pac;
+    return 0;
+}
+
+/* Create a fake PAC, setting the USER_NOT_DELEGATED bit if the client DB entry
+ * disallows forwardable tickets. */
+static krb5_error_code
+create_pac_db(krb5_context context, krb5_db_entry *client, krb5_pac *pac_out)
+{
+    krb5_boolean not_delegated;
+    /* Use disallow_forwardable as delegation_not_allowed attribute */
+    not_delegated = (client->attributes & KRB5_KDB_DISALLOW_FORWARDABLE);
+    return create_pac(context, not_delegated, pac_out);
+}
+
+/* Locate the PAC in tgt_authdata and set *pac_out to its PAC object
+ * representation.  Set it to NULL if no PAC is present. */
+static void
+parse_ticket_pac(krb5_context context, krb5_authdata **tgt_auth_data,
+                 krb5_pac *pac_out)
+{
+    krb5_authdata **authdata;
+
+    *pac_out = NULL;
+
+    check(krb5_find_authdata(context, tgt_auth_data, NULL,
+                             KRB5_AUTHDATA_WIN2K_PAC, &authdata));
+    if (authdata == NULL)
+        return;
+    assert(authdata[1] == NULL);
+    check(krb5_pac_parse(context, authdata[0]->contents, authdata[0]->length,
+                         pac_out));
+    krb5_free_authdata(context, authdata);
+}
+
+/* Verify the KDC signature against the local TGT key.  tgt_key must be the
+ * decrypted first key data entry of tgt. */
+static krb5_error_code
+verify_kdc_signature(krb5_context context, krb5_pac pac,
+                     krb5_keyblock *tgt_key, krb5_db_entry *tgt)
+{
+    krb5_error_code ret;
+    krb5_key_data *kd;
+    krb5_keyblock old_key;
+    krb5_kvno kvno;
+    int tries;
+
+    ret = krb5_pac_verify(context, pac, 0, NULL, NULL, tgt_key);
+    if (ret != KRB5KRB_AP_ERR_BAD_INTEGRITY)
+        return ret;
+
+    kvno = tgt->key_data[0].key_data_kvno - 1;
+
+    /* There is no kvno in PAC signatures, so try two previous versions. */
+    for (tries = 2; tries > 0 && kvno > 0; tries--, kvno--) {
+        ret = krb5_dbe_find_enctype(context, tgt, -1, -1, kvno, &kd);
+        if (ret)
+            return KRB5KRB_AP_ERR_BAD_INTEGRITY;
+        ret = krb5_dbe_decrypt_key_data(context, NULL, kd, &old_key, NULL);
+        if (ret)
+            return ret;
+        ret = krb5_pac_verify(context, pac, 0, NULL, NULL, &old_key);
+        krb5_free_keyblock_contents(context, &old_key);
+        if (!ret)
+            return 0;
+
+        /* Try the next lower kvno on the next iteration. */
+        kvno = kd->key_data_kvno - 1;
+    }
+
+    return KRB5KRB_AP_ERR_BAD_INTEGRITY;
+}
+
+static krb5_error_code
+verify_ticket_pac(krb5_context context, krb5_pac pac, unsigned int flags,
+                  krb5_const_principal client_princ, krb5_boolean check_realm,
+                  krb5_keyblock *server_key, krb5_keyblock *local_tgt_key,
+                  krb5_db_entry *local_tgt, krb5_timestamp authtime)
+{
+    check(krb5_pac_verify_ext(context, pac, authtime, client_princ, server_key,
+                              NULL, check_realm));
+    if (flags & KRB5_KDB_FLAG_CROSS_REALM)
+        return 0;
+    return verify_kdc_signature(context, pac, local_tgt_key, local_tgt);
+}
+
+static void
+get_pac_info(krb5_context context, krb5_authdata **in_authdata,
+             pac_info **info_out)
+{
+    krb5_error_code ret;
+    krb5_pac pac = NULL;
+    krb5_data data;
+    char *sep = NULL;
+    pac_info *info;
+
+    *info_out = NULL;
+
+    parse_ticket_pac(context, in_authdata, &pac);
+    if (pac == NULL)
+        return;
+
+    info = ealloc(sizeof(*info));
+
+    /* Read the fake logon-info buffer from the PAC and set not_delegated
+     * according to the byte value. */
+    check(krb5_pac_get_client_info(context, pac, NULL, &info->pac_princ));
+    check(krb5_pac_get_buffer(context, pac, KRB5_PAC_LOGON_INFO, &data));
+    assert(data.length == 1);
+    info->not_delegated = *data.data;
+    krb5_free_data_contents(context, &data);
+
+    ret = krb5_pac_get_buffer(context, pac, KRB5_PAC_DELEGATION_INFO, &data);
+    if (ret && ret != ENOENT)
+        abort();
+    if (!ret) {
+        sep = memchr(data.data, ':', data.length);
+        assert(sep != NULL);
+        info->deleg_info.proxy_target = k5memdup0(data.data, sep - data.data,
+                                                  &ret);
+        check(ret);
+        info->deleg_info.impersonator = k5memdup0(sep + 1, data.length - 1 -
+                                                  (sep - data.data), &ret);
+        check(ret);
+        krb5_free_data_contents(context, &data);
+    }
+
+    info->pac = pac;
+    *info_out = info;
+}
+
+/* Add a fake delegation-info buffer to pac containing the proxy target and
+ * impersonator from info. */
+static void
+add_delegation_info(krb5_context context, krb5_pac pac, pac_info *info)
+{
+    krb5_data data;
+    char *str;
+
+    if (info->deleg_info.proxy_target == NULL)
+        return;
+
+    if (asprintf(&str, "%s:%s", info->deleg_info.proxy_target,
+                 info->deleg_info.impersonator) < 0)
+        abort();
+    data = string2data(str);
+    check(krb5_pac_add_buffer(context, pac, KRB5_PAC_DELEGATION_INFO, &data));
+    free(str);
+}
+
+/* Set *out to an AD-IF-RELEVANT authdata element containing a PAC authdata
+ * element with contents pac_data. */
+static void
+encode_pac_ad(krb5_context context, krb5_data *pac_data, krb5_authdata **out)
+{
+    krb5_authdata pac_ad, *list[2], **ifrel;
+
+    pac_ad.magic = KV5M_AUTHDATA;
+    pac_ad.ad_type = KRB5_AUTHDATA_WIN2K_PAC;
+    pac_ad.contents = (krb5_octet *)pac_data->data;;
+    pac_ad.length = pac_data->length;
+    list[0] = &pac_ad;
+    list[1] = NULL;
+
+    check(krb5_encode_authdata_container(context, KRB5_AUTHDATA_IF_RELEVANT,
+                                         list, &ifrel));
+    assert(ifrel[1] == NULL);
+    *out = ifrel[0];
+    free(ifrel);
+}
+
+/* Parse a PAC client-info string into a principal name.  If xrealm_s4u is
+ * true, expect a realm in the string. */
+static krb5_error_code
+parse_pac_princ(krb5_context context, krb5_boolean xrealm_s4u, char *pac_princ,
+                krb5_principal *client_out)
+{
+    int n_atsigns = 0, flags = 0;
+    char *p = pac_princ;
+
+    while (*p++) {
+        if (*p == '@')
+            n_atsigns++;
+    }
+    if (xrealm_s4u) {
+        flags |= KRB5_PRINCIPAL_PARSE_REQUIRE_REALM;
+        n_atsigns--;
+    } else {
+        flags |= KRB5_PRINCIPAL_PARSE_NO_REALM;
+    }
+    assert(n_atsigns == 0 || n_atsigns == 1);
+    if (n_atsigns == 1)
+        flags |= KRB5_PRINCIPAL_PARSE_ENTERPRISE;
+    check(krb5_parse_name_flags(context, pac_princ, flags, client_out));
+    (*client_out)->type = KRB5_NT_MS_PRINCIPAL;
+    return 0;
+}
+
+/* Set *ad_out to a fake PAC for testing, or to NULL if it doesn't make sense
+ * to generate a PAC for the request. */
+static void
+generate_pac(krb5_context context, unsigned int flags,
+             krb5_const_principal client_princ,
+             krb5_const_principal server_princ, krb5_db_entry *client,
+             krb5_db_entry *header_server, krb5_db_entry *local_tgt,
+             krb5_keyblock *server_key, krb5_keyblock *header_key,
+             krb5_keyblock *local_tgt_key, krb5_timestamp authtime,
+             pac_info *info, krb5_authdata **ad_out)
+{
+    krb5_boolean sign_realm, check_realm;
+    krb5_data pac_data;
+    krb5_pac pac = NULL;
+    krb5_principal pac_princ = NULL;
+
+    *ad_out = NULL;
+
+    check_realm = ((flags & KRB5_KDB_FLAGS_S4U) &&
+                   (flags & KRB5_KDB_FLAG_CROSS_REALM));
+    sign_realm = ((flags & KRB5_KDB_FLAGS_S4U) &&
+                  (flags & KRB5_KDB_FLAG_ISSUING_REFERRAL));
+
+    if (client != NULL &&
+        ((flags & KRB5_KDB_FLAG_CLIENT_REFERRALS_ONLY) ||
+         (flags & KRB5_KDB_FLAG_PROTOCOL_TRANSITION))) {
+        /* For AS or local-realm S4U2Self, generate an initial PAC. */
+        check(create_pac_db(context, client, &pac));
+    } else if (info == NULL) {
+        /* If there is no input PAC, do not generate one. */
+        assert((flags & KRB5_KDB_FLAGS_S4U) == 0);
+        return;
+    } else {
+        if (IS_TGS_PRINC(server_princ) &&
+            info->deleg_info.proxy_target != NULL) {
+            /* RBCD transitive trust. */
+            assert(flags & KRB5_KDB_FLAG_CROSS_REALM);
+            assert(!(flags & KRB5_KDB_FLAG_CONSTRAINED_DELEGATION));
+            check(parse_pac_princ(context, TRUE, info->pac_princ, &pac_princ));
+            client_princ = pac_princ;
+            check_realm = TRUE;
+            sign_realm = TRUE;
+        } else if ((flags & KRB5_KDB_FLAG_CONSTRAINED_DELEGATION) &&
+                   !(flags & KRB5_KDB_FLAG_CROSS_REALM)) {
+            /*
+             * Initial RBCD and old constrained delegation requests to
+             * impersonator realm; create delegation info blob.  We cannot
+             * assume that proxy_target is NULL as the evidence ticket could
+             * have been acquired via constrained delegation.
+             */
+            free(info->deleg_info.proxy_target);
+            check(krb5_unparse_name_flags(context, server_princ,
+                                          KRB5_PRINCIPAL_UNPARSE_NO_REALM,
+                                          &info->deleg_info.proxy_target));
+            /* This is supposed to be a list of impersonators, but we currently
+             * only deal with one. */
+            free(info->deleg_info.impersonator);
+            check(krb5_unparse_name(context, header_server->princ,
+                                    &info->deleg_info.impersonator));
+        } else if (flags & KRB5_KDB_FLAG_CONSTRAINED_DELEGATION) {
+            /* Last cross realm RBCD request to proxy realm. */
+            assert(info->deleg_info.proxy_target != NULL);
+        }
+
+        /* We have already verified the PAC in get_authdata_info, but we should
+         * be able to verify the signatures here as well. */
+        check(verify_ticket_pac(context, info->pac, flags, client_princ,
+                                check_realm, header_key, local_tgt_key,
+                                local_tgt, authtime));
+
+        /* Create a new pac as we may be altering pac principal's realm */
+        check(create_pac(context, info->not_delegated, &pac));
+        add_delegation_info(context, pac, info);
+    }
+    check(krb5_pac_sign_ext(context, pac, authtime, client_princ, server_key,
+                            local_tgt_key, sign_realm, &pac_data));
+    krb5_pac_free(context, pac);
+    krb5_free_principal(context, pac_princ);
+    encode_pac_ad(context, &pac_data, ad_out);
+    krb5_free_data_contents(context, &pac_data);
+}
+
 static krb5_error_code
 test_sign_authdata(krb5_context context, unsigned int flags,
                    krb5_const_principal client_princ,
@@ -555,18 +886,35 @@ test_sign_authdata(krb5_context context, unsigned int flags,
                    void *ad_info, krb5_data ***auth_indicators,
                    krb5_authdata ***signed_auth_data)
 {
-    krb5_authdata **list, *ad;
+    testhandle h = context->dal_handle->db_context;
+    krb5_authdata *pac_ad = NULL, *test_ad = NULL, **list;
     krb5_data **inds, d;
     int i, val;
+    char *ad_type;
 
-    ad = ealloc(sizeof(*ad));
-    ad->magic = KV5M_AUTHDATA;
-    ad->ad_type = TEST_AD_TYPE;
-    ad->contents = (uint8_t *)estrdup("db-authdata-test");
-    ad->length = strlen((char *)ad->contents);
-    list = ealloc(2 * sizeof(*list));
-    list[0] = ad;
-    list[1] = NULL;
+    generate_pac(context, flags, client_princ, server_princ, client,
+                 header_server, local_tgt, server_key, header_key,
+                 local_tgt_key, authtime, ad_info, &pac_ad);
+
+    /*
+     * Omit test_ad if ad_type is mspac (only), as handle_signticket() fails in
+     * constrained delegation if the PAC is not the only authorization data
+     * element.
+     */
+    ad_type = get_string(h, "ad_type", NULL, NULL);
+    if (ad_type == NULL || strcmp(ad_type, "mspac") != 0) {
+        test_ad = ealloc(sizeof(*test_ad));
+        test_ad->magic = KV5M_AUTHDATA;
+        test_ad->ad_type = TEST_AD_TYPE;
+        test_ad->contents = (uint8_t *)estrdup("db-authdata-test");
+        test_ad->length = strlen((char *)test_ad->contents);
+    }
+    free(ad_type);
+
+    list = ealloc(3 * sizeof(*list));
+    list[0] = (test_ad != NULL) ? test_ad : pac_ad;
+    list[1] = (test_ad != NULL) ? pac_ad : NULL;
+    list[2] = NULL;
     *signed_auth_data = list;
 
     /* If we see an auth indicator "dbincrX", replace the whole indicator list
@@ -589,35 +937,144 @@ test_sign_authdata(krb5_context context, unsigned int flags,
     return 0;
 }
 
+static krb5_boolean
+match_in_table(krb5_context context, const char *table, const char *sprinc,
+               const char *tprinc)
+{
+    testhandle h = context->dal_handle->db_context;
+    krb5_error_code ret;
+    char **values, **v;
+    krb5_boolean found = FALSE;
+
+    set_names(h, table, sprinc, NULL);
+    ret = profile_get_values(h->profile, h->names, &values);
+    assert(ret == 0 || ret == PROF_NO_RELATION);
+    if (ret)
+        return FALSE;
+    for (v = values; *v != NULL; v++) {
+        if (strcmp(*v, tprinc) == 0) {
+            found = TRUE;
+            break;
+        }
+    }
+    profile_free_list(values);
+    return found;
+}
+
 static krb5_error_code
 test_check_allowed_to_delegate(krb5_context context,
                                krb5_const_principal client,
                                const krb5_db_entry *server,
                                krb5_const_principal proxy)
 {
-    krb5_error_code ret;
-    testhandle h = context->dal_handle->db_context;
-    char *sprinc, *tprinc, **values, **v;
+    char *sprinc, *tprinc;
     krb5_boolean found = FALSE;
 
     check(krb5_unparse_name_flags(context, server->princ,
                                   KRB5_PRINCIPAL_UNPARSE_NO_REALM, &sprinc));
     check(krb5_unparse_name_flags(context, proxy,
                                   KRB5_PRINCIPAL_UNPARSE_NO_REALM, &tprinc));
-    set_names(h, "delegation", sprinc, NULL);
-    ret = profile_get_values(h->profile, h->names, &values);
-    if (ret != PROF_NO_RELATION) {
-        for (v = values; *v != NULL; v++) {
-            if (strcmp(*v, tprinc) == 0) {
-                found = TRUE;
-                break;
-            }
-        }
-        profile_free_list(values);
-    }
+    found = match_in_table(context, "delegation", sprinc, tprinc);
     krb5_free_unparsed_name(context, sprinc);
     krb5_free_unparsed_name(context, tprinc);
     return found ? 0 : KRB5KDC_ERR_POLICY;
+}
+
+static krb5_error_code
+test_allowed_to_delegate_from(krb5_context context,
+                              krb5_const_principal client,
+                              krb5_const_principal server,
+                              void *server_ad_info, const krb5_db_entry *proxy)
+{
+    char *sprinc, *tprinc;
+    pac_info *info = (pac_info *)server_ad_info;
+    krb5_boolean found = FALSE;
+
+    check(krb5_unparse_name(context, proxy->princ, &sprinc));
+    check(krb5_unparse_name(context, server, &tprinc));
+    assert(strncmp(info->pac_princ, tprinc, strlen(info->pac_princ)) == 0);
+    found = match_in_table(context, "rbcd", sprinc, tprinc);
+    krb5_free_unparsed_name(context, sprinc);
+    krb5_free_unparsed_name(context, tprinc);
+    return found ? 0 : KRB5KDC_ERR_POLICY;
+}
+
+static krb5_error_code
+test_get_authdata_info(krb5_context context, unsigned int flags,
+                       krb5_authdata **in_authdata,
+                       krb5_const_principal client_princ,
+                       krb5_const_principal server_princ,
+                       krb5_keyblock *server_key, krb5_keyblock *krbtgt_key,
+                       krb5_db_entry *krbtgt, krb5_timestamp authtime,
+                       void **ad_info_out, krb5_principal *client_out)
+{
+    pac_info *info = NULL;
+    krb5_boolean rbcd_transitive, xrealm_s4u;
+    krb5_principal pac_princ = NULL;
+    char *proxy_name = NULL, *impersonator_name = NULL;
+
+    get_pac_info(context, in_authdata, &info);
+    if (info == NULL)
+        return 0;
+
+    /* Transitive RBCD requests are not flagged as constrained delegation */
+    if (info->not_delegated &&
+        (info->deleg_info.proxy_target ||
+         (flags & KRB5_KDB_FLAG_CONSTRAINED_DELEGATION))) {
+        free_pac_info(context, info);
+        return KRB5KDC_ERR_BADOPTION;
+    }
+
+    rbcd_transitive = IS_TGS_PRINC(server_princ) &&
+        (flags & KRB5_KDB_FLAG_CROSS_REALM) && info->deleg_info.proxy_target &&
+        !(flags & KRB5_KDB_FLAG_CONSTRAINED_DELEGATION);
+
+    xrealm_s4u = rbcd_transitive || ((flags & KRB5_KDB_FLAG_CROSS_REALM) &&
+                                     (flags & KRB5_KDB_FLAGS_S4U));
+
+    check(parse_pac_princ(context, xrealm_s4u, info->pac_princ, &pac_princ));
+
+    /* Cross-realm and transitive trust RBCD requests */
+    if (rbcd_transitive || ((flags & KRB5_KDB_FLAG_CROSS_REALM) &&
+                            (flags & KRB5_KDB_FLAG_CONSTRAINED_DELEGATION))) {
+        assert(info->deleg_info.proxy_target != NULL);
+        assert(info->deleg_info.impersonator != NULL);
+        /* We must be able to find the impersonator in the delegation info. */
+        assert(!krb5_principal_compare(context, client_princ, pac_princ));
+        check(krb5_unparse_name(context, client_princ, &impersonator_name));
+        assert(strcmp(info->deleg_info.impersonator, impersonator_name) == 0);
+        krb5_free_unparsed_name(context, impersonator_name);
+        client_princ = pac_princ;
+        /* In the non-transitive case we can match the proxy too. */
+        if (!rbcd_transitive) {
+            check(krb5_unparse_name_flags(context, server_princ,
+                                          KRB5_PRINCIPAL_UNPARSE_NO_REALM,
+                                          &proxy_name));
+            assert(info->deleg_info.proxy_target != NULL);
+            assert(strcmp(info->deleg_info.proxy_target, proxy_name) == 0);
+            krb5_free_unparsed_name(context, proxy_name);
+        }
+    }
+
+    check(verify_ticket_pac(context, info->pac, flags, client_princ,
+                            xrealm_s4u, server_key, krbtgt_key, krbtgt,
+                            authtime));
+
+    *ad_info_out = info;
+    if (client_out != NULL)
+        *client_out = pac_princ;
+    else
+        krb5_free_principal(context, pac_princ);
+
+    return 0;
+}
+
+static void
+test_free_authdata_info(krb5_context context, void *ad_info)
+{
+    pac_info *info = (pac_info *)ad_info;
+
+    free_pac_info(context, info);
 }
 
 kdb_vftabl PLUGIN_SYMBOL_NAME(krb5_test, kdb_function_table) = {
@@ -658,5 +1115,8 @@ kdb_vftabl PLUGIN_SYMBOL_NAME(krb5_test, kdb_function_table) = {
     NULL, /* refresh_config */
     test_check_allowed_to_delegate,
     NULL, /* free_principal_e_data */
-    test_get_s4u_x509_principal
+    test_get_s4u_x509_principal,
+    test_allowed_to_delegate_from,
+    test_get_authdata_info,
+    test_free_authdata_info
 };

--- a/src/plugins/kdb/test/kdb_test.c
+++ b/src/plugins/kdb/test/kdb_test.c
@@ -539,12 +539,13 @@ test_encrypt_key_data(krb5_context context, const krb5_keyblock *mkey,
 
 static krb5_error_code
 test_sign_authdata(krb5_context context, unsigned int flags,
-                   krb5_const_principal client_princ, krb5_db_entry *client,
+                   krb5_const_principal client_princ,
+                   krb5_const_principal server_princ, krb5_db_entry *client,
                    krb5_db_entry *server, krb5_db_entry *krbtgt,
                    krb5_keyblock *client_key, krb5_keyblock *server_key,
                    krb5_keyblock *krbtgt_key, krb5_keyblock *session_key,
                    krb5_timestamp authtime, krb5_authdata **tgt_auth_data,
-                   krb5_data ***auth_indicators,
+                   void *ad_info, krb5_data ***auth_indicators,
                    krb5_authdata ***signed_auth_data)
 {
     krb5_authdata **list, *ad;

--- a/src/plugins/kdb/test/kdb_test.c
+++ b/src/plugins/kdb/test/kdb_test.c
@@ -541,9 +541,10 @@ static krb5_error_code
 test_sign_authdata(krb5_context context, unsigned int flags,
                    krb5_const_principal client_princ,
                    krb5_const_principal server_princ, krb5_db_entry *client,
-                   krb5_db_entry *server, krb5_db_entry *krbtgt,
-                   krb5_keyblock *client_key, krb5_keyblock *server_key,
-                   krb5_keyblock *krbtgt_key, krb5_keyblock *session_key,
+                   krb5_db_entry *server, krb5_db_entry *header_server,
+                   krb5_db_entry *local_tgt, krb5_keyblock *client_key,
+                   krb5_keyblock *server_key, krb5_keyblock *header_key,
+                   krb5_keyblock *local_tgt_key, krb5_keyblock *session_key,
                    krb5_timestamp authtime, krb5_authdata **tgt_auth_data,
                    void *ad_info, krb5_data ***auth_indicators,
                    krb5_authdata ***signed_auth_data)

--- a/src/tests/gssapi/t_s4u.py
+++ b/src/tests/gssapi/t_s4u.py
@@ -278,4 +278,103 @@ r1.run([kvno, '-U', 'enterprise@abc', '-F', cert_path, r1.user_princ],
 r1.stop()
 r2.stop()
 
+mark('Resource-based constrained delegation')
+
+a_princs = {'krbtgt/A': {'keys': 'aes128-cts'},
+            'krbtgt/B': {'keys': 'aes128-cts'},
+            'user': {'keys': 'aes128-cts', 'flags': '+preauth'},
+            'sensitive': {'keys': 'aes128-cts',
+                          'flags': '+disallow_forwardable'},
+            'impersonator': {'keys': 'aes128-cts'},
+            'rb': {'keys': 'aes128-cts'}}
+a_kconf = {'realms': {'$realm': {'database_module': 'test'}},
+           'dbmodules': {'test': {'db_library': 'test',
+                                  'ad_type': 'mspac',
+                                  'princs': a_princs,
+                                  'rbcd': {'rb@A': 'impersonator@A'},
+                                  'alias': {'rb@A': 'rb',
+                                            'rb@B': '@B',
+                                            'rb@C': '@B',
+                                            'service/rb.a': 'rb',
+                                            'service/rb.b': '@B',
+                                            'service/rb.c': '@B' }}}}
+
+b_princs = {'krbtgt/B': {'keys': 'aes128-cts'},
+            'krbtgt/A': {'keys': 'aes128-cts'},
+            'krbtgt/C': {'keys': 'aes128-cts'},
+            'user': {'keys': 'aes128-cts', 'flags': '+preauth'},
+            'rb': {'keys': 'aes128-cts'}}
+b_kconf = {'realms': {'$realm': {'database_module': 'test'}},
+           'dbmodules': {'test': {'db_library': 'test',
+                                  'ad_type': 'mspac',
+                                  'princs': b_princs,
+                                  'rbcd': {'rb@B': 'impersonator@A'},
+                                  'alias': {'rb@B': 'rb',
+                                            'service/rb.b': 'rb',
+                                            'rb@C': '@C',
+                                            'impersonator@A': '@A',
+                                            'service/rb.c': '@C'}}}}
+
+c_princs = {'krbtgt/C': {'keys': 'aes128-cts'},
+            'krbtgt/B': {'keys': 'aes128-cts'},
+            'rb': {'keys': 'aes128-cts'}}
+c_kconf = {'realms': {'$realm': {'database_module': 'test'}},
+           'capaths': { 'A' : { 'C' : 'B' }},
+           'dbmodules': {'test': {'db_library': 'test',
+                                  'ad_type': 'mspac',
+                                  'princs': c_princs,
+                                  'rbcd': {'rb@C': 'impersonator@A'},
+                                  'alias': {'rb@C': 'rb',
+                                            'service/rb.c': 'rb' }}}}
+
+ra, rb, rc = cross_realms(3, xtgts=(),
+                          args=({'realm': 'A', 'kdc_conf': a_kconf},
+                                {'realm': 'B', 'kdc_conf': b_kconf},
+                                {'realm': 'C', 'kdc_conf': c_kconf}),
+                          create_kdb=False)
+
+ra.start_kdc()
+rb.start_kdc()
+rc.start_kdc()
+
+domain_realm = {'domain_realm': {'.a':'A', '.b':'B', '.c':'C'}}
+domain_conf = ra.special_env('domain_conf', False, krb5_conf=domain_realm)
+
+ra.extract_keytab('impersonator@A', ra.keytab)
+ra.kinit('impersonator@A', None, ['-k', '-t', ra.keytab])
+
+mark('Local-realm RBCD')
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'p:rb'])
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'e:rb'])
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'p:rb@A'])
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'e:rb@A'])
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'e:rb@A@'])
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'e:rb@A@A'])
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'h:service@rb.a'])
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'h:service@rb.a'], env=domain_conf)
+ra.run(['./t_s4u', 'p:' + 'sensitive@A', 'h:service@rb.a'], expected_code=1)
+ra.run(['./t_s4u', 'p:' + rb.user_princ, 'h:service@rb.a'])
+
+mark('Cross-realm RBCD')
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'e:rb@B'])
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'e:rb@B@'])
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'e:rb@B@A'])
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'h:service@rb.b'])
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'h:service@rb.b'], env=domain_conf)
+ra.run(['./t_s4u', 'p:' + 'sensitive@A', 'h:service@rb.b'], expected_code=1)
+ra.run(['./t_s4u', 'p:' + rb.user_princ, 'h:service@rb.b'])
+
+mark('RBCD transitive trust')
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'e:rb@C'])
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'e:rb@C@'])
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'e:rb@C@A'])
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'h:service@rb.c'])
+ra.run(['./t_s4u', 'p:' + ra.user_princ, 'h:service@rb.c'], env=domain_conf)
+ra.run(['./t_s4u', 'p:' + 'sensitive@A', 'h:service@rb.c'], expected_code=1)
+ra.run(['./t_s4u', 'p:' + rb.user_princ, 'h:service@rb.c'])
+
+ra.stop()
+rb.stop()
+rc.stop()
+
 success('S4U test cases')


### PR DESCRIPTION
This is work-in-progress, following the discussion on krbdev:
http://mailman.mit.edu/pipermail/krbdev/2019-March/013083.html

I'm still not happy with the chase-referral commit, which is a cleaned-up version of the prove-of-concept code. I wanted to move more logic to s4u_creds.c, implement a chase-referral loop that calls krb5_get_cred_via_tkt_ext() in each iteration, and call this loop two or three time to get the job done. It also depends whether or not we want krb5_get_credentials() to work with RBCD or the caller code can be adapted. Anyway, for now I'll start working on the KDC side (and tests) to get a better picture.