### PR TITLE
Skip URI tests when using asan

### DIFF
--- a/src/lib/krb5/os/Makefile.in
+++ b/src/lib/krb5/os/Makefile.in
@@ -232,12 +232,16 @@ check-unix-locate: t_locate_kdc
 		echo 'Skipped t_locate_kdc test: OFFLINE' >> $(SKIPTESTS); \
 	fi
 
+ASAN = @ASAN@
 check-unix-uri: t_locate_kdc
-	if [ $(HAVE_RESOLV_WRAPPER) = 1 ]; then \
-	    $(RUNPYTEST) $(srcdir)/t_discover_uri.py $(PYTESTFLAGS); \
-	else \
+	if [ $(HAVE_RESOLV_WRAPPER) = 0 ]; then \
 	    echo '*** WARNING: skipped t_discover_uri.py due to not using resolv_wrapper'; \
 	    echo 'Skipped URI discovery tests: resolv_wrapper 1.1.5 not found' >> $(SKIPTESTS); \
+	elif [ $(ASAN) = yes ]; then \
+	    echo '*** Skipping URI discovery tests: resolv_wrapper is incompatible with asan'; \
+	    echo 'Skipped URI discovery tests: incompatible with asan' >> $(SKIPTESTS); \
+	else \
+	    $(RUNPYTEST) $(srcdir)/t_discover_uri.py $(PYTESTFLAGS); \
 	fi
 
 check-unix-trace: t_trace


### PR DESCRIPTION
resolve_wrapper uses RTLD_DEEPBIND to load libresolv, triggering a
failure in the asan runtime.