### PR TITLE
Add NULL-checks to realm and principal comparisons

### DIFF
--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -3641,7 +3641,7 @@ krb5_address_order(krb5_context context, const krb5_address *addr1,
  * @param [in] princ2           Second principal
  *
  * @retval
- * TRUE if the realm names are the same; FALSE otherwise
+ * TRUE if the realm names are the same; FALSE otherwise (including if NULL)
  */
 krb5_boolean KRB5_CALLCONV
 krb5_realm_compare(krb5_context context, krb5_const_principal princ1,
@@ -3655,7 +3655,7 @@ krb5_realm_compare(krb5_context context, krb5_const_principal princ1,
  * @param [in] princ2           Second principal
  *
  * @retval
- * TRUE if the principals are the same; FALSE otherwise
+ * TRUE if the principals are the same; FALSE otherwise (including if NULL)
  */
 krb5_boolean KRB5_CALLCONV
 krb5_principal_compare(krb5_context context,

--- a/src/lib/krb5/krb/princ_comp.c
+++ b/src/lib/krb5/krb/princ_comp.c
@@ -36,6 +36,10 @@ realm_compare_flags(krb5_context context,
     const krb5_data *realm1 = &princ1->realm;
     const krb5_data *realm2 = &princ2->realm;
 
+    if (princ1 == NULL || princ2 == NULL)
+        return FALSE;
+    if (realm1 == NULL || realm2 == NULL)
+        return FALSE;
     if (realm1->length != realm2->length)
         return FALSE;
     if (realm1->length == 0)
@@ -87,6 +91,9 @@ krb5_principal_compare_flags(krb5_context context,
     krb5_principal upn1 = NULL;
     krb5_principal upn2 = NULL;
     krb5_boolean ret = FALSE;
+
+    if (princ1 == NULL || princ2 == NULL)
+        return FALSE;
 
     if (flags & KRB5_PRINCIPAL_COMPARE_ENTERPRISE) {
         /* Treat UPNs as if they were real principals */


### PR DESCRIPTION
Neither krb5_realm_compare() nor krb5_principal_compare_flags()
specify behavior on NULL entries, so define them non-matching rather
than crashing.

Also-authored-by: Nalin Dahyabhai <nalin@redhat.com>

(Patch carried downstream in Fedora since 2009; originally against 1.7.)