### PR TITLE
Improve logging documentation

### DIFF
--- a/doc/admin/conf_files/kdc_conf.rst
+++ b/doc/admin/conf_files/kdc_conf.rst
@@ -642,16 +642,19 @@ Logging specifications may have the following forms:
     facility is specified, the default is **AUTH**.
 
 In the following example, the logging messages from the KDC will go to
-the console and to the system log under the facility LOG_DAEMON with
-default severity of LOG_INFO; and the logging messages from the
-administrative server will be appended to the file
-``/var/adm/kadmin.log`` and sent to the device ``/dev/tty04``. ::
+the console and to the system log under the facility LOG_DAEMON, and
+the logging messages from the administrative server will be appended
+to the file ``/var/adm/kadmin.log`` and sent to the device
+``/dev/tty04``. ::
 
     [logging]
         kdc = CONSOLE
         kdc = SYSLOG:INFO:DAEMON
         admin_server = FILE:/var/adm/kadmin.log
         admin_server = DEVICE=/dev/tty04
+
+If no logging specification is given, the default is to use syslog.
+To disable logging entirely, specify ``default = DEVICE=/dev/null``.
 
 
 .. _otp:


### PR DESCRIPTION
The default severity was removed by commit
6ce8fd4cfa2e9b1e92debd204a5b2ddf053cca55 (ticket 8630) but the example
still talks about it; remove that text.  Add a note about the default
being syslog if nothing else is specified, and a note on how to
disable logging.
