### PR TITLE
Work around glibc bug 11941 (dlclose assertion)

### DIFF
--- a/src/util/support/plugins.c
+++ b/src/util/support/plugins.c
@@ -54,6 +54,21 @@
 #define PLUGIN_DLOPEN_FLAGS (RTLD_NOW | RTLD_LOCAL | GROUP | NODELETE)
 #endif
 
+/*
+ * glibc bug 11941, fixed in release 2.25, can cause an assertion failure in
+ * dlclose() on process exit.  Our workaround is to leak dlopen() handles
+ * (which doesn't typically manifest in leak detection tools because the
+ * handles are still reachable via a global table in libdl).  Because we
+ * dlopen() with RTLD_NODELETE, we weren't going to unload the plugin objects
+ * anyway.
+ */
+#ifdef __linux__
+#include <features.h>
+#if ! __GLIBC_PREREQ(2, 25)
+#define dlclose(x)
+#endif
+#endif
+
 #if USE_DLOPEN && USE_CFBUNDLE
 #include <CoreFoundation/CoreFoundation.h>
 


### PR DESCRIPTION
[This seems like the least worst option to get the negoex tests to work on old-but-not-ancient versions of Linux distributions.]

When building against glibc 2.24 or earlier, suppress calls to
dlclose() to prevent the assertion failure "_dl_close: Assertion
`map->l_init_called' failed" at process exit.  We need this workaround
to enable automated tests that load GSSAPI modules.