### PR TITLE
Fix handling of invalid CAMMAC service verifier

### DIFF
--- a/src/lib/krb5/krb/authdata.c
+++ b/src/lib/krb5/krb/authdata.c
@@ -557,6 +557,8 @@ extract_cammacs(krb5_context kcontext, krb5_authdata **cammacs,
         if (ret && ret != KRB5KRB_AP_ERR_BAD_INTEGRITY)
             goto cleanup;
         ret = 0;
+        if (elements == NULL)
+            continue;
 
         /* Add the verified elements to list and free the container array. */
         for (n_elements = 0; elements[n_elements] != NULL; n_elements++);


### PR DESCRIPTION
[I looked into adding a test case, but it's difficult.  Since the CAMMAC service verifier uses the same key as the ticket is encrypted in, and the KDC will reject client-requested CAMMAC authdata, there is no obvious way to produce an invalid CAMMAC service verifier without code modification.  I did test the bug and the fix manually by temporarily modifying cammac_create() to zero out the service checksum.]

In extract_cammacs(), avoid a null dereference if the CAMMAC service
verifier is invalid or the CAMMAC is empty.
