### PR TITLE
Fix doc issues with newer Doxygen and Sphinx

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -2,7 +2,6 @@
 {% set rellinks = [('search', 'Enter search criteria', 'S', 'Search')] +
                   rellinks +
                   [('index', 'Full Table of Contents', 'C', 'Contents')] %}
-{% set css_files = css_files + ["_static/kerb.css"] %}
 
 {# Add a "feedback" button to the rellinks #}
 {%- macro feedback_rellinks() %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -98,6 +98,9 @@ pygments_style = 'sphinx'
 
 # -- Options for HTML output ---------------------------------------------------
 
+def setup(app):
+    app.add_stylesheet('kerb.css')
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 # html_theme = 'default'
@@ -138,10 +141,6 @@ html_static_path = ['_static']
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
 #html_last_updated_fmt = '%b %d, %Y'
-
-# If true, SmartyPants will be used to convert quotes and dashes to
-# typographically correct entities.
-html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}

--- a/doc/tools/doxybuilder_types.py
+++ b/doc/tools/doxybuilder_types.py
@@ -25,6 +25,7 @@
 import sys
 import os
 import re
+import textwrap
 
 from lxml import etree
 
@@ -293,8 +294,10 @@ class DoxyTypes(object):
                     result.append('*%s*' % e.strip())
             elif  e.getparent().tag == 'defname':
                 result.append('%s, ' % e.strip())
-            elif  e.getparent().tag == 'linebreak':
-                result.append('\n*%s*\n' % e.strip())
+            elif e.getparent().tag == 'verbatim':
+                result.append('\n::\n\n')
+                result.append(textwrap.indent(e, '    ', lambda x: True))
+                result.append('\n')
 
         result = ' '.join(result)
 

--- a/doc/tools/func_document.tmpl
+++ b/doc/tools/func_document.tmpl
@@ -16,7 +16,7 @@ $title
 :param:
 
 #for $param in $function.parameters:
-	#if $param.name is ''
+	#if $param.name == ''
 		#continue
 	#end if
 	#if $param.direction is not None

--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -254,7 +254,7 @@ typedef krb5_principal_data * krb5_principal;
 #define KRB5_NT_MS_PRINCIPAL_AND_ID  -129 /**< NT 4 style name */
 #define KRB5_NT_ENT_PRINCIPAL_AND_ID -130 /**< NT 4 style name and SID */
 
-/** Constant version of krb5_principal_data */
+/** Constant version of krb5_principal_data. */
 typedef const krb5_principal_data *krb5_const_principal;
 
 #define krb5_princ_realm(context, princ) (&(princ)->realm)
@@ -1944,7 +1944,7 @@ typedef struct _krb5_ticket_times {
 typedef struct _krb5_authdata {
     krb5_magic magic;
     krb5_authdatatype ad_type; /**< ADTYPE */
-    unsigned int length;       /**< Length of data  */
+    unsigned int length;       /**< Length of data */
     krb5_octet *contents;      /**< Data */
 } krb5_authdata;
 
@@ -2134,7 +2134,7 @@ typedef struct _krb5_ap_rep {
     krb5_enc_data enc_part;     /**< Ciphertext of ApRepEncPart */
 } krb5_ap_rep;
 
-/** Cleartext that is encrypted and put into @c _krb5_ap_rep.  */
+/** Cleartext that is encrypted and put into @c _krb5_ap_rep. */
 typedef struct _krb5_ap_rep_enc_part {
     krb5_magic magic;
     krb5_timestamp ctime;       /**< Client time, seconds portion */
@@ -2163,7 +2163,7 @@ typedef struct _krb5_cred_info {
     krb5_address **caddrs;      /**< Array of pointers to addrs (optional) */
 } krb5_cred_info;
 
-/** Cleartext credentials information.  */
+/** Cleartext credentials information. */
 typedef struct _krb5_cred_enc_part {
     krb5_magic magic;
     krb5_int32 nonce;           /**< Nonce (optional) */
@@ -2244,14 +2244,14 @@ typedef struct _krb5_pa_pac_req {
 typedef struct krb5_replay_data {
     krb5_timestamp      timestamp;  /**< Timestamp, seconds portion */
     krb5_int32          usec;       /**< Timestamp, microseconds portion */
-    krb5_ui_4           seq;        /**< Sequence number  */
+    krb5_ui_4           seq;        /**< Sequence number */
 } krb5_replay_data;
 
 /* Flags for krb5_auth_con_genaddrs(). */
 
 /** Generate the local network address. */
 #define KRB5_AUTH_CONTEXT_GENERATE_LOCAL_ADDR       0x00000001
-/** Generate the remote network address.  */
+/** Generate the remote network address. */
 #define KRB5_AUTH_CONTEXT_GENERATE_REMOTE_ADDR      0x00000002
 /** Generate the local network address and the local port. */
 #define KRB5_AUTH_CONTEXT_GENERATE_LOCAL_FULL_ADDR  0x00000004
@@ -6423,7 +6423,7 @@ krb5_deltat_to_string(krb5_deltat deltat, char *buffer, size_t buflen);
 #define KRB5_RECVAUTH_BADAUTHVERS       0x0002
 /* initial ticket api functions */
 
-/** Text for prompt used in prompter callback function.  */
+/** Text for prompt used in prompter callback function. */
 typedef struct _krb5_prompt {
     char *prompt;      /**< The prompt to show to the user */
     int hidden;        /**< Boolean; informative prompt or hidden (e.g. PIN) */
@@ -6483,29 +6483,29 @@ krb5_prompter_posix(krb5_context context, void *data, const char *name,
  * value is required in order to complete the authentication.  The JSON format
  * of the challenge is:
  *
- *  @n {
- *  @n   "service": <string (optional)>,
- *  @n   "tokenInfo": [
- *  @n      {
- *  @n        "flags":     <number>,
- *  @n        "vendor":    <string (optional)>,
- *  @n        "challenge": <string (optional)>,
- *  @n        "length":    <number (optional)>,
- *  @n        "format":    <number (optional)>,
- *  @n        "tokenID":   <string (optional)>,
- *  @n        "algID":     <string (optional)>,
- *  @n      },
- *  @n      ...
- *  @n    ]
- *  @n  }
+ *     {
+ *       "service": <string (optional)>,
+ *       "tokenInfo": [
+ *         {
+ *           "flags":     <number>,
+ *           "vendor":    <string (optional)>,
+ *           "challenge": <string (optional)>,
+ *           "length":    <number (optional)>,
+ *           "format":    <number (optional)>,
+ *           "tokenID":   <string (optional)>,
+ *           "algID":     <string (optional)>,
+ *         },
+ *         ...
+ *       ]
+ *     }
  *
  * The answer to the question MUST be JSON formatted:
  *
- * @n  {
- * @n    "tokeninfo": <number>,
- * @n    "value":     <string (optional)>,
- * @n    "pin":       <string (optional)>,
- * @n  }
+ *     {
+ *       "tokeninfo": <number>,
+ *       "value":     <string (optional)>,
+ *       "pin":       <string (optional)>,
+ *     }
  *
  * For more detail, please see RFC 6560.
  *
@@ -6556,17 +6556,17 @@ krb5_prompter_posix(krb5_context context, void *data, const char *name,
  * below, and possibly other flags to be added later.  Any resemblance to
  * similarly-named CKF_* values in the PKCS#11 API should not be depended on.
  *
- *  @n {
- *  @n     identity <string> : flags <number>,
- *  @n     ...
- *  @n }
+ *     {
+ *         identity <string> : flags <number>,
+ *         ...
+ *     }
  *
  * The answer to the question MUST be JSON formatted:
  *
- *  @n {
- *  @n     identity <string> : password <string>,
- *  @n     ...
- *  @n }
+ *     {
+ *         identity <string> : password <string>,
+ *         ...
+ *     }
  *
  * @version New in 1.12
  */


### PR DESCRIPTION
I found several issues with the doc build on Ubuntu 20.04.  I think all of them stem from the doxygen 1.8.17 package.  I am not sure what, if anything, I will merge to address these issues, but I want a place to document the investigation.

* Seemingly harmless whitespace issues in comments cause doxygen to emit `<para><linebreak/>\n </para>` within the `<detaileddescription>` element.  A bug in our custom doxygen-to-rst script emits `\n**\n` for these, causing a Sphinx warning about unterminated inline markup.  (I don't fully understand the bug in our scripts; there are lots of `<linebreak/>`s emitted by some of the OTP responder comments, with either new or old Doxygen, and they don't cause the same output.)  The PR currently contains whitespace changes to avoid the problem.

* Python issues a warning about using `is` to compare against the empty string.  The PR has a fix.

* This version of Doxygen misrecognizes `typedef const krb5_principal_data *krb5_const_principal;` as a variable declaration rather than a typedef, so the corresponding file doesn't get generated (our script skips variable declarations).  This bug is fixed in Doxygen 1.8.18.  We could work around it with `typedef krb5_principal_data const *krb5_const_principal;` but that doesn't read well.  This problem is not currently addressed in the PR.

* doc/_templates/layout.html uses css_files, causing the warning `builder.css_files is deprecated. Please use app.add_stylesheet() instead`.  This problem is not currently yet addressed in the PR.

There is a doxygen-to-RST bridge called Breathe; if it can work for us then it might be better than our custom script (and would let us drop the dependency on Cheetah and lxml).