### PR TITLE
Correct formatting of trace log microseconds

### DIFF
--- a/src/lib/krb5/os/trace.c
+++ b/src/lib/krb5/os/trace.c
@@ -411,8 +411,8 @@ krb5int_trace(krb5_context context, const char *fmt, ...)
         goto cleanup;
     if (krb5_crypto_us_timeofday(&sec, &usec) != 0)
         goto cleanup;
-    if (asprintf(&msg, "[%d] %u.%d: %s\n", (int) getpid(), (unsigned int) sec,
-                 (int) usec, str) < 0)
+    if (asprintf(&msg, "[%d] %u.%06d: %s\n", (int)getpid(),
+                 (unsigned int)sec, (int)usec, str) < 0)
         goto cleanup;
     info.message = msg;
     context->trace_callback(context, &info, context->trace_callback_data);


### PR DESCRIPTION
[Noticed while investigating http://mailman.mit.edu/pipermail/kerberos/2020-April/022447.html , although it seems unrelated to the problem described in the message.]

Always use six digits with leading 0s to format the microseconds in
trace log timestamps; otherwise a small value appears as too large of
a fraction of a second.
