### PR TITLE
Fix error handling in gssint_mechglue_init()

### DIFF
--- a/src/lib/gssapi/mechglue/g_initialize.c
+++ b/src/lib/gssapi/mechglue/g_initialize.c
@@ -114,11 +114,19 @@ gssint_mechglue_init(void)
 	add_error_table(&et_ggss_error_table);
 
 	err = k5_mutex_finish_init(&g_mechSetLock);
+	if (err)
+		return err;
 	err = k5_mutex_finish_init(&g_mechListLock);
+	if (err)
+		return err;
 
 #ifdef _GSS_STATIC_LINK
 	err = gss_krb5int_lib_init();
+	if (err)
+		return err;
 	err = gss_spnegoint_lib_init();
+	if (err)
+		return err;
 #endif
 
 	err = gssint_mecherrmap_init();


### PR DESCRIPTION
[Probably not the solution to https://krbdev.mit.edu/rt/Ticket/Display.html?id=8863 but uncovered while investigating.]

In the unlikely event that one of the functions called by
gssint_mechglue_init() returns an error, return that error to the
caller rather than continuing on and discarding the error status.
Returning success when some of the operations failed could fool the
library finalizer into thinking that initialization completed.
Reported by Spencer Malone.
