### PR TITLE
Add password option to cred store

### DIFF
--- a/doc/appdev/gssapi.rst
+++ b/doc/appdev/gssapi.rst
@@ -206,6 +206,86 @@ so multiple invocations may be necessary to retrieve all of the
 indicators from the ticket.  (New in release 1.15.)
 
 
+Credential store extensions
+---------------------------
+
+Beginning with release 1.11, the following GSSAPI extensions declared
+in ``<gssapi/gssapi_ext.h>`` can be used to specify how credentials
+are acquired or stored::
+
+    struct gss_key_value_element_struct {
+        const char *key;
+        const char *value;
+    };
+    typedef struct gss_key_value_element_struct gss_key_value_element_desc;
+
+    struct gss_key_value_set_struct {
+        OM_uint32 count;
+        gss_key_value_element_desc *elements;
+    };
+    typedef const struct gss_key_value_set_struct gss_key_value_set_desc;
+    typedef const gss_key_value_set_desc *gss_const_key_value_set_t;
+
+    OM_uint32 gss_acquire_cred_from(OM_uint32 *minor_status,
+                                    const gss_name_t desired_name,
+                                    OM_uint32 time_req,
+                                    const gss_OID_set desired_mechs,
+                                    gss_cred_usage_t cred_usage,
+                                    gss_const_key_value_set_t cred_store,
+                                    gss_cred_id_t *output_cred_handle,
+                                    gss_OID_set *actual_mechs,
+                                    OM_uint32 *time_rec);
+
+    OM_uint32 gss_store_cred_into(OM_uint32 *minor_status,
+                                  gss_cred_id_t input_cred_handle,
+                                  gss_cred_usage_t cred_usage,
+                                  const gss_OID desired_mech,
+                                  OM_uint32 overwrite_cred,
+                                  OM_uint32 default_cred,
+                                  gss_const_key_value_set_t cred_store,
+                                  gss_OID_set *elements_stored,
+                                  gss_cred_usage_t *cred_usage_stored);
+
+The additional *cred_store* parameter allows the caller to specify
+information about how the credentials should be obtained and stored.
+The following options are supported by the krb5 mechanism:
+
+* **ccache**: For acquiring initiator credentials, the name of the
+  :ref:`credential cache <ccache_definition>` to which the handle will
+  refer.  For storing credentials, the name of the cache where the
+  credentials should be stored.  If a collection name is given, the
+  primary cache of the collection will be used; this behavior may
+  change in future releases to select a cache from the collection.
+
+* **client_keytab**: For acquiring initiator credentials, the name of
+  the :ref:`keytab <keytab_definition>` which will be used, if
+  necessary, to refresh the credentials in the cache.
+
+* **keytab**: For acquiring acceptor credentials, the name of the
+  :ref:`keytab <keytab_definition>` to which the handle will refer.
+  In release 1.19 and later, this option also determines the keytab to
+  be used for verification when initiator credentials are acquired
+  using a password and verified.
+
+* **password**: For acquiring initiator credentials, this option
+  instructs the mechanism to acquire fresh credentials into a unique
+  memory credential cache.  This option may not be used with the
+  **ccache** or **client_keytab** options, and a *desired_name* must
+  be specified.  (New in release 1.19.)
+
+* **rcache**: For acquiring acceptor credentials, the name of the
+  :ref:`replay cache <rcache_definition>` to be used when processing
+  the initiator tokens.  (New in release 1.13.)
+
+* **verify**: For acquiring initiator credentials, this option
+  instructs the mechanism to verify the credentials by obtaining a
+  ticket to a service with a known key.  The service key is obtained
+  from the keytab specified with the **keytab** option or the default
+  keytab.  The value may be the name of a principal in the keytab, or
+  the empty string.  If the empty string is given, any ``host``
+  service principal in the keytab may be used.  (New in release 1.19.)
+
+
 Importing and exporting credentials
 -----------------------------------
 

--- a/src/lib/gssapi/krb5/acquire_cred.c
+++ b/src/lib/gssapi/krb5/acquire_cred.c
@@ -1168,16 +1168,13 @@ gss_krb5int_import_cred(OM_uint32 *minor_status,
     return code;
 }
 
