### PR TITLE
Add doc build to Github Actions config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build
 
-on: [push, pull_request]
+on:
+    push: {paths: [src/**, .github/workflows/build.yml]}
+    pull_request: {paths: [src/**, .github/workflows/build.yml]}
 
 jobs:
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,27 @@
+name: Doc
+
+on:
+    push: {paths: [doc/**, src/doc/*, src/include/krb5/krb5.hin, .github/workflows/doc.yml]}
+    pull_request: {paths: [doc/**, src/doc/*, src/include/krb5/krb5.hin, .github/workflows/doc.yml]}
+
+jobs:
+    doc:
+        runs-on: ubuntu-18.04
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v1
+            - name: Linux setup
+              run: |
+                sudo apt-get update -qq
+                sudo apt-get install -y doxygen python3-lxml python3-pip python-sphinx
+                pip3 install Cheetah3
+            - name: Build documentation
+              run: |
+                cd src/doc
+                make -f Makefile.in SPHINX_ARGS=-W htmlsrc
+            - name: Upload HTML
+              uses: actions/upload-artifact@v2
+              with:
+                  name: html
+                  path: doc/html
+                  retention-days: 7


### PR DESCRIPTION
Add a second workflow to build documentation, with the HTML output as
a generated artifact.  Skip the doc workflow if no documentation files
were changed.  Skip the existing build workflow if no source files
were changed.