### PR TITLE
Add a Travis job for building with OpenSSL crypto exclusively

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,6 +1,6 @@
 cd src
 autoreconf
-./configure --enable-maintainer-mode --with-ldap
+./configure --enable-maintainer-mode --with-ldap $CONFIGURE_OPTS
 make $MAKEVARS
 make check
 make distclean

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ matrix:
   include:
   - compiler: clang
     env: MAKEVARS=CPPFLAGS=-Werror
+  - compiler: clang
+    env:
+      - MAKEVARS=CPPFLAGS=-Werror
+      - CONFIGURE_OPTS=--with-crypto-impl=openssl
   - compiler: gcc
 
 before_install:

--- a/src/lib/crypto/openssl/enc_provider/rc4.c
+++ b/src/lib/crypto/openssl/enc_provider/rc4.c
@@ -57,7 +57,7 @@ struct arcfour_state {
 
 /* In-place IOV crypto */
 static krb5_error_code
-k5_arcfour_docrypt(krb5_key key,const krb5_data *state, krb5_crypto_iov *data,
+k5_arcfour_docrypt(krb5_key key, const krb5_data *state, krb5_crypto_iov *data,
                    size_t num_data)
 {
     size_t i;
@@ -66,7 +66,7 @@ k5_arcfour_docrypt(krb5_key key,const krb5_data *state, krb5_crypto_iov *data,
     EVP_CIPHER_CTX *ctx = NULL;
     struct arcfour_state *arcstate;
 
-    arcstate = (state != NULL) ? (struct arcfour_state *) state->data : NULL;
+    arcstate = (state != NULL) ? (void *)state->data : NULL;
     if (arcstate != NULL) {
         ctx = arcstate->ctx;
         if (arcstate->loopback != arcstate)
@@ -113,7 +113,7 @@ k5_arcfour_docrypt(krb5_key key,const krb5_data *state, krb5_crypto_iov *data,
 static void
 k5_arcfour_free_state(krb5_data *state)
 {
-    struct arcfour_state *arcstate = (struct arcfour_state *) state->data;
+    struct arcfour_state *arcstate = (void *)state->data;
 
     EVP_CIPHER_CTX_free(arcstate->ctx);
     free(arcstate);
@@ -124,6 +124,15 @@ k5_arcfour_init_state(const krb5_keyblock *key,
                       krb5_keyusage keyusage, krb5_data *new_state)
 {
     struct arcfour_state *arcstate;
+
+    /*
+     * The cipher state here is a saved pointer to a struct arcfour_state
+     * object, rather than a flat byte array as in most enc providers.  The
+     * object includes a loopback pointer to detect if if the caller made a
+     * copy of the krb5_data value or otherwise assumed it was a simple byte
+     * array.  When we cast the data pointer back, we need to go through void *
+     * to avoid increased alignment warnings.
+     */
 
     /* Create a state structure with an uninitialized context. */
     arcstate = calloc(1, sizeof(*arcstate));


### PR DESCRIPTION
This matches closely the job that OpenSSL uses ([krb5.sh](https://github.com/openssl/openssl/blob/master/test/recipes/95-test_external_krb5_data/krb5.sh)) and is part of the one I use in Fedora ([krb5.spec](https://github.com/frozencemetery/krb5.fedora/blob/master/krb5.spec#L299)).

I considered making this a full "non-builtin" job, but that didn't seem especially useful given what Travis is running.