### PR TITLE
Fix t_otp.py for pyrad 2.2

### DIFF
--- a/src/tests/t_otp.py
+++ b/src/tests/t_otp.py
@@ -47,6 +47,7 @@ except ImportError:
 radius_attributes = '''
 ATTRIBUTE    User-Name    1    string
 ATTRIBUTE    User-Password   2    octets
+ATTRIBUTE    Service-Type    6    integer
 ATTRIBUTE    NAS-Identifier  32    string
 '''
 


### PR DESCRIPTION
[The good news is that pyrad is getting maintained.  The bad news is that a release on Saturday caused t_otp.py to start through an exception.  Here is a fix.]

pyrad 2.2 throws a KeyError exception in DecodePacket if any
attributes from the packet are not defined in the dictionary.  Add a
dictionary entry for Service-Type so this doesn't happen.
