### PR TITLE
libkrb5 padata helper functions

### DIFF
--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -851,11 +851,35 @@ typedef struct _krb5_cammac {
     krb5_verifier_mac **other_verifiers;
 } krb5_cammac;
 
+void krb5_free_etype_info(krb5_context, krb5_etype_info);
+
 krb5_pa_data *
 krb5int_find_pa_data(krb5_context, krb5_pa_data *const *, krb5_preauthtype);
 /* Does not return a copy; original padata sequence responsible for freeing*/
 
-void krb5_free_etype_info(krb5_context, krb5_etype_info);
+/* Allocate a pa-data object with uninitialized contents of size len.  If len
+ * is 0, set the contents field to NULL. */
+krb5_error_code
+k5_alloc_pa_data(krb5_preauthtype pa_type, size_t len, krb5_pa_data **out);
+
+/* Free a single pa-data object. */
+void
+k5_free_pa_data_element(krb5_pa_data *pa);
+
+/* Without copying, add single element *pa to *list, reallocating as necessary.
+ * If *list is NULL, allocate a new list.  Set *pa to NULL on success. */
+krb5_error_code
+k5_add_pa_data_element(krb5_pa_data ***list, krb5_pa_data **pa);
+
+/* Without copying, add a pa-data element of type pa_type to *list with the
+ * contents in data.  Set *data to empty_data() on success. */
+krb5_error_code
+k5_add_pa_data_from_data(krb5_pa_data ***list, krb5_preauthtype pa_type,
+                         krb5_data *data);
+
+/* Add an empty pa-data element of type pa_type to *list. */
+krb5_error_code
+k5_add_empty_pa_data(krb5_pa_data ***list, krb5_preauthtype pa_type);
 
 #endif /* KRB5_PREAUTH__ */
 /*

--- a/src/kdc/fast_util.c
+++ b/src/kdc/fast_util.c
@@ -456,7 +456,7 @@ static krb5_error_code
 make_padata(krb5_preauthtype pa_type, const void *contents, size_t len,
             krb5_pa_data **out)
 {
-    if (alloc_pa_data(pa_type, len, out) != 0)
+    if (k5_alloc_pa_data(pa_type, len, out) != 0)
         return ENOMEM;
     memcpy((*out)->contents, contents, len);
     return 0;
@@ -696,7 +696,8 @@ kdc_fast_make_cookie(krb5_context context, struct kdc_request_state *state,
         goto cleanup;
 
     /* Construct the cookie pa-data entry. */
-    ret = alloc_pa_data(KRB5_PADATA_FX_COOKIE, 8 + enc.ciphertext.length, &pa);
+    ret = k5_alloc_pa_data(KRB5_PADATA_FX_COOKIE, 8 + enc.ciphertext.length,
+                           &pa);
     memcpy(pa->contents, "MIT1", 4);
     store_32_be(kvno, pa->contents + 4);
     memcpy(pa->contents + 8, enc.ciphertext.data, enc.ciphertext.length);

