### PR TITLE
Fix SPNEGO fallback context handling

### DIFF
--- a/src/lib/gssapi/spnego/spnego_mech.c
+++ b/src/lib/gssapi/spnego/spnego_mech.c
@@ -972,6 +972,7 @@ init_ctx_call_init(OM_uint32 *minor_status,
 	gss_release_buffer(&tmpmin, &sc->DER_mechTypes);
 	if (put_mech_set(sc->mech_set, &sc->DER_mechTypes) < 0)
 		goto fail;
+	gss_delete_sec_context(&tmpmin, &sc->ctx_handle, GSS_C_NO_BUFFER);
 	tmpret = init_ctx_call_init(&tmpmin, sc, spcred, acc_negState,
 				    target_name, req_flags, time_req,
 				    mechtok_in, mechtok_out, time_rec,


### PR DESCRIPTION
In init_ctx_call_init(), if gss_init_sec_context() fails while
producing the first SPNEGO initiator token, we remove the first
candidate mechanism from sc->mech_set and try again.  If
sc->ctx_handle is present after the error (more likely after commit
56f7b1bc95a2a3eeb420e069e7655fb181ade5cf), we must clear it before
falling back or it will cause subsequent attempts to fail.
