### PR TITLE
Match kpasswd_server definitions in kadmin's test config

### DIFF
--- a/src/kadmin/testing/proto/krb5.conf.proto
+++ b/src/kadmin/testing/proto/krb5.conf.proto
@@ -9,6 +9,7 @@
 	__REALM__ = {
 		kdc = __KDCHOST__:1750
 		admin_server = __KDCHOST__:1751
+		kpasswd_server = __KDCHOST__:1752
 		database_module = foobar_db2_module_blah
 	}
 


### PR DESCRIPTION
kpaswd_server is defined in kdc.conf.proto, but not krb5.conf proto.
Based on a patch by Nalin Dahyabhai.

[This is part of some glue code we have downstream to make sure multiple concurrent test runs don't step on each other.  It's a trap waiting to happen, in any case.]