### PR TITLE
Implement enforce_ok_as_delegate libdefaults boolean

### DIFF
--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -212,6 +212,13 @@ The libdefaults section may contain any of the following relations:
     fallback if no URI records were found.  The default value is true.
     New in release 1.15.
 
+**enforce_ok_as_delegate**
+    If this flag to true, GSSAPI credential delegation will be
+    disabled when the ``ok-as-delegate`` flag is not set in the
+    service ticket.  If this flag is false, the ``ok-as-delegate``
+    ticket flag is only enforced when an application specifically
+    requests enforcement.  The default value is false.
+
 **err_fmt**
     This relation allows for custom error message formatting.  If a
     value is set, error messages will be formatted by substituting a

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -213,6 +213,7 @@ typedef unsigned char   u_char;
 #define KRB5_CONF_DOMAIN_REALM                 "domain_realm"
 #define KRB5_CONF_ENABLE_ONLY                  "enable_only"
 #define KRB5_CONF_ENCRYPTED_CHALLENGE_INDICATOR "encrypted_challenge_indicator"
+#define KRB5_CONF_ENFORCE_OK_AS_DELEGATE       "enforce_ok_as_delegate"
 #define KRB5_CONF_ERR_FMT                      "err_fmt"
 #define KRB5_CONF_EXTRA_ADDRESSES              "extra_addresses"
 #define KRB5_CONF_FORWARDABLE                  "forwardable"
