### PR TITLE
Pass gss_localname() through SPNEGO

### DIFF
--- a/src/lib/gssapi/spnego/gssapiP_spnego.h
+++ b/src/lib/gssapi/spnego/gssapiP_spnego.h
@@ -357,6 +357,14 @@ OM_uint32 KRB5_CALLCONV spnego_gss_wrap_size_limit
 	OM_uint32	*max_input_size
 );
 
+OM_uint32 KRB5_CALLCONV spnego_gss_localname
+(
+	OM_uint32 *minor_status,
+	const gss_name_t pname,
+	const gss_const_OID mech_type,
+	gss_buffer_t localname
+);
+
 OM_uint32 KRB5_CALLCONV spnego_gss_get_mic
 (
 	OM_uint32 *minor_status,

--- a/src/lib/gssapi/spnego/spnego_mech.c
+++ b/src/lib/gssapi/spnego/spnego_mech.c
@@ -237,7 +237,7 @@ static struct gss_config spnego_mechanism =
 	spnego_gss_inquire_context,	/* gss_inquire_context */
 	NULL,				/* gss_internal_release_oid */
 	spnego_gss_wrap_size_limit,	/* gss_wrap_size_limit */
-	NULL,				/* gssd_pname_to_uid */
+	spnego_gss_localname,
 	NULL,				/* gss_userok */
 	NULL,				/* gss_export_name */
 	spnego_gss_duplicate_name,	/* gss_duplicate_name */
@@ -2369,6 +2369,13 @@ spnego_gss_wrap_size_limit(
 				req_output_size,
 				max_input_size);
 	return (ret);
+}
+
+OM_uint32 KRB5_CALLCONV
+spnego_gss_localname(OM_uint32 *minor_status, const gss_name_t pname,
+		     const gss_const_OID mech_type, gss_buffer_t localname)
+{
+	return gss_localname(minor_status, pname, GSS_C_NO_OID, localname);
 }
 
 OM_uint32 KRB5_CALLCONV


### PR DESCRIPTION
This is an easy change, and fixes part of the problem of https://krbdev.mit.edu/rt/Ticket/Display.html?id=8782 .

The other half of that problem is that a caller might supply a mech argument as a workaround, probably the actual_mech returned by gss_accept_sec_context().  In that case, the mechglue will try to reinterpret the SPNEGO name as the underlying mech, which seems to work okay with krb5 but not so much with EAP.

I had intended to extend the gss_accept_sec_context() contract for mechanisms that return an alternate actual_mech to apply to src_name, but I ran into complications.