### PR TITLE
Avoid daylight savings time issues in tests

### DIFF
--- a/src/tests/t_kdcpolicy.py
+++ b/src/tests/t_kdcpolicy.py
@@ -12,6 +12,10 @@ kdc_conf = {'realms': {'$realm': {'default_principal_flags': '+preauth',
                                   'max_renewable_life': '1d'}}}
 realm = K5Realm(krb5_conf=krb5_conf, kdc_conf=kdc_conf)
 
+# We will be scraping timestamps from klist to compute lifetimes, so
+# use a time zone with no daylight savings time.
+realm.env['TZ'] = 'UTC'
+
 realm.run([kadminl, 'addprinc', '-pw', password('fail'), 'fail'])
 
 def verify_time(out, target_time):

--- a/src/tests/t_renew.py
+++ b/src/tests/t_renew.py
@@ -5,6 +5,10 @@ import re
 conf = {'realms': {'$realm': {'max_life': '20h', 'max_renewable_life': '20h'}}}
 realm = K5Realm(create_host=False, get_creds=False, kdc_conf=conf)
 
+# We will be scraping timestamps from klist to compute lifetimes, so
+# use a time zone with no daylight savings time.
+realm.env['TZ'] = 'UTC'
+
 def test(testname, life, rlife, exp_life, exp_rlife, env=None):
     global realm
     flags = ['-l', life]


### PR DESCRIPTION
[The more labor-intensive way to deal with this is to stop scraping klist output, such as by giving icred and gcred options to display the resulting credential lifetimes.  I might do that if I feel motivated, but this approach should be adequate if I don't.]
