### PR TITLE
Add KDC helpers for current key and kvno

### DIFF
--- a/src/kdc/cammac.c
+++ b/src/kdc/cammac.c
@@ -80,7 +80,7 @@ cammac_create(krb5_context context, krb5_enc_tkt_part *enc_tkt,
     if (ret)
         goto cleanup;
     kdc_verifier.princ = NULL;
-    kdc_verifier.kvno = tgt->key_data[0].key_data_kvno;
+    kdc_verifier.kvno = current_kvno(tgt);
     kdc_verifier.enctype = ENCTYPE_NULL;
     kdc_verifier.checksum = kdc_cksum;
 
@@ -149,7 +149,7 @@ cammac_check_kdcver(krb5_context context, krb5_cammac *cammac,
 
     /* Fetch the krbtgt key indicated by the KDC verifier.  Only allow the
      * first krbtgt key of the specified kvno. */
-    if (ver->kvno == tgt->key_data[0].key_data_kvno) {
+    if (ver->kvno == current_kvno(tgt)) {
         key = tgt_key;
     } else {
         if (krb5_dbe_find_enctype(context, tgt, -1, -1, ver->kvno, &kd) != 0)

--- a/src/kdc/fast_util.c
+++ b/src/kdc/fast_util.c
@@ -508,7 +508,7 @@ get_cookie_key(krb5_context context, krb5_db_entry *tgt,
     *key_out = NULL;
     memset(&storage, 0, sizeof(storage));
 
-    if (kvno == tgt->key_data[0].key_data_kvno) {
+    if (kvno == current_kvno(tgt)) {
         /* Use the already-decrypted first key. */
         key = tgt_key;
     } else {
@@ -711,7 +711,7 @@ kdc_fast_make_cookie(krb5_context context, struct kdc_request_state *state,
     ret = k5_alloc_pa_data(KRB5_PADATA_FX_COOKIE, 8 + enc.ciphertext.length,
                            &pa);
     memcpy(pa->contents, "MIT1", 4);
-    store_32_be(local_tgt->key_data[0].key_data_kvno, pa->contents + 4);
+    store_32_be(current_kvno(local_tgt), pa->contents + 4);
     memcpy(pa->contents + 8, enc.ciphertext.data, enc.ciphertext.length);
     *cookie_out = pa;
 

--- a/src/kdc/kdc_preauth.c
+++ b/src/kdc/kdc_preauth.c
@@ -811,7 +811,6 @@ add_freshness_token(krb5_context context, krb5_kdcpreauth_rock rock,
 {
     krb5_error_code ret;
     krb5_timestamp now;
-    krb5_key_data *kd;
     krb5_keyblock kb;
     krb5_checksum cksum;
     krb5_data d;
@@ -827,29 +826,21 @@ add_freshness_token(krb5_context context, krb5_kdcpreauth_rock rock,
                              KRB5_PADATA_AS_FRESHNESS) == NULL)
         return 0;
 
-    /* Fetch and decrypt the current local krbtgt key. */
-    ret = krb5_dbe_find_enctype(context, rock->local_tgt, -1, -1, 0, &kd);
-    if (ret)
-        goto cleanup;
-    ret = krb5_dbe_decrypt_key_data(context, NULL, kd, &kb, NULL);
-    if (ret)
-        goto cleanup;
-
     /* Compute a checksum over the current KDC time. */
     ret = krb5_timeofday(context, &now);
     if (ret)
         goto cleanup;
     store_32_be(now, ckbuf);
     d = make_data(ckbuf, sizeof(ckbuf));
-    ret = krb5_c_make_checksum(context, 0, &kb, KRB5_KEYUSAGE_PA_AS_FRESHNESS,
-                               &d, &cksum);
+    ret = krb5_c_make_checksum(context, 0, rock->local_tgt_key,
+                               KRB5_KEYUSAGE_PA_AS_FRESHNESS, &d, &cksum);
 
     /* Compose a freshness token from the time, krbtgt kvno, and checksum. */
     ret = k5_alloc_pa_data(KRB5_PADATA_AS_FRESHNESS, 8 + cksum.length, &pa);
     if (ret)
         goto cleanup;
     store_32_be(now, pa->contents);
-    store_32_be(kd->key_data_kvno, pa->contents + 4);
+    store_32_be(current_kvno(rock->local_tgt), pa->contents + 4);
     memcpy(pa->contents + 8, cksum.contents, cksum.length);
 
     ret = k5_add_pa_data_element(pa_list, &pa);

--- a/src/kdc/kdc_util.h
+++ b/src/kdc/kdc_util.h
@@ -71,6 +71,10 @@ kdc_get_server_key (krb5_context, krb5_ticket *, unsigned int,
                     krb5_db_entry **, krb5_keyblock **, krb5_kvno *);
 
 krb5_error_code
+get_first_current_key(krb5_context context, krb5_db_entry *entry,
+                      krb5_keyblock *key_out);
+
+krb5_error_code
 get_local_tgt(krb5_context context, const krb5_data *realm,
               krb5_db_entry *candidate, krb5_db_entry **alias_out,
               krb5_db_entry **storage_out, krb5_keyblock *kb_out);
@@ -421,6 +425,7 @@ struct krb5_kdcpreauth_rock_st {
     krb5_data *inner_body;
     krb5_db_entry *client;
     krb5_db_entry *local_tgt;
+    krb5_keyblock *local_tgt_key;
     krb5_key_data *client_key;
     krb5_keyblock *client_keyblock;
     struct kdc_request_state *rstate;
@@ -525,5 +530,12 @@ int check_anon(kdc_realm_t *kdc_active_realm,
 int errcode_to_protocol(krb5_error_code code);
 
 char *data2string(krb5_data *d);
+
+/* Return the current key version of entry, or 0 if it has no keys. */
+static inline krb5_kvno
+current_kvno(krb5_db_entry *entry)
+{
+    return (entry->n_key_data == 0) ? 0 : entry->key_data[0].key_data_kvno;
+}
 
 #endif /* __KRB5_KDC_UTIL__ */


### PR DESCRIPTION
Add a simple static inline function current_kvno() to safely fetch the
current kvno of a principal entry, and use it where we currently write
entry->key_data[0].key_data_kvno.

Add a function get_first_current_key() to find and decrypt the first
valid current key from an entry.  Use it in get_local_tgt() and when
selecting a ticket encryption key during AS and TGS processing.

Add a local_tgt_key field to krb5_kdcpreauth_rock_st and use it in
add_freshness_token() so we don't have to decrypt it again.