### PR TITLE
Kvno docs internal consistency

### DIFF
--- a/doc/user/user_commands/kvno.rst
+++ b/doc/user/user_commands/kvno.rst
@@ -10,13 +10,9 @@ SYNOPSIS
 [**-c** *ccache*]
 [**-e** *etype*]
 [**-q**]
-[**-h**]
+[**-u** | **-S** *sname*]
 [**-P**]
-[**-S** *sname*]
-[**-I** *for_user*]
-[**-U** *for_user*]
-[**-F** *cert_file*]
-[**--u2u** *ccache*]
+[[{**-F** *cert_file* | {**-I** | **-U**} *for_user*} [**-P**]] | **--u2u** *ccache*]
 *service1 service2* ...
 
 
@@ -39,13 +35,18 @@ OPTIONS
     of all the services named on the command line.  This is useful in
     certain backward compatibility situations.
 
+**-k** *keytab*
+    Decrypt the acquired tickets using *keytab* to confirm their
+    validity.
+
 **-q**
     Suppress printing output when successful.  If a service ticket
     cannot be obtained, an error message will still be printed and
     kvno will exit with nonzero status.
 
-**-h**
-    Prints a usage statement and exits.
+**-u**
+    Use the unknown name type in requested service principal names.
+    This option Cannot be used with *-S*.
 
 **-P**
     Specifies that the *service1 service2* ...  arguments are to be
@@ -76,16 +77,17 @@ OPTIONS
 
 **--cached-only**
     Only retrieve credentials already present in the cache, not from
-    the KDC.
+    the KDC.  (Added in release 1.19.)
 
 **--no-store**
     Do not store retrieved credentials in the cache.  If
     **--out-cache** is also specified, credentials will still be
-    stored into the output credential cache.
+    stored into the output credential cache.  (Added in release 1.19.)
 
 **--out-cache** *ccache*
     Initialize *ccache* and store all retrieved credentials into it.
-    Do not store acquired credentials in the input cache.
+    Do not store acquired credentials in the input cache.  (Added in
+    release 1.19.)
 
 **--u2u** *ccache*
     Requests a user-to-user ticket.  *ccache* must contain a local

--- a/src/clients/kvno/kvno.c
+++ b/src/clients/kvno/kvno.c
@@ -38,15 +38,18 @@
 static char *prog;
 static int quiet = 0;
 
+#define XUSAGE_BREAK "\n\t"
+
 static void
 xusage()
 {
-    fprintf(stderr, _("usage: %s [-C] [-u] [-c ccache] [-e etype]\n"), prog);
-    fprintf(stderr, _("\t[-k keytab] [-S sname] [{-I | -U} for_user | "
-                      "[-F cert_file] [-P]]\n"));
-    fprintf(stderr, _("\t[--cached-only] [--no-store] [--out-cache ccache] "
-                      "[--u2u ccache]\n"));
-    fprintf(stderr, _("\tservice1 service2 ...\n"));
+    fprintf(stderr, _("usage: %s [-c ccache] [-e etype] [-k keytab] [-q] "
+                      "[-u | -S sname]" XUSAGE_BREAK
+                      "[[{-F cert_file | {-I | -U} for_user} [-P]] | "
+                      "--u2u ccache]" XUSAGE_BREAK
+                      "[--cached-only] [--no-store] [--out-cache] "
+                      "service1 service2 ...\n"),
+            prog);
     exit(1);
 }
 

--- a/src/man/kvno.man
+++ b/src/man/kvno.man
@@ -36,13 +36,9 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 [\fB\-c\fP \fIccache\fP]
 [\fB\-e\fP \fIetype\fP]
 [\fB\-q\fP]
-[\fB\-h\fP]
+[\fB\-u\fP | \fB\-S\fP \fIsname\fP]
 [\fB\-P\fP]
-[\fB\-S\fP \fIsname\fP]
-[\fB\-I\fP \fIfor_user\fP]
-[\fB\-U\fP \fIfor_user\fP]
-[\fB\-F\fP \fIcert_file\fP]
-[\fB\-\-u2u\fP \fIccache\fP]
+[[{\fB\-F\fP \fIcert_file\fP | {\fB\-I\fP | \fB\-U\fP} \fIfor_user\fP} [\fB\-P\fP]] | \fB\-\-u2u\fP \fIccache\fP]
 \fIservice1 service2\fP ...
 .SH DESCRIPTION
 .sp
@@ -60,13 +56,18 @@ Specifies the enctype which will be requested for the session key
 of all the services named on the command line.  This is useful in
 certain backward compatibility situations.
 .TP
+\fB\-k\fP \fIkeytab\fP
+Decrypt the acquired tickets using \fIkeytab\fP to confirm their
+validity.
+.TP
 \fB\-q\fP
 Suppress printing output when successful.  If a service ticket
 cannot be obtained, an error message will still be printed and
 kvno will exit with nonzero status.
 .TP
-\fB\-h\fP
-Prints a usage statement and exits.
+\fB\-u\fP
+Use the unknown name type in requested service principal names.
+This option Cannot be used with \fI\-S\fP\&.
 .TP
 \fB\-P\fP
 Specifies that the \fIservice1 service2\fP ...  arguments are to be
@@ -97,16 +98,17 @@ certificate file must be in PEM format.
 .TP
 \fB\-\-cached\-only\fP
 Only retrieve credentials already present in the cache, not from
-the KDC.
+the KDC.  (Added in release 1.19.)
 .TP
 \fB\-\-no\-store\fP
 Do not store retrieved credentials in the cache.  If
 \fB\-\-out\-cache\fP is also specified, credentials will still be
-stored into the output credential cache.
+stored into the output credential cache.  (Added in release 1.19.)
 .TP
 \fB\-\-out\-cache\fP \fIccache\fP
 Initialize \fIccache\fP and store all retrieved credentials into it.
-Do not store acquired credentials in the input cache.
+Do not store acquired credentials in the input cache.  (Added in
+release 1.19.)
 .TP
 \fB\-\-u2u\fP \fIccache\fP
 Requests a user\-to\-user ticket.  \fIccache\fP must contain a local


### PR DESCRIPTION
It was pointed out [downstream](https://bugzilla.redhat.com/show_bug.cgi?id=1869055) that the three places `kvno` options could be documented differ.  The full state of affairs is:

```
Unimplemented but documented somewhere: []
Undocumented but implemented: [] /* not that these would be a problem necessarily */
Missing from man page synopsis: ['--cached-only', '--no-store', '--out-cache', '-C', '-k', '-u']
Missing from man page long descriptions: ['-C', '-k', '-u']
Missing from xusage: ['-h', '-q']
Complete set: ['--cached-only', '--no-store', '--out-cache', '--u2u',
               '-C', '-F', '-I', '-P', '-S', '-U',
               '-c', '-e', '-h', '-k', '-q', '-u']
```

The first commit addresses the disparity, while including some missing dependency information and removing -h.

The second commit is a different approach which reworks kvno's docs to a (possibly) more clear presentation, treating kvno as a command which has three forms of invocation.

(I feel like this has been reported before, but was unable to find a ticket number, so it's possible I'm thinking of something else.)