### PR TITLE
Fix token and type declarations in getdate.y

### DIFF
--- a/src/kadmin/cli/getdate.y
+++ b/src/kadmin/cli/getdate.y
@@ -185,12 +185,10 @@ static time_t	yyRelSeconds;
     enum _MERIDIAN	Meridian;
 }
 
-%token	tAGO tDAY tDAYZONE tID tMERIDIAN tMINUTE_UNIT tMONTH tMONTH_UNIT
-%token	tSEC_UNIT tSNUMBER tUNUMBER tZONE tDST tNEVER
-
-%type	<Number>	tDAY tDAYZONE tMINUTE_UNIT tMONTH tMONTH_UNIT
-%type	<Number>	tSEC_UNIT tSNUMBER tUNUMBER tZONE
-%type	<Meridian>	tMERIDIAN o_merid
+%token			tAGO tID tDST tNEVER
+%token	<Number>	tDAY tDAYZONE tMINUTE_UNIT tMONTH tMONTH_UNIT
+%token	<Number>	tSEC_UNIT tSNUMBER tUNUMBER tZONE tMERIDIAN
+%type	<Meridian>	o_merid
 
 %%
 


### PR DESCRIPTION
[ https://krbdev.mit.edu/rt/Ticket/Display.html?id=8927 ]

Bison 3.5 adds a warning that %type should only be applied to
non-terminals.  Use %token for terminals in getdate.y.  Reported by
Norm Green.
