### PR TITLE
s4u2proxy: only send client authdata in initial request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -444,6 +444,7 @@ local.properties
 /src/tests/responder
 /src/tests/s2p
 /src/tests/s4u2proxy
+/src/tests/s4u2self
 /src/tests/unlockiter
 
 /src/tests/asn.1/expected_encode.out

--- a/src/tests/Makefile.in
+++ b/src/tests/Makefile.in
@@ -8,10 +8,10 @@ RUN_DB_TEST = $(RUN_SETUP) KRB5_KDC_PROFILE=kdc.conf KRB5_CONFIG=krb5.conf \
 
 OBJS= adata.o etinfo.o forward.o gcred.o hist.o hooks.o hrealm.o \
 	icinterleave.o icred.o kdbtest.o localauth.o plugorder.o rdreq.o \
-	replay.o responder.o s2p.o s4u2proxy.o unlockiter.o
+	replay.o responder.o s2p.o s4u2self.o s4u2proxy.o unlockiter.o
 EXTRADEPSRCS= adata.c etinfo.c forward.c gcred.c hist.c hooks.c hrealm.c \
 	icinterleave.c icred.c kdbtest.c localauth.c plugorder.c rdreq.c \
-	replay.c responder.c s2p.c s4u2proxy.c unlockiter.c
+	replay.c responder.c s2p.c s4u2self.c s4u2proxy.c unlockiter.c
 
 TEST_DB = ./testdb
 TEST_REALM = FOO.TEST.REALM
@@ -72,6 +72,9 @@ responder: responder.o $(KRB5_BASE_DEPLIBS)
 s2p: s2p.o $(KRB5_BASE_DEPLIBS)
 	$(CC_LINK) -o $@ s2p.o $(KRB5_BASE_LIBS)
 
+s4u2self: s4u2self.o $(KRB5_BASE_DEPLIBS)
+	$(CC_LINK) -o $@ s4u2self.o $(KRB5_BASE_LIBS)
+
 s4u2proxy: s4u2proxy.o $(KRB5_BASE_DEPLIBS)
 	$(CC_LINK) -o $@ s4u2proxy.o $(KRB5_BASE_LIBS)
 
@@ -117,7 +120,7 @@ kdb_check: kdc.conf krb5.conf
 
 check-pytests: adata etinfo forward gcred hist hooks hrealm icinterleave icred
 check-pytests: kdbtest localauth plugorder rdreq replay responder s2p s4u2proxy
-check-pytests: unlockiter
+check-pytests: unlockiter s4u2self
 	$(RUNPYTEST) $(srcdir)/t_general.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_hooks.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_dump.py $(PYTESTFLAGS)
@@ -180,7 +183,7 @@ check-pytests: unlockiter
 clean:
 	$(RM) adata etinfo forward gcred hist hooks hrealm icinterleave icred
 	$(RM) kdbtest localauth plugorder rdreq replay responder s2p s4u2proxy
-	$(RM) unlockiter
+	$(RM) unlockiter s4u2self
 	$(RM) krb5.conf kdc.conf
 	$(RM) -rf kdc_realm/sandbox ldap
 	$(RM) au.log

--- a/src/tests/adata.c
+++ b/src/tests/adata.c
@@ -303,9 +303,11 @@ main(int argc, char **argv)
     check(krb5_get_credentials(ctx, KRB5_GC_NO_STORE, ccache, &in_creds,
                                &creds));
 
+    assert(in_creds.authdata == NULL || creds->authdata != NULL);
+
     check(krb5_decode_ticket(&creds->ticket, &ticket));
     check(krb5_kt_default(ctx, &keytab));
-    check(krb5_kt_get_entry(ctx, keytab, server, ticket->enc_part.kvno,
+    check(krb5_kt_get_entry(ctx, keytab, ticket->server, ticket->enc_part.kvno,
                             ticket->enc_part.enctype, &ktent));
     check(krb5_decrypt_tkt_part(ctx, &ktent.key, ticket));
 


### PR DESCRIPTION
I think this should suffice for now, skipping the realm identification part as I hope it would be simpler later. I'll try to add a test though. (see #983).