### PR TITLE
k5-buf.h integer helpers

### DIFF
--- a/src/include/k5-buf.h
+++ b/src/include/k5-buf.h
@@ -108,4 +108,58 @@ int k5_buf_status(struct k5buf *buf);
  */
 void k5_buf_free(struct k5buf *buf);
 
+static inline void
+k5_buf_add_uint16_be(struct k5buf *buf, uint16_t val)
+{
+    void *p = k5_buf_get_space(buf, 2);
+
+    if (p != NULL)
+        store_16_be(val, p);
+}
+
+static inline void
+k5_buf_add_uint16_le(struct k5buf *buf, uint16_t val)
+{
+    void *p = k5_buf_get_space(buf, 2);
+
+    if (p != NULL)
+        store_16_le(val, p);
+}
+
+static inline void
+k5_buf_add_uint32_be(struct k5buf *buf, uint32_t val)
+{
+    void *p = k5_buf_get_space(buf, 4);
+
+    if (p != NULL)
+        store_32_be(val, p);
+}
+
+static inline void
+k5_buf_add_uint32_le(struct k5buf *buf, uint32_t val)
+{
+    void *p = k5_buf_get_space(buf, 4);
+
+    if (p != NULL)
+        store_32_le(val, p);
+}
+
+static inline void
+k5_buf_add_uint64_be(struct k5buf *buf, uint64_t val)
+{
+    void *p = k5_buf_get_space(buf, 8);
+
+    if (p != NULL)
+        store_64_be(val, p);
+}
+
+static inline void
+k5_buf_add_uint64_le(struct k5buf *buf, uint64_t val)
+{
+    void *p = k5_buf_get_space(buf, 8);
+
+    if (p != NULL)
+        store_64_le(val, p);
+}
+
 #endif /* K5_BUF_H */

--- a/src/lib/gssapi/mechglue/g_export_cred.c
+++ b/src/lib/gssapi/mechglue/g_export_cred.c
@@ -66,7 +66,6 @@ gss_export_cred(OM_uint32 * minor_status, gss_cred_id_t cred_handle,
     gss_mechanism mech;
     gss_buffer_desc mech_token;
     struct k5buf buf;
-    char lenbuf[4];
     int i;
 
     status = val_exp_cred_args(minor_status, cred_handle, token);
@@ -97,11 +96,9 @@ gss_export_cred(OM_uint32 * minor_status, gss_cred_id_t cred_handle,
         }
 
         /* Append the mech OID and token to buf. */
-        store_32_be(public_oid->length, lenbuf);
-        k5_buf_add_len(&buf, lenbuf, 4);
+        k5_buf_add_uint32_be(&buf, public_oid->length);
         k5_buf_add_len(&buf, public_oid->elements, public_oid->length);
-        store_32_be(mech_token.length, lenbuf);
-        k5_buf_add_len(&buf, lenbuf, 4);
+        k5_buf_add_uint32_be(&buf, mech_token.length);
         k5_buf_add_len(&buf, mech_token.value, mech_token.length);
         gss_release_buffer(&tmpmin, &mech_token);
     }

--- a/src/lib/krb5/ccache/cc_kcm.c
+++ b/src/lib/krb5/ccache/cc_kcm.c
@@ -121,16 +121,6 @@ kcmreq_init(struct kcmreq *req, kcm_opcode opcode, krb5_ccache cache)
     }
 }
 
