### PR TITLE
Fix KDC crash when logging PKINIT enctypes

### DIFF
--- a/src/kdc/kdc_util.c
+++ b/src/kdc/kdc_util.c
@@ -1107,7 +1107,7 @@ enctype_name(krb5_enctype ktype, char *buf, size_t buflen)
     else
         return krb5_enctype_to_name(ktype, FALSE, buf, buflen);
 
-    if (strlcpy(name, buf, buflen) >= buflen)
+    if (strlcpy(buf, name, buflen) >= buflen)
         return ENOMEM;
     return 0;
 }


### PR DESCRIPTION
[It doesn't look like there's any existing way to send PKINIT enctypes in an AS or TGS request with the current code.  I tested manually by changing krb5int_parse_enctype_list() to add the enctype I wanted.

While testing this I noted that new enctypes will generate strings like "DEPRECATED:(5000)" in the KDC log, because krb5int_c_deprecated_enctype() returns true for unknown enctypes.  This requires some thought; an enctype we don't recognize could be either too old or too new to be on the list.  PKINIT enctypes are also marked as deprecated because they were never in the libk5crypto list, and it's unclear whether this is correct.]

Commit a649279727490687d54becad91fde8cf7429d951 introduced a KDC crash
bug due to transposed strlcpy() arguments.  Fix the argument order.

This bug does not affect any MIT krb5 release, but affects the Fedora
krb5 packages due to backports.  CVE-2019-14844 has been issued as a
result.
