### PR TITLE
Use two queues for concurrent t_otp.py daemons

### DIFF
--- a/src/tests/t_otp.py
+++ b/src/tests/t_otp.py
@@ -256,16 +256,17 @@ verify(daemon, queue, True, realm.user_princ, 'accept')
 ## tokens configured, with the first rejecting and the second
 ## accepting.  With the bug, the KDC incorrectly rejects the request
 ## and then performs invalid memory accesses, most likely crashing.
+queue2 = Queue()
 daemon1 = UDPRadiusDaemon(args=(server_addr, secret_file, 'accept1', queue))
-daemon2 = UnixRadiusDaemon(args=(socket_file, None, 'accept2', queue))
+daemon2 = UnixRadiusDaemon(args=(socket_file, None, 'accept2', queue2))
 daemon1.start()
 queue.get()
 daemon2.start()
-queue.get()
+queue2.get()
 oconf = '[' + otpconfig_1('udp') + ', ' + otpconfig_1('unix') + ']'
 realm.run([kadminl, 'setstr', realm.user_princ, 'otp', oconf])
 realm.kinit(realm.user_princ, 'accept2', flags=flags)
 verify(daemon1, queue, False, realm.user_princ.split('@')[0], 'accept2')
-verify(daemon2, queue, True, realm.user_princ, 'accept2')
+verify(daemon2, queue2, True, realm.user_princ, 'accept2')
 
 success('OTP tests')


### PR DESCRIPTION
t_otp.py occasionally fails during the #8708 regression test, reading
a true answer instead of the expected false answer during the first
verify() call.  Most likely the daemons are writing their answers to
the shared queue out of order.  Use a separate queue for the second
daemon to ensure correct correlation of results.