### PR TITLE
Two SPNEGO DER decoding changes

### DIFF
--- a/src/lib/gssapi/spnego/spnego_mech.c
+++ b/src/lib/gssapi/spnego/spnego_mech.c
@@ -3461,14 +3461,14 @@ get_mech_set(OM_uint32 *minor_status, unsigned char **buff_in,
 	unsigned char		*start;
 	int i;
 
-	if (**buff_in != SEQUENCE_OF)
+	if (buff_length < 1 || **buff_in != SEQUENCE_OF)
 		return (NULL);
 
 	start = *buff_in;
 	(*buff_in)++;
 
-	length = gssint_get_der_length(buff_in, buff_length, &bytes);
-	if (length < 0 || buff_length - bytes < (unsigned int)length)
+	length = gssint_get_der_length(buff_in, buff_length - 1, &bytes);
+	if (length < 0 || buff_length - 1 - bytes < (unsigned int)length)
 		return NULL;
 
 	major_status = gss_create_empty_oid_set(minor_status,
@@ -3548,11 +3548,11 @@ get_req_flags(unsigned char **buff_in, OM_uint32 bodysize,
 {
 	unsigned int len;
 
-	if (**buff_in != (CONTEXT | 0x01))
+	if (bodysize < 1 || **buff_in != (CONTEXT | 0x01))
 		return (0);
 
 	if (g_get_tag_and_length(buff_in, (CONTEXT | 0x01),
-				bodysize, &len) < 0)
+				 bodysize, &len) < 0 || len != 4)
 		return GSS_S_DEFECTIVE_TOKEN;
 
 	if (*(*buff_in)++ != BIT_STRING)

--- a/src/lib/gssapi/spnego/spnego_mech.c
+++ b/src/lib/gssapi/spnego/spnego_mech.c
@@ -3338,20 +3338,19 @@ get_mech_oid(OM_uint32 *minor_status, unsigned char **buff_in, size_t length)
 	OM_uint32	status;
 	gss_OID_desc 	toid;
 	gss_OID		mech_out = NULL;
-	unsigned char		*start, *end;
+	unsigned int	bytes;
+	int		oid_length;
 
 	if (length < 1 || **buff_in != MECH_OID)
 		return (NULL);
-
-	start = *buff_in;
-	end = start + length;
-
 	(*buff_in)++;
-	toid.length = *(*buff_in)++;
+	length--;
 
-	if ((*buff_in + toid.length) > end)
+	oid_length = gssint_get_der_length(buff_in, length, &bytes);
+	if (oid_length < 0 || length - bytes < (size_t)oid_length)
 		return (NULL);
 
+	toid.length = oid_length;
 	toid.elements = *buff_in;
 	*buff_in += toid.length;
 


### PR DESCRIPTION
The first commit is the change requested by Richard Sharpe, to interoperate with a buggy NetApp DER encoder.  The supplied patch had some vulnerabilities, so I rewrote it.

The second commit fixes read length checking issues that I noticed while investigating.  (I don't think they have a material security impact.)
