### PR TITLE
Avoid passing DB entry structures in KDC

### DIFF
--- a/src/kdc/do_as_req.c
+++ b/src/kdc/do_as_req.c
@@ -644,8 +644,8 @@ process_as_req(krb5_kdc_req *request, krb5_data *req_pkt,
     au_state->stage = VALIDATE_POL;
 
     if ((errcode = validate_as_request(kdc_active_realm,
-                                       state->request, *state->client,
-                                       *state->server, state->kdc_time,
+                                       state->request, state->client,
+                                       state->server, state->kdc_time,
                                        &state->status, &state->e_data))) {
         errcode += ERROR_TABLE_BASE_krb5;
         goto errout;

--- a/src/kdc/do_tgs_req.c
+++ b/src/kdc/do_tgs_req.c
@@ -259,7 +259,7 @@ process_tgs_req(krb5_kdc_req *request, krb5_data *pkt,
         goto cleanup;
 
     if ((retval = validate_tgs_request(kdc_active_realm,
-                                       request, *server, header_ticket,
+                                       request, server, header_ticket,
                                        kdc_time, &status, &e_data))) {
         if (retval == KDC_ERR_POLICY || retval == KDC_ERR_BADOPTION)
             au_state->violation = PROT_CONSTRAINT;

--- a/src/kdc/kdc_util.c
+++ b/src/kdc/kdc_util.c
@@ -623,8 +623,8 @@ check_anon(kdc_realm_t *kdc_active_realm,
                             KDC_OPT_ENC_TKT_IN_SKEY | KDC_OPT_CNAME_IN_ADDL_TKT)
 int
 validate_as_request(kdc_realm_t *kdc_active_realm,
-                    krb5_kdc_req *request, krb5_db_entry client,
-                    krb5_db_entry server, krb5_timestamp kdc_time,
+                    krb5_kdc_req *request, krb5_db_entry *client,
+                    krb5_db_entry *server, krb5_timestamp kdc_time,
                     const char **status, krb5_pa_data ***e_data)
 {
     krb5_error_code ret;
@@ -638,7 +638,7 @@ validate_as_request(kdc_realm_t *kdc_active_realm,
     }
 
     /* The client must not be expired */
-    if (client.expiration && ts_after(kdc_time, client.expiration)) {
+    if (client->expiration && ts_after(kdc_time, client->expiration)) {
         *status = "CLIENT EXPIRED";
         if (vague_errors)
             return(KRB_ERR_GENERIC);
@@ -648,8 +648,8 @@ validate_as_request(kdc_realm_t *kdc_active_realm,
 
     /* The client's password must not be expired, unless the server is
        a KRB5_KDC_PWCHANGE_SERVICE. */
-    if (client.pw_expiration && ts_after(kdc_time, client.pw_expiration) &&
-        !isflagset(server.attributes, KRB5_KDB_PWCHANGE_SERVICE)) {
+    if (client->pw_expiration && ts_after(kdc_time, client->pw_expiration) &&
+        !isflagset(server->attributes, KRB5_KDB_PWCHANGE_SERVICE)) {
         *status = "CLIENT KEY EXPIRED";
         if (vague_errors)
             return(KRB_ERR_GENERIC);
@@ -658,7 +658,7 @@ validate_as_request(kdc_realm_t *kdc_active_realm,
     }
 
     /* The server must not be expired */
-    if (server.expiration && ts_after(kdc_time, server.expiration)) {
+    if (server->expiration && ts_after(kdc_time, server->expiration)) {
         *status = "SERVICE EXPIRED";
         return(KDC_ERR_SERVICE_EXP);
     }
@@ -667,8 +667,8 @@ validate_as_request(kdc_realm_t *kdc_active_realm,
      * If the client requires password changing, then only allow the
      * pwchange service.
      */
-    if (isflagset(client.attributes, KRB5_KDB_REQUIRES_PWCHANGE) &&
-        !isflagset(server.attributes, KRB5_KDB_PWCHANGE_SERVICE)) {
+    if (isflagset(client->attributes, KRB5_KDB_REQUIRES_PWCHANGE) &&
+        !isflagset(server->attributes, KRB5_KDB_PWCHANGE_SERVICE)) {
         *status = "REQUIRED PWCHANGE";
         return(KDC_ERR_KEY_EXP);
     }
@@ -676,37 +676,37 @@ validate_as_request(kdc_realm_t *kdc_active_realm,
     /* Client and server must allow postdating tickets */
     if ((isflagset(request->kdc_options, KDC_OPT_ALLOW_POSTDATE) ||
          isflagset(request->kdc_options, KDC_OPT_POSTDATED)) &&
-        (isflagset(client.attributes, KRB5_KDB_DISALLOW_POSTDATED) ||
-         isflagset(server.attributes, KRB5_KDB_DISALLOW_POSTDATED))) {
+        (isflagset(client->attributes, KRB5_KDB_DISALLOW_POSTDATED) ||
+         isflagset(server->attributes, KRB5_KDB_DISALLOW_POSTDATED))) {
         *status = "POSTDATE NOT ALLOWED";
         return(KDC_ERR_CANNOT_POSTDATE);
     }
 
     /* Check to see if client is locked out */
-    if (isflagset(client.attributes, KRB5_KDB_DISALLOW_ALL_TIX)) {
+    if (isflagset(client->attributes, KRB5_KDB_DISALLOW_ALL_TIX)) {
         *status = "CLIENT LOCKED OUT";
         return(KDC_ERR_CLIENT_REVOKED);
     }
 
     /* Check to see if server is locked out */
-    if (isflagset(server.attributes, KRB5_KDB_DISALLOW_ALL_TIX)) {
+    if (isflagset(server->attributes, KRB5_KDB_DISALLOW_ALL_TIX)) {
         *status = "SERVICE LOCKED OUT";
         return(KDC_ERR_S_PRINCIPAL_UNKNOWN);
     }
 
     /* Check to see if server is allowed to be a service */
-    if (isflagset(server.attributes, KRB5_KDB_DISALLOW_SVR)) {
+    if (isflagset(server->attributes, KRB5_KDB_DISALLOW_SVR)) {
         *status = "SERVICE NOT ALLOWED";
         return(KDC_ERR_MUST_USE_USER2USER);
     }
 
-    if (check_anon(kdc_active_realm, client.princ, request->server) != 0) {
+    if (check_anon(kdc_active_realm, client->princ, request->server) != 0) {
         *status = "ANONYMOUS NOT ALLOWED";
         return(KDC_ERR_POLICY);
     }
 
     /* Perform KDB module policy checks. */
-    ret = krb5_db_check_policy_as(kdc_context, request, &client, &server,
+    ret = krb5_db_check_policy_as(kdc_context, request, client, server,
                                   kdc_time, status, e_data);
     if (ret && ret != KRB5_PLUGIN_OP_NOTSUPP)
         return errcode_to_protocol(ret);
@@ -1580,8 +1580,8 @@ kdc_process_s4u2self_req(kdc_realm_t *kdc_active_realm,
         princ->pw_expiration = 0;
         clear(princ->attributes, KRB5_KDB_REQUIRES_PWCHANGE);
 
-        code = validate_as_request(kdc_active_realm, request, *princ,
-                                   no_server, kdc_time, status, &e_data);
+        code = validate_as_request(kdc_active_realm, request, princ,
+                                   &no_server, kdc_time, status, &e_data);
         if (code) {
             krb5_db_free_principal(kdc_context, princ);
             krb5_free_pa_data(kdc_context, e_data);

--- a/src/kdc/kdc_util.h
+++ b/src/kdc/kdc_util.h
@@ -80,12 +80,12 @@ get_local_tgt(krb5_context context, const krb5_data *realm,
               krb5_db_entry **storage_out, krb5_keyblock *kb_out);
 
 int
-validate_as_request (kdc_realm_t *, krb5_kdc_req *, krb5_db_entry,
-                     krb5_db_entry, krb5_timestamp,
+validate_as_request (kdc_realm_t *, krb5_kdc_req *, krb5_db_entry *,
+                     krb5_db_entry *, krb5_timestamp,
                      const char **, krb5_pa_data ***);
 
 int
-validate_tgs_request (kdc_realm_t *, krb5_kdc_req *, krb5_db_entry,
+validate_tgs_request (kdc_realm_t *, krb5_kdc_req *, krb5_db_entry *,
                       krb5_ticket *, krb5_timestamp,
                       const char **, krb5_pa_data ***);
 


### PR DESCRIPTION
When validating AS or TGS requests, pass pointers to DB entry
structures, not the structures themselves.