### PR TITLE
Correctly import "service@" GSS host-based name

### DIFF
--- a/src/lib/gssapi/krb5/import_name.c
+++ b/src/lib/gssapi/krb5/import_name.c
@@ -102,8 +102,8 @@ parse_hostbased(const char *str, size_t len,
     memcpy(service, str, servicelen);
     service[servicelen] = '\0';
 
-    /* If present, copy the hostname. */
-    if (at != NULL) {
+    /* Copy the hostname if present (at least one character after '@'). */
+    if (len - servicelen > 1) {
         hostlen = len - servicelen - 1;
         host = malloc(hostlen + 1);
         if (host == NULL) {

--- a/src/tests/gssapi/t_gssapi.py
+++ b/src/tests/gssapi/t_gssapi.py
@@ -47,6 +47,9 @@ realm.run(['./t_accname', 'p:service2/calvin', 'h:service2'],
           expected_msg='service2/calvin')
 realm.run(['./t_accname', 'p:service2/calvin', 'h:service1'], expected_code=1,
           expected_msg=' found in keytab but does not match server principal')
+# Regression test for #8892 (trailing @ in name).
+realm.run(['./t_accname', 'p:service1/andrew', 'h:service1@'],
+          expected_msg='service1/abraham')
 
 # Test with acceptor name containing service and host.  Use the
 # client's un-canonicalized hostname as acceptor input to mirror what


### PR DESCRIPTION
[As discussed in the krbdev thread, we may also want to make changes to krb5_sname_to_principal().  But this part is pretty clearly an improvement.]

The intended way to specify only a service in a GSS host-based name is
to omit the "@" separator.  Some applications include the separator
but no hostname, and this happened to yield wildcard hostname behavior
prior to commit 996353767fe8afa7f67a3b5b465e4d70e18bad7c when
shortname qualification was added.  To restore this behavior, check in
parse_hostbased() that at least one character is present after the "@"
separator before copying the hostname.  Add a test case to t_gssapi.py.