-/* Add a 32-bit value to the request in big-endian byte order. */
-static void
-kcmreq_put32(struct kcmreq *req, uint32_t val)
-{
-    unsigned char bytes[4];
-
-    store_32_be(val, bytes);
-    k5_buf_add_len(&req->reqbuf, bytes, 4);
-}
-
 #ifdef __APPLE__
 
 /* The maximum length of an in-band request or reply as defined by the RPC
@@ -596,7 +586,7 @@ set_kdc_offset(krb5_context context, krb5_ccache cache)
 
     if (context->os_context.os_flags & KRB5_OS_TOFFSET_VALID) {
         kcmreq_init(&req, KCM_OP_SET_KDC_OFFSET, cache);
-        kcmreq_put32(&req, context->os_context.time_offset);
+        k5_buf_add_uint32_be(&req.reqbuf, context->os_context.time_offset);
         (void)cache_call(context, cache, &req);
         kcmreq_free(&req);
     }
@@ -824,7 +814,7 @@ kcm_remove_cred(krb5_context context, krb5_ccache cache, krb5_flags flags,
     struct kcmreq req;
 
     kcmreq_init(&req, KCM_OP_REMOVE_CRED, cache);
-    kcmreq_put32(&req, flags);
+    k5_buf_add_uint32_be(&req.reqbuf, flags);
     k5_marshal_mcred(&req.reqbuf, mcred);
     ret = cache_call(context, cache, &req);
     kcmreq_free(&req);

--- a/src/plugins/kdb/lmdb/marshal.c
+++ b/src/plugins/kdb/lmdb/marshal.c
@@ -36,29 +36,11 @@
 #include "klmdb-int.h"
 
 static void
-put16(struct k5buf *buf, uint16_t num)
-{
-    uint8_t n[2];
-
-    store_16_le(num, n);
-    k5_buf_add_len(buf, n, 2);
-}
-
-static void
-put32(struct k5buf *buf, uint32_t num)
-{
-    uint8_t n[4];
-
-    store_32_le(num, n);
-    k5_buf_add_len(buf, n, 4);
-}
-
-static void
 put_tl_data(struct k5buf *buf, const krb5_tl_data *tl)
 {
     for (; tl != NULL; tl = tl->tl_data_next) {
-        put16(buf, tl->tl_data_type);
-        put16(buf, tl->tl_data_length);
+        k5_buf_add_uint16_le(buf, tl->tl_data_type);
+        k5_buf_add_uint16_le(buf, tl->tl_data_length);
         k5_buf_add_len(buf, tl->tl_data_contents, tl->tl_data_length);
     }
 }
@@ -76,21 +58,21 @@ klmdb_encode_princ(krb5_context context, const krb5_db_entry *entry,
 
     k5_buf_init_dynamic(&buf);
 
-    put32(&buf, entry->attributes);
-    put32(&buf, entry->max_life);
-    put32(&buf, entry->max_renewable_life);
-    put32(&buf, entry->expiration);
-    put32(&buf, entry->pw_expiration);
-    put16(&buf, entry->n_tl_data);
-    put16(&buf, entry->n_key_data);
+    k5_buf_add_uint32_le(&buf, entry->attributes);
+    k5_buf_add_uint32_le(&buf, entry->max_life);
+    k5_buf_add_uint32_le(&buf, entry->max_renewable_life);
+    k5_buf_add_uint32_le(&buf, entry->expiration);
+    k5_buf_add_uint32_le(&buf, entry->pw_expiration);
+    k5_buf_add_uint16_le(&buf, entry->n_tl_data);
+    k5_buf_add_uint16_le(&buf, entry->n_key_data);
     put_tl_data(&buf, entry->tl_data);
     for (i = 0; i < entry->n_key_data; i++) {
         kd = &entry->key_data[i];
-        put16(&buf, kd->key_data_ver);
-        put16(&buf, kd->key_data_kvno);
+        k5_buf_add_uint16_le(&buf, kd->key_data_ver);
+        k5_buf_add_uint16_le(&buf, kd->key_data_kvno);
         for (j = 0; j < kd->key_data_ver; j++) {
-            put16(&buf, kd->key_data_type[j]);
-            put16(&buf, kd->key_data_length[j]);
+            k5_buf_add_uint16_le(&buf, kd->key_data_type[j]);
+            k5_buf_add_uint16_le(&buf, kd->key_data_length[j]);
             if (kd->key_data_length[j] > 0) {
                 k5_buf_add_len(&buf, kd->key_data_contents[j],
                                kd->key_data_length[j]);
@@ -125,26 +107,26 @@ klmdb_encode_policy(krb5_context context, const osa_policy_ent_rec *pol,
     *len_out = 0;
 
     k5_buf_init_dynamic(&buf);
-    put32(&buf, pol->pw_min_life);
-    put32(&buf, pol->pw_max_life);
-    put32(&buf, pol->pw_min_length);
-    put32(&buf, pol->pw_min_classes);
-    put32(&buf, pol->pw_history_num);
-    put32(&buf, pol->pw_max_fail);
-    put32(&buf, pol->pw_failcnt_interval);
-    put32(&buf, pol->pw_lockout_duration);
-    put32(&buf, pol->attributes);
-    put32(&buf, pol->max_life);
-    put32(&buf, pol->max_renewable_life);
+    k5_buf_add_uint32_le(&buf, pol->pw_min_life);
+    k5_buf_add_uint32_le(&buf, pol->pw_max_life);
+    k5_buf_add_uint32_le(&buf, pol->pw_min_length);
+    k5_buf_add_uint32_le(&buf, pol->pw_min_classes);
+    k5_buf_add_uint32_le(&buf, pol->pw_history_num);
+    k5_buf_add_uint32_le(&buf, pol->pw_max_fail);
+    k5_buf_add_uint32_le(&buf, pol->pw_failcnt_interval);
+    k5_buf_add_uint32_le(&buf, pol->pw_lockout_duration);
+    k5_buf_add_uint32_le(&buf, pol->attributes);
+    k5_buf_add_uint32_le(&buf, pol->max_life);
+    k5_buf_add_uint32_le(&buf, pol->max_renewable_life);
 
     if (pol->allowed_keysalts == NULL) {
-        put32(&buf, 0);
+        k5_buf_add_uint32_le(&buf, 0);
     } else {
-        put32(&buf, strlen(pol->allowed_keysalts));
+        k5_buf_add_uint32_le(&buf, strlen(pol->allowed_keysalts));
         k5_buf_add(&buf, pol->allowed_keysalts);
     }
 
-    put16(&buf, pol->n_tl_data);
+    k5_buf_add_uint16_le(&buf, pol->n_tl_data);
     put_tl_data(&buf, pol->tl_data);
 
     if (k5_buf_status(&buf) != 0)

--- a/src/plugins/preauth/spake/spake_kdc.c
+++ b/src/plugins/preauth/spake/spake_kdc.c
@@ -120,10 +120,7 @@ parse_cookie(const krb5_data *cookie, int *stage_out, int32_t *group_out,
 static void
 marshal_data(struct k5buf *buf, const krb5_data *data)
 {
-    uint8_t lenbuf[4];
-
-    store_32_be(data->length, lenbuf);
-    k5_buf_add_len(buf, lenbuf, 4);
+    k5_buf_add_uint32_be(buf, data->length);
     k5_buf_add_len(buf, data->data, data->length);
 }
 
@@ -133,18 +130,14 @@ make_cookie(int stage, int32_t group, const krb5_data *spake,
             const krb5_data *thash, krb5_data *cookie_out)
 {
     struct k5buf buf;
-    uint8_t intbuf[4];
 
     *cookie_out = empty_data();
     k5_buf_init_dynamic_zap(&buf);
 
     /* Marshal the version, stage, and group. */
