### PR TITLE
Check more errors in OpenSSL crypto backend

### DIFF
--- a/src/lib/crypto/openssl/pbkdf2.c
+++ b/src/lib/crypto/openssl/pbkdf2.c
@@ -35,6 +35,7 @@ krb5int_pbkdf2_hmac(const struct krb5_hash_provider *hash,
                     const krb5_data *pass, const krb5_data *salt)
 {
     const EVP_MD *md = NULL;
+    int ok;
 
     /* Get the message digest handle corresponding to the hash. */
     if (hash == &krb5int_hash_sha1)
@@ -46,8 +47,8 @@ krb5int_pbkdf2_hmac(const struct krb5_hash_provider *hash,
     if (md == NULL)
         return KRB5_CRYPTO_INTERNAL;
 
-    PKCS5_PBKDF2_HMAC(pass->data, pass->length, (unsigned char *)salt->data,
-                      salt->length, count, md, out->length,
-                      (unsigned char *)out->data);
-    return 0;
+    ok = PKCS5_PBKDF2_HMAC(pass->data, pass->length,
+                           (unsigned char *)salt->data, salt->length, count,
+                           md, out->length, (unsigned char *)out->data);
+    return ok ? 0 : KRB5_CRYPTO_INTERNAL;
 }


### PR DESCRIPTION
[https://github.com/openssl/openssl/pull/6674 was set to cause OpenSSL's PBKDF2 to return an error on empty salt, which was caught by the inclusion of the MIT krb5 test suite in OpenSSL's CI.  In the process I noted that our code wasn't checking the return value, which runs the risk of returning successfully with uninitalized memory in the string-to-key result.  Today I did a review of the OpenSSL backend and found that we also don't check errors for some calls within krb5int_hmac_keyblock().]

In krb5int_hmac_keyblock() and krb5int_pbkdf2_hmac(), check for errors
from previously unchecked OpenSSL function calls and return
KRB5_CRYPTO_INTERNAL if they fail.

HMAC_Init() is deprecated in OpenSSL 1.0 and later; as we are
modifying the call to check for errors, call HMAC_Init_ex() instead.
