### PR TITLE
Fix minor leak when loading GSS mechanisms

### DIFF
--- a/src/lib/gssapi/mechglue/g_initialize.c
+++ b/src/lib/gssapi/mechglue/g_initialize.c
@@ -1155,6 +1155,7 @@ gssint_get_mechanism(gss_const_OID oid)
 
 	if (krb5int_open_plugin(aMech->uLibName, &dl, &errinfo) != 0 ||
 	    errinfo.code != 0) {
+		k5_clear_error(&errinfo);
 		k5_mutex_unlock(&g_mechListLock);
 		return ((gss_mechanism)NULL);
 	}
@@ -1165,6 +1166,7 @@ gssint_get_mechanism(gss_const_OID oid)
 		aMech->mech = (*sym)(aMech->mech_type);
 	} else {
 		/* Try dynamic dispatch table */
+		k5_clear_error(&errinfo);
 		aMech->mech = build_dynamicMech(dl, aMech->mech_type);
 		aMech->freeMech = 1;
 	}


### PR DESCRIPTION
[This leak is minor as it can only happen once per dynamically loaded GSS mech, but it happens in the common case (because loaded GSS mechs typically do not define gss_mech_initialize()) and trips asan or valgrind leak detection.]

When gssint_get_mechanism() loads a GSS mech, it must clear errinfo if
krb5int_open_plugin() or krb5int_get_plugin_func() returns an error.