### PR TITLE
KCM: fix k5_input status check in get_kdc_offset()

### DIFF
--- a/src/lib/krb5/ccache/cc_kcm.c
+++ b/src/lib/krb5/ccache/cc_kcm.c
@@ -577,7 +577,7 @@ get_kdc_offset(krb5_context context, krb5_ccache cache)
     if (cache_call(context, cache, &req) != 0)
         goto cleanup;
     time_offset = k5_input_get_uint32_be(&req.reply);
-    if (!req.reply.status)
+    if (req.reply.status)
         goto cleanup;
     context->os_context.time_offset = time_offset;
     context->os_context.usec_offset = 0;


### PR DESCRIPTION
An inverted status check in get_kdc_offset() would cause querying the
offset time from the ccache to always fail (silently) on KCM.  Fix the
status check so that KCM can properly handle desync.