### PR TITLE
Clean up default ccache in dejagnu test suite

### DIFF
--- a/src/tests/dejagnu/config/default.exp
+++ b/src/tests/dejagnu/config/default.exp
@@ -275,8 +275,8 @@ proc delete_db {} {
 	$tmppwd/kdc-db.ulog \
 	$tmppwd/replica-db $tmppwd/replica-db.ok $tmppwd/replica-db.kadm5 $tmppwd/replica-db.kadm5.lock \
 	$tmppwd/replica-db~ $tmppwd/replica-db~.ok $tmppwd/replica-db~.kadm5 $tmppwd/replica-db~.kadm5.lock
-    # Creating a new database means we need a new keytab.
-    file delete $tmppwd/keytab $tmppwd/cpw_keytab
+    # Creating a new database invalidates the keytab and ccache.
+    file delete $tmppwd/keytab $tmppwd/tkt
 }
 
 delete_db


### PR DESCRIPTION
[Very rarely I would see "make check" fail in tests/dejagnu with "FAIL: des3: kpasswd testprinc/instance anothertest", which would go away on another test run.  Today I tracked it down to kpasswd trying to use an expired ccache as FAST armor.  The ccache is ordinarily removed at the end of the dejagnu test suite (simply because standalone.exp does a kdestroy at line 254 and nothing gets tickets after that), so the failure would only happen if the dejagnu tests were interrupted or failed badly and then some hours elapsed before the next make check.]

The dejagnu test suite could fail due to a leftover tmpdir/tkt ccache
containing expired tickets.  Remove the ccache file along with the
keytab in delete_db.  (The file cpw_keytab, formerly written as
cpw_srvtab, is not used in the dejagnu tests and has not been used
going back to 1.0, so replace that removal with the removal of
tmpdir/tkt.)