### PR TITLE
Use krb5_flags_to_strings() in kproplog

### DIFF
--- a/src/kprop/deps
+++ b/src/kprop/deps
@@ -56,7 +56,7 @@ $(OUTPRE)kproplog.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
   $(BUILDTOP)/include/kadm5/admin.h $(BUILDTOP)/include/kadm5/chpass_util_strings.h \
   $(BUILDTOP)/include/kadm5/kadm_err.h $(BUILDTOP)/include/krb5/krb5.h \
   $(BUILDTOP)/include/osconf.h $(BUILDTOP)/include/profile.h \
-  $(COM_ERR_DEPS) $(top_srcdir)/include/gssrpc/auth.h \
+  $(COM_ERR_DEPS) $(top_srcdir)/include/adm_proto.h $(top_srcdir)/include/gssrpc/auth.h \
   $(top_srcdir)/include/gssrpc/auth_gss.h $(top_srcdir)/include/gssrpc/auth_unix.h \
   $(top_srcdir)/include/gssrpc/clnt.h $(top_srcdir)/include/gssrpc/rename.h \
   $(top_srcdir)/include/gssrpc/rpc.h $(top_srcdir)/include/gssrpc/rpc_msg.h \

--- a/src/kprop/kproplog.c
+++ b/src/kprop/kproplog.c
@@ -19,6 +19,7 @@
 #include <syslog.h>
 #include <kdb_log.h>
 #include <kadm5/admin.h>
+#include <adm_proto.h>
 
 static char *progname;
 
@@ -36,38 +37,17 @@ usage()
 static void
 print_flags(unsigned int flags)
 {
-    unsigned int i;
-    static char *prflags[] = {
-        "DISALLOW_POSTDATED",     /* 0x00000001 */
-        "DISALLOW_FORWARDABLE",   /* 0x00000002 */
-        "DISALLOW_TGT_BASED",     /* 0x00000004 */
-        "DISALLOW_RENEWABLE",     /* 0x00000008 */
-        "DISALLOW_PROXIABLE",     /* 0x00000010 */
-        "DISALLOW_DUP_SKEY",      /* 0x00000020 */
-        "DISALLOW_ALL_TIX",       /* 0x00000040 */
-        "REQUIRES_PRE_AUTH",      /* 0x00000080 */
-        "REQUIRES_HW_AUTH",       /* 0x00000100 */
-        "REQUIRES_PWCHANGE",      /* 0x00000200 */
-        "UNKNOWN_0x00000400",     /* 0x00000400 */
-        "UNKNOWN_0x00000800",     /* 0x00000800 */
-        "DISALLOW_SVR",           /* 0x00001000 */
-        "PWCHANGE_SERVICE",       /* 0x00002000 */
-        "SUPPORT_DESMD5",         /* 0x00004000 */
-        "NEW_PRINC",              /* 0x00008000 */
-        "UNKNOWN_0x00010000",     /* 0x00010000 */
-        "UNKNOWN_0x00020000",     /* 0x00020000 */
-        "UNKNOWN_0x00040000",     /* 0x00040000 */
-        "UNKNOWN_0x00080000",     /* 0x00080000 */
-        "OK_AS_DELEGATE",         /* 0x00100000 */
-        "OK_TO_AUTH_AS_DELEGATE", /* 0x00200000 */
-        "NO_AUTH_DATA_REQUIRED",  /* 0x00400000 */
+    char **attrstrs, **sp;
 
-    };
-
-    for (i = 0; i < sizeof(prflags) / sizeof(*prflags); i++) {
-        if (flags & (krb5_flags)(1 << i))
-            printf("\t\t\t%s\n", prflags[i]);
+    if (krb5_flags_to_strings(flags, &attrstrs) != 0) {
+        printf("\t\t\t(error)\n");
+        return;
     }
+    for (sp = attrstrs; sp != NULL && *sp != NULL; sp++) {
+        printf("\t\t\t%s\n", *sp);
+        free(*sp);
+    }
+    free(attrstrs);
 }
 
 /* ctime() for uint32_t* */


### PR DESCRIPTION
[Noticed while reviewing PR #912]

Remove the local flags table in kproplog.c and instead use
krb5_flags_to_strings(), as was done for kadmin.c in commit
971fae8285427b27dfd8c9a535a18eb588ee0689.
