### PR TITLE
Allow KDB authdata to be the first ad-elements

### DIFF
--- a/src/kdc/kdc_authdata.c
+++ b/src/kdc/kdc_authdata.c
@@ -372,11 +372,14 @@ fetch_kdb_authdata(krb5_context context, unsigned int flags,
     if (ret)
         return (ret == KRB5_PLUGIN_OP_NOTSUPP) ? 0 : ret;
 
-    /* Add the KDB authdata to the ticket, without copying or filtering. */
-    ret = merge_authdata(context, db_authdata,
-                         &enc_tkt_reply->authorization_data, FALSE, FALSE);
+    /* Put the KDB authdata first in the ticket.  A successful merge places the
+     * combined list in db_authdata and releases the old ticket authdata. */
+    ret = merge_authdata(context, enc_tkt_reply->authorization_data,
+                         &db_authdata, FALSE, FALSE);
     if (ret)
         krb5_free_authdata(context, db_authdata);
+    else
+        enc_tkt_reply->authorization_data = db_authdata;
     return ret;
 }
 

--- a/src/plugins/kdb/test/kdb_test.c
+++ b/src/plugins/kdb/test/kdb_test.c
@@ -922,10 +922,11 @@ test_sign_authdata(krb5_context context, unsigned int flags,
     test_ad->contents = (uint8_t *)estrdup("db-authdata-test");
     test_ad->length = strlen((char *)test_ad->contents);
 
-    /* Assemble the authdata into a one-element or two-element list. */
+    /* Assemble the authdata into a one-element or two-element list.
+     * The PAC must be the first element. */
     list = ealloc(3 * sizeof(*list));
-    list[0] = test_ad;
-    list[1] = pac_ad;
+    list[0] = (pac_ad != NULL) ? pac_ad : test_ad;
+    list[1] = (pac_ad != NULL) ? test_ad : NULL;
     list[2] = NULL;
     *signed_auth_data = list;
 


### PR DESCRIPTION
See: http://mailman.mit.edu/pipermail/krbdev/2020-January/013200.html

This still needs some research, testing and tests, but that's basically the idea.
It is cleat that the PAC needs to proceed other ad-elements (at least unknown to Windows), while for other ad-elements, as far as i can tell the order doesn't matter.

With this patch:
```code
PYTHONPATH=../util VALGRIND="" python3 ./t_authdata.py -v
...
*** [130] Executing: ./adata -p user@B service/rb.b -2 cross_s4u_proxy_ad
?128: 0500000000000000010000000100000058000000000000000B0000001B00000060000000000000000A000000120000008000000000000000060000001000000098000000000000000700000010000000A8000000000000000000000000000000736572766963652F72622E623A696D706572736F6E61746F724041000000000000BCF73213D9D501080075007300650072000000000000000F000000F16C33374BF00452556DA63C0F000000E01827F9524CC8CD9D4B5413
 -456: db-authdata-test
 -456: db-authdata-test
 -2: cross_s4u_proxy_ad
 -456: db-authdata-test
 -456: db-authdata-test
 -2: cross_s4u_self_ad
 -456: db-authdata-test
 -456: db-authdata-test
?512: 3041A003020111A1173015A00302010FA10E040CE318D6D524DAAD5AC1B29AC3A221301F301DA0163014A003020102A10D300B1B066B72627467741B0142A1031B0141
*** [130] Completed with return code 0
```