### PR TITLE
Fix doc for krb5.conf file

### DIFF
--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -35,17 +35,11 @@ or::
         baz = quux
     }
 
-Placing a '\*' at the end of a line indicates that this is the *final*
-value for the tag.  This means that neither the remainder of this
-configuration file nor any other configuration file will be checked
-for any other values for this tag.
-
-For example, if you have the following lines::
-
-    foo = bar*
-    foo = baz
-
-then the second value of ``foo`` (``baz``) would never be read.
+Placing a '\*' after the closing bracket of a section name indicates
+that the section is *final*, meaning that if the same section appears
+within a later file specified in **KRB5_CONFIG**, it will be ignored.
+A subsection can be marked as final by placing a '\*' after either the
+tag name or the closing brace.
 
 The krb5.conf file can include other files using either of the
 following directives at the beginning of a line::

--- a/src/util/profile/Makefile.in
+++ b/src/util/profile/Makefile.in
@@ -129,7 +129,7 @@ profile_tcl: profile_tcl.o $(PROF_DEPLIB) $(COM_ERR_DEPLIB) $(SUPPORT_DEPLIB)
 clean-unix:: clean-libs clean-libobjs
 	$(RM) $(PROGS) *.o *~ core prof_err.h profile.h prof_err.c
 	$(RM) test_load test_parse test_profile test_vtable profile_tcl
-	$(RM) modtest.conf testinc.ini testinc2.ini
+	$(RM) modtest.conf testinc.ini testinc2.ini final.out
 	$(RM) -r test_include_dir
 
 clean-windows::
@@ -140,7 +140,23 @@ check-unix: test_parse test_profile test_vtable test_load modtest.conf
 	$(RUN_TEST) ./test_load
 
 DO_TCL=@DO_TCL@
-check-unix: check-unix-tcl-$(DO_TCL)
+check-unix: check-unix-final check-unix-tcl-$(DO_TCL)
+
+F1=$(srcdir)/final1.ini
+F2=$(srcdir)/final2.ini
+F3=$(srcdir)/final3.ini
+F4=$(srcdir)/final4.ini
+F5=$(srcdir)/final5.ini
+QUERY=query section subsection key
+check-unix-final: test_profile
+	$(RM) final.out
+	(echo; $(RUN_TEST) ./test_profile $(F1):$(F1) $(QUERY)) > final.out
+	(echo; $(RUN_TEST) ./test_profile $(F2):$(F1) $(QUERY)) >> final.out
+	(echo; $(RUN_TEST) ./test_profile $(F3):$(F1) $(QUERY)) >> final.out
+	(echo; $(RUN_TEST) ./test_profile $(F4):$(F1) $(QUERY)) >> final.out
+	(echo; $(RUN_TEST) ./test_profile $(F5):$(F1) $(QUERY)) >> final.out
+	cmp final.out $(srcdir)/final.expected
+	$(RM) final.out
 
 check-unix-tcl-:
 	@echo "+++"

--- a/src/util/profile/final.expected
+++ b/src/util/profile/final.expected
@@ -1,0 +1,12 @@
+
+value1
+value1
+
+value2
+value1
+
+value3
+
+value4
+
+value5

--- a/src/util/profile/final1.ini
+++ b/src/util/profile/final1.ini
@@ -1,0 +1,6 @@
+# A basic profile setting a single relation in a subsection, with
+# nothing marked final.
+[section]
+	subsection = {
+		key = value1
+	}

--- a/src/util/profile/final2.ini
+++ b/src/util/profile/final2.ini
@@ -1,0 +1,7 @@
+# In this variant the relation is marked final.  There is parsing
+# support for this but no iteration or dumping support, so the marker
+# currently has no effect.
+[section]
+	subsection = {
+		key* = value2
+	}

--- a/src/util/profile/final3.ini
+++ b/src/util/profile/final3.ini
@@ -1,0 +1,6 @@
+# In this variant the subsection is marked final via a '*' at the end
+# of the tag name.
+[section]
+	subsection* = {
+		key = value3
+	}

--- a/src/util/profile/final4.ini
+++ b/src/util/profile/final4.ini
@@ -1,0 +1,6 @@
+# In this variant the subsection is marked final via a '*' after the
+# closing brace.
+[section]
+	subsection = {
+		key = value4
+	}*

--- a/src/util/profile/final5.ini
+++ b/src/util/profile/final5.ini
@@ -1,0 +1,5 @@
+# In this variant the top-level section is marked final.
+[section]*
+	subsection = {
+		key = value5
+	}


### PR DESCRIPTION
The documentation for krb5.conf explaining how tags are marked as final
is incorrect.

http://mailman.mit.edu/pipermail/krbdev/2019-July/013131.html