### PR TITLE
Fix gssalloc_realloc() on Windows

### DIFF
--- a/src/lib/gssapi/generic/gssapi_alloc.h
+++ b/src/lib/gssapi/generic/gssapi_alloc.h
@@ -36,6 +36,9 @@ gssalloc_calloc(size_t count, size_t size)
 static inline void *
 gssalloc_realloc(void *value, size_t size)
 {
+    /* Unlike realloc(), HeapReAlloc() does not work on null values. */
+    if (value == NULL)
+        return HeapAlloc(GetProcessHeap(), 0, size);
     return HeapReAlloc(GetProcessHeap(), 0, value, size);
 }
 


### PR DESCRIPTION
gss_inquire_sec_context_by_oid(GSS_C_INQ_SSPI_SESSION_KEY) fails on
Windows because generic_gss_add_buffer_set_member() relies on the
ability to realloc() a null pointer.  Unlike realloc(), HeapReAlloc()
requires an input pointer that (from the MSDN documentation) "is
returned by an earlier call to the HeapAlloc or HeapReAlloc function".
So gssalloc_realloc() must test for null inputs and call HeapAlloc()
instead.

Reported by Eric Pauly.
