### PR TITLE
Remove unexposed mutators for session enctype lists

### DIFF
--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -1207,7 +1207,6 @@ struct hostrealm_module_handle;
 struct k5_tls_vtable_st;
 struct _krb5_context {
     krb5_magic      magic;
-    krb5_enctype    *in_tkt_etypes;
     krb5_enctype    *tgs_etypes;
     struct _krb5_os_context os_context;
     char            *default_realm;
@@ -2079,13 +2078,7 @@ struct _krb5_kt {       /* should move into k5-int.h */
     krb5_pointer data;
 };
 
-krb5_error_code krb5_set_default_in_tkt_ktypes(krb5_context,
-                                               const krb5_enctype *);
-
 krb5_error_code krb5_get_default_in_tkt_ktypes(krb5_context, krb5_enctype **);
-
-krb5_error_code krb5_set_default_tgs_ktypes(krb5_context,
-                                            const krb5_enctype *);
 
 krb5_error_code KRB5_CALLCONV
 krb5_get_tgs_ktypes(krb5_context, krb5_const_principal, krb5_enctype **);

--- a/src/lib/krb5/krb/copy_ctx.c
+++ b/src/lib/krb5/krb/copy_ctx.c
@@ -69,7 +69,6 @@ krb5_copy_context(krb5_context ctx, krb5_context *nctx_out)
 
     *nctx = *ctx;
 
-    nctx->in_tkt_etypes = NULL;
     nctx->tgs_etypes = NULL;
     nctx->default_realm = NULL;
     nctx->profile = NULL;
@@ -93,9 +92,6 @@ krb5_copy_context(krb5_context ctx, krb5_context *nctx_out)
     memset(&nctx->err, 0, sizeof(nctx->err));
     memset(&nctx->plugins, 0, sizeof(nctx->plugins));
 
-    ret = k5_copy_etypes(ctx->in_tkt_etypes, &nctx->in_tkt_etypes);
-    if (ret)
-        goto errout;
     ret = k5_copy_etypes(ctx->tgs_etypes, &nctx->tgs_etypes);
     if (ret)
         goto errout;

--- a/src/lib/krb5/krb/init_ctx.c
+++ b/src/lib/krb5/krb/init_ctx.c
@@ -310,8 +310,6 @@ krb5_free_context(krb5_context ctx)
         return;
     k5_os_free_context(ctx);
 
-    free(ctx->in_tkt_etypes);
-    ctx->in_tkt_etypes = NULL;
     free(ctx->tgs_etypes);
     ctx->tgs_etypes = NULL;
     free(ctx->default_realm);
@@ -339,9 +337,8 @@ krb5_free_context(krb5_context ctx)
 /*
  * Set the desired default ktypes, making sure they are valid.
  */
-static krb5_error_code
-set_default_etype_var(krb5_context context, const krb5_enctype *etypes,
-                      krb5_enctype **var)
+krb5_error_code KRB5_CALLCONV
+krb5_set_default_tgs_enctypes(krb5_context context, const krb5_enctype *etypes)
 {
     krb5_error_code code;
     krb5_enctype *list;
@@ -374,29 +371,9 @@ set_default_etype_var(krb5_context context, const krb5_enctype *etypes,
         list = NULL;
     }
 
-    free(*var);
-    *var = list;
+    free(context->tgs_etypes);
+    context->tgs_etypes = list;
     return 0;
-}
-
-krb5_error_code
-krb5_set_default_in_tkt_ktypes(krb5_context context,
-                               const krb5_enctype *etypes)
-{
-    return set_default_etype_var(context, etypes, &context->in_tkt_etypes);
-}
-
-krb5_error_code KRB5_CALLCONV
-krb5_set_default_tgs_enctypes(krb5_context context, const krb5_enctype *etypes)
-{
-    return set_default_etype_var(context, etypes, &context->tgs_etypes);
-}
-
-/* Old name for above function. */
-krb5_error_code
-krb5_set_default_tgs_ktypes(krb5_context context, const krb5_enctype *etypes)
-{
-    return set_default_etype_var(context, etypes, &context->tgs_etypes);
 }
 
 /*
@@ -517,9 +494,6 @@ krb5_get_default_in_tkt_ktypes(krb5_context context, krb5_enctype **ktypes)
     const char *profkey;
 
     *ktypes = NULL;
-
-    if (context->in_tkt_etypes != NULL)
-        return k5_copy_etypes(context->in_tkt_etypes, ktypes);
 
     profkey = KRB5_CONF_DEFAULT_TKT_ENCTYPES;
     ret = profile_get_string(context->profile, KRB5_CONF_LIBDEFAULTS,

--- a/src/lib/krb5/krb/t_copy_context.c
+++ b/src/lib/krb5/krb/t_copy_context.c
@@ -70,7 +70,6 @@ check_context(krb5_context c, krb5_context r)
     int i;
 
     /* Check fields which should have been propagated from r. */
-    compare_etypes(c->in_tkt_etypes, r->in_tkt_etypes);
     compare_etypes(c->tgs_etypes, r->tgs_etypes);
     check(c->os_context.time_offset == r->os_context.time_offset);
     check(c->os_context.usec_offset == r->os_context.usec_offset);
@@ -113,9 +112,8 @@ main(int argc, char **argv)
 {
     krb5_context ctx, ctx2;
     krb5_plugin_initvt_fn *mods;
-    const krb5_enctype etypes1[] = { ENCTYPE_DES3_CBC_SHA1, 0 };
-    const krb5_enctype etypes2[] = { ENCTYPE_AES128_CTS_HMAC_SHA1_96,
-                                     ENCTYPE_AES256_CTS_HMAC_SHA1_96, 0 };
+    const krb5_enctype etypes[] = { ENCTYPE_AES128_CTS_HMAC_SHA1_96,
+                                    ENCTYPE_AES256_CTS_HMAC_SHA1_96, 0 };
     krb5_prompt_type ptypes[] = { KRB5_PROMPT_TYPE_PASSWORD };
 
     /* Copy a default context and verify the result. */
@@ -126,8 +124,7 @@ main(int argc, char **argv)
 
     /* Set non-default values for all of the propagated fields in ctx. */
     ctx->allow_weak_crypto = TRUE;
-    check(krb5_set_default_in_tkt_ktypes(ctx, etypes1) == 0);
-    check(krb5_set_default_tgs_enctypes(ctx, etypes2) == 0);
+    check(krb5_set_default_tgs_enctypes(ctx, etypes) == 0);
     check(krb5_set_debugging_time(ctx, 1234, 5678) == 0);
     check(krb5_cc_set_default_name(ctx, "defccname") == 0);
     check(krb5_set_default_realm(ctx, "defrealm") == 0);

--- a/src/lib/krb5/krb/t_etypes.c
+++ b/src/lib/krb5/krb/t_etypes.c
@@ -206,21 +206,21 @@ main(int argc, char **argv)
                  * instead. */
                 copy = NULL;
                 list = NULL;
-                ret = krb5_set_default_in_tkt_ktypes(ctx, tests[i].defaults);
+                ret = krb5_set_default_tgs_enctypes(ctx, tests[i].defaults);
                 if (ret != expected_err) {
                     com_err("krb5_set_default_in_tkt_ktypes", ret, "");
                     return 2;
                 }
             }
             if (!expected_err) {
-                compare(ctx, tests[i].str ? list : ctx->in_tkt_etypes,
+                compare(ctx, tests[i].str ? list : ctx->tgs_etypes,
                         (weak) ? tests[i].expected : tests[i].expected_noweak,
                         tests[i].str, weak);
             }
             free(copy);
             free(list);
             if (!tests[i].str)
-                krb5_set_default_in_tkt_ktypes(ctx, NULL);
+                krb5_set_default_tgs_enctypes(ctx, NULL);
         }
     }
 

