### PR TITLE
Fix SPNEGO output parameter bugs

### DIFF
--- a/src/lib/gssapi/mechglue/g_accept_sec_context.c
+++ b/src/lib/gssapi/mechglue/g_accept_sec_context.c
@@ -66,6 +66,12 @@ val_acc_sec_ctx_args(
 	output_token->value = NULL;
     }
 
+    if (ret_flags != NULL)
+	*ret_flags = 0;
+
+    if (time_rec != NULL)
+	*time_rec = 0;
+
     if (d_cred != NULL)
 	*d_cred = GSS_C_NO_CREDENTIAL;
 

--- a/src/lib/gssapi/mechglue/g_init_sec_context.c
+++ b/src/lib/gssapi/mechglue/g_init_sec_context.c
@@ -63,6 +63,12 @@ val_init_sec_ctx_args(
 	output_token->value = NULL;
     }
 
+    if (ret_flags != NULL)
+	*ret_flags = 0;
+
+    if (time_rec != NULL)
+	*time_rec = 0;
+
     /* Validate arguments. */
 
     if (minor_status == NULL)

--- a/src/lib/gssapi/spnego/gssapiP_spnego.h
+++ b/src/lib/gssapi/spnego/gssapiP_spnego.h
@@ -106,6 +106,7 @@ typedef struct {
 	OM_uint32 ctx_flags;
 	gss_name_t internal_name;
 	gss_OID actual_mech;
+	gss_cred_id_t deleg_cred;
 } spnego_gss_ctx_id_rec, *spnego_gss_ctx_id_t;
 
 /*


### PR DESCRIPTION
When accepting, do not leak a name if the underlying mech reports a
src_name twice.  Record mech_type and delegated_cred_handle and report
them to the caller at the final SPNEGO step, not when the underlying
mech reports them.

When initiating or accepting, report ret_flags at every step, and
filter out PROT_READY as required by RFC 4178 section 3.1.  Report a
time_rec value at the final step even if we didn't call into the
underlying mech, using a call to gss_context_time() if necessary.

In the mechglue, initialize ret_flags and time_rec for both
gss_initialize_sec_context() and gss_accept_sec_context().
