### PR TITLE
Set lockdown attribute when creating LDAP KDB

### DIFF
--- a/src/plugins/kdb/ldap/ldap_util/kdb5_ldap_realm.c
+++ b/src/plugins/kdb/ldap/ldap_util/kdb5_ldap_realm.c
@@ -1304,7 +1304,7 @@ kdb_ldap_create_principal(krb5_context context, krb5_principal princ,
                                                      now, &db_create_princ)))
         goto cleanup;
 
-    entry.attributes = pblock->flags;
+    entry.attributes = pblock->flags | KRB5_KDB_LOCKDOWN_KEYS;
     entry.max_life = pblock->max_life;
     entry.max_renewable_life = pblock->max_rlife;
     entry.expiration = pblock->expiration;


### PR DESCRIPTION
In kdb5_ldap_util, set lockdown_keys on the special principals when
creating an LDAP KDB, as we do in kdb5_util when creating a regular
KDB.
