### PR TITLE
Accept GSS mechs which don't supply attributes

### DIFF
--- a/src/lib/gssapi/mechglue/g_accept_sec_context.c
+++ b/src/lib/gssapi/mechglue/g_accept_sec_context.c
@@ -104,6 +104,10 @@ allow_mech_by_default(gss_OID mech)
     if (status)
 	return 0;
 
+    /* If the mechanism doesn't support RFC 5587, don't exclude it. */
+    if (attrs == GSS_C_NO_OID_SET)
+	return 1;
+
     /* Check for each attribute which would cause us to exclude this mech from
      * the default credential. */
     if (generic_gss_test_oid_set_member(&minor, GSS_C_MA_DEPRECATED,


### PR DESCRIPTION
[Starting with release 1.14 we began filtering mechs like IAKERB out of the default credential, based on mechanism attributes.  As a bad side-effect, we can reject a mechanism which doesn't implement RFC 5587.

This is the most conservative fix, but it is possible that the problem should be fixed at a lower level.  It seems broken that RFC 5587 defines gss_inquire_attrs_for_mech() such that it may use GSS_C_NO_OID_SET for the empty attribute set, while gss_test_oid_set_member() does not accept that value.  (Heimdal's gss_test_oid_set_member() will actually crash on a null oid set; MIT's returns an error.)  There are contexts where GSS_C_NO_OID_SET is not equivalent to an empty OID set; for instance, in gss_acquire_cred() it asks for the default mechanism set.  Tagging @nicowilliams in case he has an opinion.]

If gss_inquire_attrs_for_mech() is called for a mechanism which does
not implement it, the all will succeed with mech_attrs set to
GSS_C_NO_OID_SET (as is explicitly allowed by RFC 5587).
generic_gss_test_oid_set_member() returns an error on this value,
causing gss_accept_sec_context() to erroneously deny the mechanism
when no verifier credential handle is supplied.  Change
allow_mech_by_default() to explicitly check for no mech attribute set.
