### PR TITLE
src/aclocal.m4: add compatibility with upcoming autoconf-2.70

### DIFF
--- a/src/aclocal.m4
+++ b/src/aclocal.m4
@@ -13,11 +13,7 @@ fi
 ac_topdir=$srcdir/$ac_reltopdir
 ac_config_fragdir=$ac_reltopdir/config
 # echo "Looking for $srcdir/$ac_config_fragdir"
-if test -d "$srcdir/$ac_config_fragdir"; then
-  AC_CONFIG_AUX_DIR(K5_TOPDIR/config)
-else
-  AC_MSG_ERROR([can not find config/ directory in $ac_reltopdir])
-fi
+AC_CONFIG_AUX_DIR(K5_TOPDIR/config)
 ])dnl
 dnl
 dnl Version info.


### PR DESCRIPTION
`autoconf-2.70` removed empty statements assignment
and exposed no-op statement problem:

```
$ autoreconf-2.70_beta3
./configure: line 2898: syntax error near unexpected token `else'
./configure: line 2898: `else'
```

The change uses `AS_IF` to avoid no-op. On autoconf-2.69 the
`./configure` diff is the following:

```diff
--- configure-2.69.pre  2020-11-06 08:20:50.000000000 +0000
+++ configure-2.69.post 2020-11-06 08:20:26.000000000 +0000
@@ -2853,3 +2853,3 @@
 # echo "Looking for $srcdir/$ac_config_fragdir"
-if test -d "$srcdir/$ac_config_fragdir"; then
+if test -d "$srcdir/$ac_config_fragdir"; then :
   ac_aux_dir=
```