### PR TITLE
Factor out mechglue context creation

### DIFF
--- a/src/lib/gssapi/mechglue/g_accept_sec_context.c
+++ b/src/lib/gssapi/mechglue/g_accept_sec_context.c
@@ -232,20 +232,10 @@ gss_cred_id_t *		d_cred;
 
     /* Now create a new context if we didn't get one. */
     if (*context_handle == GSS_C_NO_CONTEXT) {
-	status = GSS_S_FAILURE;
-	union_ctx_id = (gss_union_ctx_id_t)
-	    malloc(sizeof(gss_union_ctx_id_desc));
-	if (!union_ctx_id)
-	    return (GSS_S_FAILURE);
-
-	union_ctx_id->loopback = union_ctx_id;
-	union_ctx_id->internal_ctx_id = GSS_C_NO_CONTEXT;
-	status = generic_gss_copy_oid(&temp_minor_status, selected_mech,
-				      &union_ctx_id->mech_type);
-	if (status != GSS_S_COMPLETE) {
-	    free(union_ctx_id);
+	status = gssint_create_union_context(minor_status, selected_mech,
+					     &union_ctx_id);
+	if (status != GSS_S_COMPLETE)
 	    return (status);
-	}
     }
 
     /*

--- a/src/lib/gssapi/mechglue/g_glue.c
+++ b/src/lib/gssapi/mechglue/g_glue.c
@@ -758,3 +758,31 @@ gssint_create_copy_buffer(srcBuf, destBuf, addNullChar)
 
     return (GSS_S_COMPLETE);
 } /* ****** gssint_create_copy_buffer  ****** */
+
+OM_uint32
+gssint_create_union_context(OM_uint32 *minor, gss_const_OID mech_oid,
+			    gss_union_ctx_id_t *ctx_out)
+{
+    OM_uint32 status;
+    gss_union_ctx_id_t ctx;
+
+    *ctx_out = NULL;
+
+    ctx = calloc(1, sizeof(*ctx));
+    if (ctx == NULL) {
+	*minor = ENOMEM;
+	return GSS_S_FAILURE;
+    }
+
+    status = generic_gss_copy_oid(minor, mech_oid, &ctx->mech_type);
+    if (status != GSS_S_COMPLETE) {
+	free(ctx);
+	return status;
+    }
+
+    ctx->loopback = ctx;
+    ctx->internal_ctx_id = GSS_C_NO_CONTEXT;
+
+    *ctx_out = ctx;
+    return GSS_S_COMPLETE;
+}

--- a/src/lib/gssapi/mechglue/g_init_sec_context.c
+++ b/src/lib/gssapi/mechglue/g_init_sec_context.c
@@ -184,20 +184,10 @@ OM_uint32 *		time_rec;
      */
 
     if(*context_handle == GSS_C_NO_CONTEXT) {
-	status = GSS_S_FAILURE;
-	union_ctx_id = (gss_union_ctx_id_t)
-	    malloc(sizeof(gss_union_ctx_id_desc));
-	if (union_ctx_id == NULL)
+	status = gssint_create_union_context(minor_status, selected_mech,
+					     &union_ctx_id);
+	if (status != GSS_S_COMPLETE)
 	    goto end;
-
-	if (generic_gss_copy_oid(&temp_minor_status, selected_mech,
-				 &union_ctx_id->mech_type) != GSS_S_COMPLETE) {
-	    free(union_ctx_id);
-	    goto end;
-	}
-
-	/* copy the supplied context handle */
-	union_ctx_id->internal_ctx_id = GSS_C_NO_CONTEXT;
     } else {
 	union_ctx_id = (gss_union_ctx_id_t)*context_handle;
 	if (union_ctx_id->internal_ctx_id == GSS_C_NO_CONTEXT) {
@@ -248,7 +238,6 @@ OM_uint32 *		time_rec;
 	    free(union_ctx_id);
 	}
     } else if (*context_handle == GSS_C_NO_CONTEXT) {
-	union_ctx_id->loopback = union_ctx_id;
 	*context_handle = (gss_ctx_id_t)union_ctx_id;
     }
 

