### PR TITLE
Update documentation for default keysalts

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -271,7 +271,7 @@ else:
     rst_epilog += '.. |ckeytab| replace:: %s\n' % ckeytab
     rst_epilog += '''
 .. |krb5conf| replace:: ``/etc/krb5.conf``
-.. |defkeysalts| replace:: ``aes256-cts-hmac-sha1-96:normal aes128-cts-hmac-sha1-96:normal des3-cbc-sha1:normal arcfour-hmac-md5:normal``
+.. |defkeysalts| replace:: ``aes256-cts-hmac-sha1-96:normal aes128-cts-hmac-sha1-96:normal``
 .. |defetypes| replace:: ``aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 aes256-cts-hmac-sha384-192 aes128-cts-hmac-sha256-128 des3-cbc-sha1 arcfour-hmac-md5 camellia256-cts-cmac camellia128-cts-cmac``
 .. |defmkey| replace:: ``aes256-cts-hmac-sha1-96``
 .. |copy| unicode:: U+000A9


### PR DESCRIPTION
In commit 38a31852c3e58f6e2f6b3b035a87f817d1db5537, aes-sha1 enctypes
became the only defaults, but the documentation was not updated.