### PR TITLE
Fix potential close(-1) in cc_file.c

### DIFF
--- a/src/lib/krb5/ccache/cc_file.c
+++ b/src/lib/krb5/ccache/cc_file.c
@@ -1122,7 +1122,8 @@ delete_cred(krb5_context context, krb5_ccache cache, krb5_cc_cursor *cursor,
     }
 
 cleanup:
-    close(fd);
+    if (fd >= 0)
+        close(fd);
     zapfree(on_disk, expected.len);
     k5_buf_free(&expected);
     k5_buf_free(&overwrite);


### PR DESCRIPTION
As part of error handling in d3b39a8bac6206b5ea78b0bf6a2958c1df0b0dd5,
an error path in delete_cred() may result in close(-1).  While this
shouldn't be a prolblem in practice (just returning EBADF), it does
upset Coverity.