### PR TITLE
Convert remaining Python scripts to Python 3

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -495,7 +495,7 @@ check-unix: check-lmdb-$(HAVE_LMDB)
 	cat $(SKIPTESTS)
 
 check-pytests-no: check-postrecurse
-	@echo 'Skipped python test scripts: python 2.5 or later required' >> \
+	@echo 'Skipped python test scripts: python 3 required' >> \
 		$(SKIPTESTS)
 
 check-cmocka-no: check-postrecurse
@@ -567,7 +567,6 @@ coverity prevent cov: Makefiles
 FIND = find
 XARGS = xargs
 EMACS = emacs
-PYTHON = python
 
 INDENTDIRS = \
 	appl \
@@ -671,7 +670,7 @@ mark-cstyle-bsd:
 check-copyright:
 	(cd $(top_srcdir) && \
 	$(FIND) . \( -name '*.[ch]' -o -name '*.hin' \) -print0 | \
-	$(XARGS) -0 python util/krb5-check-copyright.py)
+	$(XARGS) -0 $(PYTHON) util/krb5-check-copyright.py)
 
 tags: FORCE
 	(cd $(top_srcdir) && \

--- a/src/util/cstyle-file.py
+++ b/src/util/cstyle-file.py
@@ -57,7 +57,7 @@ from subprocess import call
 from tempfile import NamedTemporaryFile
 
 def warn(ln, msg):
-    print '%5d  %s' % (ln, msg)
+    print('%5d  %s' % (ln, msg))
 
 
 # If lines[0] indicates the krb5 C style, try to use emacs to reindent
@@ -70,7 +70,7 @@ def emacs_reindent(lines):
     util_dir = os.path.dirname(sys.argv[0])
     cstyle_el = os.path.join(util_dir, 'krb5-c-style.el')
     reindent_el = os.path.join(util_dir, 'krb5-batch-reindent.el')
-    with NamedTemporaryFile(suffix='.c') as f:
+    with NamedTemporaryFile(suffix='.c', mode='w+') as f:
         f.write(''.join(lines))
         f.flush()
         args = ['emacs', '-q', '-batch', '-l', cstyle_el, '-l', reindent_el,

--- a/src/util/cstyle.py
+++ b/src/util/cstyle.py
@@ -44,7 +44,7 @@ def usage():
 # Run a command and return a list of its output lines.
 def run(args):
     # subprocess.check_output would be ideal here, but requires Python 2.7.
-    p = Popen(args, stdout=PIPE, stderr=PIPE)
+    p = Popen(args, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     out, err = p.communicate()
     if p.returncode != 0:
         sys.stderr.write('Failed command: ' + ' '.join(args) + '\n')
@@ -85,8 +85,8 @@ def check_file(filename, rev, new_lines):
         p1 = Popen(['cat', filename], stdout=PIPE)
     else:
         p1 = Popen(['git', 'show', rev + ':' + filename], stdout=PIPE)
-    p2 = Popen(['python', 'src/util/cstyle-file.py'], stdin=p1.stdout,
-               stdout=PIPE)
+    p2 = Popen([sys.executable, 'src/util/cstyle-file.py'], stdin=p1.stdout,
+               stdout=PIPE, universal_newlines=True)
     p1.stdout.close()
     out, err = p2.communicate()
     if p2.returncode != 0:
@@ -97,9 +97,9 @@ def check_file(filename, rev, new_lines):
         m = line_re.match(line)
         if int(m.group(1)) in new_lines:
             if first:
-                print '  ' + dispname + ':'
+                print('  ' + dispname + ':')
                 first = False
-            print '    ' + line
+            print('    ' + line)
 
 
 # Determine the lines of each file modified by diff (a sequence of
@@ -153,8 +153,8 @@ def check_series(revlist):
 # Parse arguments.
 try:
     opts, args = getopt.getopt(sys.argv[1:], 'w')
-except getopt.GetoptError, err:
-    print str(err)
+except getopt.GetoptError as err:
+    print(str(err))
     usage()
 if len(args) > 1:
     usage()

--- a/src/util/krb5-check-copyright.py
+++ b/src/util/krb5-check-copyright.py
@@ -29,7 +29,7 @@ import sys
 import re
 
 def warn(fname, ln, msg):
-    print '%s: %d: %s' % (fname, ln + 1, msg)
+    print('%s: %d: %s' % (fname, ln + 1, msg))
 
 def indicates_license(line):
     return 'Copyright' in line or 'COPYRIGHT' in line or 'License' in line

--- a/src/util/krb5-mark-cstyle.py
+++ b/src/util/krb5-mark-cstyle.py
@@ -15,7 +15,7 @@ def dofile(fname, style):
     newname = fname + ".new"
     infile = open(fname)
     outfile = open(newname, "w")
-    first = infile.next()
+    first = next(infile)
     if (first != style):
         changed = True
         outfile.write(style)
@@ -43,5 +43,5 @@ parser.add_option("--cstyle", action="store", dest="style",
 (options, args) = parser.parse_args()
 
 for fname in args:
-    print fname
+    print(fname)
     dofile(fname, styles[options.style])

--- a/src/util/testrealm.py
+++ b/src/util/testrealm.py
@@ -68,16 +68,16 @@ pwfile = open(pwfilename, 'w')
 pwfile.write('user: %s\nadmin: %s\n' % (password('user'), password('admin')))
 pwfile.close()
 
-print
-print 'Realm files are in %s' % realm.testdir
-print 'KRB5_CONFIG is %s' % env['KRB5_CONFIG']
-print 'KRB5_KDC_PROFILE is %s' % env['KRB5_KDC_PROFILE']
-print 'KRB5CCNAME is %s' % env['KRB5CCNAME']
-print 'KRB5_KTNAME is %s' % env['KRB5_KTNAME']
-print 'KRB5RCACHEDIR is %s' % env['KRB5RCACHEDIR']
-print 'Password for user is %s (see also %s)' % (password('user'), pwfilename)
-print 'Password for admin is %s' % password('admin')
-print
+print()
+print('Realm files are in %s' % realm.testdir)
+print('KRB5_CONFIG is %s' % env['KRB5_CONFIG'])
+print('KRB5_KDC_PROFILE is %s' % env['KRB5_KDC_PROFILE'])
+print('KRB5CCNAME is %s' % env['KRB5CCNAME'])
+print('KRB5_KTNAME is %s' % env['KRB5_KTNAME'])
+print('KRB5RCACHEDIR is %s' % env['KRB5RCACHEDIR'])
+print('Password for user is %s (see also %s)' % (password('user'), pwfilename))
+print('Password for admin is %s' % password('admin'))
+print()
 
 subprocess.call([os.getenv('SHELL')], env=env)
 success('Create test krb5 realm.')


### PR DESCRIPTION
Commit e23d24beacb73581bbf4351250f3955e6fd44361 missed some Python
scripts, in part because of the "PYTHON = python" line in
src/Makefile.in from commit 7be2ef2b6c8c491781251a5023db48d7690f5fa8.
Remove that line and convert the remaining scripts.  Also fix the
check-pytests-no warning to mention Python 3 instead of Python 2.5.