### PR TITLE
Set the default ksu PATH to match login

### DIFF
--- a/src/clients/ksu/Makefile.in
+++ b/src/clients/ksu/Makefile.in
@@ -1,6 +1,6 @@
 mydir=clients$(S)ksu
 BUILDTOP=$(REL)..$(S)..
-DEFINES = -DGET_TGT_VIA_PASSWD -DPRINC_LOOK_AHEAD -DCMD_PATH='"/bin /local/bin"'
+DEFINES = -DGET_TGT_VIA_PASSWD -DPRINC_LOOK_AHEAD -DCMD_PATH='"/usr/local/sbin /usr/local/bin /sbin /bin /usr/sbin /usr/bin"'
 
 KSU_LIBS=@KSU_LIBS@
 


### PR DESCRIPTION
Include the /usr tree and .../sbin variants.  Drop nonstandard /local.

Also-authored-by: Nalin Dahyabhai <nalin@redhat.com>

(This patch has been carried in Fedora since 2011 against 1.10.)