### PR TITLE
Fix SPNEGO acceptor mech filtering

### DIFF
--- a/src/lib/gssapi/spnego/spnego_mech.c
+++ b/src/lib/gssapi/spnego/spnego_mech.c
@@ -1380,7 +1380,7 @@ acc_ctx_new(OM_uint32 *minor_status,
 		goto cleanup;
 	}
 
-	ret = get_negotiable_mechs(minor_status, sc, spcred, GSS_C_INITIATE);
+	ret = get_negotiable_mechs(minor_status, sc, spcred, GSS_C_ACCEPT);
 	if (ret != GSS_S_COMPLETE) {
 		*return_token = NO_TOKEN_SEND;
 		goto cleanup;


### PR DESCRIPTION
[I'll issue a patch release for this soon.  The bug was my fault, not Luke's, since it happened when I redid the SPNEGO integration.]

Commit c2ca2f26eaf817a6a7ed42257c380437ab802bd9 (ticket 8851)
accidentally changed SPNEGO's acceptor code to filter mechanisms by
the obtainability of initiator credentials rather than acceptor
credentials, when the default acceptor credential is used.

ticket: 8908 (new)
tags: pullup
target_version: 1.18-next