### PR TITLE
Minimize usage of tgs_server in KDC

### DIFF
--- a/src/kdc/kdc_util.h
+++ b/src/kdc/kdc_util.h
@@ -37,10 +37,9 @@
 #include "reqstate.h"
 
 krb5_error_code check_hot_list (krb5_ticket *);
-krb5_boolean is_local_principal(kdc_realm_t *kdc_active_realm,
-                                krb5_const_principal princ1);
 krb5_boolean krb5_is_tgs_principal (krb5_const_principal);
 krb5_boolean is_cross_tgs_principal(krb5_const_principal);
+krb5_boolean is_local_tgs_principal(krb5_const_principal);
 krb5_error_code
 add_to_transited (krb5_data *,
                   krb5_data *,


### PR DESCRIPTION
Where possible, use the realm of the request server principal
(canonicalized via KDB lookup, if available) in preference to
tgs_server.  This change facilitates alias realm support and potential
future support for serving multiple realms from the same KDB.

S4U2Self local user testing currently uses the uncanonicalized request
realm after this change, which will require attention for alias realm
support.

FAST armor ticket checking is unaffected by this change (it still
compares against tgs_server).  This check poses no issue for realm
aliases, as both tgs_server and the armor ticket server should have
canonical realms, but it will require attention for multi-realm KDB
support.

Remove is_local_principal() as it is no longer used.  Add an
is_local_tgs_principal() helper and shorten is_cross_tgs_principal().