### PR TITLE
Fix to musl libc issue introduced by bf5953c

### DIFF
--- a/src/util/support/plugins.c
+++ b/src/util/support/plugins.c
@@ -62,8 +62,7 @@
  * dlopen() with RTLD_NODELETE, we weren't going to unload the plugin objects
  * anyway.
  */
-#ifdef __linux__
-#include <features.h>
+#ifdef __GLIBC__PREREQ
 #if ! __GLIBC_PREREQ(2, 25)
 #define dlclose(x)
 #endif


### PR DESCRIPTION
#992 - Commit bf5953c549a6d279977df69ffe89b2ba51460eaf introduced  __GLIBC_PREREQ which causes compilation against musl libc to fail.