### PR TITLE
Return GSS_S_NO_CRED from krb5 gss_acquire_cred

### DIFF
--- a/src/lib/gssapi/krb5/acquire_cred.c
+++ b/src/lib/gssapi/krb5/acquire_cred.c
@@ -211,7 +211,7 @@ acquire_accept_cred(krb5_context context, OM_uint32 *minor_status,
         }
     }
     if (code) {
-        major = GSS_S_CRED_UNAVAIL;
+        major = GSS_S_NO_CRED;
         goto cleanup;
     }
 
@@ -223,7 +223,7 @@ acquire_accept_cred(krb5_context context, OM_uint32 *minor_status,
                 k5_change_error_message_code(context, code, KG_KEYTAB_NOMATCH);
                 code = KG_KEYTAB_NOMATCH;
             }
-            major = GSS_S_CRED_UNAVAIL;
+            major = GSS_S_NO_CRED;
             goto cleanup;
         }
 
@@ -240,7 +240,7 @@ acquire_accept_cred(krb5_context context, OM_uint32 *minor_status,
         /* Make sure we have a keytab with keys in it. */
         code = krb5_kt_have_content(context, kt);
         if (code) {
-            major = GSS_S_CRED_UNAVAIL;
+            major = GSS_S_NO_CRED;
             goto cleanup;
         }
     }
@@ -750,7 +750,7 @@ acquire_init_cred(krb5_context context,
 
 error:
     *minor_status = code;
-    return GSS_S_CRED_UNAVAIL;
+    return GSS_S_NO_CRED;
 }
 
 static OM_uint32
@@ -1022,7 +1022,7 @@ kerr:
     k5_mutex_unlock(&cred->lock);
     save_error_info(code, context);
     *minor_status = code;
-    return GSS_S_CRED_UNAVAIL;
+    return GSS_S_NO_CRED;
 }
 
 OM_uint32
@@ -1209,7 +1209,7 @@ krb5_gss_acquire_cred_from(OM_uint32 *minor_status,
         code = krb5_cc_resolve(context, value, &ccache);
         if (code != 0) {
             *minor_status = code;
-            ret = GSS_S_CRED_UNAVAIL;
+            ret = GSS_S_NO_CRED;
             goto out;
         }
     }
@@ -1222,7 +1222,7 @@ krb5_gss_acquire_cred_from(OM_uint32 *minor_status,
         code = krb5_kt_resolve(context, value, &client_keytab);
         if (code != 0) {
             *minor_status = code;
-            ret = GSS_S_CRED_UNAVAIL;
+            ret = GSS_S_NO_CRED;
             goto out;
         }
     }
@@ -1235,7 +1235,7 @@ krb5_gss_acquire_cred_from(OM_uint32 *minor_status,
         code = krb5_kt_resolve(context, value, &keytab);
         if (code != 0) {
             *minor_status = code;
-            ret = GSS_S_CRED_UNAVAIL;
+            ret = GSS_S_NO_CRED;
             goto out;
         }
     }

--- a/src/lib/gssapi/krb5/store_cred.c
+++ b/src/lib/gssapi/krb5/store_cred.c
@@ -116,14 +116,14 @@ copy_initiator_creds(OM_uint32 *minor_status,
         code = krb5_cc_resolve(context, ccache_name, &ccache);
         if (code != 0) {
             *minor_status = code;
-            major_status = GSS_S_CRED_UNAVAIL;
+            major_status = GSS_S_FAILURE;
             goto cleanup;
         }
         code = krb5_cc_initialize(context, ccache,
                                   kcred->name->princ);
         if (code != 0) {
             *minor_status = code;
-            major_status = GSS_S_CRED_UNAVAIL;
+            major_status = GSS_S_FAILURE;
             goto cleanup;
         }
     }

--- a/src/tests/gssapi/t_add_cred.c
+++ b/src/tests/gssapi/t_add_cred.c
@@ -63,7 +63,7 @@ main()
     major = gss_add_cred(&minor, GSS_C_NO_CREDENTIAL, name, &mech_krb5,
                          GSS_C_INITIATE, GSS_C_INDEFINITE, GSS_C_INDEFINITE,
                          &cred1, NULL, NULL, NULL);
-    assert(major == GSS_S_CRED_UNAVAIL);
+    assert(major == GSS_S_NO_CRED);
     gss_release_name(&minor, &name);
 
     /* Create cred1 with a krb5 initiator cred by passing an output handle but


### PR DESCRIPTION
Earlier versions of the GSS-API spec (RFCs 1508 and 2078) do not list
GSS_S_NO_CRED as a valid error code for gss_acquire_cred.  As a
result, the OpenVision developers of the GSSAPI krb5 mech created
GSS_S_CRED_UNAVAIL as an alias for GSS_S_FAILURE and returned it when
no valid credentials could be obtained.  RFC 2743 lists GSS_S_NO_CRED
as the proper return code when matching credentials cannot be
accessed.  Change the krb5 gss_acquire_cred() implementation to return
GSS_S_NO_CRED where it currently returns GSS_S_CRED_UNAVAIL.

Also stop using GSS_S_CRED_UNAVAIL in the krb5 gss_store_cred(), but
change it to explicitly use GSS_S_FAILURE instead.  RFC 5588 specifies
GSS_S_NO_CRED as indicating a problem with input_cred_handle, not the
receiving store, so GSS_S_NO_CRED would be inappropriate.
