### PR TITLE
Ignore bad enctypes in krb5_string_to_keysalts()

### DIFF
--- a/src/lib/kadm5/str_conv.c
+++ b/src/lib/kadm5/str_conv.c
@@ -340,9 +340,10 @@ krb5_string_to_keysalts(const char *string, const char *tupleseps,
     while ((ksp = strtok_r(p, tseps, &tlasts)) != NULL) {
         /* Pass a null pointer to subsequent calls to strtok_r(). */
         p = NULL;
-        ret = string_to_keysalt(ksp, ksaltseps, &etype, &stype);
-        if (ret)
-            goto cleanup;
+
+        /* Discard unrecognized keysalts. */
+        if (string_to_keysalt(ksp, ksaltseps, &etype, &stype) != 0)
+            continue;
 
         /* Ignore duplicate keysalts if caller asks. */
         if (!dups && krb5_keysalt_is_present(ksalts, nksalts, etype, stype))


### PR DESCRIPTION
Fixes a problem where the presence of legacy/unrecognized keysalts in
supported_enctypes would prevent the kadmin programs from starting.