### PR TITLE
Fix three configure tests for Xcode 12

### DIFF
--- a/src/aclocal.m4
+++ b/src/aclocal.m4
@@ -833,7 +833,7 @@ if test -n "$tcl_conf" ; then
       done
       LIBS="$old_LIBS `eval echo x $TCL_LIB_SPEC $TCL_LIBS | sed 's/^x//'`"
       LDFLAGS="$old_LDFLAGS $TCL_LD_FLAGS"
-      AC_TRY_LINK( , [Tcl_CreateInterp ();],
+      AC_TRY_LINK([#include <tcl.h>], [Tcl_CreateInterp ();],
 	tcl_ok_conf=$file
 	tcl_vers_maj=$TCL_MAJOR_VERSION
 	tcl_vers_min=$TCL_MINOR_VERSION
@@ -1601,8 +1601,9 @@ if test -r conftest.1 && test -r conftest.2 ; then true ; else
 fi
 a=no
 b=no
-# blindly assume we have 'unlink'...
-AC_TRY_RUN([void foo1() __attribute__((constructor));
+# blindly assume we have 'unlink' and unistd.h.
+AC_TRY_RUN([#include <unistd.h>
+void foo1() __attribute__((constructor));
 void foo1() { unlink("conftest.1"); }
 void foo2() __attribute__((destructor));
 void foo2() { unlink("conftest.2"); }

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -759,6 +759,7 @@ AC_CACHE_CHECK([for in6addr_any definition in library],
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
+#include <stdio.h>
 ],[
   struct sockaddr_in6 in;
   in.sin6_addr = in6addr_any;


### PR DESCRIPTION
Xcode 12 will change its clang to have
-Werror=implicit-function-declaration by default.  Fix three autoconf
tests which generate this warning due to missing include declarations.
Reported by Misty De Meo.
