### PR TITLE
Don't warn in kadmin when no principal policy is specified

### DIFF
--- a/doc/admin/admin_commands/kadmin_local.rst
+++ b/doc/admin/admin_commands/kadmin_local.rst
@@ -419,7 +419,7 @@ Options:
 Example::
 
     kadmin: addprinc jennifer
-    WARNING: no policy specified for "jennifer@ATHENA.MIT.EDU";
+    No policy specified for "jennifer@ATHENA.MIT.EDU";
     defaulting to no policy.
     Enter password for principal jennifer@ATHENA.MIT.EDU:
     Re-enter password for principal jennifer@ATHENA.MIT.EDU:

--- a/doc/admin/database.rst
+++ b/doc/admin/database.rst
@@ -103,7 +103,7 @@ If you want to create a principal which is contained by a LDAP object,
 all you need to do is::
 
     kadmin: addprinc -x dn=cn=jennifer,dc=example,dc=com jennifer
-    WARNING: no policy specified for "jennifer@ATHENA.MIT.EDU";
+    No policy specified for "jennifer@ATHENA.MIT.EDU";
     defaulting to no policy.
     Enter password for principal jennifer@ATHENA.MIT.EDU:  <= Type the password.
     Re-enter password for principal jennifer@ATHENA.MIT.EDU:  <=Type it again.
@@ -114,7 +114,7 @@ If you want to create a principal under a specific LDAP container and
 link to an existing LDAP object, all you need to do is::
 
     kadmin: addprinc -x containerdn=dc=example,dc=com -x linkdn=cn=david,dc=example,dc=com david
-    WARNING: no policy specified for "david@ATHENA.MIT.EDU";
+    No policy specified for "david@ATHENA.MIT.EDU";
     defaulting to no policy.
     Enter password for principal david@ATHENA.MIT.EDU:  <= Type the password.
     Re-enter password for principal david@ATHENA.MIT.EDU:  <=Type it again.

--- a/doc/admin/install_kdc.rst
+++ b/doc/admin/install_kdc.rst
@@ -239,7 +239,7 @@ is created::
 
     kadmin.local: addprinc admin/admin@ATHENA.MIT.EDU
 
-    WARNING: no policy specified for "admin/admin@ATHENA.MIT.EDU";
+    No policy specified for "admin/admin@ATHENA.MIT.EDU";
     assigning "default".
     Enter password for principal admin/admin@ATHENA.MIT.EDU:  <= Enter a password.
     Re-enter password for principal admin/admin@ATHENA.MIT.EDU:  <= Type it again.
@@ -316,11 +316,11 @@ following::
 
     shell% kadmin
     kadmin: addprinc -randkey host/kerberos.mit.edu
-    NOTICE: no policy specified for "host/kerberos.mit.edu@ATHENA.MIT.EDU"; assigning "default"
+    No policy specified for "host/kerberos.mit.edu@ATHENA.MIT.EDU"; assigning "default"
     Principal "host/kerberos.mit.edu@ATHENA.MIT.EDU" created.
 
     kadmin: addprinc -randkey host/kerberos-1.mit.edu
-    NOTICE: no policy specified for "host/kerberos-1.mit.edu@ATHENA.MIT.EDU"; assigning "default"
+    No policy specified for "host/kerberos-1.mit.edu@ATHENA.MIT.EDU"; assigning "default"
     Principal "host/kerberos-1.mit.edu@ATHENA.MIT.EDU" created.
 
 It is not strictly necessary to have the master KDC server in the

--- a/src/kadmin/cli/kadmin.c
+++ b/src/kadmin/cli/kadmin.c
@@ -1229,13 +1229,13 @@ kadmin_addprinc(int argc, char *argv[])
         /* If the policy "default" exists, assign it. */
         if (policy_exists("default")) {
             if (!script_mode) {
-                fprintf(stderr, _("NOTICE: no policy specified for %s; "
+                fprintf(stderr, _("No policy specified for %s; "
                                   "assigning \"default\"\n"), canon);
             }
             princ.policy = "default";
             mask |= KADM5_POLICY;
         } else if (!script_mode) {
-            fprintf(stderr, _("WARNING: no policy specified for %s; "
+            fprintf(stderr, _("No policy specified for %s; "
                               "defaulting to no policy\n"), canon);
         }
     }

--- a/src/man/kadmin.man
+++ b/src/man/kadmin.man
@@ -458,7 +458,7 @@ Example:
 .nf
 .ft C
 kadmin: addprinc jennifer
-WARNING: no policy specified for "jennifer@ATHENA.MIT.EDU";
+No policy specified for "jennifer@ATHENA.MIT.EDU";
 defaulting to no policy.
 Enter password for principal jennifer@ATHENA.MIT.EDU:
 Re\-enter password for principal jennifer@ATHENA.MIT.EDU:

--- a/src/po/de.po
+++ b/src/po/de.po
@@ -1690,16 +1690,16 @@ msgstr "WARNUNG: Richtlinie »%s« existiert nicht.\n"
 
 #: ../../src/kadmin/cli/kadmin.c:1230
 #, c-format
-msgid "NOTICE: no policy specified for %s; assigning \"default\"\n"
+msgid "No policy specified for %s; assigning \"default\"\n"
 msgstr ""
-"HINWEIS: Für %s wurde keine Richtlinie angegeben, es wird »default« "
+"Für %s wurde keine Richtlinie angegeben, es wird »default« "
 "zugewiesen\n"
 
 #: ../../src/kadmin/cli/kadmin.c:1235
 #, c-format
-msgid "WARNING: no policy specified for %s; defaulting to no policy\n"
+msgid "No policy specified for %s; defaulting to no policy\n"
 msgstr ""
-"WARNUNG: Für %s wurde keine Richtlinie angegeben, es wird die Vorgabe "
+"Für %s wurde keine Richtlinie angegeben, es wird die Vorgabe "
 "»keine\n"
 "Richtlinie« verwandt.\n"
 

--- a/src/po/mit-krb5.pot
+++ b/src/po/mit-krb5.pot
@@ -1645,12 +1645,12 @@ msgstr ""
 
 #: ../../src/kadmin/cli/kadmin.c:1228
 #, c-format
-msgid "NOTICE: no policy specified for %s; assigning \"default\"\n"
+msgid "No policy specified for %s; assigning \"default\"\n"
 msgstr ""
 
 #: ../../src/kadmin/cli/kadmin.c:1234
 #, c-format
-msgid "WARNING: no policy specified for %s; defaulting to no policy\n"
+msgid "No policy specified for %s; defaulting to no policy\n"
 msgstr ""
 
 #: ../../src/kadmin/cli/kadmin.c:1276


### PR DESCRIPTION
Not having policy deined is a normal occurrence.  While it's a useful
message to log in case it's unexpected, the current form is
unnecessarily alarmist and would cause less concern without being
prefixed by "WARNING" or "NOTICE".

[I can see an argument against this change that it may break some scripts which check for this line.  If that's a greater concern, I'll withdraw this PR.]