### PR TITLE
Simplify libreadline configure support

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1339,9 +1339,9 @@ if test "x$with_libedit" != xno; then
 elif test "x$with_readline" = xyes; then
   AC_MSG_NOTICE([Using GNU Readline])
   AC_CHECK_LIB([readline], [main], :,
-	       AC_MSG_FAILURE([Cannot find readline library.]), [-lncurses])
+	       AC_MSG_FAILURE([Cannot find readline library.]))
   AC_DEFINE([HAVE_READLINE], 1, [Define if building with GNU Readline.])
-  RL_LIBS='-lreadline -lhistory -lncurses'
+  RL_LIBS='-lreadline'
 else
   AC_MSG_RESULT([Not using any readline support])
 fi


### PR DESCRIPTION
[We got a report from someone who had built a custom system where readline was built against libncursesw instead of libncurses.  This approach will generate better shared library dependencies.  It won't work well on platforms which use all static libraries or don't have shared library dependencies, but I'm not too concerned about that since linking against libreadline isn't the default.  People can set LIBS to compensate in a pinch.  There is an AX_LIB_READLINE in the autoconf archive, but it's a little annoying to use within the source code so I'm going to pass on that until it seems like there's a need.  Unfortunately readline doesn't seem to participate in pkg-config so that's not an option.]

If configure is explicitly asked to build with libreadline, look for
and link against only -lreadline, relying on the platform to resolve
any dependencies.
