### PR TITLE
Add KRB5_PRINCIPAL_PARSE_NO_DEF_REALM flag

### DIFF
--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -3430,6 +3430,7 @@ krb5_parse_name(krb5_context context, const char *name,
 #define KRB5_PRINCIPAL_PARSE_ENTERPRISE    0x4 /**< Create single-component
                                                   enterprise principle */
 #define KRB5_PRINCIPAL_PARSE_IGNORE_REALM  0x8 /**< Ignore realm if present */
+#define KRB5_PRINCIPAL_PARSE_NO_DEF_REALM  0x10 /**< Don't add default realm */
 
 /**
  * Convert a string principal name to a krb5_principal with flags.

--- a/src/lib/krb5/krb/parse.c
+++ b/src/lib/krb5/krb/parse.c
@@ -183,6 +183,7 @@ krb5_parse_name_flags(krb5_context context, const char *name,
     krb5_boolean require_realm = (flags & KRB5_PRINCIPAL_PARSE_REQUIRE_REALM);
     krb5_boolean no_realm = (flags & KRB5_PRINCIPAL_PARSE_NO_REALM);
     krb5_boolean ignore_realm = (flags & KRB5_PRINCIPAL_PARSE_IGNORE_REALM);
+    krb5_boolean no_def_realm = (flags & KRB5_PRINCIPAL_PARSE_NO_DEF_REALM);
 
     *principal_out = NULL;
 
@@ -191,11 +192,8 @@ krb5_parse_name_flags(krb5_context context, const char *name,
         goto cleanup;
     parse_name_into_princ(name, enterprise, princ);
 
-    /*
-     * If a realm was not found, then use the default realm, unless
-     * KRB5_PRINCIPAL_PARSE_NO_REALM was specified in which case the
-     * realm will be empty.
-     */
+    /* If a realm was not included, use the default realm, unless flags
+     * indicate otherwise. */
     if (!has_realm) {
         if (require_realm) {
             ret = KRB5_PARSE_MALFORMED;
@@ -203,7 +201,7 @@ krb5_parse_name_flags(krb5_context context, const char *name,
                       _("Principal %s is missing required realm"), name);
             goto cleanup;
         }
-        if (!no_realm && !ignore_realm) {
+        if (!no_realm && !ignore_realm && !no_def_realm) {
             ret = krb5_get_default_realm(context, &default_realm);
             if (ret)
                 goto cleanup;


### PR DESCRIPTION
[I discovered this flag in Heimdal while investigating a possible mitigation for https://krbdev.mit.edu/rt/Ticket/Display.html?id=8903 .  Implementing it seems like a good idea regardless of what we do about that issue.]

Implement KRB5_PRINCIPAL_PARSE_NO_DEF_REALM from Heimdal.  This flag
for krb5_parse_name_flags() suppresses the addition of the default
realm, but allows and preserves the realm if one is specified in the
string.
