### PR TITLE
Rename hmac() function.

### DIFF
--- a/src/lib/crypto/builtin/pbkdf2.c
+++ b/src/lib/crypto/builtin/pbkdf2.c
@@ -73,10 +73,12 @@ static void printd (const char *descr, krb5_data *d) {
  * Implements the hmac-sha1 PRF.  pass has been pre-hashed (if
  * necessary) and converted to a key already; salt has had the block
  * index appended to the original salt.
+ *
+ * NetBSD 8 declares an hmac() function in stdlib.h, so avoid that name.
  */
 static krb5_error_code
-hmac(const struct krb5_hash_provider *hash, krb5_keyblock *pass,
-     krb5_data *salt, krb5_data *out)
+k5_hmac(const struct krb5_hash_provider *hash, krb5_keyblock *pass,
+        krb5_data *salt, krb5_data *out)
 {
     krb5_error_code err;
     krb5_crypto_iov iov;
@@ -111,7 +113,7 @@ F(char *output, char *u_tmp1, char *u_tmp2,
 
     out = make_data(u_tmp1, hlen);
 
-    err = hmac(hash, pass, &sdata, &out);
+    err = k5_hmac(hash, pass, &sdata, &out);
     if (err)
         return err;
 
@@ -121,7 +123,7 @@ F(char *output, char *u_tmp1, char *u_tmp2,
     sdata.length = hlen;
     for (j = 2; j <= count; j++) {
         memcpy(u_tmp2, u_tmp1, hlen);
-        err = hmac(hash, pass, &sdata, &out);
+        err = k5_hmac(hash, pass, &sdata, &out);
         if (err)
             return err;
 


### PR DESCRIPTION
NetBSD's libc includes a hmac() function as well; this avoids a
build problem on NetBSD.