-    store_16_be(1, intbuf);
-    k5_buf_add_len(&buf, intbuf, 2);
-    store_16_be(stage, intbuf);
-    k5_buf_add_len(&buf, intbuf, 2);
-    store_32_be(group, intbuf);
-    k5_buf_add_len(&buf, intbuf, 4);
+    k5_buf_add_uint16_be(&buf, 1);
+    k5_buf_add_uint16_be(&buf, stage);
+    k5_buf_add_uint32_be(&buf, group);
 
     /* Marshal the data fields. */
     marshal_data(&buf, spake);

--- a/src/util/support/utf8_conv.c
+++ b/src/util/support/utf8_conv.c
@@ -94,7 +94,6 @@ k5_utf8_to_utf16le(const char *utf8, uint8_t **utf16_out, size_t *nbytes_out)
     struct k5buf buf;
     krb5_ucs4 ch;
     size_t chlen, i;
-    uint8_t *p;
 
     *utf16_out = NULL;
     *nbytes_out = 0;
@@ -127,16 +126,13 @@ k5_utf8_to_utf16le(const char *utf8, uint8_t **utf16_out, size_t *nbytes_out)
 
         /* Characters in the basic multilingual plane are encoded using two
          * bytes; other characters are encoded using four bytes. */
-        p = k5_buf_get_space(&buf, IS_BMP(ch) ? 2 : 4);
-        if (p == NULL)
-            return ENOMEM;
         if (IS_BMP(ch)) {
-            store_16_le(ch, p);
+            k5_buf_add_uint16_le(&buf, ch);
         } else {
             /* 0x10000 is subtracted from ch; then the high ten bits plus
              * 0xD800 and the low ten bits plus 0xDC00 are the surrogates. */
-            store_16_le(HIGH_SURROGATE(ch), p);
-            store_16_le(LOW_SURROGATE(ch), p + 2);
+            k5_buf_add_uint16_le(&buf, HIGH_SURROGATE(ch));
+            k5_buf_add_uint16_le(&buf, LOW_SURROGATE(ch));
         }
 
         /* Move to next UTF-8 character. */


### PR DESCRIPTION
This was prompted by the NegoEx code, but there are enough uses of k5_buf for integers to warrant the helpers already.

I left ccmarshal.c alone because its helpers have to conditionalize on the format version.