--- a/src/lib/gssapi/mechglue/g_set_context_option.c
+++ b/src/lib/gssapi/mechglue/g_set_context_option.c
@@ -71,37 +71,23 @@ gss_set_sec_context_option (OM_uint32 *minor_status,
 					      &internal_ctx,
 					      desired_object,
 					      value);
-    if (status == GSS_S_COMPLETE) {
-	if (ctx == NULL && internal_ctx != GSS_C_NO_CONTEXT) {
-	    /* Allocate a union context handle to wrap new context */
-	    ctx = (gss_union_ctx_id_t)malloc(sizeof(*ctx));
-	    if (ctx == NULL) {
-		*minor_status = ENOMEM;
-		gssint_delete_internal_sec_context(&minor,
-						   &mech->mech_type,
-						   &internal_ctx,
-						   GSS_C_NO_BUFFER);
-		return GSS_S_FAILURE;
-	    }
-
-	    status = generic_gss_copy_oid(minor_status,
-					  &mech->mech_type,
-					  &ctx->mech_type);
-	    if (status != GSS_S_COMPLETE) {
-		gssint_delete_internal_sec_context(&minor,
-						   ctx->mech_type,
-						   &internal_ctx,
-						   GSS_C_NO_BUFFER);
-		free(ctx);
-		return status;
-	    }
-
-	    ctx->loopback = ctx;
-	    ctx->internal_ctx_id = internal_ctx;
-	    *context_handle = (gss_ctx_id_t)ctx;
-	}
-    } else
+    if (status != GSS_S_COMPLETE) {
 	map_error(minor_status, mech);
+	return status;
+    }
 
-    return status;
+    if (ctx == NULL && internal_ctx != GSS_C_NO_CONTEXT) {
+	status = gssint_create_union_context(minor_status, &mech->mech_type,
+					     &ctx);
+	if (status != GSS_S_COMPLETE) {
+	    gssint_delete_internal_sec_context(&minor, ctx->mech_type,
+					       &internal_ctx, GSS_C_NO_BUFFER);
+	    return status;
+	}
+
+	ctx->internal_ctx_id = internal_ctx;
+	*context_handle = (gss_ctx_id_t)ctx;
+    }
+
+    return GSS_S_COMPLETE;
 }

--- a/src/lib/gssapi/mechglue/g_set_context_option.c
+++ b/src/lib/gssapi/mechglue/g_set_context_option.c
@@ -96,6 +96,7 @@ gss_set_sec_context_option (OM_uint32 *minor_status,
 		return status;
 	    }
 
+	    ctx->loopback = ctx;
 	    ctx->internal_ctx_id = internal_ctx;
 	    *context_handle = (gss_ctx_id_t)ctx;
 	}

--- a/src/lib/gssapi/mechglue/mglueP.h
+++ b/src/lib/gssapi/mechglue/mglueP.h
@@ -769,6 +769,12 @@ OM_uint32 gssint_create_copy_buffer(
 	int			/* NULL terminate buffer ? */
 );
 
+OM_uint32 gssint_create_union_context(
+	OM_uint32 *minor,	/* minor_status */
+	gss_const_OID,		/* mech_oid */
+	gss_union_ctx_id_t *	/* ctx_out */
+);
+
 OM_uint32 gssint_copy_oid_set(
 	OM_uint32 *,			/* minor_status */
 	const gss_OID_set_desc * const,	/* oid set */


### PR DESCRIPTION
The first commit is a bugfix extracted from Luke's NegoEx implementation.  gss_set_sec_context_option() is probably unused (particularly in the mode where you create a context with it) but I wanted the bugfix to be separate and backported.

The second commit factors out four instances of creating a union context (which will go up to six with NegoEx) into a helper function.
