### PR TITLE
Fix config realm change logic in FILE remove_cred

### DIFF
--- a/src/lib/krb5/ccache/cc_file.c
+++ b/src/lib/krb5/ccache/cc_file.c
@@ -1058,8 +1058,7 @@ delete_cred(krb5_context context, krb5_ccache cache, krb5_cc_cursor *cursor,
 
     /* For config entries, also change the realm so that other implementations
      * won't match them. */
-    if (cred->server != NULL && cred->server->realm.length > 0 &&
-        strcmp(cred->server->realm.data, "X-CACHECONF:") == 0)
+    if (data_eq_string(cred->server->realm, "X-CACHECONF:"))
         memcpy(cred->server->realm.data, "X-RMED-CONF:", 12);
 
     k5_marshal_cred(&overwrite, fcursor->version, cred);


### PR DESCRIPTION
[I missed this in review, but Coverity found a forward-null and reverse-null defect on the same line.  We should never use C string functions on krb5_data values as they are not guaranteed to be zero-terminated.]

Use data_eq_string() to check the server realm, and do not check if
cred->server is NULL since it is not expected to be (and
k5_marshal_cred() would have already crashed if it were).