-OM_uint32 KRB5_CALLCONV
-krb5_gss_acquire_cred_from(OM_uint32 *minor_status,
-                           const gss_name_t desired_name,
-                           OM_uint32 time_req,
-                           const gss_OID_set desired_mechs,
-                           gss_cred_usage_t cred_usage,
-                           gss_const_key_value_set_t cred_store,
-                           gss_cred_id_t *output_cred_handle,
-                           gss_OID_set *actual_mechs,
-                           OM_uint32 *time_rec)
+static OM_uint32
+acquire_cred_from(OM_uint32 *minor_status, const gss_name_t desired_name,
+                  OM_uint32 time_req, const gss_OID_set desired_mechs,
+                  gss_cred_usage_t cred_usage,
+                  gss_const_key_value_set_t cred_store, krb5_boolean iakerb,
+                  gss_cred_id_t *output_cred_handle,
+                  gss_OID_set *actual_mechs, OM_uint32 *time_rec)
 {
     krb5_context context = NULL;
     krb5_error_code code = 0;
@@ -1246,7 +1243,7 @@ krb5_gss_acquire_cred_from(OM_uint32 *minor_status,
 
     ret = acquire_cred_context(context, minor_status, desired_name, NULL,
                                time_req, cred_usage, ccache, client_keytab,
-                               keytab, rcname, 0, output_cred_handle,
+                               keytab, rcname, iakerb, output_cred_handle,
                                time_rec);
 
 out:
@@ -1258,4 +1255,38 @@ out:
         krb5_kt_close(context, keytab);
     krb5_free_context(context);
     return ret;
+}
+
+OM_uint32 KRB5_CALLCONV
+krb5_gss_acquire_cred_from(OM_uint32 *minor_status,
+                           const gss_name_t desired_name,
+                           OM_uint32 time_req,
+                           const gss_OID_set desired_mechs,
+                           gss_cred_usage_t cred_usage,
+                           gss_const_key_value_set_t cred_store,
+                           gss_cred_id_t *output_cred_handle,
+                           gss_OID_set *actual_mechs,
+                           OM_uint32 *time_rec)
+{
+    return acquire_cred_from(minor_status, desired_name, time_req,
+                             desired_mechs, cred_usage, cred_store,
+                             FALSE, output_cred_handle, actual_mechs,
+                             time_rec);
+}
+
+OM_uint32 KRB5_CALLCONV
+iakerb_gss_acquire_cred_from(OM_uint32 *minor_status,
+                             const gss_name_t desired_name,
+                             OM_uint32 time_req,
+                             const gss_OID_set desired_mechs,
+                             gss_cred_usage_t cred_usage,
+                             gss_const_key_value_set_t cred_store,
+                             gss_cred_id_t *output_cred_handle,
+                             gss_OID_set *actual_mechs,
+                             OM_uint32 *time_rec)
+{
+    return acquire_cred_from(minor_status, desired_name, time_req,
+                             desired_mechs, cred_usage, cred_store,
+                             TRUE, output_cred_handle, actual_mechs,
+                             time_rec);
 }

--- a/src/lib/gssapi/krb5/gssapiP_krb5.h
+++ b/src/lib/gssapi/krb5/gssapiP_krb5.h
@@ -1296,6 +1296,7 @@ data_to_gss(krb5_data *input_k5data, gss_buffer_t output_buffer)
 #define KRB5_CS_KEYTAB_URN "keytab"
 #define KRB5_CS_CCACHE_URN "ccache"
 #define KRB5_CS_RCACHE_URN "rcache"
+#define KRB5_CS_PASSWORD_URN "password"
 
 OM_uint32
 kg_value_from_cred_store(gss_const_key_value_set_t cred_store,

--- a/src/lib/gssapi/krb5/gssapiP_krb5.h
+++ b/src/lib/gssapi/krb5/gssapiP_krb5.h
@@ -1297,6 +1297,7 @@ data_to_gss(krb5_data *input_k5data, gss_buffer_t output_buffer)
 #define KRB5_CS_CCACHE_URN "ccache"
 #define KRB5_CS_RCACHE_URN "rcache"
 #define KRB5_CS_PASSWORD_URN "password"
+#define KRB5_CS_VERIFY_URN "verify"
 
 OM_uint32
 kg_value_from_cred_store(gss_const_key_value_set_t cred_store,

--- a/src/lib/gssapi/krb5/gssapiP_krb5.h
+++ b/src/lib/gssapi/krb5/gssapiP_krb5.h
@@ -549,6 +549,17 @@ iakerb_gss_acquire_cred_with_password(
     gss_OID_set *actual_mechs,
     OM_uint32 *time_rec);
 
+OM_uint32 KRB5_CALLCONV
+iakerb_gss_acquire_cred_from(OM_uint32 *minor_status,
+                             const gss_name_t desired_name,
+                             OM_uint32 time_req,
+                             const gss_OID_set desired_mechs,
+                             gss_cred_usage_t cred_usage,
+                             gss_const_key_value_set_t cred_store,
+                             gss_cred_id_t *output_cred_handle,
+                             gss_OID_set *actual_mechs,
+                             OM_uint32 *time_rec);
+
 OM_uint32 KRB5_CALLCONV krb5_gss_release_cred
 (OM_uint32*,       /* minor_status */
  gss_cred_id_t*    /* cred_handle */

--- a/src/lib/gssapi/krb5/gssapi_krb5.c
+++ b/src/lib/gssapi/krb5/gssapi_krb5.c
@@ -996,7 +996,7 @@ static struct gss_config iakerb_mechanism = {
     krb5_gss_inquire_saslname_for_mech,
     krb5_gss_inquire_mech_for_saslname,
     krb5_gss_inquire_attrs_for_mech,
-    krb5_gss_acquire_cred_from,
+    iakerb_gss_acquire_cred_from,
     krb5_gss_store_cred_into,
     iakerb_gss_acquire_cred_with_password,
     krb5_gss_export_cred,

--- a/src/tests/gssapi/Makefile.in
+++ b/src/tests/gssapi/Makefile.in
@@ -50,6 +50,7 @@ check-pytests: ccinit ccrefresh t_accname t_add_cred t_bindings t_ccselect \
 	t_export_name t_imp_cred t_inq_cred t_inq_ctx t_inq_mechs_name t_iov \
 	t_lifetime t_pcontok t_s4u t_s4u2proxy_krb5 t_spnego t_srcattrs
 	$(RUNPYTEST) $(srcdir)/t_gssapi.py $(PYTESTFLAGS)
+	$(RUNPYTEST) $(srcdir)/t_credstore.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_bindings.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_ccselect.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_client_keytab.py $(PYTESTFLAGS)

--- a/src/tests/gssapi/t_credstore.c
+++ b/src/tests/gssapi/t_credstore.c
@@ -42,7 +42,7 @@ main(int argc, char *argv[])
 {
     OM_uint32 minor, major;
     gss_key_value_set_desc store;
-    gss_name_t name;
+    gss_name_t name = GSS_C_NO_NAME;
     gss_cred_usage_t cred_usage = GSS_C_BOTH;
     gss_OID_set mechs = GSS_C_NO_OID_SET;
     gss_cred_id_t cred = GSS_C_NO_CREDENTIAL;
@@ -71,7 +71,9 @@ main(int argc, char *argv[])
     /* Get the principal name. */
     if (*argv == NULL)
         usage();
-    name = import_name(*argv++);
+    if (**argv != '\0')
+        name = import_name(*argv);
+    argv++;
 
     /* Put any remaining arguments into the store. */
     store.elements = calloc(argc, sizeof(struct gss_key_value_element_struct));

--- a/src/tests/gssapi/t_credstore.py
+++ b/src/tests/gssapi/t_credstore.py
@@ -1,0 +1,50 @@
+from k5test import *
+
+realm = K5Realm()
+
+mark('gss_store_cred_into() and ccache/keytab')
+storagecache = 'FILE:' + os.path.join(realm.testdir, 'user_store')
+servicekeytab = os.path.join(realm.testdir, 'kt')
+service_cs = 'service/cs@%s' % realm.realm
+realm.addprinc(service_cs)
+realm.extract_keytab(service_cs, servicekeytab)
+realm.kinit(service_cs, None, ['-k', '-t', servicekeytab])
+msgs = ('Storing %s -> %s in %s' % (service_cs, realm.krbtgt_princ,
+                                    storagecache),
+        'Retrieving %s from FILE:%s' % (service_cs, servicekeytab))
+realm.run(['./t_credstore', '-s', 'p:' + service_cs, 'ccache', storagecache,
+           'keytab', servicekeytab], expected_trace=msgs)
+
+mark('rcache')
+# t_credstore -r should produce a replay error normally, but not with
+# rcache set to "none:".
+output = realm.run(['./t_credstore', '-r', '-a', 'p:' + realm.host_princ],
+                   expected_code=1)
+if 'gss_accept_sec_context(2): Request is a replay' not in output:
+    fail('Expected replay error not seen in t_credstore output')
+realm.run(['./t_credstore', '-r', '-a', 'p:' + realm.host_princ,
+           'rcache', 'none:'])
+
+# Test password feature.
+mark('password')
+# Must be used with a desired name.
+realm.run(['./t_credstore', '-i', '', 'password', 'pw'],
+          expected_code=1, expected_msg='An invalid name was supplied')
+# Must not be used with a client keytab.
+realm.run(['./t_credstore', '-i', 'u:' + realm.user_princ,
+           'password', 'pw', 'client_keytab', servicekeytab],
+          expected_code=1, expected_msg='Credential usage type is unknown')
+# Must not be used with a ccache.
+realm.run(['./t_credstore', '-i', 'u:' + realm.user_princ,
+           'password', 'pw', 'ccache', storagecache],
+          expected_code=1, expected_msg='Credential usage type is unknown')
+# Must be acquiring initiator credentials.
+realm.run(['./t_credstore', '-a', 'u:' + realm.user_princ, 'password', 'pw'],
+          expected_code=1, expected_msg='Credential usage type is unknown')
+msgs = ('Getting initial credentials for %s' % realm.user_princ,
+        'Storing %s -> %s in MEMORY:' % (realm.user_princ, realm.krbtgt_princ),
+        'Destroying ccache MEMORY:')
+realm.run(['./t_credstore', '-i', 'u:' + realm.user_princ, 'password',
+           password('user')], expected_trace=msgs)
+
+success('Credential store tests')

--- a/src/tests/gssapi/t_gssapi.py
+++ b/src/tests/gssapi/t_gssapi.py
@@ -67,27 +67,6 @@ realm.run(['./t_imp_cred', 'p:service1/andrew', 'service1/abraham'])
 realm.run(['./t_imp_cred', 'p:service2/dwight'], expected_code=1,
           expected_msg=' not found in keytab')
 
-# Test credential store extension.
-tmpccname = 'FILE:' + os.path.join(realm.testdir, 'def_cache')
-realm.env['KRB5CCNAME'] = tmpccname
-storagecache = 'FILE:' + os.path.join(realm.testdir, 'user_store')
-servicekeytab = os.path.join(realm.testdir, 'kt')
-service_cs = 'service/cs@%s' % realm.realm
-realm.addprinc(service_cs)
-realm.extract_keytab(service_cs, servicekeytab)
-realm.kinit(service_cs, None, ['-k', '-t', servicekeytab])
-realm.run(['./t_credstore', '-s', 'p:' + service_cs, 'ccache', storagecache,
-           'keytab', servicekeytab])
-
-# Test rcache feature of cred stores.  t_credstore -r should produce a
-# replay error normally, but not with rcache set to "none:".
-output = realm.run(['./t_credstore', '-r', '-a', 'p:' + realm.host_princ],
-                   expected_code=1)
-if 'gss_accept_sec_context(2): Request is a replay' not in output:
-    fail('Expected replay error not seen in t_credstore output')
-realm.run(['./t_credstore', '-r', '-a', 'p:' + realm.host_princ,
-           'rcache', 'none:'])
-
 # Verify that we can't acquire acceptor creds without a keytab.
 os.remove(realm.keytab)
 output = realm.run(['./t_accname', 'p:abc'], expected_code=1)


### PR DESCRIPTION
This patch make the gss_acquire_cred_from_store() function also cover
the same functionality of gss_acquire_cred_with_password().

This makes the interface "complete" in the sense that it allows to cover
all possible acquire scenarios in a single API.

More importantly it makes it safer to acquire cred with password in
processes that need to do so in a thread safe manner. By specifying
unique ccache anmes in the cred store we avoid other non-thread safe
methods (or heavy synchronization) to use different ccaches which
are needed with the current gss_acquire_cred_with_password() interface.
