### PR TITLE
Aliases support in S4U

### DIFF
--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -2379,6 +2379,12 @@ krb5_get_credentials_for_user(krb5_context context, krb5_flags options,
                               krb5_creds **out_creds);
 
 krb5_error_code KRB5_CALLCONV
+krb5_get_creds_for_user_to_self(krb5_context context, krb5_flags options,
+                                krb5_ccache ccache, krb5_creds *in_creds,
+                                krb5_data *subject_cert, krb5_principal self,
+                                krb5_creds **out_creds);
+
+krb5_error_code KRB5_CALLCONV
 krb5_get_credentials_for_proxy(krb5_context context,
                                krb5_flags options,
                                krb5_ccache ccache,

--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -736,6 +736,11 @@ krb5_error_code krb5_db_get_authdata_info(krb5_context context,
 
 void krb5_db_free_authdata_info(krb5_context context, void *ad_info);
 
+krb5_error_code krb5_db_check_alias(krb5_context kcontext,
+                                    const krb5_db_entry *self,
+                                    krb5_const_principal princ,
+                                    krb5_boolean *is_self);
+
 /**
  * Sort an array of @a krb5_key_data keys in descending order by their kvno.
  * Key data order within a kvno is preserved.
@@ -1523,6 +1528,14 @@ typedef struct _kdb_vftabl {
 
     void (*free_authdata_info)(krb5_context context,
                                void *ad_info);
+
+    /*
+     *
+     */
+    krb5_error_code (*check_alias)(krb5_context kcontext,
+                                   const krb5_db_entry *self,
+                                   krb5_const_principal princ,
+                                   krb5_boolean *is_self);
 
     /* End of minor version 0 for major version 8. */
 } kdb_vftabl;

--- a/src/kdc/do_as_req.c
+++ b/src/kdc/do_as_req.c
@@ -599,9 +599,10 @@ process_as_req(krb5_kdc_req *request, krb5_data *req_pkt,
     /*
      * Note that according to the referrals draft we should
      * always canonicalize enterprise principal names.
+     * -- that didn't make it to RFC 6806 and Windows KDC does not implicitly
+     *    canonicalize enterprise principal names.
      */
-    if (isflagset(state->request->kdc_options, KDC_OPT_CANONICALIZE) ||
-        state->request->client->type == KRB5_NT_ENTERPRISE_PRINCIPAL) {
+    if (isflagset(state->request->kdc_options, KDC_OPT_CANONICALIZE)) {
         setflag(state->c_flags, KRB5_KDB_FLAG_CANONICALIZE);
         setflag(state->c_flags, KRB5_KDB_FLAG_ALIAS_OK);
     }

--- a/src/lib/kdb/kdb5.c
+++ b/src/lib/kdb/kdb5.c
@@ -327,6 +327,7 @@ copy_vtable(const kdb_vftabl *in, kdb_vftabl *out)
     out->allowed_to_delegate_from = in->allowed_to_delegate_from;
     out->get_authdata_info = in->get_authdata_info;
     out->free_authdata_info = in->free_authdata_info;
+    out->check_alias = in->check_alias;
 
     /* Set defaults for optional fields. */
     if (out->fetch_master_key == NULL)
@@ -2806,6 +2807,23 @@ krb5_db_free_authdata_info(krb5_context kcontext, void *ad_info)
     if (v->free_authdata_info == NULL)
         return;
     v->free_authdata_info(kcontext, ad_info);
+}
+
+krb5_error_code
+krb5_db_check_alias(krb5_context kcontext,
+                    const krb5_db_entry *self,
+                    krb5_const_principal princ,
+                    krb5_boolean *is_self)
+{
+    krb5_error_code ret;
+    kdb_vftabl *v;
+
+    ret = get_vftabl(kcontext, &v);
+    if (ret)
+        return ret;
+    if (v->check_alias == NULL)
+        return KRB5_PLUGIN_OP_NOTSUPP;
+    return v->check_alias(kcontext, self, princ, is_self);
 }
 
 void

--- a/src/lib/kdb/libkdb5.exports
+++ b/src/lib/kdb/libkdb5.exports
@@ -5,6 +5,7 @@ krb5_db_alloc
 krb5_db_free
 krb5_db_allowed_to_delegate_from
 krb5_db_audit_as_req
+krb5_db_check_alias
 krb5_db_check_allowed_to_delegate
 krb5_db_get_s4u_x509_principal
 krb5_db_check_policy_as

--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -392,6 +392,7 @@ krb5_get_cred_via_tkt
 krb5_get_credentials
 krb5_get_credentials_for_proxy
 krb5_get_credentials_for_user
+krb5_get_creds_for_user_to_self
 krb5_get_credentials_renew
 krb5_get_credentials_validate
 krb5_get_default_config_files

--- a/src/lib/krb5_32.def
+++ b/src/lib/krb5_32.def
@@ -499,3 +499,6 @@ EXPORTS
 	k5_size_context					@467 ; PRIVATE GSSAPI
 	k5_size_keyblock				@468 ; PRIVATE GSSAPI
 	k5_size_principal				@469 ; PRIVATE GSSAPI
+
+; new
+	krb5_get_creds_for_user_to_self			@470 ; PRIVATE GSSAPI

--- a/src/tests/gssapi/Makefile.in
+++ b/src/tests/gssapi/Makefile.in
@@ -18,15 +18,16 @@ SRCS=	$(srcdir)/ccinit.c $(srcdir)/ccrefresh.c $(srcdir)/common.c \
 	$(srcdir)/t_inq_mechs_name.c $(srcdir)/t_iov.c \
 	$(srcdir)/t_lifetime.c $(srcdir)/t_namingexts.c $(srcdir)/t_oid.c \
 	$(srcdir)/t_pcontok.c $(srcdir)/t_prf.c $(srcdir)/t_s4u.c \
-	$(srcdir)/t_s4u2proxy_krb5.c $(srcdir)/t_saslname.c \
-	$(srcdir)/t_spnego.c $(srcdir)/t_srcattrs.c
+	$(srcdir)/t_s4u_alias_krb5.c $(srcdir)/t_s4u2proxy_krb5.c \
+	$(srcdir)/t_saslname.c $(srcdir)/t_spnego.c $(srcdir)/t_srcattrs.c
 
 OBJS=	ccinit.o ccrefresh.o common.o t_accname.o t_add_cred.o t_ccselect.o \
 	t_ciflags.o t_context.o t_credstore.o t_enctypes.o t_err.o \
 	t_export_cred.o t_export_name.o t_gssexts.o t_imp_cred.o t_imp_name.o \
 	t_invalid.o t_inq_cred.o t_inq_ctx.o t_inq_mechs_name.o t_iov.o \
 	t_lifetime.o t_namingexts.o t_oid.o t_pcontok.o t_prf.o t_s4u.o \
-	t_s4u2proxy_krb5.o t_saslname.o t_spnego.o t_srcattrs.o
+	t_s4u2proxy_krb5.o t_saslname.o t_spnego.o t_srcattrs.o \
+	t_s4u_alias_krb5.o
 
 COMMON_DEPS= common.o $(GSS_DEPLIBS) $(KRB5_BASE_DEPLIBS)
 COMMON_LIBS= common.o $(GSS_LIBS) $(KRB5_BASE_LIBS)
@@ -35,7 +36,7 @@ all: ccinit ccrefresh t_accname t_add_cred t_ccselect t_ciflags t_context \
 	t_credstore t_enctypes t_err t_export_cred t_export_name t_gssexts \
 	t_imp_cred t_imp_name t_invalid t_inq_cred t_inq_ctx t_inq_mechs_name \
 	t_iov t_lifetime t_namingexts t_oid t_pcontok t_prf t_s4u \
-	t_s4u2proxy_krb5 t_saslname t_spnego t_srcattrs
+	t_s4u2proxy_krb5 t_saslname t_spnego t_srcattrs t_s4u_alias_krb5
 
 check-unix: t_oid
 	$(RUN_TEST) ./t_invalid
@@ -46,7 +47,7 @@ check-unix: t_oid
 check-pytests: ccinit ccrefresh t_accname t_add_cred t_ccselect t_ciflags \
 	t_context t_credstore t_enctypes t_err t_export_cred t_export_name \
 	t_imp_cred t_inq_cred t_inq_ctx t_inq_mechs_name t_iov t_lifetime \
-	t_pcontok t_s4u t_s4u2proxy_krb5 t_spnego t_srcattrs
+	t_pcontok t_s4u t_s4u2proxy_krb5 t_spnego t_srcattrs t_s4u_alias_krb5
 	$(RUNPYTEST) $(srcdir)/t_gssapi.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_ccselect.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_client_keytab.py $(PYTESTFLAGS)
@@ -108,6 +109,8 @@ t_prf: t_prf.o $(COMMON_DEPS)
 	$(CC_LINK) -o $@ t_prf.o $(COMMON_LIBS)
 t_s4u: t_s4u.o $(COMMON_DEPS)
 	$(CC_LINK) -o $@ t_s4u.o $(COMMON_LIBS)
+t_s4u_alias_krb5: t_s4u_alias_krb5.o $(COMMON_DEPS)
+	$(CC_LINK) -o $@ t_s4u_alias_krb5.o $(COMMON_LIBS)
 t_s4u2proxy_krb5: t_s4u2proxy_krb5.o $(COMMON_DEPS)
 	$(CC_LINK) -o $@ t_s4u2proxy_krb5.o $(COMMON_LIBS)
 t_saslname: t_saslname.o $(COMMON_DEPS)
@@ -123,4 +126,4 @@ clean:
 	$(RM) t_export_name t_gssexts t_imp_cred t_imp_name t_invalid
 	$(RM) t_inq_cred t_inq_ctx t_inq_mechs_name t_iov t_lifetime
 	$(RM) t_namingexts t_oid t_pcontok t_prf t_s4u t_s4u2proxy_krb5
-	$(RM) t_saslname t_spnego t_srcattrs
+	$(RM) t_saslname t_spnego t_srcattrs t_s4u_alias_krb5

--- a/src/tests/gssapi/deps
+++ b/src/tests/gssapi/deps
@@ -168,6 +168,10 @@ $(OUTPRE)t_s4u.$(OBJEXT): $(BUILDTOP)/include/gssapi/gssapi.h \
   $(BUILDTOP)/include/gssapi/gssapi_ext.h $(BUILDTOP)/include/gssapi/gssapi_krb5.h \
   $(BUILDTOP)/include/krb5/krb5.h $(COM_ERR_DEPS) $(top_srcdir)/include/krb5.h \
   common.h t_s4u.c
+$(OUTPRE)t_s4u_alias_krb5.$(OBJEXT): $(BUILDTOP)/include/gssapi/gssapi.h \
+  $(BUILDTOP)/include/gssapi/gssapi_ext.h $(BUILDTOP)/include/gssapi/gssapi_krb5.h \
+  $(BUILDTOP)/include/krb5/krb5.h $(COM_ERR_DEPS) $(top_srcdir)/include/krb5.h \
+  common.h t_s4u_alias_krb5.c
 $(OUTPRE)t_s4u2proxy_krb5.$(OBJEXT): $(BUILDTOP)/include/gssapi/gssapi.h \
   $(BUILDTOP)/include/gssapi/gssapi_ext.h $(BUILDTOP)/include/gssapi/gssapi_krb5.h \
   $(BUILDTOP)/include/krb5/krb5.h $(COM_ERR_DEPS) $(top_srcdir)/include/krb5.h \

--- a/src/tests/gssapi/t_s4u.py
+++ b/src/tests/gssapi/t_s4u.py
@@ -377,4 +377,58 @@ ra.stop()
 rb.stop()
 rc.stop()
 
+mark('S4U using aliases names')
+
+x_princs = {'krbtgt/X': {'keys': 'aes128-cts'},
+            'krbtgt/Y': {'keys': 'aes128-cts'},
+            'user': {'keys': 'aes128-cts', 'flags': '+preauth'},
+            'impersonator': {'keys': 'aes128-cts',
+                             'flags': '+ok_to_auth_as_delegate'},
+            'srv/rb_cd': {'keys': 'aes128-cts'},
+            'srv/rb_cd2': {'keys': 'aes128-cts'},
+            'srv/legacy_cd': {'keys': 'aes128-cts'}}
+x_kconf = {'realms': {'$realm': {'database_module': 'test'}},
+           'dbmodules': {'test': {'db_library': 'test',
+                                  'canon_type': 'mswin',
+                                  'princs': x_princs,
+                                  'rbcd': {'srv/rb_cd@X': 'imp_client@X',
+                                           'srv/rb_cd2@X': 'imp@abc@X'},
+                                  'delegation': {'imp_server': 'srv/legacy_cd'},
+                                  'alias': {'imp_client': 'impersonator',
+                                            'imp@abc': 'impersonator',
+                                            'imp_server': 'impersonator'}}}}
+
+y_princs = {'krbtgt/Y': {'keys': 'aes128-cts'},
+            'krbtgt/X': {'keys': 'aes128-cts'},
+            'user': {'keys': 'aes128-cts', 'flags': '+preauth'}}
+y_kconf = {'realms': {'$realm': {'database_module': 'test'}},
+           'dbmodules': {'test': {'db_library': 'test',
+                                  'princs': y_princs,
+                                  'alias': {'imp_server@X': '@X'}}}}
+
+rx, ry = cross_realms(2, xtgts=(),
+                      args=({'realm': 'X', 'kdc_conf': x_kconf},
+                            {'realm': 'Y', 'kdc_conf': y_kconf}),
+                      create_kdb=False)
+
+rx.start_kdc()
+ry.start_kdc()
+
+rx.extract_keytab('imp_client@X', rx.keytab)
+rx.kinit('imp_client@X', None, ['-f', '-k', '-t', rx.keytab])
+rx.run(['./t_s4u_alias_krb5', rx.user_princ, 'imp_server', 'srv/rb_cd'])
+rx.run(['./t_s4u_alias_krb5', ry.user_princ, 'imp_server', 'srv/rb_cd'])
+rx.run(['./t_s4u_alias_krb5', rx.user_princ, 'imp_server', 'srv/legacy_cd'])
+rx.run(['./t_s4u_alias_krb5', ry.user_princ, 'imp_server', 'srv/legacy_cd'])
+
+rx.extract_keytab('imp\@abc@X', rx.keytab)
+rx.kinit('imp@abc@X', None, ['-E', '-f', '-k', '-t', rx.keytab])
+rx.run(['./t_s4u_alias_krb5', rx.user_princ, 'imp_server', 'srv/rb_cd2'])
+rx.run(['./t_s4u_alias_krb5', ry.user_princ, 'imp_server', 'srv/rb_cd2'])
+rx.run(['./t_s4u_alias_krb5', rx.user_princ, 'imp_server', 'srv/legacy_cd'])
+rx.run(['./t_s4u_alias_krb5', ry.user_princ, 'imp_server', 'srv/legacy_cd'])
+
+rx.stop()
+ry.stop()
+
 success('S4U test cases')

--- a/src/tests/gssapi/t_s4u_alias_krb5.c
+++ b/src/tests/gssapi/t_s4u_alias_krb5.c
@@ -1,0 +1,101 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ * Copyright (C) 2019 by the Massachusetts Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Usage: ./s4u_alias_krb5 client alias target
+ *
+ * The default ccache contains a TGT for the intermediate service.
+ * An S4U2Self is made for client using alias as server name.  The
+ * resulting ticket is used to make an S4U2Proxy request to target.
+ */
+
+#include <k5-int.h>
+
+static krb5_context ctx;
+
+static void
+check(krb5_error_code code)
+{
+    const char *errmsg;
+
+    if (code) {
+        errmsg = krb5_get_error_message(ctx, code);
+        fprintf(stderr, "%s\n", errmsg);
+        krb5_free_error_message(ctx, errmsg);
+        exit(1);
+    }
+}
+
+int
+main(int argc, char **argv)
+{
+    krb5_context context;
+    krb5_ccache defcc;
+    krb5_principal client, me, alias_me, target;
+    krb5_creds in_creds = {0}, *out_creds = NULL;
+    krb5_flags options = KRB5_GC_NO_STORE;
+
+    assert(argc == 4);
+    check(krb5_init_context(&context));
+
+    check(krb5_parse_name(context, argv[1], &client));
+    check(krb5_parse_name(context, argv[2], &alias_me));
+    check(krb5_parse_name(context, argv[3], &target));
+
+    /* Open the default ccache and determine me */
+    check(krb5_cc_default(context, &defcc));
+    check(krb5_cc_get_principal(context, defcc, &me));
+
+    /* S4U2Self using alias server name */
+    in_creds.client = client;
+    in_creds.server = alias_me;
+    check(krb5_get_creds_for_user_to_self(context, options, defcc, &in_creds,
+                                          NULL, me, &out_creds));
+
+    /* S4U2Proxy using second ticket with alias server name */
+    in_creds.client = me;
+    in_creds.server = target;
+    in_creds.second_ticket = out_creds->ticket;
+    out_creds->ticket = empty_data();
+    krb5_free_creds(context, out_creds);
+    check(krb5_get_credentials(context, KRB5_GC_CONSTRAINED_DELEGATION |
+                               options, defcc, &in_creds, &out_creds));
+    free(in_creds.second_ticket.data);
+
+    krb5_cc_close(context, defcc);
+    krb5_free_principal(context, client);
+    krb5_free_principal(context, me);
+    krb5_free_principal(context, alias_me);
+    krb5_free_principal(context, target);
+    krb5_free_creds(context, out_creds);
+    krb5_free_context(context);
+    return 0;
+}


### PR DESCRIPTION
Windows clients use aliases extensively, simple aliases like LHS of the UPN, no dollar suffix for machine accounts and a variety of enterprise names are used for TGT client name, as well as SPNs and enterprise names for servers. Specifically in S4U2Self the request server may be a different principal name than header client, and in S4U2Proxy the second ticket server may be a different principal name than header client.

This also helps with integrating in samba, and plugin in its current test-suits, see related wip:
https://gitlab.com/samba-team/samba/merge_requests/818