### PR TITLE
Allow names to be canonicalized in non-krbtgt AS reply

### DIFF
--- a/src/lib/krb5/krb/get_in_tkt.c
+++ b/src/lib/krb5/krb/get_in_tkt.c
@@ -230,17 +230,12 @@ verify_as_reply(krb5_context            context,
     if (canon_req) {
         canon_ok = IS_TGS_PRINC(request->server) &&
             IS_TGS_PRINC(as_reply->enc_part2->server);
-        if (!canon_ok && (request->kdc_options & KDC_OPT_REQUEST_ANONYMOUS)) {
-            canon_ok = krb5_principal_compare_any_realm(context,
-                                                        as_reply->client,
-                                                        krb5_anonymous_principal());
-        }
     } else
         canon_ok = 0;
 
     if ((!canon_ok &&
-         (!krb5_principal_compare(context, as_reply->client, request->client) ||
-          !krb5_principal_compare(context, as_reply->enc_part2->server, request->server)))
+         !krb5_principal_compare(context, as_reply->enc_part2->server, request->server))
+        || (!canon_req && !krb5_principal_compare(context, as_reply->client, request->client))
         || !krb5_principal_compare(context, as_reply->enc_part2->server, as_reply->ticket->server)
         || (request->nonce != as_reply->enc_part2->nonce)
         /* XXX check for extraneous flags */

--- a/src/tests/t_kdb.py
+++ b/src/tests/t_kdb.py
@@ -389,6 +389,9 @@ realm.run([kadminl, 'modprinc', '+requires_preauth', 'canon'])
 realm.kinit('canon', password('canon'))
 realm.kinit('alias', password('canon'), ['-C'])
 
+# Test client name canonicalization in non-krbtgt AS reply
+realm.kinit('alias', password('canon'), ['-C', '-S', 'kadmin/changepw'])
+
 mark('LDAP password history')
 
 # Test password history.


### PR DESCRIPTION
if we verified returned PA-REQ-ENC-PA-REP, per RFC 6806.

I'm working on a test, see also related work in samba:
https://gitlab.com/samba-team/samba/merge_requests/840