### PR TITLE
Three code hygiene fixes

### DIFF
--- a/src/lib/gssapi/spnego/negoex_ctx.c
+++ b/src/lib/gssapi/spnego/negoex_ctx.c
@@ -454,6 +454,7 @@ verify_checksum(OM_uint32 *minor, spnego_gss_ctx_id_t ctx,
 
     /* Verify the checksum over the existing transcript and the portion of the
      * input token leading up to the verify message. */
+    assert(input_token != NULL);
     iov[0].flags = KRB5_CRYPTO_TYPE_DATA;
     iov[0].data = make_data(ctx->negoex_transcript.data,
                             ctx->negoex_transcript.len);

--- a/src/lib/kadm5/kadm_rpc_xdr.c
+++ b/src/lib/kadm5/kadm_rpc_xdr.c
@@ -1125,14 +1125,16 @@ xdr_krb5_salttype(XDR *xdrs, krb5_int32 *objp)
 bool_t
 xdr_krb5_keyblock(XDR *xdrs, krb5_keyblock *objp)
 {
+   char *cp;
+
    /* XXX This only works because free_keyblock assumes ->contents
       is allocated by malloc() */
-
    if(!xdr_krb5_enctype(xdrs, &objp->enctype))
       return FALSE;
-   if(!xdr_bytes(xdrs, (char **) &objp->contents, (unsigned int *)
-		 &objp->length, ~0))
+   cp = (char *)objp->contents;
+   if(!xdr_bytes(xdrs, &cp, &objp->length, ~0))
       return FALSE;
+   objp->contents = (uint8_t *)cp;
    return TRUE;
 }
 

--- a/src/lib/krb5/krb/ser_ctx.c
+++ b/src/lib/krb5/krb/ser_ctx.c
@@ -204,8 +204,11 @@ k5_externalize_context(krb5_context context,
         return (kret);
 
     /* Finally, handle profile, if appropriate */
-    if (context->profile != NULL)
+    if (context->profile != NULL) {
         kret = profile_ser_externalize(NULL, context->profile, &bp, &remain);
+        if (kret)
+            return (kret);
+    }
 
     /*
      * If we were successful, write trailer then update the pointer and

--- a/src/lib/rpc/authgss_prot.c
+++ b/src/lib/rpc/authgss_prot.c
@@ -50,6 +50,7 @@ xdr_rpc_gss_buf(XDR *xdrs, gss_buffer_t buf, u_int maxsize)
 {
 	bool_t xdr_stat;
 	u_int tmplen;
+	char *cp;
 
 	if (xdrs->x_op != XDR_DECODE) {
 		if (buf->length > UINT_MAX)
@@ -57,7 +58,9 @@ xdr_rpc_gss_buf(XDR *xdrs, gss_buffer_t buf, u_int maxsize)
 		else
 			tmplen = buf->length;
 	}
-	xdr_stat = xdr_bytes(xdrs, (char **)&buf->value, &tmplen, maxsize);
+	cp = buf->value;
+	xdr_stat = xdr_bytes(xdrs, &cp, &tmplen, maxsize);
+	buf->value = cp;
 
 	if (xdr_stat && xdrs->x_op == XDR_DECODE)
 		buf->length = tmplen;


### PR DESCRIPTION
Two of these address Coverity defects (one real, one a false positive).  The third addresses warnings from clang under macOS.  (The macOS build is still not warning-clean because of deprecations warnings; macOS has decided that daemon() and the entire libldap API are deprecated.  We might be able to except deprecation warnings from -Werror.)

I still need to verify that the assert() squashes the false-positive defect by manually submitting a build to Coverity scan.  There's a regularly scheduled build in the queue right now so that will take a bit.
