### PR TITLE
Allow deletion of require_auth with LDAP KDB

### DIFF
--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.c
@@ -721,6 +721,8 @@ get_int_from_tl_data(krb5_context context, krb5_db_entry *entry, int type,
     void *ptr;
     int *intptr;
 
+    *intval = 0;
+
     tl_data.tl_data_type = KDB_TL_USER_INFO;
     ret = krb5_dbe_lookup_tl_data(context, entry, &tl_data);
     if (ret || tl_data.tl_data_length == 0)

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
@@ -627,12 +627,22 @@ update_ldap_mod_auth_ind(krb5_context context, krb5_db_entry *entry,
     char *auth_ind = NULL;
     char *strval[10] = { 0 };
     char *ai, *ai_save = NULL;
-    int sv_num = sizeof(strval) / sizeof(*strval);
+    int mask, sv_num = sizeof(strval) / sizeof(*strval);
 
     ret = krb5_dbe_get_string(context, entry, KRB5_KDB_SK_REQUIRE_AUTH,
                               &auth_ind);
-    if (ret || auth_ind == NULL)
-        goto cleanup;
+    if (ret)
+        return ret;
+    if (auth_ind == NULL) {
+        /* If we know krbPrincipalAuthInd attributes are present from loading
+         * the entry, delete them. */
+        ret = krb5_get_attributes_mask(context, entry, &mask);
+        if (!ret && (mask & KDB_AUTH_IND_ATTR)) {
+            return krb5_add_str_mem_ldap_mod(mods, "krbPrincipalAuthInd",
+                                             LDAP_MOD_DELETE, NULL);
+        }
+        return 0;
+    }
 
     ai = strtok_r(auth_ind, " ", &ai_save);
     while (ai != NULL && i < sv_num) {
@@ -642,8 +652,6 @@ update_ldap_mod_auth_ind(krb5_context context, krb5_db_entry *entry,
 
     ret = krb5_add_str_mem_ldap_mod(mods, "krbPrincipalAuthInd",
                                     LDAP_MOD_REPLACE, strval);
-
-cleanup:
     krb5_dbe_free_string(context, auth_ind);
     return ret;
 }
@@ -1251,18 +1259,19 @@ krb5_ldap_put_principal(krb5_context context, krb5_db_entry *entry,
 
     } /* Modify Key data ends here */
 
-    /* Auth indicators will also be stored in krbExtraData when processing
-     * tl_data. */
-    st = update_ldap_mod_auth_ind(context, entry, &mods);
-    if (st != 0)
-        goto cleanup;
-
     /* Set tl_data */
     if (entry->tl_data != NULL) {
         int count = 0;
         struct berval **ber_tl_data = NULL;
         krb5_tl_data *ptr;
         krb5_timestamp unlock_time;
+
+        /* Normalize required auth indicators, but also store them as string
+         * attributes within krbExtraData. */
+        st = update_ldap_mod_auth_ind(context, entry, &mods);
+        if (st != 0)
+            goto cleanup;
+
         for (ptr = entry->tl_data; ptr != NULL; ptr = ptr->tl_data_next) {
             if (ptr->tl_data_type == KRB5_TL_LAST_PWD_CHANGE
 #ifdef SECURID


### PR DESCRIPTION
In update_ldap_mod_auth_ind(), if there is no string attribute value
for require_auth, check for krbPrincipalAuthInd attributes that might
need to be removed.  (This will only work if the entry is loaded and
then modified, but that is the normal case for an existing entry.)

Move the update_ldap_mod_auth_ind() call inside the tl-data
conditional (which should perhaps be a check for KADM5_TL_DATA in the
mask instead).  A modification which did not intend to update tl-data
should not remove the krbPrincipalAuthInd attributes.

Change get_int_from_tl_data() to to zero its output so that it can't
leave a garbage value behind if it returns 0 (as it does if no
KDB_TL_USER_INFO tl-data is present).

Based on a patch by Glenn Machin.

ticket: 8877
tags: pullup
target_version: 1.18-next