### PR TITLE
Simplify SPNEGO get_available_mechs()

### DIFF
--- a/src/lib/gssapi/spnego/spnego_mech.c
+++ b/src/lib/gssapi/spnego/spnego_mech.c
@@ -3099,57 +3099,33 @@ get_available_mechs(OM_uint32 *minor_status,
 	gss_const_key_value_set_t cred_store,
 	gss_cred_id_t *creds, gss_OID_set *rmechs, OM_uint32 *time_rec)
 {
-	unsigned int	i;
-	int		found = 0;
 	OM_uint32 major_status = GSS_S_COMPLETE, tmpmin;
 	gss_OID_set mechs, goodmechs;
 	gss_OID_set_desc except_attrs;
-	gss_OID_desc attr_oids[2];
+	gss_OID_desc attr_oids[3];
+
+	*rmechs = GSS_C_NO_OID_SET;
 
 	attr_oids[0] = *GSS_C_MA_DEPRECATED;
 	attr_oids[1] = *GSS_C_MA_NOT_DFLT_MECH;
-	except_attrs.count = 2;
+	attr_oids[2] = *GSS_C_MA_MECH_NEGO;     /* Exclude ourselves */
+	except_attrs.count = sizeof(attr_oids) / sizeof(attr_oids[0]);
 	except_attrs.elements = attr_oids;
 	major_status = gss_indicate_mechs_by_attrs(minor_status,
 						   GSS_C_NO_OID_SET,
 						   &except_attrs,
 						   GSS_C_NO_OID_SET, &mechs);
 
-	if (major_status != GSS_S_COMPLETE) {
-		return (major_status);
-	}
-
-	major_status = gss_create_empty_oid_set(minor_status, rmechs);
-
-	if (major_status != GSS_S_COMPLETE) {
-		(void) gss_release_oid_set(minor_status, &mechs);
-		return (major_status);
-	}
-
-	for (i = 0; i < mechs->count && major_status == GSS_S_COMPLETE; i++) {
-		if ((mechs->elements[i].length
-		    != spnego_mechanism.mech_type.length) ||
-		    memcmp(mechs->elements[i].elements,
-			spnego_mechanism.mech_type.elements,
-			spnego_mechanism.mech_type.length)) {
-
-			major_status = gss_add_oid_set_member(minor_status,
-							      &mechs->elements[i],
-							      rmechs);
-			if (major_status == GSS_S_COMPLETE)
-				found++;
-		}
-	}
-
 	/*
 	 * If the caller wanted a list of creds returned,
 	 * trim the list of mechanisms down to only those
 	 * for which the creds are valid.
 	 */
-	if (found > 0 && major_status == GSS_S_COMPLETE && creds != NULL) {
+	if (mechs->count > 0 && major_status == GSS_S_COMPLETE &&
+	    creds != NULL) {
 		major_status = gss_acquire_cred_from(minor_status, name,
 						     GSS_C_INDEFINITE,
-						     *rmechs, usage,
+						     mechs, usage,
 						     cred_store, creds,
 						     &goodmechs, time_rec);
 
@@ -3157,16 +3133,16 @@ get_available_mechs(OM_uint32 *minor_status,
 		 * Drop the old list in favor of the new
 		 * "trimmed" list.
 		 */
-		(void) gss_release_oid_set(&tmpmin, rmechs);
 		if (major_status == GSS_S_COMPLETE) {
-			(void) gssint_copy_oid_set(&tmpmin,
-					goodmechs, rmechs);
-			(void) gss_release_oid_set(&tmpmin, &goodmechs);
+			(void) gss_release_oid_set(&tmpmin, &mechs);
+			mechs = goodmechs;
 		}
 	}
 
-	(void) gss_release_oid_set(&tmpmin, &mechs);
-	if (found == 0 || major_status != GSS_S_COMPLETE) {
+	if (mechs->count > 0 && major_status == GSS_S_COMPLETE) {
+		*rmechs = mechs;
+	} else {
+		(void) gss_release_oid_set(&tmpmin, &mechs);
 		*minor_status = ERR_SPNEGO_NO_MECHS_AVAILABLE;
 		map_errcode(minor_status);
 		if (major_status == GSS_S_COMPLETE)


### PR DESCRIPTION
[This is in the NegoEx PR, but is unrelated, so I'm extracting it for separate review.]

Exclude all negotiation mechanisms when getting the set of available
mechs, avoiding the need to make a copy and specifically exclude
SPNEGO.
