### PR TITLE
Add "make regen"

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -683,5 +683,12 @@ tags: FORCE
 FORCE:
 .PHONY: FORCE tags
 
+# Update versioned automatically-generated files.
+regen:
+	$(MAKE) depend
+	(cd man && $(MAKE) man)
+	(cd po && $(MAKE) update-po)
+	(cd lib/krb5/krb && $(RM) deltat.c && $(MAKE) deltat.c)
+
 distclean-unix:
 	$(RM) $(top_srcdir)/TAGS


### PR DESCRIPTION
Add a top-level Makefile.in target to update checked-in generated
files, to simplify release engineering and repository maintenance.