### PR TITLE
Allow gss_unwrap_iov() of unpadded RC4 tokens

### DIFF
--- a/src/lib/gssapi/krb5/util_crypt.c
+++ b/src/lib/gssapi/krb5/util_crypt.c
@@ -649,14 +649,11 @@ kg_fixup_padding_iov(OM_uint32 *minor_status, gss_iov_buffer_desc *iov,
     data = kg_locate_iov(iov, iov_count, GSS_IOV_BUFFER_TYPE_DATA);
     padding = kg_locate_iov(iov, iov_count, GSS_IOV_BUFFER_TYPE_PADDING);
 
-    if (data == NULL) {
+    /* Do nothing if padding is absent or empty, to allow unwrapping of WinRM
+     * unpadded RC4 tokens using an explicit IOV array. */
+    if (data == NULL || padding == NULL || padding->buffer.length == 0) {
         *minor_status = 0;
         return GSS_S_COMPLETE;
-    }
-
-    if (padding == NULL || padding->buffer.length == 0) {
-        *minor_status = EINVAL;
-        return GSS_S_FAILURE;
     }
 
     p = (unsigned char *)padding->buffer.value;


### PR DESCRIPTION
[Long discussion at https://github.com/heimdal/heimdal/issues/739 ]

Windows Remote Management, when used with an RC4 session key, appears
to generate GSS wrap tokens with no padding instead of the expected
one byte (RFC 4757 section 7.3).  These tokens cannot be decoded with
gss_unwrap() or a STREAM buffer (even with Microsoft SSPI), but SSPI
allows them to be decoded using explicit IOVs with either a
zero-length padding buffer or no padding buffer.  Allow these cases to
work in kg_fixup_padding_iov().  (It is already possible to make this
work with HEADER | DATA | DATA, but only by
accident--kg_fixup_padding_iov() doesn't find a data buffer because
kg_locate_iov() only looks for singleton buffers, so it exits early.)
