### PR TITLE
Stop creating hostbased principals in new KDBs

### DIFF
--- a/doc/admin/admin_commands/kadmin_local.rst
+++ b/doc/admin/admin_commands/kadmin_local.rst
@@ -44,9 +44,9 @@ Kerberos principals, password policies, and service key tables
 (keytabs).
 
 The remote kadmin client uses Kerberos to authenticate to kadmind
-using the service principal ``kadmin/ADMINHOST`` (where *ADMINHOST* is
-the fully-qualified hostname of the admin server) or ``kadmin/admin``.
-If the credentials cache contains a ticket for one of these
+using the service principal ``kadmin/admin`` or ``kadmin/ADMINHOST``
+(where *ADMINHOST* is the fully-qualified hostname of the admin
+server).  If the credentials cache contains a ticket for one of these
 principals, and the **-c** credentials_cache option is specified, that
 ticket is used to authenticate to kadmind.  Otherwise, the **-p** and
 **-k** options are used to specify the client Kerberos principal name
@@ -100,10 +100,10 @@ OPTIONS
     fully anonymous operation.
 
 **-c** *credentials_cache*
-    Use *credentials_cache* as the credentials cache.  The
-    cache should contain a service ticket for the ``kadmin/ADMINHOST``
-    (where *ADMINHOST* is the fully-qualified hostname of the admin
-    server) or ``kadmin/admin`` service; it can be acquired with the
+    Use *credentials_cache* as the credentials cache.  The cache
+    should contain a service ticket for the ``kadmin/admin`` or
+    ``kadmin/ADMINHOST`` (where *ADMINHOST* is the fully-qualified
+    hostname of the admin server) service; it can be acquired with the
     :ref:`kinit(1)` program.  If this option is not specified, kadmin
     requests a new service ticket from the KDC, and stores it in its
     own temporary ccache.

--- a/doc/admin/database.rst
+++ b/doc/admin/database.rst
@@ -26,8 +26,8 @@ local filesystem (or through LDAP).  kadmin.local is necessary to set
 up enough of the database to be able to use the remote version.
 
 kadmin can authenticate to the admin server using the service
-principal ``kadmin/HOST`` (where *HOST* is the hostname of the admin
-server) or ``kadmin/admin``.  If the credentials cache contains a
+principal ``kadmin/admin`` or ``kadmin/HOST`` (where *HOST* is the
+hostname of the admin server).  If the credentials cache contains a
 ticket for either service principal and the **-c** ccache option is
 specified, that ticket is used to authenticate to KADM5.  Otherwise,
 the **-p** and **-k** options are used to specify the client Kerberos
@@ -811,9 +811,9 @@ Both master and replica sides must have a principal named
 ``kiprop/hostname`` (where *hostname* is the lowercase,
 fully-qualified, canonical name for the host) registered in the
 Kerberos database, and have keys for that principal stored in the
-default keytab file (|keytab|).  In release 1.13, the
-``kiprop/hostname`` principal is created automatically for the master
-KDC, but it must still be created for replica KDCs.
+default keytab file (|keytab|).  The ``kiprop/hostname`` principal may
+have been created automatically for the master KDC, but it must always
+be created for replica KDCs.
 
 On the master KDC side, the ``kiprop/hostname`` principal must be
 listed in the kadmind ACL file :ref:`kadm5.acl(5)`, and given the

--- a/src/tests/dejagnu/krb-standalone/kadmin.exp
+++ b/src/tests/dejagnu/krb-standalone/kadmin.exp
@@ -1098,10 +1098,11 @@ proc kadmin_test { } {
 	return
     }
 
-    # test fallback to kadmin/admin
-    if {![kadmin_delete_locked_down kadmin/$hostname] \
+    # test fallback to kadmin/hostname
+    if {![kadmin_add_rnd kadmin/$hostname] \
+	    || ![kadmin_delete_locked_down kadmin/admin] \
 	    || ![kadmin_list] \
-	    || ![kadmin_add_rnd kadmin/$hostname -allow_tgs_req] \
+	    || ![kadmin_add_rnd kadmin/admin -allow_tgs_req] \
 	    || ![kadmin_list]} {
 	return
     }

--- a/src/tests/t_iprop.py
+++ b/src/tests/t_iprop.py
@@ -188,6 +188,7 @@ for realm in multidb_realms(kdc_conf=conf, create_user=False,
 
     # Create the principal used to authenticate kpropd to kadmind.
     kiprop_princ = 'kiprop/' + hostname
+    realm.addprinc(kiprop_princ)
     realm.extract_keytab(kiprop_princ, realm.keytab)
 
     # Create the initial replica databases.

--- a/src/tests/t_kadmin_acl.py
+++ b/src/tests/t_kadmin_acl.py
@@ -331,6 +331,7 @@ realm.run([kadmin, '-c', realm.ccache, 'cpw', '-randkey', '-e', 'aes256-cts',
 # Test authentication to kadmin/hostname.
 mark('authentication to kadmin/hostname')
 kadmin_hostname = 'kadmin/' + hostname
+realm.addprinc(kadmin_hostname)
 realm.run([kadminl, 'delprinc', 'kadmin/admin'])
 msgs = ('Getting initial credentials for user/admin@KRBTEST.COM',
         'Setting initial creds service to kadmin/admin',

--- a/src/tests/t_kadmin_acl.py
+++ b/src/tests/t_kadmin_acl.py
@@ -328,6 +328,20 @@ realm.run([kadmin, '-c', realm.ccache, 'cpw', '-randkey', 'none'],
 realm.run([kadmin, '-c', realm.ccache, 'cpw', '-randkey', '-e', 'aes256-cts',
            'none'], expected_code=1, expected_msg=msg)
 
+# Test authentication to kadmin/hostname.
+mark('authentication to kadmin/hostname')
+kadmin_hostname = 'kadmin/' + hostname
+realm.run([kadminl, 'delprinc', 'kadmin/admin'])
+msgs = ('Getting initial credentials for user/admin@KRBTEST.COM',
+        'Setting initial creds service to kadmin/admin',
+        '/Server not found in Kerberos database',
+        'Getting initial credentials for user/admin@KRBTEST.COM',
+        'Setting initial creds service to ' + kadmin_hostname,
+        'Decrypted AS reply')
+realm.run([kadmin, '-p', 'user/admin', 'listprincs'], expected_code=1,
+          expected_msg="Operation requires ``list'' privilege",
+          input=password('user/admin'), expected_trace=msgs)
+
 # Test operations disallowed at the libkadm5 layer.
 realm.run([kadminl, 'delprinc', 'K/M'],
           expected_code=1, expected_msg='Cannot change protected principal')


### PR DESCRIPTION
This PR contains one approach to addressing KDB creation when dns_canonicalize_hostname isn't true.  The first commit changes the kadmin client preference order to kadmin/admin first, and the second stops creating kadmin/hostname and kiprop/hostname.  I prefer this approach because it's technically simple compared to the other options.
