### PR TITLE
Don't OpenSSL failures are due to lack of memory

### DIFF
--- a/src/lib/crypto/openssl/hash_provider/hash_evp.c
+++ b/src/lib/crypto/openssl/hash_provider/hash_evp.c
@@ -58,7 +58,7 @@ hash_evp(const EVP_MD *type, const krb5_crypto_iov *data, size_t num_data,
     }
     ok = ok && EVP_DigestFinal_ex(ctx, (uint8_t *)output->data, NULL);
     EVP_MD_CTX_free(ctx);
-    return ok ? 0 : ENOMEM;
+    return ok ? 0 : KRB5_CRYPTO_INTERNAL;
 }
 
 static krb5_error_code

--- a/src/lib/crypto/openssl/sha256.c
+++ b/src/lib/crypto/openssl/sha256.c
@@ -48,5 +48,5 @@ k5_sha256(const krb5_data *in, size_t n, uint8_t out[K5_SHA256_HASHLEN])
         ok = ok && EVP_DigestUpdate(ctx, in[i].data, in[i].length);
     ok = ok && EVP_DigestFinal_ex(ctx, out, NULL);
     EVP_MD_CTX_free(ctx);
-    return ok ? 0 : ENOMEM;
+    return ok ? 0 : KRB5_CRYPTO_INTERNAL;
 }


### PR DESCRIPTION
More recent versions of OpenSSL can fail for other reasons.  Indicate a
crypto-related error occurred rather than a memory error to aid
debugging.