### PR TITLE
Add stubs for some removed replay cache functions

### DIFF
--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -522,6 +522,10 @@ krb5_principal_compare
 krb5_principal_compare_any_realm
 krb5_principal_compare_flags
 krb5_prompter_posix
+krb5_rc_default
+krb5_rc_destroy
+krb5_rc_get_lifespan
+krb5_rc_initialize
 krb5_rd_cred
 krb5_rd_error
 krb5_rd_priv

--- a/src/lib/krb5/rcache/rc_base.c
+++ b/src/lib/krb5/rcache/rc_base.c
@@ -160,3 +160,39 @@ k5_rc_tag_from_ciphertext(krb5_context context, const krb5_enc_data *enc,
     *tag_out = make_data(cdata->data + cdata->length - len, len);
     return 0;
 }
+
+/*
+ * Stub functions for former internal replay cache functions used by OpenSSL
+ * (despite the lack of prototypes) before the OpenSSL 1.1 release.
+ */
+
+krb5_error_code krb5_rc_default(krb5_context, krb5_rcache *);
+krb5_error_code KRB5_CALLCONV krb5_rc_destroy(krb5_context, krb5_rcache);
+krb5_error_code KRB5_CALLCONV krb5_rc_get_lifespan(krb5_context, krb5_rcache,
+                                                   krb5_deltat *);
+krb5_error_code KRB5_CALLCONV krb5_rc_initialize(krb5_context, krb5_rcache,
+                                                 krb5_deltat);
+
+krb5_error_code
+krb5_rc_default(krb5_context context, krb5_rcache *rc)
+{
+    return EINVAL;
+}
+
+krb5_error_code KRB5_CALLCONV
+krb5_rc_destroy(krb5_context context, krb5_rcache rc)
+{
+    return EINVAL;
+}
+
+krb5_error_code KRB5_CALLCONV
+krb5_rc_get_lifespan(krb5_context context, krb5_rcache rc, krb5_deltat *span)
+{
+    return EINVAL;
+}
+
+krb5_error_code KRB5_CALLCONV
+krb5_rc_initialize(krb5_context context, krb5_rcache rc, krb5_deltat span)
+{
+    return EINVAL;
+}


### PR DESCRIPTION
[Prompted by https://github.com/alicevision/meshroom/issues/850#issuecomment-612966660 ]

Commit dcb853ac32779b173f39e19c0f24b0087de85771 removed some replay
cache functions that haven't been considered part of the libkrb5 API.
Some of these functions were used in OpenSSL (despite the lack of
prototypes) prior to the OpenSSL 1.1 release.  Run-time linker errors
can occur if an OpenSSL 1.0.x (or earlier) libssl is used with a 1.18
libkrb5, even though the Kerberos code would likely never be used.

Add stubs for the four functions historically used in OpenSSL.

ticket: 8905 (new)
tags: pullup
target_version: 1.18-next