### PR TITLE
Make fiat 128-bit typedefs work with older gcc

### DIFF
--- a/src/plugins/preauth/spake/edwards25519.c
+++ b/src/plugins/preauth/spake/edwards25519.c
@@ -68,7 +68,9 @@
  *   generation.  The fiat_25519_selectznz and fiat_25519_carry_scmul_121666
  *   functions were removed from both branches as they are not used here (the
  *   former because it is not used by the BoringSSL code and the latter because
- *   it is only used by the X25519 code).
+ *   it is only used by the X25519 code).  The fiat_25519_int128 and
+ *   fiat_25519_uint128 typedefs were adjusted to work with older versions of
+ *   gcc.
  *
  * - fe_cmov() has the initial "Silence an unused function warning" part
  *   removed, as we removed fiat_25519_selectznz instead.

--- a/src/plugins/preauth/spake/edwards25519_fiat.h
+++ b/src/plugins/preauth/spake/edwards25519_fiat.h
@@ -11,8 +11,8 @@
 #include <stdint.h>
 typedef unsigned char fiat_25519_uint1;
 typedef signed char fiat_25519_int1;
-typedef signed __int128 fiat_25519_int128;
-typedef unsigned __int128 fiat_25519_uint128;
+typedef int128_t fiat_25519_int128;
+typedef uint128_t fiat_25519_uint128;
 
 
 /*


### PR DESCRIPTION
Use the int128_t and uint128_t types defined by edwards25519.c, rather
than [un]signed __int128 which does not compile with gcc 4.4.
Reported by Norm Green.
