### PR TITLE
gsstest from SAP reports too large lifetime skew between acceptor and initiator ctx 

### DIFF
--- a/src/lib/gssapi/krb5/accept_sec_context.c
+++ b/src/lib/gssapi/krb5/accept_sec_context.c
@@ -352,8 +352,8 @@ kg_accept_dce(minor_status, context_handle, verifier_cred_handle,
         *mech_type = ctx->mech_used;
 
     if (time_rec) {
-        *time_rec = ts_delta(ctx->krb_times.endtime, now) +
-            ctx->k5_context->clockskew;
+	    *time_rec = ts_delta(ctx->krb_times.endtime, now) +
+		ctx->k5_context->clockskew;
     }
 
     /* Never return GSS_C_DELEG_FLAG since we don't support DCE credential
@@ -1133,7 +1133,7 @@ kg_accept_krb5(minor_status, context_handle,
     /* Add the maximum allowable clock skew as a grace period for context
      * expiration, just as we do for the ticket. */
     if (time_rec)
-        *time_rec = ts_delta(ctx->krb_times.endtime, now) + context->clockskew;
+	    *time_rec = ts_delta(ctx->krb_times.endtime, now) + context->clockskew;
 
     if (ret_flags)
         *ret_flags = ctx->gss_flags;

--- a/src/lib/gssapi/krb5/acquire_cred.c
+++ b/src/lib/gssapi/krb5/acquire_cred.c
@@ -591,7 +591,7 @@ kg_cred_set_initial_refresh(krb5_context context, krb5_gss_cred_id_rec *cred,
 
     /* Make a note to refresh these when they are halfway to expired. */
     refresh = ts_incr(times->starttime,
-                      ts_delta(times->endtime, times->starttime) / 2);
+		      (ts_delta(times->endtime, times->starttime) + context->clockskew)/ 2);
     set_refresh_time(context, cred->ccache, refresh);
 }
 
@@ -853,8 +853,8 @@ acquire_cred_context(krb5_context context, OM_uint32 *minor_status,
                                   GSS_C_NO_NAME);
             if (GSS_ERROR(ret))
                 goto error_out;
-            *time_rec = ts_after(cred->expire, now) ?
-                ts_delta(cred->expire, now) : 0;
+	    *time_rec = ts_after(cred->expire, now) ?
+		ts_delta(cred->expire, now) + context->clockskew : 0;
             k5_mutex_unlock(&cred->lock);
         }
     }

--- a/src/lib/gssapi/krb5/context_time.c
+++ b/src/lib/gssapi/krb5/context_time.c
@@ -52,8 +52,7 @@ krb5_gss_context_time(minor_status, context_handle, time_rec)
     }
 
     lifetime = ts_delta(ctx->krb_times.endtime, now);
-    if (!ctx->initiate)
-        lifetime += ctx->k5_context->clockskew;
+    lifetime += ctx->k5_context->clockskew;
     if (lifetime <= 0) {
         *time_rec = 0;
         *minor_status = 0;

--- a/src/lib/gssapi/krb5/init_sec_context.c
+++ b/src/lib/gssapi/krb5/init_sec_context.c
@@ -671,7 +671,8 @@ kg_new_connection(
     if (time_rec) {
         if ((code = krb5_timeofday(context, &now)))
             goto cleanup;
-        *time_rec = ts_delta(ctx->krb_times.endtime, now);
+	*time_rec = ts_delta(ctx->krb_times.endtime, now) +
+		context->clockskew;
     }
 
     /* set the other returns */
@@ -885,7 +886,8 @@ mutual_auth(
     if (time_rec) {
         if ((code = krb5_timeofday(context, &now)))
             goto fail;
-        *time_rec = ts_delta(ctx->krb_times.endtime, now);
+	*time_rec = ts_delta(ctx->krb_times.endtime, now) +
+		context->clockskew;
     }
 
     if (ret_flags)

--- a/src/lib/gssapi/krb5/inq_context.c
+++ b/src/lib/gssapi/krb5/inq_context.c
@@ -121,8 +121,7 @@ krb5_gss_inquire_context(minor_status, context_handle, initiator_name,
         /* Add the maximum allowable clock skew as a grace period for context
          * expiration, just as we do for the ticket during authentication. */
         lifetime = ts_delta(ctx->krb_times.endtime, now);
-        if (!ctx->initiate)
-            lifetime += context->clockskew;
+        lifetime += context->clockskew;
         if (lifetime < 0)
             lifetime = 0;
 

--- a/src/lib/gssapi/krb5/inq_cred.c
+++ b/src/lib/gssapi/krb5/inq_cred.c
@@ -131,7 +131,7 @@ krb5_gss_inquire_cred(minor_status, cred_handle, name, lifetime_ret,
     }
 
     if (cred->expire != 0) {
-        lifetime = ts_delta(cred->expire, now);
+        lifetime = ts_delta(cred->expire, now) + context->clockskew;
         if (lifetime < 0)
             lifetime = 0;
     }


### PR DESCRIPTION
this fixes the [gsstest](https://archive.sap.com/documents/docs/DOC-14051) from SAP  to complain on 5 minute difference between initiator and acceptor security contexts lifetime (acceptor lifetime is 5 minutes greater).

change also fixes tests, which complain on mismatch between GSS context lifetime and credential lifetime.

I'm still not sure if it is a hack or right approach. I did poke around and it looks MIT kerberos is the only gssapi implementation, which gives acceptor context lifetime exta `clockskew` seconds. I understand the [change](https://github.com/krb5/krb5/commit/b496ce4095133536e0ace36b74130e4b9ecb5e11) has been introduced to fix issues with kerberized NFS. I don't understand why `gsstest` requires acceptor and initiator lifetime close to each other (according to source code to skew must not exceed 20 secs).

We were notified about the issue by one of our customers, who happens to be fighting with upgrade from S11.3 to S11.4. The kerberos upgrade from 1.8.4 to 1.16.1 is part of that game. The addition of `clockskew` arrived to kerberos 1.14.

Also the fix in this pull request does not get kerberized SAP to run. There seems to be yet another issue around integrity/message sequence check. As I'm still learning the kerberos stuff, so I would rather ask questions:
   - is `gsstest` requirement to keep acceptor and initiator context lifetime close to each other legitimate? I've briefly poked to RFCs but could not find anything on this?

   - does change in this pull request make sense? or are there some undesired implications?

thanks a lot
sashan