--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -557,10 +557,8 @@ krb5_ser_unpack_int64
 krb5_server_decrypt_ticket_keytab
 krb5_set_config_files
 krb5_set_debugging_time
-krb5_set_default_in_tkt_ktypes
 krb5_set_default_realm
 krb5_set_default_tgs_enctypes
-krb5_set_default_tgs_ktypes
 krb5_set_error_message
 krb5_set_password
 krb5_set_password_using_ccache

--- a/src/tests/etinfo.c
+++ b/src/tests/etinfo.c
@@ -119,24 +119,18 @@ main(int argc, char **argv)
     krb5_error *error;
     krb5_kdc_rep *asrep;
     krb5_pa_data **padata;
-    krb5_enctype *enctypes, def[] = { ENCTYPE_NULL };
     krb5_preauthtype pa_type = KRB5_PADATA_NONE;
     unsigned int flags;
     int master = 0;
 
-    if (argc < 2 && argc > 4) {
-        fprintf(stderr, "Usage: %s princname [enctypes] [patype]\n", argv[0]);
+    if (argc < 2 || argc > 3) {
+        fprintf(stderr, "Usage: %s princname [patype]\n", argv[0]);
         exit(1);
     }
     check(krb5_init_context(&ctx));
     check(krb5_parse_name(ctx, argv[1], &client));
-    if (argc >= 3) {
-        check(krb5int_parse_enctype_list(ctx, "", argv[2], def, &enctypes));
-        krb5_set_default_in_tkt_ktypes(ctx, enctypes);
-        free(enctypes);
-    }
-    if (argc >= 4)
-        pa_type = atoi(argv[3]);
+    if (argc >= 3)
+        pa_type = atoi(argv[2]);
 
     check(krb5_get_init_creds_opt_alloc(ctx, &opt));
     if (pa_type != KRB5_PADATA_NONE)

--- a/src/tests/t_etype_info.py
+++ b/src/tests/t_etype_info.py
@@ -16,7 +16,9 @@ realm.run([kadminl, 'addprinc', '-nokey', '+requires_preauth', 'nokeyuser'])
 # list.  Compare the output to the expected lines, ignoring order.
 def test_etinfo(princ, enctypes, expected_lines):
     mark('etinfo test: %s %s' % (princ.partition('@')[0], enctypes))
-    lines = realm.run(['./etinfo', princ, enctypes]).splitlines()
+    conf = {'libdefaults': {'default_tkt_enctypes': enctypes}}
+    etypes_env = realm.special_env('etypes', False, krb5_conf=conf)
+    lines = realm.run(['./etinfo', princ], env=etypes_env).splitlines()
     if sorted(lines) != sorted(expected_lines):
         fail('Unexpected output for princ %s, etypes %s' % (princ, enctypes))
 
@@ -60,8 +62,8 @@ conf = {'plugins': {'kdcpreauth': {'module': 'test:' + testpreauth},
                     'clpreauth': {'module': 'test:' + testpreauth}}}
 realm = K5Realm(create_host=False, get_creds=False, krb5_conf=conf)
 realm.run([kadminl, 'setstr', realm.user_princ, '2rt', '2rtval'])
-out = realm.run(['./etinfo', realm.user_princ, 'aes128-cts', '-123'])
-if out != 'more etype_info2 aes128-cts KRBTEST.COMuser\n':
+out = realm.run(['./etinfo', realm.user_princ, '-123'])
+if out != 'more etype_info2 aes256-cts KRBTEST.COMuser\n':
     fail('Unexpected output for MORE_PREAUTH_DATA_REQUIRED test')
 
 success('KDC etype-info tests')


### PR DESCRIPTION
(Follow-up to https://github.com/krb5/krb5/pull/1025#issuecomment-576038319 )
    
krb5_set_default_in_tkt_ktypes() and krb5_set_default_tgs_ktypes() are
not publicly exposed, so remove them.  Also remove the now-unused
in_tkt_etypes field from krb5_context.  Update test suite consumers, and
remove etype info tests that no longer test anything.