### PR TITLE
Squashing Coverity NEGATIVE_RETURNS strerror defects

### DIFF
--- a/src/util/support/errors.c
+++ b/src/util/support/errors.c
@@ -78,10 +78,9 @@ k5_get_error(struct errinfo *ep, long code)
 
     lock();
     if (fptr == NULL) {
+        /* Should be rare; fptr should be set whenever libkrb5 is loaded. */
         unlock();
-        if (strerror_r(code, buf, sizeof(buf)) == 0)
-            return oom_check(strdup(buf));
-        return oom_check(strdup(strerror(code)));
+        return oom_check(strdup(_("Error code translation unavailable")));
     }
     r = fptr(code);
 #ifndef HAVE_COM_ERR_INTL


### PR DESCRIPTION
We have about four dozen NEGATIVE_RETURNS defects in Coverity scan, most of which are of the form "hey, I noticed that com_err codes can be negative, and you're passing one to k5_get_error() via krb5_get_error_message() or something, and that function can use strerror(), which can't accept a negative number".

This is aggravating because:

* As far as I can tell Coverity is wrong.  strerror() and strerror_r() have defined behavior for any integer, and will say "Unknown error -1" or similar on negative numbers.

* The relevant code in k5_get_error() only triggers if fptr is NULL, which we do not expect to happen in practice.  libkrb5 sets fptr to error_message() at library initialization time and back to NULL at finalization time.  libkrb5support has no public API, so k5_get_error() should only get invoked via libkrb5.  (error_message() can also call strerror() internally, but since a dynamic function call is involved, Coverity won't report defects about that.)

* New defects will keep cropping up with every new use of krb5_get_error_message() or similar.

I have a placeholder commit in this PR for now, but I am also considering the option of removing the strerror() and strerror_r() calls from the `fptr == NULL` case and returning a fixed string.