### PR TITLE
Move more KDC checks to validate_tgs_request()

### DIFF
--- a/src/kdc/kdc_util.h
+++ b/src/kdc/kdc_util.h
@@ -84,9 +84,14 @@ validate_as_request (kdc_realm_t *, krb5_kdc_req *, krb5_db_entry *,
                      const char **, krb5_pa_data ***);
 
 int
-validate_tgs_request (kdc_realm_t *, krb5_kdc_req *, krb5_db_entry *,
-                      krb5_ticket *, krb5_timestamp,
-                      const char **, krb5_pa_data ***);
+validate_tgs_request(kdc_realm_t *kdc_active_realm,
+                     krb5_kdc_req *request, krb5_db_entry *server,
+                     krb5_ticket *ticket, const krb5_ticket *stkt,
+                     krb5_db_entry *stkt_server, krb5_timestamp kdc_time,
+                     krb5_pa_s4u_x509_user *s4u_x509_user,
+                     krb5_db_entry *s4u2self_client,
+                     krb5_boolean is_crossrealm, krb5_boolean is_referral,
+                     const char **status, krb5_pa_data ***e_data);
 
 krb5_flags
 get_ticket_flags(krb5_flags reqflags, krb5_db_entry *client,
@@ -262,12 +267,9 @@ return_enc_padata(krb5_context context,
 krb5_error_code
 kdc_process_s4u2self_req (kdc_realm_t *kdc_active_realm,
                           krb5_kdc_req *request,
-                          krb5_const_principal client_princ,
-                          unsigned int c_flags,
                           const krb5_db_entry *server,
                           krb5_keyblock *tgs_subkey,
                           krb5_keyblock *tgs_session,
-                          krb5_timestamp kdc_time,
                           krb5_pa_s4u_x509_user **s4u2self_req,
                           krb5_db_entry **princ_ptr,
                           const char **status);
@@ -461,6 +463,9 @@ struct krb5_kdcpreauth_rock_st {
 
 /* TGS-REQ options which are not compatible with referrals */
 #define NO_REFERRAL_OPTION (NON_TGT_OPTION | KDC_OPT_ENC_TKT_IN_SKEY)
+
+/* Options incompatible with AS and S4U2Self requests */
+#define AS_INVALID_OPTIONS (NO_REFERRAL_OPTION | KDC_OPT_CNAME_IN_ADDL_TKT)
 
 /*
  * Mask of KDC options that request the corresponding ticket flag with

--- a/src/kdc/tgs_policy.c
+++ b/src/kdc/tgs_policy.c
@@ -94,6 +94,13 @@ check_tgs_opts(krb5_kdc_req *req, krb5_ticket *tkt, const char **status)
             }
         }
     }
+
+    if (isflagset(tkt->enc_part2->flags, TKT_FLG_INVALID) &&
+        !isflagset(req->kdc_options, KDC_OPT_VALIDATE)) {
+        *status = "TICKET NOT VALID";
+        return KRB_AP_ERR_TKT_NYV;
+    }
+
     return 0;
 }
 
@@ -237,40 +244,180 @@ check_tgs_times(krb5_kdc_req *req, krb5_ticket_times *times,
     return 0;
 }
 
+/* Check for local user tickets issued by foreign realms.  This check is
+ * skipped for S4U2Self requests. */
 static int
-check_tgs_s4u2proxy(kdc_realm_t *kdc_active_realm,
-                    krb5_kdc_req *req, const char **status)
+check_tgs_lineage(krb5_db_entry *server, krb5_ticket *tkt,
+                  krb5_boolean is_crossrealm, const char **status)
 {
-    if (req->kdc_options & KDC_OPT_CNAME_IN_ADDL_TKT) {
-        /* Check that second ticket is in request. */
-        if (!req->second_ticket || !req->second_ticket[0]) {
-            *status = "NO_2ND_TKT";
-            return KDC_ERR_BADOPTION;
-        }
+    if (is_crossrealm && data_eq(tkt->enc_part2->client->realm,
+                                 server->princ->realm)) {
+        *status = "INVALID LINEAGE";
+        return KDC_ERR_POLICY;
     }
     return 0;
 }
 
 static int
-check_tgs_u2u(kdc_realm_t *kdc_active_realm, krb5_kdc_req *req,
-              krb5_const_principal server_princ, const char **status)
+check_tgs_s4u2self(kdc_realm_t *kdc_active_realm, krb5_kdc_req *req,
+                   krb5_db_entry *server, krb5_ticket *tkt,
+                   krb5_timestamp kdc_time,
+                   krb5_pa_s4u_x509_user *s4u_x509_user, krb5_db_entry *client,
+                   krb5_boolean is_crossrealm, krb5_boolean is_referral,
+                   const char **status, krb5_pa_data ***e_data)
 {
-    krb5_const_principal second_server_princ;
+    krb5_db_entry empty_server = { 0 };
 
-    if (req->kdc_options & KDC_OPT_ENC_TKT_IN_SKEY) {
-        /* Check that second ticket is in request. */
-        if (!req->second_ticket || !req->second_ticket[0]) {
-            *status = "NO_2ND_TKT";
-            return KDC_ERR_BADOPTION;
-        }
-        /* Check that second ticket is a TGT to the server realm. */
-        second_server_princ = req->second_ticket[0]->server;
-        if (!is_local_tgs_principal(second_server_princ) ||
-            !data_eq(second_server_princ->data[1], server_princ->realm)) {
-            *status = "2ND_TKT_NOT_TGS";
-            return KDC_ERR_POLICY;
-        }
+    /* If the server is local, check that the request is for self. */
+    if (!is_referral &&
+        !is_client_db_alias(kdc_context, server, tkt->enc_part2->client)) {
+        *status = "INVALID_S4U2SELF_REQUEST_SERVER_MISMATCH";
+        return KDC_ERR_C_PRINCIPAL_UNKNOWN; /* match Windows error */
     }
+
+    /* S4U2Self requests must use options valid for AS requests. */
+    if (req->kdc_options & AS_INVALID_OPTIONS) {
+        *status = "INVALID S4U2SELF OPTIONS";
+        return KDC_ERR_BADOPTION;
+    }
+
+    /*
+     * Valid S4U2Self requests can occur in the following combinations:
+     *
+     * (1) local TGT, local user, local server
+     * (2) cross TGT, local user, issuing referral
+     * (3) cross TGT, non-local user, issuing referral
+     * (4) cross TGT, non-local user, local server
+     *
+     * The first case is for a single-realm S4U2Self scenario; the second,
+     * third, and fourth cases are for the initial, intermediate (if any), and
+     * final cross-realm requests in a multi-realm scenario.
+     */
+
+    if (!is_crossrealm && is_referral) {
+        /* This could happen if the requesting server no longer exists, and we
+         * found a referral instead.  Treat this as a server lookup failure. */
+        *status = "LOOKING_UP_SERVER";
+        return KDC_ERR_S_PRINCIPAL_UNKNOWN;
+    }
+    if (client != NULL && is_crossrealm && !is_referral) {
+        /* A local server should not need a cross-realm TGT to impersonate
+         * a local principal. */
+        *status = "NOT_CROSS_REALM_REQUEST";
+        return KDC_ERR_C_PRINCIPAL_UNKNOWN; /* match Windows error */
+    }
+    if (client == NULL && !is_crossrealm) {
+        /*
+         * The server is asking to impersonate a principal from another realm,
+         * using a local TGT.  It should instead ask that principal's realm and
+         * follow referrals back to us.
+         */
+        *status = "S4U2SELF_CLIENT_NOT_OURS";
+        return KDC_ERR_POLICY; /* match Windows error */
+    }
+    if (client == NULL && s4u_x509_user->user_id.user->length == 0) {
+        /*
+         * Only a KDC in the client realm can handle a certificate-only
+         * S4U2Self request.  Other KDCs require a principal name and ignore
+         * the subject-certificate field.
+         */
+        *status = "INVALID_XREALM_S4U2SELF_REQUEST";
+        return KDC_ERR_POLICY; /* match Windows error */
+    }
+
+    if (client != NULL) {
+        /* Validate the client policy.  Use an empty server principal to bypass
+         * server policy checks. */
+        return validate_as_request(kdc_active_realm, req, client,
+                                   &empty_server, kdc_time, status, e_data);
+    }
+
+    return 0;
+}
+
+static int
+check_tgs_s4u2proxy(kdc_realm_t *kdc_active_realm, krb5_kdc_req *req,
+                    krb5_db_entry *server, krb5_ticket *tkt,
+                    const krb5_ticket *stkt, krb5_db_entry *stkt_server,
+                    krb5_boolean is_crossrealm, krb5_boolean is_referral,
+                    const char **status)
+{
+    /* A second ticket must be present in the request. */
+    if (stkt == NULL) {
+        *status = "NO_2ND_TKT";
+        return KDC_ERR_BADOPTION;
+    }
+
+    /* Constrained delegation is mutually exclusive with renew/forward/etc.
+     * (and therefore requires the header ticket to be a TGT). */
+    if (req->kdc_options & (NON_TGT_OPTION | KDC_OPT_ENC_TKT_IN_SKEY)) {
+        *status = "INVALID_S4U2PROXY_OPTIONS";
+        return KDC_ERR_BADOPTION;
+    }
+
+    /* Can't get a TGT (otherwise it would be unconstrained delegation). */
+    if (krb5_is_tgs_principal(req->server)) {
+        *status = "NOT_ALLOWED_TO_DELEGATE";
+        return KDC_ERR_POLICY;
+    }
+
+    /*
+     * An S4U2Proxy request must be an initial request to the impersonator's
+     * realm (possibly for a target resource in the same realm), or a final
+     * cross-realm RBCD request to the resource realm.  Intermediate
+     * referral-chasing requests do not use the CNAME-IN-ADDL-TKT flag.
+     */
+
+    /* For an initial or same-realm request, the second ticket server and
+     * header ticket client must be the same principal. */
+    if (!is_crossrealm && !is_client_db_alias(kdc_context, stkt_server,
+                                              tkt->enc_part2->client)) {
+        *status = "EVIDENCE_TICKET_MISMATCH";
+        return KDC_ERR_SERVER_NOMATCH;
+    }
+
+    /*
+     * For a cross-realm request, the second ticket must be a referral TGT to
+     * our realm with the impersonator as client.  (Unlike the header ticket,
+     * the second ticket contains authdata for the subject client.)  The target
+     * server must also be local, so we must not be issuing a referral.
+     */
+    if (is_crossrealm &&
+        (is_referral || !is_cross_tgs_principal(stkt_server->princ) ||
+         !data_eq(stkt_server->princ->data[1], server->princ->realm) ||
+         !krb5_principal_compare(kdc_context, stkt->enc_part2->client,
+                                 tkt->enc_part2->client))) {
+        *status = "XREALM_EVIDENCE_TICKET_MISMATCH";
+        return KDC_ERR_BADOPTION;
+    }
+
+    return 0;
+}
+
+static int
+check_tgs_u2u(kdc_realm_t *kdc_active_realm, krb5_kdc_req *req,
+              const krb5_ticket *stkt, krb5_db_entry *server,
+              const char **status)
+{
+    /* A second ticket must be present in the request. */
+    if (stkt == NULL) {
+        *status = "NO_2ND_TKT";
+        return KDC_ERR_BADOPTION;
+    }
+
+    /* The second ticket must be a TGT to the server realm. */
+    if (!is_local_tgs_principal(stkt->server) ||
+        !data_eq(stkt->server->data[1], server->princ->realm)) {
+        *status = "2ND_TKT_NOT_TGS";
+        return KDC_ERR_POLICY;
+    }
+
+    /* The second ticket client must match the requested server. */
+    if (!is_client_db_alias(kdc_context, server, stkt->enc_part2->client)) {
+        *status = "2ND_TKT_MISMATCH";
+        return KDC_ERR_SERVER_NOMATCH;
+    }
+
     return 0;
 }
 
@@ -321,7 +468,11 @@ check_tgs_tgt(kdc_realm_t *kdc_active_realm, krb5_kdc_req *req,
 int
 validate_tgs_request(kdc_realm_t *kdc_active_realm,
                      krb5_kdc_req *request, krb5_db_entry *server,
-                     krb5_ticket *ticket, krb5_timestamp kdc_time,
+                     krb5_ticket *ticket, const krb5_ticket *stkt,
+                     krb5_db_entry *stkt_server, krb5_timestamp kdc_time,
+                     krb5_pa_s4u_x509_user *s4u_x509_user,
+                     krb5_db_entry *s4u2self_client,
+                     krb5_boolean is_crossrealm, krb5_boolean is_referral,
                      const char **status, krb5_pa_data ***e_data)
 {
     int errcode;
@@ -355,13 +506,31 @@ validate_tgs_request(kdc_realm_t *kdc_active_realm,
         return(KRB_AP_ERR_REPEAT);
     }
 
-    errcode = check_tgs_u2u(kdc_active_realm, request, server->princ, status);
+    if (s4u_x509_user != NULL) {
+        errcode = check_tgs_s4u2self(kdc_active_realm, request, server, ticket,
+                                     kdc_time, s4u_x509_user, s4u2self_client,
+                                     is_crossrealm, is_referral,
+                                     status, e_data);
+    } else {
+        errcode = check_tgs_lineage(server, ticket, is_crossrealm, status);
+    }
     if (errcode != 0)
         return errcode;
 
-    errcode = check_tgs_s4u2proxy(kdc_active_realm, request, status);
-    if (errcode != 0)
-        return errcode;
+    if (request->kdc_options & KDC_OPT_ENC_TKT_IN_SKEY) {
+        errcode = check_tgs_u2u(kdc_active_realm, request, stkt, server,
+                                status);
+        if (errcode != 0)
+            return errcode;
+    }
+
+    if (request->kdc_options & KDC_OPT_CNAME_IN_ADDL_TKT) {
+        errcode = check_tgs_s4u2proxy(kdc_active_realm, request, server,
+                                      ticket, stkt, stkt_server, is_crossrealm,
+                                      is_referral, status);
+        if (errcode != 0)
+            return errcode;
+    }
 
     if (check_anon(kdc_active_realm, ticket->enc_part2->client,
                    request->server) != 0) {


### PR DESCRIPTION
[This will require a merge with PR #1106 because of the moved lineage and S4U2Self checks, but it shouldn't be too difficult.]

[I would have liked to move the FX_ARMOR check from kdc_process_tgs_req(), but unfortunately RFC 6113 requires us to check the authenticator authdata as well as the ticket authdata, and it doesn't seem worth it to preserve the authenticator beyond kdc_process_tgs_req().]

Move the following validity checks into validate_tgs_request():

* the INVALID ticket flag check from kdc_process_tgs_req()
* the lineage check from process_tgs_req()
* all S4U2Self validity checks from kdc_process_s4u2self_req()

In process_tgs_req(), add an is_crossrealm boolean to for convenience.

There are some minor behavior changes:

* For invalid S4U2Self request options, the status string is changed
  from "INVALID AS OPTIONS" to "INVALID S4U2SELF OPTIONS".

* For a header ticket with the INVALID flag, the reply code is changed
  to KRB_AP_ERR_TKT_NYV (as specified in RFC 4120) and the status
  string to "TICKET NOT VALID".

* For a lineage check failure, the explicit KDC log is removed, and
  the status string is changed to "INVALID LINEAGE".

* e_data returned from the KDB check_policy_as() method will be
  included in the error for S4U2Self requests.
