### PR TITLE
Expand dns_canonicalize_hostname=fallback support

### DIFF
--- a/src/include/k5-trace.h
+++ b/src/include/k5-trace.h
@@ -229,8 +229,8 @@ void krb5int_trace(krb5_context context, const char *fmt, ...);
           salt, s2kparams)
 #define TRACE_INIT_CREDS_IDENTIFIED_REALM(c, realm)                     \
     TRACE(c, "Identified realm of client principal as {data}", realm)
-#define TRACE_INIT_CREDS_KEYTAB_LOOKUP(c, etypes)               \
-    TRACE(c, "Looked up etypes in keytab: {etypes}", etypes)
+#define TRACE_INIT_CREDS_KEYTAB_LOOKUP(c, princ, etypes)                \
+    TRACE(c, "Found entries for {princ} in keytab: {etypes}", princ, etypes)
 #define TRACE_INIT_CREDS_KEYTAB_LOOKUP_FAILED(c, code)          \
     TRACE(c, "Couldn't lookup etypes in keytab: {kerr}", code)
 #define TRACE_INIT_CREDS_PREAUTH(c)                     \

--- a/src/kprop/kprop_util.c
+++ b/src/kprop/kprop_util.c
@@ -73,26 +73,22 @@ sn2princ_realm(krb5_context context, const char *hostname, const char *sname,
                const char *realm, krb5_principal *princ_out)
 {
     krb5_error_code ret;
-    char *canonhost, localname[MAXHOSTNAMELEN];
+    krb5_principal princ;
 
     *princ_out = NULL;
     assert(sname != NULL && realm != NULL);
 
-    /* If hostname is NULL, use the local hostname. */
-    if (hostname == NULL) {
-        if (gethostname(localname, MAXHOSTNAMELEN) != 0)
-            return SOCKET_ERRNO;
-        hostname = localname;
-    }
-
-    ret = krb5_expand_hostname(context, hostname, &canonhost);
+    ret = krb5_sname_to_principal(context, hostname, sname, KRB5_NT_SRV_HST,
+                                  &princ);
     if (ret)
         return ret;
 
-    ret = krb5_build_principal(context, princ_out, strlen(realm), realm, sname,
-                               canonhost, (char *)NULL);
-    krb5_free_string(context, canonhost);
-    if (!ret)
-        (*princ_out)->type = KRB5_NT_SRV_HST;
-    return ret;
+    ret = krb5_set_principal_realm(context, princ, realm);
+    if (ret) {
+        krb5_free_principal(context, princ);
+        return ret;
+    }
+
+    *princ_out = princ;
+    return 0;
 }

--- a/src/lib/gssapi/krb5/init_sec_context.c
+++ b/src/lib/gssapi/krb5/init_sec_context.c
@@ -165,44 +165,37 @@ static krb5_error_code get_credentials(context, cred, server, now,
             goto cleanup;
     }
 
-    /*
-     * For IAKERB or constrained delegation, only check the cache in this step.
-     * For IAKERB we will ask the server to make any necessary TGS requests;
-     * for constrained delegation we will adjust in_creds and make an S4U2Proxy
-     * request below if the cache lookup fails.
-     */
-    if (cred->impersonator != NULL || cred->iakerb_mech)
+    /* Try constrained delegation if we have proxy credentials. */
+    if (cred->impersonator != NULL) {
+        /* If we are trying to get a ticket to ourselves, we should use the
+         * the evidence ticket directly from cache. */
+        if (krb5_principal_compare(context, cred->impersonator,
+                                   server->princ)) {
+            flags |= KRB5_GC_CACHED;
+        } else {
+            memset(&mcreds, 0, sizeof(mcreds));
+            mcreds.magic = KV5M_CREDS;
+            mcreds.server = cred->impersonator;
+            mcreds.client = cred->name->princ;
+            code = krb5_cc_retrieve_cred(context, cred->ccache,
+                                         KRB5_TC_MATCH_AUTHDATA, &mcreds,
+                                         &evidence_creds);
+            if (code)
+                goto cleanup;
+
+            in_creds.client = cred->impersonator;
+            in_creds.second_ticket = evidence_creds.ticket;
+            flags = KRB5_GC_CANONICALIZE | KRB5_GC_CONSTRAINED_DELEGATION;
+        }
+    }
+
+    /* For IAKERB, only check the cache in this step.  We will ask the server
+     * to make any necessary TGS requests. */
+    if (cred->iakerb_mech)
         flags |= KRB5_GC_CACHED;
 
     code = krb5_get_credentials(context, flags, cred->ccache,
                                 &in_creds, &result_creds);
