### PR TITLE
Harmonize macOS pack declarations with Heimdal

### DIFF
--- a/src/include/CredentialsCache.h
+++ b/src/include/CredentialsCache.h
@@ -52,7 +52,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#if TARGET_OS_MAC
+#if defined(__APPLE__) && (defined(__ppc__) || defined(__ppc64__) || defined(__i386__) || defined(__x86_64__))
 #pragma pack(push,2)
 #endif
 
@@ -1518,7 +1518,7 @@ CCACHE_API cc_int32 cc_initialize (cc_context_t  *out_context,
     ((iterator) -> functions -> clone (iterator, new_iterator))
 /*!@}*/
 
-#if TARGET_OS_MAC
+#if defined(__APPLE__) && (defined(__ppc__) || defined(__ppc64__) || defined(__i386__) || defined(__x86_64__))
 #pragma pack(pop)
 #endif
 

--- a/src/include/CredentialsCache2.h
+++ b/src/include/CredentialsCache2.h
@@ -50,7 +50,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#if TARGET_OS_MAC
+#if defined(__APPLE__) && (defined(__ppc__) || defined(__ppc64__) || defined(__i386__) || defined(__x86_64__))
 #pragma pack(push,2)
 #endif
 
@@ -291,7 +291,7 @@ cc_lock_request (apiCB          *in_context,
                  const cc_int32  in_lock_type)
     CCAPI_DEPRECATED;
 
-#if TARGET_OS_MAC
+#if defined(__APPLE__) && (defined(__ppc__) || defined(__ppc64__) || defined(__i386__) || defined(__x86_64__))
 #pragma pack(pop)
 #endif
 

--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -106,8 +106,8 @@
 
 KRB5INT_BEGIN_DECLS
 
-#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
-#    pragma pack(push,2)
+#if defined(__APPLE__) && (defined(__ppc__) || defined(__ppc64__) || defined(__i386__) || defined(__x86_64__))
+#pragma pack(push,2)
 #endif
 
 #if (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) >= 30203
@@ -8552,8 +8552,8 @@ void KRB5_CALLCONV
 krb5_set_kdc_recv_hook(krb5_context context, krb5_post_recv_fn recv_hook,
                        void *data);
 
-#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
-#    pragma pack(pop)
+#if defined(__APPLE__) && (defined(__ppc__) || defined(__ppc64__) || defined(__i386__) || defined(__x86_64__))
+#pragma pack(pop)
 #endif
 
 KRB5INT_END_DECLS

--- a/src/lib/gssapi/generic/gssapi.hin
+++ b/src/lib/gssapi/generic/gssapi.hin
@@ -39,8 +39,8 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
-#    pragma pack(push,2)
+#if defined(__APPLE__) && (defined(__ppc__) || defined(__ppc64__) || defined(__i386__) || defined(__x86_64__))
+#pragma pack(push,2)
 #endif
 
 #if defined(_MSDOS) || defined(_WIN32)
@@ -816,8 +816,8 @@ gss_set_neg_mechs(
     gss_cred_id_t,      /* cred_handle */
     const gss_OID_set); /* mech_set */
 
-#if defined(TARGET_OS_MAC) && TARGET_OS_MAC
-#    pragma pack(pop)
+#if defined(__APPLE__) && (defined(__ppc__) || defined(__ppc64__) || defined(__i386__) || defined(__x86_64__))
+#pragma pack(pop)
 #endif
 
 #ifdef __cplusplus

--- a/src/lib/krb5/krb/gic_opt.c
+++ b/src/lib/krb5/krb/gic_opt.c
@@ -13,7 +13,7 @@
 #endif
 
 /* Match struct packing of krb5_get_init_creds_opt on macOS. */
-#if TARGET_OS_MAC
+#if defined(__APPLE__) && (defined(__ppc__) || defined(__ppc64__) || defined(__i386__) || defined(__x86_64__))
 #pragma pack(push,2)
 #endif
 struct extended_options {
@@ -30,7 +30,7 @@ struct extended_options {
     void *responder_data;
     int pac_request;            /* -1 unset, 0 false, 1 true */
 };
-#if TARGET_OS_MAC
+#if defined(__APPLE__) && (defined(__ppc__) || defined(__ppc64__) || defined(__i386__) || defined(__x86_64__))
 #pragma pack(pop)
 #endif
 


### PR DESCRIPTION
[The use of pragma pack in the ABI is an ancient MIT krb5 mistake that isn't easily fixed by either us or Apple.  We don't want to be incompatible with macOS on ARM or to give Apple reason to migrate it to ARM.]

Replace the TARGET_OS_MAC conditionals with the conditionals used in
Heimdal, so that we do not pack structures inconsistently with macOS
on ARM.  Suggested by Luke Howard.