--- a/src/kdc/kdc_util.h
+++ b/src/kdc/kdc_util.h
@@ -198,12 +198,6 @@ return_padata(krb5_context context, krb5_kdcpreauth_rock rock,
 void
 free_padata_context(krb5_context context, void *padata_context);
 
-krb5_error_code
-alloc_pa_data(krb5_preauthtype pa_type, size_t len, krb5_pa_data **out);
-
-krb5_error_code
-add_pa_data_element(krb5_pa_data ***list, krb5_pa_data *pa);
-
 /* kdc_preauth_ec.c */
 krb5_error_code
 kdcpreauth_encrypted_challenge_initvt(krb5_context context, int maj_ver,

--- a/src/lib/krb5/krb/Makefile.in
+++ b/src/lib/krb5/krb/Makefile.in
@@ -77,6 +77,7 @@ STLIBOBJS= \
 	mk_safe.o	\
 	pac.o		\
 	pac_sign.o	\
+	padata.o	\
 	parse.o		\
 	parse_host_string.o	\
 	plugin.o	\
@@ -190,6 +191,7 @@ OBJS=	$(OUTPRE)addr_comp.$(OBJEXT)	\
 	$(OUTPRE)mk_safe.$(OBJEXT)	\
 	$(OUTPRE)pac.$(OBJEXT)		\
 	$(OUTPRE)pac_sign.$(OBJEXT)	\
+	$(OUTPRE)padata.$(OBJEXT)	\
 	$(OUTPRE)parse.$(OBJEXT)	\
 	$(OUTPRE)parse_host_string.$(OBJEXT)	\
 	$(OUTPRE)plugin.$(OBJEXT)	\
@@ -303,6 +305,7 @@ SRCS=	$(srcdir)/addr_comp.c	\
 	$(srcdir)/mk_safe.c	\
 	$(srcdir)/pac.c		\
 	$(srcdir)/pac_sign.c	\
+	$(srcdir)/padata.c	\
 	$(srcdir)/parse.c	\
 	$(srcdir)/parse_host_string.c	\
 	$(srcdir)/plugin.c	\

--- a/src/lib/krb5/krb/fast.c
+++ b/src/lib/krb5/krb/fast.c
@@ -618,23 +618,6 @@ krb5int_fast_free_state(krb5_context context,
     free(state);
 }
 
-krb5_pa_data *
-krb5int_find_pa_data(krb5_context context, krb5_pa_data *const *padata,
-                     krb5_preauthtype pa_type)
-{
-    krb5_pa_data * const *tmppa;
-
-    if (padata == NULL)
-        return NULL;
-
-    for (tmppa = padata; *tmppa != NULL; tmppa++) {
-        if ((*tmppa)->pa_type == pa_type)
-            break;
-    }
-
-    return *tmppa;
-}
-
 /*
  * Implement FAST negotiation as specified in RFC 6806 section 11.  If
  * the encrypted part of rep sets the enc-pa-rep flag, look for and

--- a/src/lib/krb5/krb/get_in_tkt.c
+++ b/src/lib/krb5/krb/get_in_tkt.c
@@ -402,40 +402,6 @@ make_preauth_list(krb5_context  context,
 
 #define MAX_IN_TKT_LOOPS 16
 
-/* Add a pa-data item with the specified type and contents to *padptr. */
-static krb5_error_code
-add_padata(krb5_pa_data ***padptr, krb5_preauthtype pa_type,
-           const void *contents, unsigned int length)
-{
-    size_t size = 0;
-    krb5_pa_data **pad = *padptr;
-    krb5_pa_data *pa= NULL;
-    if (pad)
-        for (size=0; pad[size]; size++);
-    pad = realloc(pad, sizeof(*pad)*(size+2));
-    if (pad == NULL)
-        return ENOMEM;
-    *padptr = pad;
-    pad[size] = pad[size + 1] = NULL;
-
-    pa = malloc(sizeof(krb5_pa_data));
-    if (pa == NULL)
-        return ENOMEM;
-    pa->contents = NULL;
-    pa->length = length;
-    if (contents != NULL) {
-        pa->contents = malloc(length);
-        if (pa->contents == NULL) {
-            free(pa);
-            return ENOMEM;
-        }
-        memcpy(pa->contents, contents, length);
-    }
-    pa->pa_type = pa_type;
-    pad[size] = pa;
-    return 0;
-}
-
 /* Sort a pa_data sequence so that types named in the "preferred_preauth_types"
  * libdefaults entry are listed before any others. */
 static krb5_error_code
@@ -1300,8 +1266,8 @@ maybe_add_pac_request(krb5_context context, krb5_init_creds_context ctx)
     code = encode_krb5_pa_pac_req(&pac_req, &encoded);
     if (code)
         return code;
-    code = add_padata(&ctx->request->padata, KRB5_PADATA_PAC_REQUEST,
-                      encoded->data, encoded->length);
+    code = k5_add_pa_data_from_data(&ctx->request->padata,
+                                    KRB5_PADATA_PAC_REQUEST, encoded);
     krb5_free_data(context, encoded);
     return code;
 }
@@ -1313,6 +1279,7 @@ init_creds_step_request(krb5_context context,
 {
     krb5_error_code code;
     krb5_preauthtype pa_type;
+    krb5_data copy;
     struct errinfo save = EMPTY_ERRINFO;
     uint32_t rcode = (ctx->err_reply == NULL) ? 0 : ctx->err_reply->error;
 
@@ -1414,21 +1381,25 @@ init_creds_step_request(krb5_context context,
         ctx->encoded_previous_request = NULL;
     }
     if (ctx->info_pa_permitted) {
-        code = add_padata(&ctx->request->padata, KRB5_PADATA_AS_FRESHNESS,
-                          NULL, 0);
+        code = k5_add_empty_pa_data(&ctx->request->padata,
+                                    KRB5_PADATA_AS_FRESHNESS);
         if (code)
             goto cleanup;
-        code = add_padata(&ctx->request->padata, KRB5_ENCPADATA_REQ_ENC_PA_REP,
-                          NULL, 0);
+        code = k5_add_empty_pa_data(&ctx->request->padata,
+                                    KRB5_ENCPADATA_REQ_ENC_PA_REP);
     }
     if (code)
         goto cleanup;
 
     if (ctx->subject_cert != NULL) {
-        code = add_padata(&ctx->request->padata, KRB5_PADATA_S4U_X509_USER,
-                          ctx->subject_cert->data, ctx->subject_cert->length);
+        code = krb5int_copy_data_contents(context, ctx->subject_cert, &copy);
         if (code)
-            return code;
+            goto cleanup;
+        code = k5_add_pa_data_from_data(&ctx->request->padata,
+                                        KRB5_PADATA_S4U_X509_USER, &copy);
+        krb5_free_data_contents(context, &copy);
+        if (code)
+            goto cleanup;
     }
 
     code = maybe_add_pac_request(context, ctx);

--- a/src/lib/krb5/krb/padata.c
+++ b/src/lib/krb5/krb/padata.c
@@ -1,0 +1,127 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* lib/krb5/krb/padata.c - utility functions for krb5_pa_data lists */
+/*
+ * Copyright (C) 2019 by the Massachusetts Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "k5-int.h"
+
+krb5_pa_data *
+krb5int_find_pa_data(krb5_context context, krb5_pa_data *const *pa_list,
+                     krb5_preauthtype pa_type)
+{
+    krb5_pa_data *const *pa;
+
+    for (pa = pa_list; pa != NULL && *pa != NULL; pa++) {
+        if ((*pa)->pa_type == pa_type)
+            return *pa;
+    }
+    return NULL;
+}
+
+krb5_error_code
+k5_alloc_pa_data(krb5_preauthtype pa_type, size_t len, krb5_pa_data **out)
+{
+    krb5_pa_data *pa;
+    uint8_t *buf = NULL;
+
+    *out = NULL;
+    if (len > 0) {
+        buf = malloc(len);
+        if (buf == NULL)
+            return ENOMEM;
+    }
+    pa = malloc(sizeof(*pa));
+    if (pa == NULL) {
+        free(buf);
+        return ENOMEM;
+    }
+    pa->magic = KV5M_PA_DATA;
+    pa->pa_type = pa_type;
+    pa->length = len;
+    pa->contents = buf;
+    *out = pa;
+    return 0;
+}
+
+void
+k5_free_pa_data_element(krb5_pa_data *pa)
+{
+    if (pa != NULL) {
+        free(pa->contents);
+        free(pa);
+    }
+}
+
+krb5_error_code
+k5_add_pa_data_element(krb5_pa_data ***list, krb5_pa_data **pa)
+{
+    size_t count;
+    krb5_pa_data **newlist;
+
+    for (count = 0; *list != NULL && (*list)[count] != NULL; count++);
+
+    newlist = realloc(*list, (count + 2) * sizeof(*newlist));
+    if (newlist == NULL)
+        return ENOMEM;
+    newlist[count] = *pa;
+    newlist[count + 1] = NULL;
+    *pa = NULL;
+    *list = newlist;
+    return 0;
+}
+
+krb5_error_code
+k5_add_pa_data_from_data(krb5_pa_data ***list, krb5_preauthtype pa_type,
+                         krb5_data *data)
+{
+    krb5_error_code ret;
+    krb5_pa_data *pa;
+
+    ret = k5_alloc_pa_data(pa_type, 0, &pa);
+    if (ret)
+        return ret;
+    pa->contents = (uint8_t *)data->data;
+    pa->length = data->length;
+    ret = k5_add_pa_data_element(list, &pa);
+    if (ret) {
+        free(pa);
+        return ret;
+    }
+    *data = empty_data();
+    return 0;
+}
+
+krb5_error_code
+k5_add_empty_pa_data(krb5_pa_data ***list, krb5_preauthtype pa_type)
+{
+    krb5_data empty = empty_data();
+
+    return k5_add_pa_data_from_data(list, pa_type, &empty);
+}

--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -117,6 +117,10 @@ initialize_krb5_error_table
 initialize_k5e1_error_table
 initialize_kv5m_error_table
 initialize_prof_error_table
+k5_add_empty_pa_data
+k5_add_pa_data_element
+k5_add_pa_data_from_data
+k5_alloc_pa_data
 k5_authind_decode
 k5_build_conf_principals
 k5_ccselect_free_context
@@ -129,6 +133,7 @@ k5_free_cammac
 k5_free_data_ptr_list
 k5_free_otp_tokeninfo
 k5_free_kkdcp_message
+k5_free_pa_data_element
 k5_free_pa_otp_challenge
 k5_free_pa_otp_req
 k5_free_secure_cookie


### PR DESCRIPTION
After recent discussion in PR #912 I came up with this.  The pattern here is that we only claim memory on success, but null out the caller's pointer when we do so, allowing the caller to free unconditionally.

I am particularly fond of k5_add_pa_data_from_data(), as it simplifies many call sites where we just constructed an ASN.1 encoding.  I wish its name weren't so long, as every call also includes a relatively long constant name for the pa-data type and that eats up 80 columns very quickly.  But it's hard to come up with a shorter name which is even vaguely evocative of what it does.

k5_free_pa_data_element() is a slightly awkward name when compared to k5_alloc_pa_data().  My intent is to avoid confusion with krb5_free_pa_data() which frees a whole list.

I didn't touch preauth2.c, even the call site which adds a single element, because that file currently tracks the size along with the list and the new helpers do not.

One call site gets more verbose, where we copy the subject cert data into pa-data, and need to explicitly make a copy.  It's not too bad, though.