-
-    /*
-     * Try constrained delegation if we have proxy credentials, unless
-     * we are trying to get a ticket to ourselves (in which case we could
-     * just use the evidence ticket directly from cache).
-     */
-    if (code == KRB5_CC_NOTFOUND && cred->impersonator != NULL &&
-        !cred->iakerb_mech &&
-        !krb5_principal_compare(context, cred->impersonator, server->princ)) {
-
-        memset(&mcreds, 0, sizeof(mcreds));
-        mcreds.magic = KV5M_CREDS;
-        mcreds.server = cred->impersonator;
-        mcreds.client = cred->name->princ;
-        code = krb5_cc_retrieve_cred(context, cred->ccache,
-                                     KRB5_TC_MATCH_AUTHDATA, &mcreds,
-                                     &evidence_creds);
-        if (code)
-            goto cleanup;
-
-        in_creds.client = cred->impersonator;
-        in_creds.second_ticket = evidence_creds.ticket;
-        flags = KRB5_GC_CANONICALIZE | KRB5_GC_CONSTRAINED_DELEGATION;
-        code = krb5_get_credentials(context, flags, cred->ccache,
-                                    &in_creds, &result_creds);
-    }
-
     if (code)
         goto cleanup;
 

--- a/src/lib/krb5/ccache/cc_retr.c
+++ b/src/lib/krb5/ccache/cc_retr.c
@@ -58,15 +58,14 @@ static krb5_boolean
 princs_match(krb5_context context, krb5_flags whichfields,
              const krb5_creds *mcreds, const krb5_creds *creds)
 {
-    krb5_principal_data princ;
-
-    if (!krb5_principal_compare(context, mcreds->client, creds->client))
+    if (mcreds->client != NULL &&
+        !krb5_principal_compare(context, mcreds->client, creds->client))
         return FALSE;
+    if (mcreds->server == NULL)
+        return TRUE;
     if (whichfields & KRB5_TC_MATCH_SRV_NAMEONLY) {
-        /* Ignore the server realm. */
-        princ = *mcreds->server;
-        princ.realm = creds->server->realm;
-        return krb5_principal_compare(context, &princ, creds->server);
+        return krb5_principal_compare_any_realm(context, mcreds->server,
+                                                creds->server);
     } else {
         return krb5_principal_compare(context, mcreds->server, creds->server);
     }

--- a/src/lib/krb5/ccache/ccapi/stdcc_util.c
+++ b/src/lib/krb5/ccache/ccapi/stdcc_util.c
@@ -945,8 +945,13 @@ standard_fields_match(context, mcreds, creds)
     krb5_context context;
     const krb5_creds *mcreds, *creds;
 {
-    return (krb5_principal_compare(context, mcreds->client,creds->client) &&
-            krb5_principal_compare(context, mcreds->server,creds->server));
+    if (mcreds->client != NULL &&
+        !krb5_principal_compare(context, mcreds->client, creds->client))
+        return FALSE;
+    if (mcreds->server != NULL &&
+        !krb5_principal_compare(context, mcreds->server,creds->server))
+        return FALSE;
+    return TRUE;
 }
 
 /* only match the server name portion, not the server realm portion */
@@ -956,19 +961,14 @@ srvname_match(context, mcreds, creds)
     krb5_context context;
     const krb5_creds *mcreds, *creds;
 {
-    krb5_boolean retval;
-    krb5_principal_data p1, p2;
-
-    retval = krb5_principal_compare(context, mcreds->client,creds->client);
-    if (retval != TRUE)
-        return retval;
-    /*
-     * Hack to ignore the server realm for the purposes of the compare.
-     */
-    p1 = *mcreds->server;
-    p2 = *creds->server;
-    p1.realm = p2.realm;
-    return krb5_principal_compare(context, &p1, &p2);
+    if (mcreds->client != NULL &&
+        !krb5_principal_compare(context, mcreds->client, creds->client))
+        return FALSE;
+    if (mcreds->server != NULL &&
+        !krb5_principal_compare_any_realm(context, mcreds->server,
+                                          creds->server))
+        return FALSE;
+    return TRUE;
 }
 
 

--- a/src/lib/krb5/ccache/ccfns.c
+++ b/src/lib/krb5/ccache/ccfns.c
@@ -96,7 +96,8 @@ krb5_cc_retrieve_cred(krb5_context context, krb5_ccache cache,
     TRACE_CC_RETRIEVE(context, cache, mcreds, ret);
     if (ret != KRB5_CC_NOTFOUND)
         return ret;
-    if (!krb5_is_referral_realm(&mcreds->server->realm))
+    if (mcreds->client == NULL || mcreds->server == NULL ||
+        !krb5_is_referral_realm(&mcreds->server->realm))
         return ret;
 
     /*

--- a/src/lib/krb5/krb/deps
+++ b/src/lib/krb5/krb/deps
@@ -499,12 +499,13 @@ get_in_tkt.so get_in_tkt.po $(OUTPRE)get_in_tkt.$(OBJEXT): \
 gic_keytab.so gic_keytab.po $(OUTPRE)gic_keytab.$(OBJEXT): \
   $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/krb5/krb5.h \
   $(BUILDTOP)/include/osconf.h $(BUILDTOP)/include/profile.h \
-  $(COM_ERR_DEPS) $(top_srcdir)/include/k5-buf.h $(top_srcdir)/include/k5-err.h \
-  $(top_srcdir)/include/k5-gmt_mktime.h $(top_srcdir)/include/k5-int-pkinit.h \
-  $(top_srcdir)/include/k5-int.h $(top_srcdir)/include/k5-json.h \
-  $(top_srcdir)/include/k5-platform.h $(top_srcdir)/include/k5-plugin.h \
-  $(top_srcdir)/include/k5-thread.h $(top_srcdir)/include/k5-trace.h \
-  $(top_srcdir)/include/krb5.h $(top_srcdir)/include/krb5/authdata_plugin.h \
+  $(COM_ERR_DEPS) $(srcdir)/../os/os-proto.h $(top_srcdir)/include/k5-buf.h \
+  $(top_srcdir)/include/k5-err.h $(top_srcdir)/include/k5-gmt_mktime.h \
+  $(top_srcdir)/include/k5-int-pkinit.h $(top_srcdir)/include/k5-int.h \
+  $(top_srcdir)/include/k5-json.h $(top_srcdir)/include/k5-platform.h \
+  $(top_srcdir)/include/k5-plugin.h $(top_srcdir)/include/k5-thread.h \
+  $(top_srcdir)/include/k5-trace.h $(top_srcdir)/include/krb5.h \
+  $(top_srcdir)/include/krb5/authdata_plugin.h $(top_srcdir)/include/krb5/locate_plugin.h \
   $(top_srcdir)/include/krb5/plugin.h $(top_srcdir)/include/port-sockets.h \
   $(top_srcdir)/include/socket-utils.h gic_keytab.c init_creds_ctx.h \
   int-proto.h
@@ -940,13 +941,14 @@ rd_req.so rd_req.po $(OUTPRE)rd_req.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
 rd_req_dec.so rd_req_dec.po $(OUTPRE)rd_req_dec.$(OBJEXT): \
   $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/krb5/krb5.h \
   $(BUILDTOP)/include/osconf.h $(BUILDTOP)/include/profile.h \
-  $(COM_ERR_DEPS) $(srcdir)/../rcache/memrcache.h $(top_srcdir)/include/k5-buf.h \
-  $(top_srcdir)/include/k5-err.h $(top_srcdir)/include/k5-gmt_mktime.h \
-  $(top_srcdir)/include/k5-int-pkinit.h $(top_srcdir)/include/k5-int.h \
-  $(top_srcdir)/include/k5-platform.h $(top_srcdir)/include/k5-plugin.h \
-  $(top_srcdir)/include/k5-thread.h $(top_srcdir)/include/k5-trace.h \
-  $(top_srcdir)/include/k5-utf8.h $(top_srcdir)/include/krb5.h \
-  $(top_srcdir)/include/krb5/authdata_plugin.h $(top_srcdir)/include/krb5/plugin.h \
+  $(COM_ERR_DEPS) $(srcdir)/../os/os-proto.h $(srcdir)/../rcache/memrcache.h \
+  $(top_srcdir)/include/k5-buf.h $(top_srcdir)/include/k5-err.h \
+  $(top_srcdir)/include/k5-gmt_mktime.h $(top_srcdir)/include/k5-int-pkinit.h \
+  $(top_srcdir)/include/k5-int.h $(top_srcdir)/include/k5-platform.h \
+  $(top_srcdir)/include/k5-plugin.h $(top_srcdir)/include/k5-thread.h \
+  $(top_srcdir)/include/k5-trace.h $(top_srcdir)/include/k5-utf8.h \
+  $(top_srcdir)/include/krb5.h $(top_srcdir)/include/krb5/authdata_plugin.h \
+  $(top_srcdir)/include/krb5/locate_plugin.h $(top_srcdir)/include/krb5/plugin.h \
   $(top_srcdir)/include/port-sockets.h $(top_srcdir)/include/socket-utils.h \
   auth_con.h authdata.h int-proto.h rd_req_dec.c
 rd_safe.so rd_safe.po $(OUTPRE)rd_safe.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
@@ -997,12 +999,13 @@ s4u_authdata.so s4u_authdata.po $(OUTPRE)s4u_authdata.$(OBJEXT): \
 s4u_creds.so s4u_creds.po $(OUTPRE)s4u_creds.$(OBJEXT): \
   $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/krb5/krb5.h \
   $(BUILDTOP)/include/osconf.h $(BUILDTOP)/include/profile.h \
-  $(COM_ERR_DEPS) $(top_srcdir)/include/k5-buf.h $(top_srcdir)/include/k5-err.h \
-  $(top_srcdir)/include/k5-gmt_mktime.h $(top_srcdir)/include/k5-int-pkinit.h \
-  $(top_srcdir)/include/k5-int.h $(top_srcdir)/include/k5-platform.h \
-  $(top_srcdir)/include/k5-plugin.h $(top_srcdir)/include/k5-thread.h \
-  $(top_srcdir)/include/k5-trace.h $(top_srcdir)/include/krb5.h \
-  $(top_srcdir)/include/krb5/authdata_plugin.h $(top_srcdir)/include/krb5/plugin.h \
+  $(COM_ERR_DEPS) $(srcdir)/../os/os-proto.h $(top_srcdir)/include/k5-buf.h \
+  $(top_srcdir)/include/k5-err.h $(top_srcdir)/include/k5-gmt_mktime.h \
+  $(top_srcdir)/include/k5-int-pkinit.h $(top_srcdir)/include/k5-int.h \
+  $(top_srcdir)/include/k5-platform.h $(top_srcdir)/include/k5-plugin.h \
+  $(top_srcdir)/include/k5-thread.h $(top_srcdir)/include/k5-trace.h \
+  $(top_srcdir)/include/krb5.h $(top_srcdir)/include/krb5/authdata_plugin.h \
+  $(top_srcdir)/include/krb5/locate_plugin.h $(top_srcdir)/include/krb5/plugin.h \
   $(top_srcdir)/include/port-sockets.h $(top_srcdir)/include/socket-utils.h \
   int-proto.h s4u_creds.c
 sendauth.so sendauth.po $(OUTPRE)sendauth.$(OBJEXT): \

--- a/src/lib/krb5/krb/get_creds.c
+++ b/src/lib/krb5/krb/get_creds.c
@@ -102,6 +102,11 @@ krb5int_construct_matching_creds(krb5_context context, krb5_flags options,
             return KRB5_NO_2ND_TKT;
     }
 
+    /* For S4U2Proxy requests we don't know the impersonated client in this
+     * API, but matching against the second ticket is good enough. */
+    if (options & KRB5_GC_CONSTRAINED_DELEGATION)
+        mcreds->client = NULL;
+
     return 0;
 }
 

--- a/src/lib/krb5/krb/get_creds.c
+++ b/src/lib/krb5/krb/get_creds.c
@@ -119,7 +119,7 @@ krb5int_construct_matching_creds(krb5_context context, krb5_flags options,
  * generate the next request.  If it's time to advance to another state, any of
  * the three functions can make a tail call to begin_<nextstate> to do so.
  *
- * The overall process is as follows:
+ * The general process is as follows:
  *   1. Get a TGT for the service principal's realm (STATE_GET_TGT).
  *   2. Make one or more referrals queries (STATE_REFERRALS).
  *   3. In some cases, get a TGT for the fallback realm (STATE_GET_TGT again).
@@ -129,6 +129,9 @@ krb5int_construct_matching_creds(krb5_context context, krb5_flags options,
  * getting_tgt_for field in the context keeps track of what state we will go to
  * after successfully obtaining the TGT, and the end_get_tgt() function
  * advances to the proper next state.
+ *
+ * If fallback DNS canonicalization is in use, the process can be repeated a
+ * second time for the second server principal canonicalization candidate.
  */
 
 enum state {
@@ -153,6 +156,8 @@ struct _krb5_tkt_creds_context {
     krb5_flags req_options;     /* Caller-requested KRB5_GC_* options */
     krb5_flags req_kdcopt;      /* Caller-requested options as KDC options */
     krb5_authdata **authdata;   /* Caller-requested authdata */
+    struct canonprinc iter;     /* Iterator over canonicalized server princs */
+    krb5_boolean referral_req;  /* Server initially contained referral realm */
 
     /* The following fields are used in multiple steps. */
     krb5_creds *cur_tgt;        /* TGT to be used for next query */
@@ -484,7 +489,7 @@ try_fallback(krb5_context context, krb5_tkt_creds_context ctx)
 
     /* If the request used a specified realm, make a non-referral request to
      * that realm (in case it's a KDC which rejects KDC_OPT_CANONICALIZE). */
-    if (!krb5_is_referral_realm(&ctx->req_server->realm))
+    if (!ctx->referral_req)
         return begin_non_referral(context, ctx);
 
     if (ctx->server->length < 2) {
@@ -1015,10 +1020,13 @@ check_cache(krb5_context context, krb5_tkt_creds_context ctx)
     krb5_error_code code;
     krb5_creds mcreds;
     krb5_flags fields;
+    krb5_creds req_in_creds;
 
-    /* Perform the cache lookup. */
+    /* Check the cache for the originally requested server principal. */
+    req_in_creds = *ctx->in_creds;
+    req_in_creds.server = ctx->req_server;
     code = krb5int_construct_matching_creds(context, ctx->req_options,
-                                            ctx->in_creds, &mcreds, &fields);
+                                            &req_in_creds, &mcreds, &fields);
     if (code)
         return code;
     code = cache_get(context, ctx->ccache, fields, &mcreds, &ctx->reply_creds);
@@ -1044,12 +1052,9 @@ begin(krb5_context context, krb5_tkt_creds_context ctx)
 {
     krb5_error_code code;
 
-    code = check_cache(context, ctx);
-    if (code != 0 || ctx->state == STATE_COMPLETE)
-        return code;
-
     /* If the server realm is unspecified, start with the client realm. */
-    if (krb5_is_referral_realm(&ctx->server->realm)) {
+    ctx->referral_req = krb5_is_referral_realm(&ctx->server->realm);
+    if (ctx->referral_req) {
         krb5_free_data_contents(context, &ctx->server->realm);
         code = krb5int_copy_data_contents(context, &ctx->client->realm,
                                           &ctx->server->realm);
@@ -1072,6 +1077,7 @@ krb5_tkt_creds_init(krb5_context context, krb5_ccache ccache,
 {
     krb5_error_code code;
     krb5_tkt_creds_context ctx = NULL;
+    krb5_const_principal canonprinc;
 
     TRACE_TKT_CREDS(context, in_creds, ccache);
     ctx = k5alloc(sizeof(*ctx), &code);
@@ -1089,14 +1095,28 @@ krb5_tkt_creds_init(krb5_context context, krb5_ccache ccache,
 
     ctx->state = STATE_BEGIN;
 
+    /* Copy the matching cred so we can modify it.  Steal the copy of the
+     * service principal name to remember the original request server. */
     code = krb5_copy_creds(context, in_creds, &ctx->in_creds);
     if (code != 0)
         goto cleanup;
-    ctx->client = ctx->in_creds->client;
-    ctx->server = ctx->in_creds->server;
-    code = krb5_copy_principal(context, ctx->server, &ctx->req_server);
+    ctx->req_server = ctx->in_creds->server;
+    ctx->in_creds->server = NULL;
+
+    /* Get the first canonicalization candidate for the requested server. */
+    ctx->iter.princ = ctx->req_server;
+
+    code = k5_canonprinc(context, &ctx->iter, &canonprinc);
+    if (code == 0 && canonprinc == NULL)
+        code = KRB5KDC_ERR_S_PRINCIPAL_UNKNOWN;
     if (code != 0)
         goto cleanup;
+    code = krb5_copy_principal(context, canonprinc, &ctx->in_creds->server);
+    if (code != 0)
+        goto cleanup;
+
+    ctx->client = ctx->in_creds->client;
+    ctx->server = ctx->in_creds->server;
     code = krb5_cc_dup(context, ccache, &ctx->ccache);
     if (code != 0)
         goto cleanup;
@@ -1138,6 +1158,7 @@ krb5_tkt_creds_free(krb5_context context, krb5_tkt_creds_context ctx)
         return;
     krb5int_fast_free_state(context, ctx->fast_state);
     krb5_free_creds(context, ctx->in_creds);
+    free_canonprinc(&ctx->iter);
     krb5_cc_close(context, ctx->ccache);
     krb5_free_principal(context, ctx->req_server);
     krb5_free_authdata(context, ctx->authdata);
@@ -1195,6 +1216,7 @@ krb5_tkt_creds_step(krb5_context context, krb5_tkt_creds_context ctx,
 {
     krb5_error_code code;
     krb5_boolean no_input = (in == NULL || in->length == 0);
+    krb5_const_principal canonprinc;
 
     *out = empty_data();
     *realm = empty_data();
@@ -1205,6 +1227,12 @@ krb5_tkt_creds_step(krb5_context context, krb5_tkt_creds_context ctx,
     if (no_input != (ctx->state == STATE_BEGIN) ||
         ctx->state == STATE_COMPLETE)
         return EINVAL;
+
+    if (ctx->state == STATE_BEGIN) {
+        code = check_cache(context, ctx);
+        if (code != 0 || ctx->state == STATE_COMPLETE)
+            return code;
+    }
 
     ctx->caller_out = out;
     ctx->caller_realm = realm;
@@ -1218,37 +1246,32 @@ krb5_tkt_creds_step(krb5_context context, krb5_tkt_creds_context ctx,
     }
 
     if (ctx->state == STATE_BEGIN)
-        return begin(context, ctx);
+        code = begin(context, ctx);
     else if (ctx->state == STATE_GET_TGT)
-        return step_get_tgt(context, ctx);
+        code = step_get_tgt(context, ctx);
     else if (ctx->state == STATE_GET_TGT_OFFPATH)
-        return step_get_tgt_offpath(context, ctx);
+        code = step_get_tgt_offpath(context, ctx);
     else if (ctx->state == STATE_REFERRALS)
-        return step_referrals(context, ctx);
+        code = step_referrals(context, ctx);
     else if (ctx->state == STATE_NON_REFERRAL)
-        return step_non_referral(context, ctx);
+        code = step_non_referral(context, ctx);
     else
-        return EINVAL;
-}
+        code = EINVAL;
 
-static krb5_error_code
-try_get_creds(krb5_context context, krb5_flags options, krb5_ccache ccache,
-              krb5_creds *in_creds, krb5_creds *creds_out)
-{
-    krb5_error_code code;
-    krb5_tkt_creds_context ctx = NULL;
+    /* Terminate on success or most errors. */
+    if (code != KRB5KDC_ERR_S_PRINCIPAL_UNKNOWN)
+        return code;
 
-    code = krb5_tkt_creds_init(context, ccache, in_creds, options, &ctx);
+    /* Restart with the next server principal canonicalization candidate. */
+    code = k5_canonprinc(context, &ctx->iter, &canonprinc);
     if (code)
-        goto cleanup;
-    code = krb5_tkt_creds_get(context, ctx);
-    if (code)
-        goto cleanup;
-    code = krb5_tkt_creds_get_creds(context, ctx, creds_out);
-
-cleanup:
-    krb5_tkt_creds_free(context, ctx);
-    return code;
+        return code;
+    if (canonprinc == NULL)
+        return KRB5KDC_ERR_S_PRINCIPAL_UNKNOWN;
+    krb5_free_principal(context, ctx->in_creds->server);
+    code = krb5_copy_principal(context, canonprinc, &ctx->in_creds->server);
+    ctx->server = ctx->in_creds->server;
+    return begin(context, ctx);
 }
 
 krb5_error_code KRB5_CALLCONV
@@ -1258,10 +1281,7 @@ krb5_get_credentials(krb5_context context, krb5_flags options,
 {
     krb5_error_code code;
     krb5_creds *ncreds = NULL;
-    krb5_creds canon_creds, store_creds;
-    krb5_principal_data canon_server;
-    krb5_data canon_components[2];
-    char *hostname = NULL, *canon_hostname = NULL;
+    krb5_tkt_creds_context ctx = NULL;
 
     *out_creds = NULL;
 
@@ -1277,59 +1297,22 @@ krb5_get_credentials(krb5_context context, krb5_flags options,
     if (ncreds == NULL)
         goto cleanup;
 
-    code = try_get_creds(context, options, ccache, in_creds, ncreds);
-    if (!code) {
-        *out_creds = ncreds;
-        return 0;
-    }
-
-    /* Possibly try again with the canonicalized hostname, if the server is
-     * host-based and we are configured for fallback canonicalization. */
-    if (code != KRB5KDC_ERR_S_PRINCIPAL_UNKNOWN)
+    /* Make and execute a krb5_tkt_creds context to get the credential. */
+    code = krb5_tkt_creds_init(context, ccache, in_creds, options, &ctx);
+    if (code != 0)
         goto cleanup;
-    if (context->dns_canonicalize_hostname != CANONHOST_FALLBACK)
+    code = krb5_tkt_creds_get(context, ctx);
+    if (code != 0)
         goto cleanup;
-    if (in_creds->server->type != KRB5_NT_SRV_HST ||
-        in_creds->server->length != 2)
+    code = krb5_tkt_creds_get_creds(context, ctx, ncreds);
+    if (code != 0)
         goto cleanup;
-
-    hostname = k5memdup0(in_creds->server->data[1].data,
-                         in_creds->server->data[1].length, &code);
-    if (hostname == NULL)
-        goto cleanup;
-    code = k5_expand_hostname(context, hostname, TRUE, &canon_hostname);
-    if (code)
-        goto cleanup;
-
-    TRACE_GET_CREDS_FALLBACK(context, canon_hostname);
-
-    /* Make shallow copies of in_creds and its server to alter the hostname. */
-    canon_components[0] = in_creds->server->data[0];
-    canon_components[1] = string2data(canon_hostname);
-    canon_server = *in_creds->server;
-    canon_server.data = canon_components;
-    canon_creds = *in_creds;
-    canon_creds.server = &canon_server;
-
-    code = try_get_creds(context, options | KRB5_GC_NO_STORE, ccache,
-                         &canon_creds, ncreds);
-    if (code)
-        goto cleanup;
-
-    if (!(options & KRB5_GC_NO_STORE)) {
-        /* Store the creds under the originally requested server name.  The
-         * ccache layer will also store them under the ticket server name. */
-        store_creds = *ncreds;
-        store_creds.server = in_creds->server;
-        (void)krb5_cc_store_cred(context, ccache, &store_creds);
-    }
 
     *out_creds = ncreds;
     ncreds = NULL;
 
 cleanup:
-    free(hostname);
-    free(canon_hostname);
     krb5_free_creds(context, ncreds);
+    krb5_tkt_creds_free(context, ctx);
     return code;
 }

--- a/src/lib/krb5/krb/get_in_tkt.c
+++ b/src/lib/krb5/krb/get_in_tkt.c
@@ -1051,9 +1051,6 @@ krb5_init_creds_init(krb5_context context,
         ctx->request->kdc_options |= KDC_OPT_REQUEST_ANONYMOUS;
         ctx->request->client->type = KRB5_NT_WELLKNOWN;
     }
-    code = restart_init_creds_loop(context, ctx, FALSE);
-    if (code)
-        goto cleanup;
 
     *pctx = ctx;
     ctx = NULL;
@@ -1858,6 +1855,10 @@ krb5_init_creds_step(krb5_context context,
             goto copy_realm;
         }
         if (code != 0 || ctx->complete)
+            goto cleanup;
+    } else {
+        code = restart_init_creds_loop(context, ctx, FALSE);
+        if (code)
             goto cleanup;
     }
 

--- a/src/lib/krb5/krb/init_creds_ctx.h
+++ b/src/lib/krb5/krb/init_creds_ctx.h
@@ -22,6 +22,7 @@ struct _krb5_init_creds_context {
     krb5_get_init_creds_opt opt_storage;
     krb5_boolean identify_realm;
     const krb5_data *subject_cert;
+    krb5_principal keytab_princ;
     char *in_tkt_service;
     krb5_prompter_fct prompter;
     void *prompter_data;

--- a/src/lib/krb5/krb/int-proto.h
+++ b/src/lib/krb5/krb/int-proto.h
@@ -79,9 +79,9 @@ clpreauth_otp_initvt(krb5_context context, int maj_ver, int min_ver,
                      krb5_plugin_vtable vtable);
 
 krb5_error_code
-krb5int_construct_matching_creds(krb5_context context, krb5_flags options,
-                                 krb5_creds *in_creds, krb5_creds *mcreds,
-                                 krb5_flags *fields);
+k5_get_cached_cred(krb5_context context, krb5_flags options,
+                   krb5_ccache ccache, krb5_creds *in_creds,
+                   krb5_creds **creds_out);
 
 #define IS_TGS_PRINC(p) ((p)->length == 2 &&                            \
                          data_eq_string((p)->data[0], KRB5_TGS_NAME))

--- a/src/lib/krb5/krb/s4u_creds.c
+++ b/src/lib/krb5/krb/s4u_creds.c
@@ -1119,6 +1119,13 @@ get_proxy_cred_from_kdc(krb5_context context, krb5_flags options,
             code = KRB5KRB_AP_WRONG_PRINC;
             goto cleanup;
         }
+
+        /* Put the original evidence ticket in the output creds. */
+        krb5_free_data_contents(context, &tkt->second_ticket);
+        code = krb5int_copy_data_contents(context, &in_creds->second_ticket,
+                                          &tkt->second_ticket);
+        if (code)
+            goto cleanup;
     }
 
     /* Note the authdata we asked for in the output creds. */
@@ -1145,10 +1152,32 @@ k5_get_proxy_cred_from_kdc(krb5_context context, krb5_flags options,
 {
     krb5_error_code code;
     krb5_const_principal canonprinc;
-    krb5_creds copy, *creds;
+    krb5_creds mcreds, copy, *creds, *ncreds;
+    krb5_flags fields;
     struct canonprinc iter = { in_creds->server, .no_hostrealm = TRUE };
 
     *out_creds = NULL;
+
+    code = krb5int_construct_matching_creds(context, options, in_creds,
+                                            &mcreds, &fields);
+    if (code != 0)
+        return code;
+
+    ncreds = calloc(1, sizeof(*ncreds));
+    if (ncreds == NULL)
+        return ENOMEM;
+    ncreds->magic = KV5M_CRED;
+
+    code = krb5_cc_retrieve_cred(context, ccache, fields, &mcreds, ncreds);
+    if (code) {
+        free(ncreds);
+    } else {
+        *out_creds = ncreds;
+    }
+
+    if ((code != KRB5_CC_NOTFOUND && code != KRB5_CC_NOT_KTYPE) ||
+        options & KRB5_GC_CACHED)
+        return code;
 
     copy = *in_creds;
     while ((code = k5_canonprinc(context, &iter, &canonprinc)) == 0 &&
@@ -1195,9 +1224,6 @@ krb5_get_credentials_for_proxy(krb5_context context,
                                krb5_creds **out_creds)
 {
     krb5_error_code code;
-    krb5_creds mcreds;
-    krb5_creds *ncreds = NULL;
-    krb5_flags fields;
     krb5_data *evidence_tkt_data = NULL;
     krb5_creds s4u_creds;
 
@@ -1218,30 +1244,6 @@ krb5_get_credentials_for_proxy(krb5_context context,
         code = EINVAL;
         goto cleanup;
     }
-
-    code = krb5int_construct_matching_creds(context, options, in_creds,
-                                            &mcreds, &fields);
-    if (code != 0)
-        goto cleanup;
-
-    ncreds = calloc(1, sizeof(*ncreds));
-    if (ncreds == NULL) {
-        code = ENOMEM;
-        goto cleanup;
-    }
-    ncreds->magic = KV5M_CRED;
-
-    code = krb5_cc_retrieve_cred(context, ccache, fields, &mcreds, ncreds);
-    if (code != 0) {
-        free(ncreds);
-        ncreds = in_creds;
-    } else {
-        *out_creds = ncreds;
-    }
-
-    if ((code != KRB5_CC_NOTFOUND && code != KRB5_CC_NOT_KTYPE)
-        || options & KRB5_GC_CACHED)
-        goto cleanup;
 
     code = encode_krb5_ticket(evidence_tkt, &evidence_tkt_data);
     if (code != 0)

--- a/src/lib/krb5/krb/s4u_creds.c
+++ b/src/lib/krb5/krb/s4u_creds.c
@@ -1152,29 +1152,12 @@ k5_get_proxy_cred_from_kdc(krb5_context context, krb5_flags options,
 {
     krb5_error_code code;
     krb5_const_principal canonprinc;
-    krb5_creds mcreds, copy, *creds, *ncreds;
-    krb5_flags fields;
+    krb5_creds copy, *creds;
     struct canonprinc iter = { in_creds->server, .no_hostrealm = TRUE };
 
     *out_creds = NULL;
 
-    code = krb5int_construct_matching_creds(context, options, in_creds,
-                                            &mcreds, &fields);
-    if (code != 0)
-        return code;
-
-    ncreds = calloc(1, sizeof(*ncreds));
-    if (ncreds == NULL)
-        return ENOMEM;
-    ncreds->magic = KV5M_CRED;
-
-    code = krb5_cc_retrieve_cred(context, ccache, fields, &mcreds, ncreds);
-    if (code) {
-        free(ncreds);
-    } else {
-        *out_creds = ncreds;
-    }
-
+    code = k5_get_cached_cred(context, options, ccache, in_creds, out_creds);
     if ((code != KRB5_CC_NOTFOUND && code != KRB5_CC_NOT_KTYPE) ||
         options & KRB5_GC_CACHED)
         return code;

--- a/src/lib/krb5/os/os-proto.h
+++ b/src/lib/krb5/os/os-proto.h
@@ -83,6 +83,36 @@ struct sendto_callback_info {
     void *data;
 };
 
+/*
+ * Initialize with all zeros except for princ.  Set no_hostrealm to disable
+ * host-to-realm lookup, which ordinarily happens after canonicalizing the host
+ * part.  Set subst_defrealm to substitute the default realm for the referral
+ * realm after realm lookup (this has no effect if no_hostrealm is set).  Free
+ * with free_canonprinc() when done.
+ */
+struct canonprinc {
+    krb5_const_principal princ;
+    krb5_boolean no_hostrealm;
+    krb5_boolean subst_defrealm;
+    int step;
+    char *canonhost;
+    char *realm;
+    krb5_principal_data copy;
+    krb5_data components[2];
+};
+
+/* Yield one or two candidate canonical principal names for iter, then NULL.
+ * Output names are valid for one iteration and must not be freed. */
+krb5_error_code k5_canonprinc(krb5_context context, struct canonprinc *iter,
+                              krb5_const_principal *princ_out);
+
+static inline void
+free_canonprinc(struct canonprinc *iter)
+{
+    free(iter->canonhost);
+    free(iter->realm);
+}
+
 krb5_error_code k5_expand_hostname(krb5_context context, const char *host,
                                    krb5_boolean is_fallback,
                                    char **canonhost_out);

--- a/src/tests/s4u2proxy.c
+++ b/src/tests/s4u2proxy.c
@@ -124,6 +124,9 @@ main(int argc, char **argv)
                                          KRB5_GC_CANONICALIZE, defcc,
                                          &mcred, ev_ticket, &new_cred));
 
+    assert(data_eq(new_cred->second_ticket, ev_cred.ticket));
+    assert(new_cred->second_ticket.length != 0);
+
     /* Store the new cred in the default ccache. */
     check(krb5_cc_store_cred(context, defcc, new_cred));
 


### PR DESCRIPTION
This isn't complete, but I may have to switch focus next week so I'm putting up what I have so far.  The goal is to iron out a lot of edge cases, and make the server side of things less likely to break regardless of what the qualify_shortname default is.  The design is:

* A lightweight iterator over the one or two service principal candidates, so we can do fallback in more places without duplicating code.

* When dns_canonicalize_hostname=fallback, delay all processing of the sn2princ inputs until use, so that both canonicalizations can be dependent on the original sn2princ inputs and realm lookup can be done properly on each candidate.  (Heimdal does the same thing if the canonicalization rules are non-trivial.)

* Integrate fallback support into the stepwise TGS state machine, so that we don't break IAKERB with delayed canonicalization.

* Add fallback support to k5_get_proxy_cred_from_kdc(), krb5_kt_get_entry(), and the krb5_init_creds_set_keytab() enctype lookup.

* Cache credentials under the unprocessed sn2princ name.

TBD:

* Address the S4U2Proxy must-use-referrals requirement in a way that works with delayed canonicalization.  Currently the GSS code unsets the realm before making an S4U2Proxy request, but the delayed realm lookup defeats that.  [Edit: this is done]

* Address kprop's sn2princ_realm(), which works like the old sn2princ.  [Edit: this is done.  It would be nice to avoid the realm lookup like the old version did, but the logic has gotten too complicated for that, and simply overwriting the realm should serve.  In the default dns_canonicalize_hostname=fallback configuration no realm lookup will be performed because it is deferred.]

* Address KDB creation.

* The k5_get_cached_cred() refactor probably isn't needed for this change and could be separated out.  [Edit: this is done]

* The handling of KRB5_NT_UNKNOWN is incorrect and causes an assertion failure.  The correct behavior is to look up the realm but not canonicalize the hostname.  (Though, if we don't know it's a host-based service name, why look up the realm in host-to-realm?  But that is the historical behavior.)  [Edit: this is fixed, without changing the behavior.  We might still consider changing the behavior, which would simplify the code a bit.]

* Add client principal canonicalization to the get_init_creds state machine.  This is necessary for kprop as well as kinit -k and kadmin -k.  [Edit: every in-tree operation using sn2princ results as AS client principals uses a keytab, so it's probably fine to just use the keytab as an authority.  This is now done.]

* The iterator should check for the second result being identical to the first and not yield it if so.  [Edit: this is done]

* Tests.  Also check for memory errors (including leaks) with an asan build.  [Edit: I think the important cases are tested.  The asan test run is clean with #1097 fixed.]

See also: https://krbdev.mit.edu/rt/Ticket/Display.html?id=8925