### PR TITLE
Prevent deletion of K/M

### DIFF
--- a/src/lib/kadm5/srv/svr_principal.c
+++ b/src/lib/kadm5/srv/svr_principal.c
@@ -537,6 +537,10 @@ kadm5_delete_principal(void *server_handle, krb5_principal principal)
     if (principal == NULL)
         return EINVAL;
 
+    /* Deleting K/M is mostly unrecoverable, so don't allow it. */
+    if (krb5_principal_compare(handle->context, principal, master_princ))
+        return KADM5_PROTECT_PRINCIPAL;
+
     if ((ret = kdb_get_entry(handle, principal, &kdb, &adb)))
         return(ret);
     ret = k5_kadm5_hook_remove(handle->context, handle->hook_handles,

--- a/src/tests/t_kadmin_acl.py
+++ b/src/tests/t_kadmin_acl.py
@@ -328,4 +328,10 @@ realm.run([kadmin, '-c', realm.ccache, 'cpw', '-randkey', 'none'],
 realm.run([kadmin, '-c', realm.ccache, 'cpw', '-randkey', '-e', 'aes256-cts',
            'none'], expected_code=1, expected_msg=msg)
 
+# Test operations disallowed at the libkadm5 layer.
+realm.run([kadminl, 'delprinc', 'K/M'],
+          expected_code=1, expected_msg='Cannot change protected principal')
+realm.run([kadminl, 'cpw', '-pw', 'pw', 'kadmin/history'],
+          expected_code=1, expected_msg='Cannot change protected principal')
+
 success('kadmin ACL enforcement')


### PR DESCRIPTION
In libkadm5srv, do not allow deletion of the master key principal, as
it is very difficult to recover a KDB after doing so.
