### PR TITLE
Allow KDC to canonicalize realm in TGS client

### DIFF
--- a/src/lib/krb5/krb/get_creds.c
+++ b/src/lib/krb5/krb/get_creds.c
@@ -571,10 +571,12 @@ step_referrals(krb5_context context, krb5_tkt_creds_context ctx)
     if (ctx->reply_code != 0)
         return try_fallback(context, ctx);
 
-    if (krb5_principal_compare(context, ctx->reply_creds->server,
-                               ctx->server)) {
-        /* We got the ticket we asked for... but we didn't necessarily ask for
-         * it with the right enctypes.  Try a non-referral request if so. */
+    /* Check if we got the ticket we asked for.  Allow the KDC to canonicalize
+     * the realm. */
+    if (krb5_principal_compare_any_realm(context, ctx->reply_creds->server,
+                                         ctx->server)) {
+        /* We didn't necessarily ask for it with the right enctypes.  Try a
+         * non-referral request if so. */
         if (wrong_enctype(context, ctx->reply_creds->keyblock.enctype)) {
             TRACE_TKT_CREDS_WRONG_ENCTYPE(context);
             return begin_non_referral(context, ctx);

--- a/src/lib/krb5/krb/s4u_creds.c
+++ b/src/lib/krb5/krb/s4u_creds.c
@@ -592,9 +592,8 @@ krb5_get_self_cred_from_kdc(krb5_context context,
         /* Only include a cert in the initial request to the client realm. */
         s4u_user.user_id.subject_cert = empty_data();
 
-        if (krb5_principal_compare(context,
-                                   in_creds->server,
-                                   (*out_creds)->server)) {
+        if (krb5_principal_compare_any_realm(context, in_creds->server,
+                                             (*out_creds)->server)) {
             /* Verify that the unprotected client name in the reply matches the
              * checksum-protected one from the client realm's KDC padata. */
             if (!krb5_principal_compare(context, (*out_creds)->client,


### PR DESCRIPTION
Active Directory canonicalizes the srealm field of TGS replies,
whether or not the client requests canonicalization.  Allow this for
regular TGS and S4U2Self referrals queries by comparing only the name
part of the service principal.  The S4U2Proxy code is already correct.
