### PR TITLE
Set pw_expiration during LDAP load

### DIFF
--- a/src/kadmin/dbutil/dump.c
+++ b/src/kadmin/dbutil/dump.c
@@ -722,7 +722,7 @@ process_k5beta7_princ(krb5_context context, const char *fname, FILE *filep,
     dbentry->fail_auth_count = u5;
     dbentry->mask = KADM5_LOAD | KADM5_PRINCIPAL | KADM5_ATTRIBUTES |
         KADM5_MAX_LIFE | KADM5_MAX_RLIFE |
-        KADM5_PRINC_EXPIRE_TIME | KADM5_LAST_SUCCESS |
+        KADM5_PRINC_EXPIRE_TIME | KADM5_PW_EXPIRATION | KADM5_LAST_SUCCESS |
         KADM5_LAST_FAILED | KADM5_FAIL_AUTH_COUNT;
 
     /* Read tagged data. */

--- a/src/tests/t_kdb.py
+++ b/src/tests/t_kdb.py
@@ -538,13 +538,19 @@ realm.run([kadminl, 'getprinc', 'pwuser'],
 
 realm.stop()
 
-# Briefly test dump and load.
+# Test dump and load.  Include a regression test for #8882
+# (pw_expiration not set during load operation).
 mark('LDAP dump and load')
+realm.run([kadminl, 'modprinc', '-pwexpire', 'now', 'pwuser'])
 dumpfile = os.path.join(realm.testdir, 'dump')
 realm.run([kdb5_util, 'dump', dumpfile])
 realm.run([kdb5_util, 'load', dumpfile], expected_code=1,
           expected_msg='KDB module requires -update argument')
+realm.run([kadminl, 'delprinc', 'pwuser'])
 realm.run([kdb5_util, 'load', '-update', dumpfile])
+out = realm.run([kadminl, 'getprinc', 'pwuser'])
+if 'Password expiration date: [never]' in out:
+    fail('pw_expiration not preserved across dump and load')
 
 # Destroy the realm.
 kldaputil(['destroy', '-f'])


### PR DESCRIPTION
When loading a principal entry in process_k5beta7_princ(), set the
KADM5_PW_EXPIRATION mask bit so that the password expiration time is
set on the principal entry.  Add a regression test.

Reported (with fix) by Glenn Machin.
