### PR TITLE
Install gssapi/gssapi_alloc.h properly

### DIFF
--- a/src/lib/gssapi/generic/Makefile.in
+++ b/src/lib/gssapi/generic/Makefile.in
@@ -103,7 +103,7 @@ STLIBOBJS = \
 	util_token.o \
 	gssapi_err_generic.o
 
-EXPORTED_HEADERS= gssapi_generic.h  gssapi_ext.h
+EXPORTED_HEADERS= gssapi_generic.h  gssapi_ext.h gssapi_alloc.h
 EXPORTED_BUILT_HEADERS= gssapi.h
 
 $(OBJS): $(EXPORTED_HEADERS) $(ETHDRS)

--- a/src/windows/installer/wix/files.wxi
+++ b/src/windows/installer/wix/files.wxi
@@ -365,6 +365,7 @@
                         <Directory Id="dirinc_krb5_gssapi" Name="gssapi" FileSource="$(var.IncDir)gssapi\">
                             <Component Id="cmp_dirinc_krb5_gssapi" Guid="BD3C190B-1EBB-4d14-81DD-B2000DC4EAC7" DiskId="1">
                                 <File Id="fil_gssapi_h" Name="gssapi.h" KeyPath="yes" />
+                                <File Id="fil_gssapi_alloc_h" Name="gssapi_alloc.h" />
                                 <File Id="fil_gssapi_ext_h" Name="gssapi_ext.h" />
                                 <File Id="fil_gssapi_generic_h" Name="gssapi_generic.h" />
                                 <File Id="fil_gssapi_krb5_h" Name="gssapi_krb5.h" />


### PR DESCRIPTION
Release 1.10 added gssapi_alloc.h, but only added it to "make install"
for Windows, not to the wix installer or to the regular install.