@@ -1255,6 +1256,7 @@ struct _krb5_context {
 
     krb5_boolean allow_weak_crypto;
     krb5_boolean ignore_acceptor_hostname;
+    krb5_boolean enforce_ok_as_delegate;
     enum dns_canonhost dns_canonicalize_hostname;
 
     krb5_trace_callback trace_callback;

--- a/src/lib/gssapi/krb5/init_sec_context.c
+++ b/src/lib/gssapi/krb5/init_sec_context.c
@@ -563,6 +563,13 @@ kg_new_connection(
     ctx->seed_init = 0;
     ctx->seqstate = 0;
 
+    /* enforce_ok_as_delegate causes GSS_C_DELEG_FLAG to be treated as
+     * GSS_C_DELEG_POLICY_FLAG (so ok-as-delegate is always enforced). */
+    if (context->enforce_ok_as_delegate && (req_flags & GSS_C_DELEG_FLAG)) {
+        req_flags &= ~GSS_C_DELEG_FLAG;
+        req_flags |= GSS_C_DELEG_POLICY_FLAG;
+    }
+
     ctx->gss_flags = req_flags & (GSS_C_CONF_FLAG | GSS_C_INTEG_FLAG |
                                   GSS_C_MUTUAL_FLAG | GSS_C_REPLAY_FLAG |
                                   GSS_C_SEQUENCE_FLAG | GSS_C_DELEG_FLAG |

--- a/src/lib/krb5/krb/init_ctx.c
+++ b/src/lib/krb5/krb/init_ctx.c
@@ -232,6 +232,11 @@ krb5_init_context_profile(profile_t profile, krb5_flags flags,
         goto cleanup;
     ctx->ignore_acceptor_hostname = tmp;
 
+    retval = get_boolean(ctx, KRB5_CONF_ENFORCE_OK_AS_DELEGATE, 0, &tmp);
+    if (retval)
+        goto cleanup;
+    ctx->enforce_ok_as_delegate = tmp;
+
     retval = get_tristate(ctx, KRB5_CONF_DNS_CANONICALIZE_HOSTNAME, "fallback",
                           CANONHOST_FALLBACK, 1, &tmp);
     if (retval)

--- a/src/lib/krb5/krb/t_copy_context.c
+++ b/src/lib/krb5/krb/t_copy_context.c
@@ -85,6 +85,7 @@ check_context(krb5_context c, krb5_context r)
     check(c->use_conf_ktypes == r->use_conf_ktypes);
     check(c->allow_weak_crypto == r->allow_weak_crypto);
     check(c->ignore_acceptor_hostname == r->ignore_acceptor_hostname);
+    check(c->enforce_ok_as_delegate == r->enforce_ok_as_delegate);
     check(c->dns_canonicalize_hostname == r->dns_canonicalize_hostname);
     compare_string(c->plugin_base_dir, r->plugin_base_dir);
 
@@ -139,6 +140,7 @@ main(int argc, char **argv)
     ctx->udp_pref_limit = 2345;
     ctx->use_conf_ktypes = TRUE;
     ctx->ignore_acceptor_hostname = TRUE;
+    ctx->enforce_ok_as_delegate = TRUE;
     ctx->dns_canonicalize_hostname = CANONHOST_FALSE;
     free(ctx->plugin_base_dir);
     check((ctx->plugin_base_dir = strdup("/a/b/c/d")) != NULL);

--- a/src/man/krb5.conf.man
+++ b/src/man/krb5.conf.man
@@ -76,25 +76,11 @@ fubar = {
 .UNINDENT
 .UNINDENT
 .sp
-Placing a \(aq*\(aq at the end of a line indicates that this is the \fIfinal\fP
-value for the tag.  This means that neither the remainder of this
-configuration file nor any other configuration file will be checked
-for any other values for this tag.
-.sp
-For example, if you have the following lines:
-.INDENT 0.0
-.INDENT 3.5
-.sp
-.nf
-.ft C
-foo = bar*
-foo = baz
-.ft P
-.fi
-.UNINDENT
-.UNINDENT
-.sp
-then the second value of \fBfoo\fP (\fBbaz\fP) would never be read.
+Placing a \(aq*\(aq after the closing bracket of a section name indicates
+that the section is \fIfinal\fP, meaning that if the same section appears
+within a later file specified in \fBKRB5_CONFIG\fP, it will be ignored.
+A subsection can be marked as final by placing a \(aq*\(aq after either the
+tag name or the closing brace.
 .sp
 The krb5.conf file can include other files using either of the
 following directives at the beginning of a line:
@@ -197,10 +183,7 @@ If this flag is set to false, then weak encryption types (as noted
 in Encryption_types in kdc.conf(5)) will be filtered
 out of the lists \fBdefault_tgs_enctypes\fP,
 \fBdefault_tkt_enctypes\fP, and \fBpermitted_enctypes\fP\&.  The default
-value for this tag is false, which may cause authentication
-failures in existing Kerberos infrastructures that do not support
-strong crypto.  Users in affected environments should set this tag
-to true until their infrastructure adopts stronger ciphers.
+value for this tag is false.
 .TP
 \fBcanonicalize\fP
 If this flag is set to true, initial ticket requests to the KDC
@@ -259,9 +242,7 @@ the client should request when making a TGS\-REQ, in order of
 preference from highest to lowest.  The list may be delimited with
 commas or whitespace.  See Encryption_types in
 kdc.conf(5) for a list of the accepted values for this tag.
-The default value is \fBaes256\-cts\-hmac\-sha1\-96 aes128\-cts\-hmac\-sha1\-96 aes256\-cts\-hmac\-sha384\-192 aes128\-cts\-hmac\-sha256\-128 des3\-cbc\-sha1 arcfour\-hmac\-md5 camellia256\-cts\-cmac camellia128\-cts\-cmac\fP, but weak encryption types
-will be implicitly removed from this list if the value of
-\fBallow_weak_crypto\fP is false.
+The default value is \fBaes256\-cts\-hmac\-sha1\-96 aes128\-cts\-hmac\-sha1\-96 aes256\-cts\-hmac\-sha384\-192 aes128\-cts\-hmac\-sha256\-128 des3\-cbc\-sha1 arcfour\-hmac\-md5 camellia256\-cts\-cmac camellia128\-cts\-cmac\fP\&.
 .sp
 Do not set this unless required for specific backward
 compatibility purposes; stale values of this setting can prevent
@@ -273,9 +254,7 @@ Identifies the supported list of session key encryption types that
 the client should request when making an AS\-REQ, in order of
 preference from highest to lowest.  The format is the same as for
 default_tgs_enctypes.  The default value for this tag is
-\fBaes256\-cts\-hmac\-sha1\-96 aes128\-cts\-hmac\-sha1\-96 aes256\-cts\-hmac\-sha384\-192 aes128\-cts\-hmac\-sha256\-128 des3\-cbc\-sha1 arcfour\-hmac\-md5 camellia256\-cts\-cmac camellia128\-cts\-cmac\fP, but weak encryption types will be implicitly
-removed from this list if the value of \fBallow_weak_crypto\fP is
-false.
+\fBaes256\-cts\-hmac\-sha1\-96 aes128\-cts\-hmac\-sha1\-96 aes256\-cts\-hmac\-sha384\-192 aes128\-cts\-hmac\-sha256\-128 des3\-cbc\-sha1 arcfour\-hmac\-md5 camellia256\-cts\-cmac camellia128\-cts\-cmac\fP\&.
 .sp
 Do not set this unless required for specific backward
 compatibility purposes; stale values of this setting can prevent
@@ -315,6 +294,13 @@ and other servers for a realm, if they are not listed in the
 krb5.conf information for the realm.  SRV records are used as a
 fallback if no URI records were found.  The default value is true.
 New in release 1.15.
+.TP
+\fBenforce_ok_as_delegate\fP
+If this flag to true, GSSAPI credential delegation will be
+disabled when the \fBok\-as\-delegate\fP flag is not set in the
+service ticket.  If this flag is false, the \fBok\-as\-delegate\fP
+ticket flag is only enforced when an application specifically
+requests enforcement.  The default value is false.
 .TP
 \fBerr_fmt\fP
 This relation allows for custom error message formatting.  If a
@@ -393,9 +379,7 @@ used across NATs.  The default value is true.
 \fBpermitted_enctypes\fP
 Identifies all encryption types that are permitted for use in
 session key encryption.  The default value for this tag is
-\fBaes256\-cts\-hmac\-sha1\-96 aes128\-cts\-hmac\-sha1\-96 aes256\-cts\-hmac\-sha384\-192 aes128\-cts\-hmac\-sha256\-128 des3\-cbc\-sha1 arcfour\-hmac\-md5 camellia256\-cts\-cmac camellia128\-cts\-cmac\fP, but weak encryption types will be implicitly
-removed from this list if the value of \fBallow_weak_crypto\fP is
-false.
+\fBaes256\-cts\-hmac\-sha1\-96 aes128\-cts\-hmac\-sha1\-96 aes256\-cts\-hmac\-sha384\-192 aes128\-cts\-hmac\-sha256\-128 des3\-cbc\-sha1 arcfour\-hmac\-md5 camellia256\-cts\-cmac camellia128\-cts\-cmac\fP\&.
 .TP
 \fBplugin_base_dir\fP
 If set, determines the base directory where krb5 plugins are


### PR DESCRIPTION
If this flag is set to true, then GSSAPI credential delegation will be
disabled when the "ok-as-delegate" flag is not set in the service ticket.