### PR TITLE
Do not assume KRB5_KDB_FLAG_CANONICALIZE for enterprise principals

### DIFF
--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -1057,15 +1057,18 @@ typedef struct _kdb_vftabl {
      * in-realm alias, fill in a different value for entries->princ than the
      * one requested.
      *
-     * A module can return out-of-realm referrals if KRB5_KDB_FLAG_CANONICALIZE
-     * is set.  For AS request clients (KRB5_KDB_FLAG_CLIENT_REFERRALS_ONLY is
-     * also set), the module should do so by simply filling in an out-of-realm
-     * name in entries->princ and setting all other fields to NULL.  Otherwise,
-     * the module should return the entry for the cross-realm TGS of the
-     * referred-to realm.  For TGS referals, the module can also include
-     * tl-data of type KRB5_TL_SERVER_REFERRAL containing ASN.1-encoded Windows
-     * referral data as documented in draft-ietf-krb-wg-kerberos-referrals-11
-     * appendix A; this will be returned to the client as encrypted padata.
+     * A module can return a referral to another realm if
+     * KRB5_KDB_FLAG_CANONICALIZE is set, or if
+     * KRB5_KDB_FLAG_CLIENT_REFERRALS_ONLY is set and search_for->type is
+     * KRB5_NT_ENTERPRISE_PRINCIPAL.  If KRB5_KDB_FLAG_CLIENT_REFERRALS_ONLY is
+     * set, the module should return a referral by simply filling in an
+     * out-of-realm name in (*entry)->princ and setting all other fields to
+     * NULL.  Otherwise, the module should return the entry for the cross-realm
+     * TGS of the referred-to realm.  For TGS referals, the module can also
+     * include tl-data of type KRB5_TL_SERVER_REFERRAL containing ASN.1-encoded
+     * Windows referral data as documented in
+     * draft-ietf-krb-wg-kerberos-referrals-11 appendix A; this will be
+     * returned to the client as encrypted padata.
      */
     krb5_error_code (*get_principal)(krb5_context kcontext,
                                      krb5_const_principal search_for,

--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -121,8 +121,6 @@
 #define KRB5_KDB_FLAG_USER_TO_USER              0x00000800
 /* Cross-realm */
 #define KRB5_KDB_FLAG_CROSS_REALM               0x00001000
-/* Allow in-realm aliases */
-#define KRB5_KDB_FLAG_ALIAS_OK                  0x00002000
 /* Issuing referral */
 #define KRB5_KDB_FLAG_ISSUING_REFERRAL          0x00004000
 
@@ -1047,15 +1045,9 @@ typedef struct _kdb_vftabl {
      *     part of the realm being served, and a referral or alternate TGT will
      *     be issued instead.
      *
-     * KRB5_KDB_FLAG_ALIAS_OK: Set by the KDC for server principal lookups and
-     *     for AS request client principal lookups with canonicalization
-     *     requested; also set by the admin interface.  Determines whether the
-     *     module should return in-realm aliases.
-     *
-     * A module can return in-realm aliases if KRB5_KDB_FLAG_ALIAS_OK is set,
-     * or if search_for->type is KRB5_NT_ENTERPRISE_PRINCIPAL.  To return an
-     * in-realm alias, fill in a different value for entries->princ than the
-     * one requested.
+     * A module may return an in-realm alias by setting (*entry)->princ to the
+     * canonical name.  The KDC will decide based on the request whether to use
+     * the requested name or the canonical name in the issued ticket.
      *
      * A module can return a referral to another realm if
      * KRB5_KDB_FLAG_CANONICALIZE is set, or if

--- a/src/kdc/do_as_req.c
+++ b/src/kdc/do_as_req.c
@@ -596,14 +596,13 @@ process_as_req(krb5_kdc_req *request, krb5_data *req_pkt,
      * of cross realm TGS entries.
      */
     setflag(state->c_flags, KRB5_KDB_FLAG_CLIENT_REFERRALS_ONLY);
-    /*
-     * Note that according to the referrals draft we should
-     * always canonicalize enterprise principal names.
-     */
+    /* Enterprise principals are implicitly alias-ok. */
     if (isflagset(state->request->kdc_options, KDC_OPT_CANONICALIZE) ||
         state->request->client->type == KRB5_NT_ENTERPRISE_PRINCIPAL) {
-        setflag(state->c_flags, KRB5_KDB_FLAG_CANONICALIZE);
         setflag(state->c_flags, KRB5_KDB_FLAG_ALIAS_OK);
+    }
+    if (isflagset(state->request->kdc_options, KDC_OPT_CANONICALIZE)) {
+        setflag(state->c_flags, KRB5_KDB_FLAG_CANONICALIZE);
     }
     if (include_pac_p(kdc_context, state->request)) {
         setflag(state->c_flags, KRB5_KDB_FLAG_INCLUDE_PAC);

--- a/src/kdc/do_as_req.c
+++ b/src/kdc/do_as_req.c
@@ -596,11 +596,7 @@ process_as_req(krb5_kdc_req *request, krb5_data *req_pkt,
      * of cross realm TGS entries.
      */
     setflag(state->c_flags, KRB5_KDB_FLAG_CLIENT_REFERRALS_ONLY);
-    /* Enterprise principals are implicitly alias-ok. */
-    if (isflagset(state->request->kdc_options, KDC_OPT_CANONICALIZE) ||
-        state->request->client->type == KRB5_NT_ENTERPRISE_PRINCIPAL) {
-        setflag(state->c_flags, KRB5_KDB_FLAG_ALIAS_OK);
-    }
+
     if (isflagset(state->request->kdc_options, KDC_OPT_CANONICALIZE)) {
         setflag(state->c_flags, KRB5_KDB_FLAG_CANONICALIZE);
     }
@@ -639,7 +635,6 @@ process_as_req(krb5_kdc_req *request, krb5_data *req_pkt,
     au_state->stage = SRVC_PRINC;
 
     s_flags = 0;
-    setflag(s_flags, KRB5_KDB_FLAG_ALIAS_OK);
     if (isflagset(state->request->kdc_options, KDC_OPT_CANONICALIZE)) {
         setflag(s_flags, KRB5_KDB_FLAG_CANONICALIZE);
     }

--- a/src/kdc/do_tgs_req.c
+++ b/src/kdc/do_tgs_req.c
@@ -238,7 +238,6 @@ process_tgs_req(krb5_kdc_req *request, krb5_data *pkt,
     /* XXX make sure server here has the proper realm...taken from AP_REQ
        header? */
 
-    setflag(s_flags, KRB5_KDB_FLAG_ALIAS_OK);
     if (isflagset(request->kdc_options, KDC_OPT_CANONICALIZE)) {
         setflag(c_flags, KRB5_KDB_FLAG_CANONICALIZE);
         setflag(s_flags, KRB5_KDB_FLAG_CANONICALIZE);

--- a/src/kdc/kdc_preauth.c
+++ b/src/kdc/kdc_preauth.c
@@ -489,7 +489,7 @@ match_client(krb5_context context, krb5_kdcpreauth_rock rock,
         krb5_principal_compare(context, princ, client))
         return TRUE;
 
-    if (krb5_db_get_principal(context, princ, KRB5_KDB_FLAG_ALIAS_OK, &ent))
+    if (krb5_db_get_principal(context, princ, 0, &ent))
         return FALSE;
     match = krb5_principal_compare(context, ent->princ, client);
     krb5_db_free_principal(context, ent);

--- a/src/kdc/kdc_util.c
+++ b/src/kdc/kdc_util.c
@@ -403,9 +403,8 @@ kdc_rd_ap_req(kdc_realm_t *kdc_active_realm,
         match_enctype = 0;
     }
 
-    retval = kdc_get_server_key(kdc_context, apreq->ticket,
-                                KRB5_KDB_FLAG_ALIAS_OK, match_enctype, server,
-                                NULL, NULL);
+    retval = kdc_get_server_key(kdc_context, apreq->ticket, 0, match_enctype,
+                                server, NULL, NULL);
     if (retval)
         return retval;
 

--- a/src/lib/kadm5/srv/server_kdb.c
+++ b/src/lib/kadm5/srv/server_kdb.c
@@ -264,8 +264,7 @@ kdb_get_entry(kadm5_server_handle_t handle,
 
     *kdb_ptr = NULL;
 
-    ret = krb5_db_get_principal(handle->context, principal,
-                                KRB5_KDB_FLAG_ALIAS_OK, &kdb);
+    ret = krb5_db_get_principal(handle->context, principal, 0, &kdb);
     if (ret == KRB5_KDB_NOENTRY)
         return(KADM5_UNK_PRINC);
     if (ret)

--- a/src/lib/kdb/kdb5.c
+++ b/src/lib/kdb/kdb5.c
@@ -1038,8 +1038,7 @@ krb5_db_rename_principal(krb5_context kcontext, krb5_principal source,
         logging(kcontext))
         return KRB5_PLUGIN_OP_NOTSUPP;
 
-    status = krb5_db_get_principal(kcontext, target, KRB5_KDB_FLAG_ALIAS_OK,
-                                   &entry);
+    status = krb5_db_get_principal(kcontext, target, 0, &entry);
     if (status == 0) {
         krb5_db_free_principal(kcontext, entry);
         return KRB5_KDB_INUSE;

--- a/src/lib/kdb/kdb_default.c
+++ b/src/lib/kdb/kdb_default.c
@@ -524,8 +524,7 @@ krb5_db_def_rename_principal(krb5_context kcontext,
     if (source == NULL || target == NULL)
         return EINVAL;
 
-    ret = krb5_db_get_principal(kcontext, source, KRB5_KDB_FLAG_ALIAS_OK,
-                                &kdb);
+    ret = krb5_db_get_principal(kcontext, source, 0, &kdb);
     if (ret)
         goto cleanup;
 

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
@@ -189,15 +189,12 @@ krb5_ldap_get_principal(krb5_context context, krb5_const_principal searchfor,
             if ((values=ldap_get_values(ld, ent, "krbcanonicalname")) != NULL) {
                 if (values[0] && strcmp(values[0], user) != 0) {
                     /* We matched an alias, not the canonical name. */
-                    if (flags & KRB5_KDB_FLAG_ALIAS_OK) {
-                        st = krb5_ldap_parse_principal_name(values[0], &cname);
-                        if (st != 0)
-                            goto cleanup;
-                        st = krb5_parse_name(context, cname, &cprinc);
-                        if (st != 0)
-                            goto cleanup;
-                    } else /* No canonicalization, so don't return aliases. */
-                        found = FALSE;
+                    st = krb5_ldap_parse_principal_name(values[0], &cname);
+                    if (st != 0)
+                        goto cleanup;
+                    st = krb5_parse_name(context, cname, &cprinc);
+                    if (st != 0)
+                        goto cleanup;
                 }
                 ldap_value_free(values);
                 if (!found)

--- a/src/plugins/kdb/test/kdb_test.c
+++ b/src/plugins/kdb/test/kdb_test.c
@@ -351,14 +351,12 @@ test_get_principal(krb5_context context, krb5_const_principal search_for,
                                   &search_name));
     canon = get_string(h, "alias", search_name, NULL);
     if (canon != NULL) {
-        if (!(flags & KRB5_KDB_FLAG_ALIAS_OK) &&
-            search_for->type != KRB5_NT_ENTERPRISE_PRINCIPAL) {
-            ret = KRB5_KDB_NOENTRY;
-            goto cleanup;
-        }
         check(krb5_parse_name(context, canon, &princ));
         if (!krb5_realm_compare(context, search_for, princ)) {
-            if (flags & KRB5_KDB_FLAG_CLIENT_REFERRALS_ONLY) {
+            /* Out of realm */
+            if ((flags & KRB5_KDB_FLAG_CLIENT_REFERRALS_ONLY) &&
+                ((flags & KRB5_KDB_FLAG_CANONICALIZE) ||
+                 search_for->type == KRB5_NT_ENTERPRISE_PRINCIPAL)) {
                 /* Return a client referral by creating an entry with only the
                  * principal set. */
                 *entry = ealloc(sizeof(**entry));
@@ -486,9 +484,7 @@ test_get_s4u_x509_principal(krb5_context context, const krb5_data *client_cert,
                                   &princ_name));
     canon = get_string(h, "alias", princ_name, NULL);
     krb5_free_unparsed_name(context, princ_name);
-    if (canon != NULL &&
-        ((flags & KRB5_KDB_FLAG_ALIAS_OK) ||
-         princ->type == KRB5_NT_ENTERPRISE_PRINCIPAL)) {
+    if (canon != NULL) {
         check(krb5_parse_name(context, canon, &canon_princ));
         match = krb5_principal_compare(context, canon_princ, (*entry)->princ);
         krb5_free_principal(context, canon_princ);

--- a/src/tests/t_kdb.py
+++ b/src/tests/t_kdb.py
@@ -340,10 +340,13 @@ ldap_modify('dn: krbPrincipalName=canon@KRBTEST.COM,cn=t1,cn=krb5\n'
             'changetype: modify\n'
             'add: krbPrincipalName\n'
             'krbPrincipalName: alias@KRBTEST.COM\n'
+            'krbPrincipalName: ent@abc@KRBTEST.COM\n'
             '-\n'
             'add: krbCanonicalName\n'
             'krbCanonicalName: canon@KRBTEST.COM\n')
 realm.run([kadminl, 'getprinc', 'alias'],
+          expected_msg='Principal: canon@KRBTEST.COM\n')
+realm.run([kadminl, 'getprinc', 'ent\@abc'],
           expected_msg='Principal: canon@KRBTEST.COM\n')
 realm.run([kadminl, 'getprinc', 'canon'],
           expected_msg='Principal: canon@KRBTEST.COM\n')
@@ -388,6 +391,15 @@ realm.klist('canon@KRBTEST.COM', 'alias@KRBTEST.COM')
 realm.run([kadminl, 'modprinc', '+requires_preauth', 'canon'])
 realm.kinit('canon', password('canon'))
 realm.kinit('alias', password('canon'), ['-C'])
+
+# Test enterprise alias with and without canonicalization.
+realm.kinit('ent@abc', password('canon'), ['-E', '-C'])
+realm.run([kvno, 'alias'])
+realm.klist('canon@KRBTEST.COM', 'alias@KRBTEST.COM')
+
+realm.kinit('ent@abc', password('canon'), ['-E'])
+realm.run([kvno, 'alias'])
+realm.klist('ent\@abc@KRBTEST.COM', 'alias@KRBTEST.COM')
 
 # Test client name canonicalization in non-krbtgt AS reply
 realm.kinit('alias', password('canon'), ['-C', '-S', 'kadmin/changepw'])

--- a/src/tests/t_kdb.py
+++ b/src/tests/t_kdb.py
@@ -383,8 +383,9 @@ realm.klist(realm.user_princ, 'alias@KRBTEST.COM')
 
 # Test client principal aliases, with and without preauth.
 realm.kinit('canon', password('canon'))
-realm.kinit('alias', password('canon'), expected_code=1,
-            expected_msg='not found in Kerberos database')
+realm.kinit('alias', password('canon'))
+realm.run([kvno, 'alias'])
+realm.klist('alias@KRBTEST.COM', 'alias@KRBTEST.COM')
 realm.kinit('alias', password('canon'), ['-C'])
 realm.run([kvno, 'alias'])
 realm.klist('canon@KRBTEST.COM', 'alias@KRBTEST.COM')


### PR DESCRIPTION
As discussed, i think it would be good to have this with the api change.