### PR TITLE
Fix AS-REQ checking of KDB-modified indicators

### DIFF
--- a/src/kdc/do_as_req.c
+++ b/src/kdc/do_as_req.c
@@ -211,13 +211,6 @@ finish_process_as_req(struct as_req_state *state, krb5_error_code errcode)
 
     au_state->stage = ENCR_REP;
 
-    errcode = check_indicators(kdc_context, state->server,
-                               state->auth_indicators);
-    if (errcode) {
-        state->status = "HIGHER_AUTHENTICATION_REQUIRED";
-        goto egress;
-    }
-
     state->ticket_reply.enc_part2 = &state->enc_tkt_reply;
 
     errcode = check_kdcpolicy_as(kdc_context, state->request, state->client,
@@ -298,6 +291,13 @@ finish_process_as_req(struct as_req_state *state, krb5_error_code errcode)
         krb5_klog_syslog(LOG_INFO, _("AS_REQ : handle_authdata (%d)"),
                          errcode);
         state->status = "HANDLE_AUTHDATA";
+        goto egress;
+    }
+
+    errcode = check_indicators(kdc_context, state->server,
+                               state->auth_indicators);
+    if (errcode) {
+        state->status = "HIGHER_AUTHENTICATION_REQUIRED";
         goto egress;
     }
 


### PR DESCRIPTION
[I found this bug while looking into implementing http://mailman.mit.edu/pipermail/krbdev/2020-February/013208.html .]

Commit 7196c03f18f14695abeb5ae4923004469b172f0f (ticket 8823) gave the
KDB the ability to modify auth indicators, but it happens after the
asserted indicators are checked against the server principal
requirements.  In finish_process_as_req(), move the call to
check_indicators() after the call to handle_authdata() so that the
final indicator list is checked.

For the test case, add string attribute functionality to the test KDB
module, and fix a bug where test_get_principal() would return failure
if a principal has no keys.  Also add a test case for AS-REQ
enforcement of normally asserted auth indicators.
