### PR TITLE
Preserve intermediate yacc files for debuginfo generation

### DIFF
--- a/src/kadmin/cli/Makefile.in
+++ b/src/kadmin/cli/Makefile.in
@@ -37,3 +37,8 @@ clean-unix::
 # CC_LINK is not meant for compilation and this use may break in the future.
 datetest: getdate.c
 	$(CC_LINK) $(ALL_CFLAGS) -DTEST -o datetest getdate.c
+
+%.c: %.y
+	$(RM) y.tab.c $@
+	$(YACC.y) $<
+	$(CP) y.tab.c $@

--- a/src/plugins/kdb/ldap/ldap_util/Makefile.in
+++ b/src/plugins/kdb/ldap/ldap_util/Makefile.in
@@ -20,7 +20,7 @@ $(PROG): $(OBJS) $(KADMSRV_DEPLIBS) $(KRB5_BASE_DEPLIB) $(GETDATE)
 getdate.c: $(GETDATE)
 	$(RM) getdate.c y.tab.c
 	$(YACC) $(GETDATE)
-	$(MV) y.tab.c getdate.c
+	$(CP) y.tab.c getdate.c
 
 install:
 	$(INSTALL_PROGRAM) $(PROG) ${DESTDIR}$(ADMIN_BINDIR)/$(PROG)


### PR DESCRIPTION
Keep y.tab.c files around because the debuginfo points to them.

Also-authored-by: Nalin Dahyabhai <nalin@redhat.com>

(Originally part of fixes for [rhbz#729044](https://bugzilla.redhat.com/show_bug.cgi?id=729044); carried downstream in Fedora since 2011, originally against 1.9.1.)