### PR TITLE
New leash API to prevent show change password window using LEASHDLL

### DIFF
--- a/src/windows/include/leashwin.h
+++ b/src/windows/include/leashwin.h
@@ -205,6 +205,9 @@ DWORD Leash_reset_default_mslsa_import();
 DWORD Leash_get_default_preserve_kinit_settings();
 DWORD Leash_set_default_preserve_kinit_settings(DWORD onoff);
 DWORD Leash_reset_default_preserve_kinit_settings();
+DWORD Leash_get_show_password_prompt();
+DWORD Leash_set_show_password_prompt(DWORD onoff);
+DWORD Leash_reset_show_password_prompt();
 #ifdef __cplusplus
 }
 #endif

--- a/src/windows/include/loadfuncs-leash.h
+++ b/src/windows/include/loadfuncs-leash.h
@@ -372,6 +372,24 @@ TYPEDEF_FUNC(
     Leash_reset_defaults,
     (void)
     );
+TYPEDEF_FUNC(
+    DWORD,
+    CALLCONV_C,
+    Leash_reset_show_password_prompt,
+    (void)
+    );
+TYPEDEF_FUNC(
+    DWORD,
+    CALLCONV_C,
+    Leash_set_show_password_prompt,
+    (DWORD)
+    );
+TYPEDEF_FUNC(
+    DWORD,
+    CALLCONV_C,
+    Leash_get_show_password_prompt,
+    (void)
+    );		
 /* They are not yet all here... */
 
 #endif /* __LOADFUNCS_LEASH_H__ */

--- a/src/windows/leash/Leash.cpp
+++ b/src/windows/leash/Leash.cpp
@@ -489,6 +489,8 @@ DECL_FUNC_PTR(Leash_get_default_mslsa_import);
 DECL_FUNC_PTR(Leash_import);
 DECL_FUNC_PTR(Leash_importable);
 DECL_FUNC_PTR(Leash_renew);
