### PR TITLE
Fix Leash crash when ticket autorenewal fails

### DIFF
--- a/src/windows/leash/LeashView.cpp
+++ b/src/windows/leash/LeashView.cpp
@@ -838,33 +838,6 @@ UINT CLeashView::RenewTicket(void * hWnd)
         return 0;
     }
 
-    krb5_error_code code;
-    krb5_ccache mslsa_ccache=0;
-    krb5_principal princ = 0;
-    char * pname = 0;
-
-    if (code = pkrb5_cc_resolve(CLeashApp::m_krbv5_context, "MSLSA:", &mslsa_ccache))
-        goto cleanup;
-
-    if (code = pkrb5_cc_get_principal(CLeashApp::m_krbv5_context, mslsa_ccache, &princ))
-        goto cleanup;
-
-    if (code = pkrb5_unparse_name(CLeashApp::m_krbv5_context, princ, &pname))
-        goto cleanup;
-
-    if ( !strcmp(ticketinfo.Krb5.principal, pname) )
-        m_importedTickets = 1;
-
-  cleanup:
-    if (pname)
-        pkrb5_free_unparsed_name(CLeashApp::m_krbv5_context, pname);
-
-    if (princ)
-        pkrb5_free_principal(CLeashApp::m_krbv5_context, princ);
-
-    if (mslsa_ccache)
-        pkrb5_cc_close(CLeashApp::m_krbv5_context, mslsa_ccache);
-
     // If imported from Kerberos LSA, re-import
     // Otherwise, init the tickets
     if ( m_importedTickets )


### PR DESCRIPTION
CLeashView::RenewTicket() falls back to an ImportTicket or InitTicket
operation if ticket renewal fails.  A 2004 commit (from the old
pismere repository) added code to heuristically determine whether
Leash's cache was imported by comparing the MSLSA cache principal name
to ticketinfo.Krb5.principal.  Commit
9bc411e72fce5bed3ed00ae5b09f8c239309bae0 broke this code by removing
the call to initialize ticketinfo.Krb5 and by making
ticketinfo.Krb5.principal ephemeral.  The strcmp() call now crashes
the process with a null dereference.

Fix the crash by removing the heuristic detection of imported tickets,
using the current value of m_importedTickets (which should be correct
unless Leash was restarted after the tickets were obtained) to decide
whether to import or initialize tickets.
