### PR TITLE
Fix overzealous SPNEGO src_name/deleg_cred release

### DIFF
--- a/src/lib/gssapi/spnego/spnego_mech.c
+++ b/src/lib/gssapi/spnego/spnego_mech.c
@@ -1566,12 +1566,12 @@ acc_ctx_call_acc(OM_uint32 *minor_status, spnego_gss_ctx_id_t sc,
 	}
 
 	mcred = (spcred == NULL) ? GSS_C_NO_CREDENTIAL : spcred->mcred;
-	(void) gss_release_name(&tmpmin, &sc->internal_name);
-	(void) gss_release_cred(&tmpmin, &sc->deleg_cred);
 	if (negoex) {
 		ret = negoex_accept(minor_status, sc, mcred, mechtok_in,
 				    mechtok_out, time_rec);
 	} else {
+		(void) gss_release_name(&tmpmin, &sc->internal_name);
+		(void) gss_release_cred(&tmpmin, &sc->deleg_cred);
 		ret = gss_accept_sec_context(minor_status, &sc->ctx_handle,
 					     mcred, mechtok_in,
 					     GSS_C_NO_CHANNEL_BINDINGS,


### PR DESCRIPTION
Commit 24b844714dea3e47b17511746b5df5b6ddf13d43 (ticket 8845) added
releases of sc->internal_name and sc->deleg_cred before calling the
underlying mech's gss_accept_sec_context(), to avoid a potential leak
if the mech reports a value multiple times.  Commit
c2ca2f26eaf817a6a7ed42257c380437ab802bd9 (ticket 8851) added a branch
which calls negoex_accept() instead of calling directly into the
underlying mech.  If negoex_accept() doesn't call into the mech on the
last acceptor leg, the src_name and deleg_cred values from the final
mech call are lost.

Move the releases to the non-NegoEx branch.  negoex_accept() already
does its own releases when it calls into the mech.

Reported by Luke Howard.
