### PR TITLE
Avoid backward seeks when reading keytab files

### DIFF
--- a/src/lib/krb5/keytab/kt_file.c
+++ b/src/lib/krb5/keytab/kt_file.c
@@ -921,6 +921,8 @@ krb5_ktfileint_internal_read_entry(krb5_context context, krb5_keytab id, krb5_ke
             size = ntohl(size);
 
         if (size < 0) {
+            if (size == INT32_MIN)  /* INT32_MIN inverts to itself. */
+                return KRB5_KT_FORMAT;
             if (fseek(KTFILEP(id), -size, SEEK_CUR)) {
                 return errno;
             }
@@ -1347,6 +1349,8 @@ krb5_ktfileint_find_slot(krb5_context context, krb5_keytab id, krb5_int32 *size_
                 return errno;
         } else if (size < 0) {
             /* Empty record; use if it's big enough, seek past otherwise. */
+            if (size == INT32_MIN)  /* INT32_MIN inverts to itself. */
+                return KRB5_KT_FORMAT;
             size = -size;
             if (size >= *size_needed) {
                 *size_needed = size;

--- a/src/tests/t_keytab.py
+++ b/src/tests/t_keytab.py
@@ -185,5 +185,12 @@ test_addent(realm, 'default', '-f -e aes128-cts')
 test_addent(realm, 'exp', '-f')
 test_addent(realm, 'pexp', '-f')
 
-success('Keytab-related tests')
+# Regression test for #8914: INT32_MIN length can cause backwards seek
+mark('invalid record length')
+f = open(realm.keytab, 'wb')
+f.write(b'\x05\x02\x80\x00\x00\x00')
+f.close()
+msg = 'Bad format in keytab while scanning keytab'
+realm.run([klist, '-k'], expected_code=1, expected_msg=msg)
+
 success('Keytab-related tests')


### PR DESCRIPTION
[See https://krbdev.mit.edu/rt/Ticket/Display.html?id=8914 ]

When considering or bypassing an empty record in a keytab file, check
for a lenth of INT32_MIN.  Otherwise we could perform a backwards
seek, as the inverse of INT32_MIN is still negative.
