### PR TITLE
Prevent use of invalid local TGT key

### DIFF
--- a/src/kdc/kdc_util.c
+++ b/src/kdc/kdc_util.c
@@ -514,6 +514,7 @@ get_local_tgt(krb5_context context, const krb5_data *realm,
     krb5_error_code ret;
     krb5_principal princ;
     krb5_db_entry *storage = NULL, *tgt;
+    krb5_key_data *kd;
 
     *alias_out = NULL;
     *storage_out = NULL;
@@ -534,12 +535,11 @@ get_local_tgt(krb5_context context, const krb5_data *realm,
         tgt = candidate;
     }
 
-    if (tgt->n_key_data == 0) {
-        ret = KRB5_KDB_NO_MATCHING_KEY;
+    /* Find and decrypt the first valid key of the current kvno. */
+    ret = krb5_dbe_find_enctype(context, tgt, -1, -1, 0, &kd);
+    if (ret)
         goto cleanup;
-    }
-    ret = krb5_dbe_decrypt_key_data(context, NULL, &tgt->key_data[0], key_out,
-                                    NULL);
+    ret = krb5_dbe_decrypt_key_data(context, NULL, kd, key_out, NULL);
     if (ret)
         goto cleanup;
 


### PR DESCRIPTION
Commit 570967e11bd5ea60a82fc8157ad7d07602402ebb took a shortcut in
get_local_tgt() by using the first key data entry in the TGT principal
entry.  This is usually correct, but if the first key data entry has
an invalid enctype (such as a single-DES enctype), we can select a key
we can't use.  Call krb5_dbe_find_enctype() instead.  Reported by
Leonard Peirce.
