### PR TITLE
Secure getenv

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -148,7 +148,7 @@ AC_SUBST(po)
 
 # for kdc
 AC_CHECK_HEADERS(sys/sockio.h ifaddrs.h unistd.h fnmatch.h)
-AC_CHECK_FUNCS(vsprintf vasprintf vsnprintf strlcpy fnmatch)
+AC_CHECK_FUNCS(vsprintf vasprintf vsnprintf strlcpy fnmatch secure_getenv)
 
 EXTRA_SUPPORT_SYMS=
 AC_CHECK_FUNC(strlcpy,
@@ -207,6 +207,18 @@ KRB5_NEED_PROTO([#include <string.h>
 /* Solaris 8 declares swab in stdlib.h.  */
 #include <stdlib.h>
 ],swab,1)
+
+AC_CHECK_FUNC(secure_getenv,
+[SECURE_GETENV_ST_OBJ=
+SECURE_GETENV_OBJ=
+SECURE_GETENV_INIT=],
+[SECURE_GETENV_ST_OBJ=secure_getenv.o
+SECURE_GETENV_OBJ='$(OUTPRE)secure_getenv.$(OBJEXT)'
+SECURE_GETENV_INIT=k5_secure_getenv_init
+EXTRA_SUPPORT_SYMS="$EXTRA_SUPPORT_SYMS k5_secure_getenv"])
+AC_SUBST(SECURE_GETENV_OBJ)
+AC_SUBST(SECURE_GETENV_ST_OBJ)
+AC_SUBST(SECURE_GETENV_INIT)
 
 AC_PROG_AWK
 KRB5_AC_INET6
@@ -442,7 +454,7 @@ AC_PROG_LEX
 AC_C_CONST
 AC_HEADER_DIRENT
 AC_FUNC_STRERROR_R
-AC_CHECK_FUNCS(strdup setvbuf seteuid setresuid setreuid setegid setresgid setregid setsid flock fchmod chmod strptime geteuid setenv unsetenv getenv gmtime_r localtime_r bswap16 bswap64 mkstemp getusershell access getcwd srand48 srand srandom stat strchr strerror timegm explicit_bzero explicit_memset)
+AC_CHECK_FUNCS(strdup setvbuf seteuid setresuid setreuid setegid setresgid setregid setsid flock fchmod chmod strptime geteuid setenv unsetenv getenv gmtime_r localtime_r bswap16 bswap64 mkstemp getusershell access getcwd srand48 srand srandom stat strchr strerror timegm explicit_bzero explicit_memset getresuid getresgid)
 
 AC_CHECK_FUNC(mkstemp,
 [MKSTEMP_ST_OBJ=

--- a/src/include/k5-platform.h
+++ b/src/include/k5-platform.h
@@ -45,6 +45,7 @@
  * + path manipulation
  * + _, N_, dgettext, bindtextdomain (for localization)
  * + getopt_long
+ * + secure_getenv
  * + fetching filenames from a directory
  */
 
@@ -1133,6 +1134,14 @@ extern int k5_getopt_long(int nargc, char **nargv, char *options,
                           struct option *long_options, int *index);
 #define getopt_long k5_getopt_long
 #endif /* HAVE_GETOPT_LONG */
+
+#if defined(_WIN32)
+/* On Windows there is never a need to ignore the process environment. */
+#define secure_getenv getenv
+#elif !defined(HAVE_SECURE_GETENV)
+#define secure_getenv k5_secure_getenv
+extern char *k5_secure_getenv(const char *name);
+#endif
 
 /* Set *fnames_out to a null-terminated list of filenames within dirname,
  * sorted according to strcmp().  Return 0 on success, or ENOENT/ENOMEM. */

--- a/src/lib/kadm5/alt_prof.c
+++ b/src/lib/kadm5/alt_prof.c
@@ -73,7 +73,7 @@ krb5_aprof_init(char *fname, char *envname, krb5_pointer *acontextp)
     ret = krb5_get_default_config_files(&filenames);
     if (ret)
         return ret;
-    if (envname == NULL || (kdc_config = getenv(envname)) == NULL)
+    if (envname == NULL || (kdc_config = secure_getenv(envname)) == NULL)
         kdc_config = fname;
     k5_buf_init_dynamic(&buf);
     if (kdc_config)

--- a/src/lib/krb5/ccache/ccselect_k5identity.c
+++ b/src/lib/krb5/ccache/ccselect_k5identity.c
@@ -135,7 +135,7 @@ get_homedir(krb5_context context)
     struct passwd pwx, *pwd;
 
     if (!context->profile_secure)
-        homedir = getenv("HOME");
+        homedir = secure_getenv("HOME");
 
     if (homedir == NULL) {
         if (k5_getpwuid_r(geteuid(), &pwx, pwbuf, sizeof(pwbuf), &pwd) != 0)

--- a/src/lib/krb5/os/ccdefname.c
+++ b/src/lib/krb5/os/ccdefname.c
@@ -300,7 +300,7 @@ krb5_cc_default_name(krb5_context context)
         return os_ctx->default_ccname;
 
     /* Try the environment variable first. */
-    envstr = getenv(KRB5_ENV_CCNAME);
+    envstr = secure_getenv(KRB5_ENV_CCNAME);
     if (envstr != NULL) {
         os_ctx->default_ccname = strdup(envstr);
         return os_ctx->default_ccname;

--- a/src/lib/krb5/os/expand_path.c
+++ b/src/lib/krb5/os/expand_path.c
@@ -280,7 +280,7 @@ expand_temp_folder(krb5_context context, PTYPE param, const char *postfix,
     const char *p = NULL;
 
     if (context == NULL || !context->profile_secure)
-        p = getenv("TMPDIR");
+        p = secure_getenv("TMPDIR");
     *ret = strdup((p != NULL) ? p : "/tmp");
     if (*ret == NULL)
         return ENOMEM;

--- a/src/lib/krb5/os/init_os_ctx.c
+++ b/src/lib/krb5/os/init_os_ctx.c
@@ -243,7 +243,7 @@ os_get_default_config_files(profile_filespec_t **pfiles, krb5_boolean secure)
     char *name = 0;
 
     if (!secure) {
-        char *env = getenv("KRB5_CONFIG");
+        char *env = secure_getenv("KRB5_CONFIG");
         if (env) {
             name = strdup(env);
             if (!name) return ENOMEM;
@@ -298,7 +298,7 @@ os_get_default_config_files(profile_filespec_t **pfiles, krb5_boolean secure)
     if (secure) {
         filepath = DEFAULT_SECURE_PROFILE_PATH;
     } else {
-        filepath = getenv("KRB5_CONFIG");
+        filepath = secure_getenv("KRB5_CONFIG");
         if (!filepath) filepath = DEFAULT_PROFILE_PATH;
     }
 
@@ -344,7 +344,7 @@ add_kdc_config_file(profile_filespec_t **pfiles)
     size_t count = 0;
     profile_filespec_t *newfiles;
 
-    file = getenv(KDC_PROFILE_ENV);
+    file = secure_getenv(KDC_PROFILE_ENV);
     if (file == NULL)
         file = DEFAULT_KDC_PROFILE;
 

--- a/src/lib/krb5/os/ktdefname.c
+++ b/src/lib/krb5/os/ktdefname.c
@@ -42,7 +42,7 @@ kt_default_name(krb5_context context, char **name_out)
         *name_out = strdup(krb5_overridekeyname);
         return (*name_out == NULL) ? ENOMEM : 0;
     } else if (context->profile_secure == FALSE &&
-               (str = getenv("KRB5_KTNAME")) != NULL) {
+               (str = secure_getenv("KRB5_KTNAME")) != NULL) {
         *name_out = strdup(str);
         return (*name_out == NULL) ? ENOMEM : 0;
     } else if (profile_get_string(context->profile, KRB5_CONF_LIBDEFAULTS,
@@ -63,7 +63,7 @@ k5_kt_client_default_name(krb5_context context, char **name_out)
     char *str;
 
     if (context->profile_secure == FALSE &&
-        (str = getenv("KRB5_CLIENT_KTNAME")) != NULL) {
+        (str = secure_getenv("KRB5_CLIENT_KTNAME")) != NULL) {
         *name_out = strdup(str);
         return (*name_out == NULL) ? ENOMEM : 0;
     } else if (profile_get_string(context->profile, KRB5_CONF_LIBDEFAULTS,

--- a/src/lib/krb5/os/trace.c
+++ b/src/lib/krb5/os/trace.c
@@ -389,7 +389,7 @@ k5_init_trace(krb5_context context)
 {
     const char *filename;
 
-    filename = getenv("KRB5_TRACE");
+    filename = secure_getenv("KRB5_TRACE");
     if (filename)
         (void) krb5_set_trace_filename(context, filename);
 }

--- a/src/lib/krb5/rcache/rc_base.c
+++ b/src/lib/krb5/rcache/rc_base.c
@@ -107,7 +107,7 @@ char *
 krb5_rc_default_type(krb5_context context)
 {
     char *s;
-    if ((s = getenv("KRB5RCACHETYPE")))
+    if ((s = secure_getenv("KRB5RCACHETYPE")))
         return s;
     else
         return "dfl";
@@ -117,7 +117,7 @@ char *
 krb5_rc_default_name(krb5_context context)
 {
     char *s;
-    if ((s = getenv("KRB5RCACHENAME")))
+    if ((s = secure_getenv("KRB5RCACHENAME")))
         return s;
     else
         return (char *) 0;

--- a/src/lib/krb5/rcache/rc_io.c
+++ b/src/lib/krb5/rcache/rc_io.c
@@ -48,13 +48,13 @@ getdir(void)
 {
     char *dir;
 
-    if (!(dir = getenv("KRB5RCACHEDIR"))) {
+    if (!(dir = secure_getenv("KRB5RCACHEDIR"))) {
 #if defined(_WIN32)
         if (!(dir = getenv("TEMP")))
             if (!(dir = getenv("TMP")))
                 dir = "C:";
 #else
-        if (!(dir = getenv("TMPDIR"))) {
+        if (!(dir = secure_getenv("TMPDIR"))) {
 #ifdef RCTMPDIR
             dir = RCTMPDIR;
 #else

--- a/src/plugins/preauth/pkinit/pkinit_identity.c
+++ b/src/plugins/preauth/pkinit/pkinit_identity.c
@@ -29,15 +29,9 @@
  * SUCH DAMAGES.
  */
 
-#include <errno.h>
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <dlfcn.h>
-#include <unistd.h>
-#include <dirent.h>
-
 #include "pkinit.h"
+#include <dlfcn.h>
+#include <dirent.h>
 
 static void
 free_list(char **list)
@@ -430,7 +424,8 @@ process_option_identity(krb5_context context,
     switch (idtype) {
     case IDTYPE_ENVVAR:
         return process_option_identity(context, plg_cryptoctx, req_cryptoctx,
-                                       idopts, id_cryptoctx, getenv(residual));
+                                       idopts, id_cryptoctx,
+                                       secure_getenv(residual));
         break;
     case IDTYPE_FILE:
         retval = parse_fs_options(context, idopts, residual);

--- a/src/plugins/tls/k5tls/openssl.c
+++ b/src/plugins/tls/k5tls/openssl.c
@@ -399,7 +399,7 @@ load_anchor(SSL_CTX *ctx, const char *location)
     } else if (strncmp(location, "DIR:", 4) == 0) {
         return load_anchor_dir(store, location + 4);
     } else if (strncmp(location, "ENV:", 4) == 0) {
-        envloc = getenv(location + 4);
+        envloc = secure_getenv(location + 4);
         if (envloc == NULL)
             return ENOENT;
         return load_anchor(ctx, envloc);

--- a/src/util/profile/prof_file.c
+++ b/src/util/profile/prof_file.c
@@ -182,7 +182,7 @@ errcode_t profile_open_file(const_profile_filespec_t filespec,
     prf->magic = PROF_MAGIC_FILE;
 
     if (filespec[0] == '~' && filespec[1] == '/') {
-        home_env = getenv("HOME");
+        home_env = secure_getenv("HOME");
 #ifdef HAVE_PWD_H
         if (home_env == NULL) {
             uid_t uid;

--- a/src/util/support/Makefile.in
+++ b/src/util/support/Makefile.in
@@ -15,7 +15,7 @@ LIBBASE=krb5support
 LIBMAJOR=@SUPPORTLIB_MAJOR@
 LIBMINOR=1
 
-LIBINITFUNC=krb5int_thread_support_init
+LIBINITFUNC=krb5int_thread_support_init @SECURE_GETENV_INIT@
 LIBFINIFUNC=krb5int_thread_support_fini
 
 GETTIMEOFDAY_ST_OBJ= @GETTIMEOFDAY_ST_OBJ@
@@ -52,6 +52,11 @@ GETOPT_LONG_ST_OBJ= @GETOPT_LONG_ST_OBJ@
 GETOPT_LONG_OBJ= @GETOPT_LONG_OBJ@
 ##DOS##GETOPT_LONG_ST_OBJ= getopt_long.o
 ##DOS##GETOPT_LONG_OBJ= $(OUTPRE)getopt_long.$(OBJEXT)
+
+SECURE_GETENV_ST_OBJ= @SECURE_GETENV_ST_OBJ@
+SECURE_GETENV_OBJ= @SECURE_GETENV_OBJ@
+##DOS##SECURE_GETENV_ST_OBJ=
+##DOS##SECURE_GETENV_OBJ=
 
 IPC_ST_OBJ=
 IPC_OBJ=
@@ -93,7 +98,8 @@ STLIBOBJS= \
 	$(PRINTF_ST_OBJ) \
 	$(MKSTEMP_ST_OBJ) \
 	$(GETOPT_ST_OBJ) \
-	$(GETOPT_LONG_ST_OBJ)
+	$(GETOPT_LONG_ST_OBJ) \
+	$(SECURE_GETENV_OBJ)
 
 LIBOBJS= \
 	$(OUTPRE)threads.$(OBJEXT) \
@@ -121,7 +127,8 @@ LIBOBJS= \
 	$(PRINTF_OBJ) \
 	$(MKSTEMP_OBJ) \
 	$(GETOPT_OBJ) \
-	$(GETOPT_LONG_OBJ)
+	$(GETOPT_LONG_OBJ) \
+	$(SECURE_GETENV_OBJ)
 
 SRCS=\
 	$(srcdir)/threads.c \
@@ -156,7 +163,8 @@ SRCS=\
 	$(srcdir)/t_utf8.c \
 	$(srcdir)/t_utf16.c \
 	$(srcdir)/getopt.c \
-	$(srcdir)/getopt_long.c
+	$(srcdir)/getopt_long.c \
+	$(srcdir)/secure_getenv.c
 
 SHLIB_EXPDEPS =
 # Add -lm if dumping thread stats, for sqrt.

--- a/src/util/support/secure_getenv.c
+++ b/src/util/support/secure_getenv.c
@@ -1,0 +1,111 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* util/support/secure_getenv.c - secure_getenv() portability support */
+/*
+ * Copyright (C) 2019 by the Massachusetts Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file contains the fallback implementation for secure_getenv(), which is
+ * currently only provided by glibc 2.17 and later.  The goal is to ignore the
+ * environment if this process is (or previously was) running at elevated
+ * privilege compared to the calling process.
+ *
+ * In this fallback version we compare the real and effective uid/gid, and also
+ * compare the saved uid/gid if possible.  These comparisons detect a setuid or
+ * setgid process which is still running with elevated privilege; if we can
+ * fetch the saved uid/gid, we also detect a process which has temporarily
+ * dropped privilege with seteuid() or setegid().  These comparisons do not
+ * detect the case where a setuid or setgid process has permanently dropped
+ * privilege before the library initializer ran; this is not ideal because such
+ * a process may possess a privileged resource or have privileged information
+ * in its address space.
+ *
+ * Heimdal also looks at the ELF aux vector in /proc/self/auxv to determine the
+ * starting uid/euid/gid/euid on Solaris/Illumos and NetBSD.  On FreeBSD this
+ * approach can determine the executable path to do a stat() check.  We do not
+ * go to this length due to the amount of code required.
+ *
+ * The BSDs and Solaris provide issetugid(), but the FreeBSD and NetBSD
+ * versions are not useful; they return true if a non-setuid/setgid executable
+ * is run by root and drops privilege, such as Apache httpd.  We do not want to
+ * ignore the process environment in this case.
+ *
+ * On some platforms a process may have elevated privilege via mechanisms other
+ * than setuid/setgid.  glibc's secure_getenv() should detect these cases on
+ * Linux; we do not detect them in this fallback version.
+ */
+
+#include "k5-platform.h"
+
+static int elevated_privilege = 0;
+
+MAKE_INIT_FUNCTION(k5_secure_getenv_init);
+
+int
+k5_secure_getenv_init()
+{
+    int saved_errno = errno;
+
+#ifdef HAVE_GETRESUID
+    {
+        uid_t r, e, s;
+        if (getresuid(&r, &e, &s) == 0) {
+            if (r != e || r != s)
+                elevated_privilege = 1;
+        }
+    }
+#else
+    if (getuid() != geteuid())
+        elevated_privilege = 1;
+#endif
+
+#ifdef HAVE_GETRESGID
+    {
+        gid_t r, e, s;
+        if (!elevated_privilege && getresgid(&r, &e, &s) == 0) {
+            if (r != e || r != s)
+                elevated_privilege = 1;
+        }
+    }
+#else
+    if (!elevated_privilege && getgid() != getegid())
+        elevated_privilege = 1;
+#endif
+
+    errno = saved_errno;
+    return 0;
+}
+
+char *
+k5_secure_getenv(const char *name)
+{
+    if (CALL_INIT_FUNCTION(k5_secure_getenv_init) != 0)
+        return NULL;
+    return elevated_privilege ? NULL : getenv(name);
+}


### PR DESCRIPTION
The first commit is a placeholder for now.  I'm submitting this early to have a place to discuss implementation details (or at least record my own thoughts on them).

The goal here is to automatically ignore environment variables in our libraries when the process has higher privileges than its environment.  Currently we have a programmatic way to create "secure" krb5_contexts which ignore most environment variables; we have no story for GSS.

On glibc 2.17+, secure_getenv() solves the problem.  Its semantics seem solid as far as I can tell.  None of the other platforms I looked at have secure_getenv(), and I don't think other libc implementations for Linux have it.

On Windows there is, as far as I know, never a need to ignore the process environment.

An imperfect but simple fallback to detect elevated privileges is "getuid() != geteuid() || getgid() != getegid()", as libev and probably a bunch of other libraries do.  This doesn't detect exotic system features (such as executables having elevated privileges other than running as a different uid or gid), and it doesn't detect the case where an executable started off with elevated privileges, acquired a privileged resource or read in privileged data, then dropped privileges.

The BSDs have issetugid(), but unfortunately FreeBSD (and NetBSD according to Nico) messed it up, returning true if a process run as root lowered its privilege level using setuid() or similar.  We don't want to ignore environment variables in that case because the process environment is more privileged than the process, not less.  Ignoring the process environment for programs like Apache httpd would be a large inconvenience.

Nico did a bunch of research on this for Heimdal and came up with libroken/{secure_getenv.c,issuid.c,getauxval.c}.  The sum of these is more code than I'm really comfortable with.  The full logic is:

1. If getauxval(AT_SECURE) is available and succeeds, use that answer authoritatively.
2. If getauxval(AT_EUID), getauxval(AT_UID), getauxval(AT_EGID), and getauxval(AT_GID) all succeed and the uid/euid and gid/egid match, decide there is no elevated privilege.  If a uid/euid or gid/egid mismatch is detected, decide there is elevated privilege.  I believe these are the values from process start time, so this check won't miss the temporary-setuid case. 
3. If issetugid() is available and says 0, decide there is no elevated privilege.  But because of FreeBSD
4. If getauxval(AT_EXECPATH) succeeds and can be stat()d, answer authoritatively based on whether S_ISUID or S_ISGID is present in the mode.  (The file there isn't guaranteed to be the one we're executing, but since setuid/setgid programs are installed that way by root, there's no realistic attack scenario.)
5. Detect runtime uid/euid/saved-uid and gid/egid/saved-gid mismatches using getresuid() and getresgid() if possible.  Otherwise check using getuid()/geteuid()/getgid()/getegid().

Rather than use the system getauxval(), libroken uses its own implementation which reads /proc/self/auxv and parses it.  getauxval() itself seems to only be present in glibc 2.16+, and appears to have been broken (doesn't set errno on failure) before glibc 2.19.  The libroken implementation may also work on Solaris/Illumos, and on Linux systems with older glibc versions.

There is also the question of memoization.  Heimdal's implementation memoizes inside issuid() using a static integer with no locking, beginning with the value -1 and changing to 0 or 1.  This probably works okay in a practical threaded environment, but might run afoul of tools which detect thread-safety violations.  We could do more careful memoization using a library initializer, or an explicit pthread_once() in secure_getenv().
