### PR TITLE
Fix missing field in /etc/gss/mech documentation

### DIFF
--- a/doc/admin/host_config.rst
+++ b/doc/admin/host_config.rst
@@ -203,15 +203,17 @@ GSSAPI mechanism modules are registered using the file
 |sysconfdir|\ ``/gss/mech.d`` directory with a ``.conf``
 suffix.  Each line in these files has the form::
 
-    oid  pathname  [options]  <type>
+    name  oid  pathname  [options]  <type>
 
-Only the oid and pathname are required.  *oid* is the object
-identifier of the GSSAPI mechanism to be registered.  *pathname* is a
-path to the module shared object or DLL.  *options* (if present) are
-options provided to the plugin module, surrounded in square brackets.
-*type* (if present) can be used to indicate a special type of module.
-Currently the only special module type is "interposer", for a module
-designed to intercept calls to other mechanisms.
+Only the name, oid, and pathname are required.  *name* is the
+mechanism name, which may be used for debugging or logging purposes.
+*oid* is the object identifier of the GSSAPI mechanism to be
+registered.  *pathname* is a path to the module shared object or DLL.
+*options* (if present) are options provided to the plugin module,
+surrounded in square brackets.  *type* (if present) can be used to
+indicate a special type of module.  Currently the only special module
+type is "interposer", for a module designed to intercept calls to
+other mechanisms.
 
 If the environment variable **GSS_MECH_CONFIG** is set, its value is
 used as the sole mechanism configuration filename.


### PR DESCRIPTION
/etc/gss/mech lines begin with a name field, but this field was not
included in the format documentation.
