### PR TITLE
WIP: Support tgt-less creds via delegation policy

### DIFF
--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -299,6 +299,7 @@ typedef unsigned char   u_char;
 #define KRB5_CONF_V4_REALM                     "v4_realm"
 #define KRB5_CONF_VERIFY_AP_REQ_NOFAIL         "verify_ap_req_nofail"
 #define KRB5_CONF_CLIENT_AWARE_GSS_BINDINGS    "client_aware_channel_bindings"
+#define KRB5_CONF_DELEGATION_POLICY            "delegation_policy"
 
 /* Cache configuration variables */
 #define KRB5_CC_CONF_FAST_AVAIL                "fast_avail"

--- a/src/lib/gssapi/krb5/accept_sec_context.c
+++ b/src/lib/gssapi/krb5/accept_sec_context.c
@@ -683,25 +683,20 @@ get_delegation_policy(krb5_context context, krb5_gss_cred_id_t cred,
         delegstr = strdup(cred->delegation_policy);
         if (delegstr == NULL)
             return ENOMEM;
-
-        code = parse_delegation_policy(context, delegstr, cred->usage,
-                                       have_tgt, out_delegation_type);
-        free(delegstr);
-
-        return code;
+    } else {
+        code = profile_get_string(context->profile, KRB5_CONF_LIBDEFAULTS,
+                                  KRB5_CONF_DELEGATION_POLICY, NULL,
+                                  "client-tgt,proxy-creds", &delegstr);
+        if (code)
+            return code;
+        assert(delegstr != NULL);
     }
-
-    code = profile_get_string(context->profile, KRB5_CONF_LIBDEFAULTS,
-                              KRB5_CONF_DELEGATION_POLICY, NULL,
-                              "client-tgt,proxy-creds", &delegstr);
-    if (code)
-        return code;
-    assert(delegstr != NULL);
 
     code = parse_delegation_policy(context, delegstr, cred->usage,
                                    have_tgt, out_delegation_type);
 
-    profile_release_string(delegstr);
+    // XXX is this ok?
+    free(delegstr);
 
     return code;
 }

--- a/src/lib/gssapi/krb5/gssapiP_krb5.h
+++ b/src/lib/gssapi/krb5/gssapiP_krb5.h
@@ -175,7 +175,7 @@ typedef struct _krb5_gss_cred_id_rec {
     gss_cred_usage_t usage;
     krb5_gss_name_t name;
     krb5_principal impersonator;
-    const char *delegation_policy;
+    char *delegation_policy;
     unsigned int default_identity : 1;
     unsigned int iakerb_mech : 1;
     unsigned int destroy_ccache : 1;

--- a/src/lib/gssapi/krb5/gssapiP_krb5.h
+++ b/src/lib/gssapi/krb5/gssapiP_krb5.h
@@ -175,6 +175,7 @@ typedef struct _krb5_gss_cred_id_rec {
     gss_cred_usage_t usage;
     krb5_gss_name_t name;
     krb5_principal impersonator;
+    const char *delegation_policy;
     unsigned int default_identity : 1;
     unsigned int iakerb_mech : 1;
     unsigned int destroy_ccache : 1;
@@ -1284,6 +1285,7 @@ data_to_gss(krb5_data *input_k5data, gss_buffer_t output_buffer)
 #define KRB5_CS_KEYTAB_URN "keytab"
 #define KRB5_CS_CCACHE_URN "ccache"
 #define KRB5_CS_RCACHE_URN "rcache"
+#define KRB5_CS_DELEGP_URN "delegation_policy"
 
 OM_uint32
 kg_value_from_cred_store(gss_const_key_value_set_t cred_store,
@@ -1434,5 +1436,9 @@ gss_krb5int_get_cred_impersonator(OM_uint32 *minor_status,
                                   const gss_cred_id_t cred_handle,
                                   const gss_OID desired_object,
                                   gss_buffer_set_t *data_set);
+
+typedef enum {
+    DELEG_NONE, DELEG_CLIENT_TGT, DELEG_CLIENT_TICKET, DELEG_PROXY_CREDS
+} delegation_types;
 
 #endif /* _GSSAPIP_KRB5_H_ */

--- a/src/lib/gssapi/krb5/rel_cred.c
+++ b/src/lib/gssapi/krb5/rel_cred.c
@@ -80,6 +80,8 @@ krb5_gss_release_cred(minor_status, cred_handle)
     if (cred->password != NULL)
         zapfree(cred->password, strlen(cred->password));
 
+    xfree(cred->delegation_policy);
+
     xfree(cred);
 
     *cred_handle = NULL;


### PR DESCRIPTION
This could be useful for local auth (such as sudo), for S4U2Self and for S4U2Proxy use cases, the latter when used alongside a privileged daemon proxy with access to impersonator TGT.

Following the mail thread on krbdev:
http://mailman.mit.edu/pipermail/krbdev/2020-June/013277.html
Discussion summary:
http://mailman.mit.edu/pipermail/krbdev/2020-June/013278.html