### PR TITLE
Require Python 3.2.4 for test scripts

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -494,8 +494,9 @@ check-prerecurse: runenv.py
 check-unix: check-lmdb-$(HAVE_LMDB)
 	cat $(SKIPTESTS)
 
+MINPYTHON = @PYTHON_MINVERSION@
 check-pytests-no: check-postrecurse
-	@echo 'Skipped python test scripts: python 3 required' >> \
+	@echo 'Skipped python test scripts: python $(MINPYTHON) required' >> \
 		$(SKIPTESTS)
 
 check-cmocka-no: check-postrecurse

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1142,14 +1142,18 @@ else
 fi
 AC_SUBST(HAVE_RUNTEST)
 
-# For Python tests.
+# For Python tests.  Python version 3.2.4 is required as prior
+# versions do not accept string input to subprocess.Popen.communicate
+# when universal_newlines is set.
+PYTHON_MINVERSION=3.2.4
+AC_SUBST(PYTHON_MINVERSION)
 AC_CHECK_PROG(PYTHON,python3,python3)
 if test x"$PYTHON" = x; then
 	AC_CHECK_PROG(PYTHON,python,python)
 fi
 HAVE_PYTHON=no
 if test x"$PYTHON" != x; then
-	wantver="(sys.hexversion >= 0x3000000)"
+	wantver="(sys.hexversion >= 0x30204F0)"
 	if "$PYTHON" -c "import sys; sys.exit(not $wantver and 1 or 0)"; then
 		HAVE_PYTHON=yes
 	fi


### PR DESCRIPTION
In Python 3 releases before 3.2.4, the subprocess.Popen.communicate
method does not accept string inputs when universal_newlines=True is
set (see https://bugs.python.org/issue16903).

Also substitute the minimum Python version displayed by "make
check-pytests-no" from configure.ac to help keep it in sync with the
minimum version we check for.

[One of the buildbot workers runs Ubuntu 12.04, which maxes out at Python 3.2.3.  The alternatives to bumping the minimum version are unattractive, as Python 3.3+ doesn't accept bytes input to subprocess.Popen.communicate() when universal_newlines is set.  We could check the Python version, or we could stop using universal_newlines=True and explicitly encode inputs and decode outputs.  We'd have to do that in at least three places--twice in t_kdb.py and once in k5test.py.]
