### PR TITLE
Don't skip past zero byte in profile parsing

### DIFF
--- a/src/util/profile/prof_parse.c
+++ b/src/util/profile/prof_parse.c
@@ -48,7 +48,7 @@ static void parse_quoted_string(char *str)
     char *to, *from;
 
     for (to = from = str; *from && *from != '"'; to++, from++) {
-        if (*from == '\\') {
+        if (*from == '\\' && *(from + 1) != '\0') {
             from++;
             switch (*from) {
             case 'n':


### PR DESCRIPTION
In parse_quoted_string(), only process an escape sequence if there is
a second character after the backlash, to avoid reading past the
terminating zero byte.  Reported by Lutz Justen.