+DECL_FUNC_PTR(Leash_get_show_password_prompt);
+DECL_FUNC_PTR(Leash_set_show_password_prompt);
 
 FUNC_INFO leash_fi[] = {
     MAKE_FUNC_INFO(Leash_kdestroy),
@@ -503,6 +505,8 @@ FUNC_INFO leash_fi[] = {
     MAKE_FUNC_INFO(Leash_import),
     MAKE_FUNC_INFO(Leash_importable),
     MAKE_FUNC_INFO(Leash_renew),
+	MAKE_FUNC_INFO(Leash_get_show_password_prompt),	
+	MAKE_FUNC_INFO(Leash_set_show_password_prompt),	
     END_FUNC_INFO
 };
 

--- a/src/windows/leash/Lglobals.h
+++ b/src/windows/leash/Lglobals.h
@@ -72,7 +72,8 @@ extern DECL_FUNC_PTR(Leash_get_default_mslsa_import);
 extern DECL_FUNC_PTR(Leash_import);
 extern DECL_FUNC_PTR(Leash_importable);
 extern DECL_FUNC_PTR(Leash_renew);
-
+extern DECL_FUNC_PTR(Leash_get_show_password_prompt);
+extern DECL_FUNC_PTR(Leash_set_show_password_prompt);
 // psapi functions
 extern DECL_FUNC_PTR(GetModuleFileNameExA);
 extern DECL_FUNC_PTR(EnumProcessModules);

--- a/src/windows/leashdll/krb5routines.c
+++ b/src/windows/leashdll/krb5routines.c
@@ -243,7 +243,10 @@ DWORD                       publicIP
 	pkrb5_get_init_creds_opt_set_proxiable(options,
                                            proxiable ? 1 : 0);
 	pkrb5_get_init_creds_opt_set_renew_life(options,
-                                            renew_life);
+                                            renew_life);											
+	pkrb5_get_init_creds_opt_set_change_password_prompt(options, 
+														Leash_get_show_password_prompt());											
+														
     if (addressless)
         pkrb5_get_init_creds_opt_set_address_list(options,NULL);
     else {

--- a/src/windows/leashdll/leash-int.h
+++ b/src/windows/leashdll/leash-int.h
@@ -264,6 +264,7 @@ cc_free_NC_info,
 #define LEASH_REGISTRY_VALUE_RENEW_MIN "renew_min"
 #define LEASH_REGISTRY_VALUE_RENEW_MAX "renew_max"
 #define LEASH_REGISTRY_VALUE_PRESERVE_KINIT "preserve_kinit_options"
+#define LEASH_REGISTRY_VALUE_SHOW_PASSWORD_PROMPT "show_password_prompt"
 
 /* must match values used within krb5_32.dll */
 #define KRB5_REGISTRY_KEY_NAME "Software\\MIT\\Kerberos5"

--- a/src/windows/leashdll/leashdll.c
+++ b/src/windows/leashdll/leashdll.c
@@ -26,6 +26,7 @@ DECL_FUNC_PTR(krb5_get_init_creds_opt_set_forwardable);
 DECL_FUNC_PTR(krb5_get_init_creds_opt_set_proxiable);
 DECL_FUNC_PTR(krb5_get_init_creds_opt_set_address_list);
 DECL_FUNC_PTR(krb5_get_init_creds_opt_set_out_ccache);
+DECL_FUNC_PTR(krb5_get_init_creds_opt_set_change_password_prompt);
 DECL_FUNC_PTR(krb5_get_init_creds_password);
 DECL_FUNC_PTR(krb5_build_principal_ext);
 DECL_FUNC_PTR(krb5_cc_get_name);

--- a/src/windows/leashdll/leashdll.h
+++ b/src/windows/leashdll/leashdll.h
@@ -78,6 +78,7 @@ extern DECL_FUNC_PTR(krb5_get_init_creds_opt_set_proxiable);
 extern DECL_FUNC_PTR(krb5_get_init_creds_opt_set_renew_life);
 extern DECL_FUNC_PTR(krb5_get_init_creds_opt_set_address_list);
 extern DECL_FUNC_PTR(krb5_get_init_creds_opt_set_out_ccache);
+extern DECL_FUNC_PTR(krb5_get_init_creds_opt_set_change_password_prompt);
 extern DECL_FUNC_PTR(krb5_get_init_creds_password);
 extern DECL_FUNC_PTR(krb5_build_principal_ext);
 extern DECL_FUNC_PTR(krb5_cc_get_name);

--- a/src/windows/leashdll/leashw32.def
+++ b/src/windows/leashdll/leashw32.def
@@ -69,6 +69,9 @@ EXPORTS
     Leash_importable
     Leash_renew
     Leash_reset_defaults
-
+	Leash_get_show_password_prompt		
+	Leash_set_show_password_prompt
+	Leash_reset_show_password_prompt	
+	
 	; XXX - These have to go...
     not_an_API_Leash_AcquireInitialTicketsIfNeeded

--- a/src/windows/leashdll/lshfunc.c
+++ b/src/windows/leashdll/lshfunc.c
@@ -2336,6 +2336,71 @@ Leash_get_default_preserve_kinit_settings(
     return 1;
 }
 
+static
+BOOL
+get_show_password_prompt(
+    HKEY hBaseKey,
+    DWORD * result
+    )
+{
+    return get_DWORD_from_registry(hBaseKey,
+                                   LEASH_REGISTRY_KEY_NAME,
+                                   LEASH_REGISTRY_VALUE_SHOW_PASSWORD_PROMPT,
+                                   result);
+}
+
+DWORD
+Leash_reset_show_password_prompt(
+    )
+{
+    HKEY hKey;
+    LONG rc;
+
+    rc = RegOpenKeyEx(HKEY_CURRENT_USER, LEASH_SETTINGS_REGISTRY_KEY_NAME, 0, KEY_WRITE, &hKey);
+    if (rc)
+        return rc;
+
+    rc = RegDeleteValue(hKey, LEASH_REGISTRY_VALUE_SHOW_PASSWORD_PROMPT);
+    RegCloseKey(hKey);
+
+    return rc;
+}
+
+DWORD
+Leash_set_show_password_prompt(
+    DWORD onoff
+    )
+{
+    HKEY hKey;
+    LONG rc;
+
+    rc = RegCreateKeyEx(HKEY_CURRENT_USER, LEASH_REGISTRY_KEY_NAME, 0,
+                        0, 0, KEY_WRITE, 0, &hKey, 0);
+    if (rc)
+        return rc;
+
+    rc = RegSetValueEx(hKey, LEASH_REGISTRY_VALUE_SHOW_PASSWORD_PROMPT, 0, REG_DWORD,
+                       (LPBYTE) &onoff, sizeof(DWORD));
+    RegCloseKey(hKey);
+
+    return rc;
+}
+
+DWORD
+Leash_get_show_password_prompt(
+    )
+{
+    HMODULE hmLeash;
+    DWORD result;
+
+    if (get_show_password_prompt(HKEY_CURRENT_USER, &result) ||
+        get_show_password_prompt(HKEY_LOCAL_MACHINE, &result))
+    {
+        return result;
+    }	
+    return 0;
+}
+
 void
 Leash_reset_defaults(void)
 {
@@ -2354,6 +2419,7 @@ Leash_reset_defaults(void)
     Leash_reset_default_uppercaserealm();
     Leash_reset_default_mslsa_import();
     Leash_reset_default_preserve_kinit_settings();
+	Leash_reset_show_password_prompt();
 }
 
 static void


### PR DESCRIPTION
Hello,
We created a new leash API to prevent show the "change password window" in LEASH_KINIT and return control to call program. This new API is called:
Leash_set_show_password_prompt(DWORD onoff).
For implement this solution we use the unused existing API:
krb5_get_init_creds opt_set change_password prompt.