### PR TITLE
Fix test suite issues affecting Travis images

### DIFF
--- a/src/appl/simple/server/sim_server.c
+++ b/src/appl/simple/server/sim_server.c
@@ -69,10 +69,8 @@ main(int argc, char *argv[])
     int flags = 0;                      /* for recvfrom() */
     int on = 1;
     struct servent *serv;
-    struct hostent *host;
     struct sockaddr_in s_sock;          /* server's address */
     struct sockaddr_in c_sock;          /* client's address */
-    char full_hname[MAXHOSTNAMELEN];
     char *cp;
     extern char * optarg;
     int ch;
@@ -133,6 +131,7 @@ main(int argc, char *argv[])
     /* Set up server address */
     memset(&s_sock, 0, sizeof(s_sock));
     s_sock.sin_family = AF_INET;
+    s_sock.sin_addr.s_addr = INADDR_ANY;
 
     if (port == 0) {
         /* Look up service */
@@ -144,17 +143,6 @@ main(int argc, char *argv[])
     } else {
         s_sock.sin_port = htons(port);
     }
-
-    if (gethostname(full_hname, sizeof(full_hname)) < 0) {
-        perror("gethostname");
-        exit(1);
-    }
-
-    if ((host = gethostbyname(full_hname)) == (struct hostent *)0) {
-        fprintf(stderr, "%s: host unknown\n", full_hname);
-        exit(1);
-    }
-    memcpy(&s_sock.sin_addr, host->h_addr, sizeof(s_sock.sin_addr));
 
     /* Open socket */
     if ((sock = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {

--- a/src/kadmin/testing/scripts/qualname.plin
+++ b/src/kadmin/testing/scripts/qualname.plin
@@ -1,19 +1,20 @@
-#!/afs/athena/contrib/perl/p
+#!/usr/bin/perl
+use Socket qw(:addrinfo);
+use strict;
 
+my $hostname;
 if ($#ARGV == -1) {
     chop($hostname = `hostname`);
 } else {
     $hostname = $ARGV[0];
 }
 
-if (! (($name,$type,$addr) = (gethostbyname($hostname))[0,2,4])) {
-    print STDERR "No such host: $hostname\n";
-    exit(1);
-}
-if (! ($qualname = (gethostbyaddr($addr,$type))[0])) {
-    $qualname = $name;
-}
+my ($gaerr, @addrs) = getaddrinfo($hostname, "", {flags => AI_CANONNAME});
+die "No such host: $hostname ($gaerr)" if $gaerr;
+my ($canonname, $addr) = ($addrs[0]->{canonname}, $addrs[0]->{addr});
+
+my ($gnerr, $name, $servicename) = getnameinfo($addr, NI_NAMEREQD);
+my $qualname = $gnerr ? $name : $name;
 
 $qualname =~ tr/A-Z/a-z/;	# lowercase our name for keytab use.
 print "$qualname\n";
-

--- a/src/tests/gssapi/t_ccselect.py
+++ b/src/tests/gssapi/t_ccselect.py
@@ -76,8 +76,9 @@ r1.addprinc(bob, password('bob'))
 r2.addprinc(zaphod, password('zaphod'))
 
 # Create host principals and keytabs for fallback realm tests.
-r1.addprinc('host/localhost')
-r2.addprinc('host/localhost')
+if hostname != 'localhost':
+    r1.addprinc('host/localhost')
+    r2.addprinc('host/localhost')
 r1.addprinc('host/' + foo)
 r2.addprinc('host/' + foo2)
 r1.addprinc('host/' + foobar)

--- a/src/tests/resolve/Makefile.in
+++ b/src/tests/resolve/Makefile.in
@@ -8,7 +8,7 @@ SRCS=$(srcdir)/resolve.c $(srcdir)/addrinfo-test.c \
 all: resolve addrinfo-test fake-addrinfo-test
 
 resolve: resolve.o
-	$(CC_LINK) -o $@ resolve.o $(LIBS)
+	$(CC_LINK) -o $@ resolve.o $(SUPPORT_LIB) $(LIBS)
 
 addrinfo-test: addrinfo-test.o
 	$(CC_LINK) -o $@ addrinfo-test.o $(SUPPORT_LIB) $(LIBS)


### PR DESCRIPTION
In the utilities used by the dejagnu test suites, use
getaddrinfo()/getnameinfo() instead of
gethostbyname()/gethostbyaddr(), as the results can vary when the
local hostname appears in multiple lines in /etc/hosts.

In t_ccselect.py, don't cause an error if the canonicalized local
hostname is "localhost".  The tests will continue to run in this case,
as long as we don't try to create duplicate principals.

In sim_server.c, bind to the wildcard address instead of the resolved
local hostname, to resolve a mysterious problem observed in Travis
where the second of three sim_client send() operations fails with
ECONNREFUSED.