### PR TITLE
kdc: Record the kdc_time and authtime earlier

### DIFF
--- a/src/kdc/do_as_req.c
+++ b/src/kdc/do_as_req.c
@@ -546,6 +546,11 @@ process_as_req(krb5_kdc_req *request, krb5_data *req_pkt,
     /* Seed the audit trail with the request ID and basic information. */
     kau_as_req(kdc_context, TRUE, au_state);
 
+    errcode = krb5_timeofday(kdc_context, &state->kdc_time);
+    if (errcode)
+        goto errout;
+    state->authtime = state->kdc_time;
+
     if (fetch_asn1_field((unsigned char *) req_pkt->data,
                          1, 4, &encoded_req_body) != 0) {
         errcode = ASN1_BAD_ID;
@@ -670,10 +675,6 @@ process_as_req(krb5_kdc_req *request, krb5_data *req_pkt,
     state->rock.local_tgt = state->local_tgt;
 
     au_state->stage = VALIDATE_POL;
-
-    if ((errcode = krb5_timeofday(kdc_context, &state->kdc_time)))
-        goto errout;
-    state->authtime = state->kdc_time; /* for audit_as_request() */
 
     if ((errcode = validate_as_request(kdc_active_realm,
                                        state->request, *state->client,

--- a/src/kdc/kdc_util.h
+++ b/src/kdc/kdc_util.h
@@ -305,20 +305,6 @@ kdc_check_transited_list (kdc_realm_t *kdc_active_realm,
                           const krb5_data *realm1,
                           const krb5_data *realm2);
 
-krb5_error_code
-audit_as_request (krb5_kdc_req *request,
-                  krb5_db_entry *client,
-                  krb5_db_entry *server,
-                  krb5_timestamp authtime,
-                  krb5_error_code errcode);
-
-krb5_error_code
-audit_tgs_request (krb5_kdc_req *request,
-                   krb5_const_principal client,
-                   krb5_db_entry *server,
-                   krb5_timestamp authtime,
-                   krb5_error_code errcode);
-
 void
 kdc_get_ticket_endtime(kdc_realm_t *kdc_active_realm,
                        krb5_timestamp now,


### PR DESCRIPTION
If you want to know how long an authication takes for auditing, we
should note the time earlier as looking up the principal is part of it.