### PR TITLE
Handle NULL result from OpenSSL evp functions

### DIFF
--- a/src/lib/crypto/openssl/hash_provider/hash_evp.c
+++ b/src/lib/crypto/openssl/hash_provider/hash_evp.c
@@ -42,6 +42,11 @@ hash_evp(const EVP_MD *type, const krb5_crypto_iov *data, size_t num_data,
     size_t i;
     int ok;
 
+    /* Starting in OpenSSL 3.0, the evp_*() calls can fail if the appropriate
+     * provider is not loaded. */
+    if (type == NULL)
+        return KRB5_CRYPTO_INTERNAL;
+
     if (output->length != (unsigned int)EVP_MD_size(type))
         return KRB5_CRYPTO_INTERNAL;
 


### PR DESCRIPTION
Starting in OpenSSL 3.0, the evp_*() functions can fail if the
appropriate provider is not loaded.  This is most likely observed with
the legacy evp_md4().  While the OpenSSL functions cope with NULL value,
we incorrectly return ENOMEM from hash_evp(), which complicates
debugging.

Analyzed by the OpenSSL folks (@kaduk, @levitte, @mspncp, @mattcaswell) at https://github.com/openssl/openssl/pull/10992