### PR TITLE
Add static object build rules for AESNI sources

### DIFF
--- a/src/lib/crypto/builtin/aes/Makefile.in
+++ b/src/lib/crypto/builtin/aes/Makefile.in
@@ -34,10 +34,10 @@ GEN_OBJS=\
 
 all-unix: all-libobjs # aes-gen
 
-iaesx64@SHOBJEXT@: $(srcdir)/iaesx64.s
+iaesx64@SHOBJEXT@ iaesx64@STOBJEXT@: $(srcdir)/iaesx64.s
 	$(YASM) $(AESNI_FLAGS) -o $@ $(srcdir)/iaesx64.s
 
-iaesx86@SHOBJEXT@: $(srcdir)/iaesx86.s
+iaesx86@SHOBJEXT@ iaesx86@STOBJEXT@: $(srcdir)/iaesx86.s
 	$(YASM) $(AESNI_FLAGS) -o $@ $(srcdir)/iaesx86.s
 
 includes: depend


### PR DESCRIPTION
From https://krbdev.mit.edu/rt/Ticket/Display.html?id=8910 .

I created the --enable-static --disable-shared build option primarily in order to use gcov, which didn't support shared libraries at the time.  (It does now, although last I checked, it couldn't handle concurrent execution properly, so it gives some false negatives for coverage when you run the test suite.)  It does some pretty hackish things to make some-but-not-all plugins work, so I'm always nervous when people write in about trying to use it.  That aside, this is a trivial fix and it doesn't hurt anything.
