### PR TITLE
Reduce warnings from mainline autoconf

### DIFF
--- a/src/aclocal.m4
+++ b/src/aclocal.m4
@@ -95,9 +95,9 @@ dnl Maintainer mode, akin to what automake provides, 'cept we don't
 dnl want to use automake right now.
 AC_DEFUN([KRB5_AC_MAINTAINER_MODE],
 [AC_ARG_ENABLE([maintainer-mode],
-AC_HELP_STRING([--enable-maintainer-mode],[enable rebuilding of source files, Makefiles, etc]),
-USE_MAINTAINER_MODE=$enableval,
-USE_MAINTAINER_MODE=no)
+  [AS_HELP_STRING([--enable-maintainer-mode],
+    [enable rebuilding of source files, Makefiles, etc])],
+  [USE_MAINTAINER_MODE=$enableval], [USE_MAINTAINER_MODE=no])
 if test "$USE_MAINTAINER_MODE" = yes; then
   MAINTAINER_MODE_TRUE=
   MAINTAINER_MODE_FALSE='#'
@@ -116,7 +116,9 @@ dnl
 AC_DEFUN([KRB5_AC_INITFINI],[
 dnl Do we want initialization at load time?
 AC_ARG_ENABLE([delayed-initialization],
-AC_HELP_STRING([--disable-delayed-initialization],initialize library code when loaded @<:@delay until first use@:>@), , enable_delayed_initialization=yes)
+  [AS_HELP_STRING([--disable-delayed-initialization],
+    [initialize library code when loaded @<:@delay until first use@:>@])],
+  [], [enable_delayed_initialization=yes])
 case "$enable_delayed_initialization" in
   yes)
     AC_DEFINE(DELAY_INITIALIZER,1,[Define if library initialization should be delayed until first use]) ;;
@@ -156,7 +158,9 @@ AC_SUBST(DL_LIB)
 dnl Hack for now.
 AC_DEFUN([KRB5_AC_ENABLE_THREADS],[
 AC_ARG_ENABLE([thread-support],
-AC_HELP_STRING([--disable-thread-support],don't enable thread support @<:@enabled@:>@), , enable_thread_support=yes)
+  [AS_HELP_STRING([--disable-thread-support],
+    [don't enable thread support @<:@enabled@:>@])],
+  [], [enable_thread_support=yes])
 if test "$enable_thread_support" = yes ; then
   AC_MSG_NOTICE(enabling thread support)
   AC_DEFINE(ENABLE_THREADS,1,[Define if thread support enabled])
@@ -238,9 +242,13 @@ dnl DECLARE_SYS_ERRLIST - check for sys_errlist in libc
 dnl
 AC_DEFUN([DECLARE_SYS_ERRLIST],
 [AC_CACHE_CHECK([for sys_errlist declaration], krb5_cv_decl_sys_errlist,
-[AC_TRY_COMPILE([#include <stdio.h>
-#include <errno.h>], [1+sys_nerr;],
-krb5_cv_decl_sys_errlist=yes, krb5_cv_decl_sys_errlist=no)])
+[AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#include <stdio.h>
+      #include <errno.h>
+    ]],
+    [[1+sys_nerr;]])],
+  [krb5_cv_decl_sys_errlist=yes], [krb5_cv_decl_sys_errlist=no])])
 # assume sys_nerr won't be declared w/o being in libc
 if test $krb5_cv_decl_sys_errlist = yes; then
   AC_DEFINE(SYS_ERRLIST_DECLARED,1,[Define if sys_errlist is defined in errno.h])
@@ -249,8 +257,11 @@ else
   # This means that sys_errlist is not declared in errno.h, but may still
   # be in libc.
   AC_CACHE_CHECK([for sys_errlist in libc], krb5_cv_var_sys_errlist,
-  [AC_TRY_LINK([extern int sys_nerr;], [if (1+sys_nerr < 0) return 1;],
-  krb5_cv_var_sys_errlist=yes, krb5_cv_var_sys_errlist=no;)])
+  [AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM(
+      [[extern int sys_nerr;]],
+      [[if (1+sys_nerr < 0) return 1;]])],
+    [krb5_cv_var_sys_errlist=yes], [krb5_cv_var_sys_errlist=no])])
   if test $krb5_cv_var_sys_errlist = yes; then
     AC_DEFINE(HAVE_SYS_ERRLIST,1,[Define if sys_errlist in libc])
     # Do this cruft for backwards compatibility for now.
@@ -266,10 +277,18 @@ dnl
 AC_DEFUN(CHECK_SIGPROCMASK,[
 AC_MSG_CHECKING([for use of sigprocmask])
 AC_CACHE_VAL(krb5_cv_func_sigprocmask_use,
-[AC_TRY_LINK([#include <signal.h>], [sigprocmask(SIG_SETMASK,0,0);],
- krb5_cv_func_sigprocmask_use=yes,
-AC_TRY_LINK([#include <signal.h>], [sigmask(1);], 
- krb5_cv_func_sigprocmask_use=no, krb5_cv_func_sigprocmask_use=yes))])
+[AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#include <signal.h>
+    ]],
+    [[sigprocmask(SIG_SETMASK, 0, 0);]])],
+  [krb5_cv_func_sigprocmask_use=yes],
+  [AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM(
+      [[#include <signal.h>
+      ]],
+      [[sigmask(1);]])],
+    [krb5_cv_func_sigprocmask_use=no], [krb5_cv_func_sigprocmask_use=yes])])])
 AC_MSG_RESULT($krb5_cv_func_sigprocmask_use)
 if test $krb5_cv_func_sigprocmask_use = yes; then
  AC_DEFINE(USE_SIGPROCMASK,1,[Define if sigprocmask should be used])
@@ -289,17 +308,23 @@ AC_DEFUN(CHECK_WAIT_TYPE,[
 AC_MSG_CHECKING([if argument to wait is int *])
 AC_CACHE_VAL(krb5_cv_struct_wait,
 dnl Test for prototype clash - if there is none - then assume int * works
-[AC_TRY_COMPILE([#include <sys/types.h>
-#include <sys/wait.h>
-extern pid_t wait(int *);],[], krb5_cv_struct_wait=no,dnl
-dnl Else fallback on old stuff
-[AC_TRY_COMPILE(
-[#include <sys/wait.h>], [union wait i;
-#ifdef WEXITSTATUS
-  WEXITSTATUS (i);
-#endif
-], 
-	krb5_cv_struct_wait=yes, krb5_cv_struct_wait=no)])])
+[AC_COMPILE_IFELSE(
+  [AC_LANG_SOURCE(
+    [[#include <sys/types.h>
+      #include <sys/wait.h>
+      extern pid_t wait(int *);]])],
+  [krb5_cv_struct_wait=no],
+  dnl Else fallback on old stuff
+  [AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM(
+      [[#include <sys/wait.h>
+      ]],
+      [[union wait i;
+        #ifdef WEXITSTATUS
+        WEXITSTATUS (i);
+        #endif
+      ]])],
+    [krb5_cv_struct_wait=yes], [krb5_cv_struct_wait=no])])])
 AC_MSG_RESULT($krb5_cv_struct_wait)
 if test $krb5_cv_struct_wait = no; then
 	AC_DEFINE(WAIT_USES_INT,1,[Define if wait takes int as a argument])
@@ -312,43 +337,17 @@ AC_DEFUN(CHECK_SIGNALS,[
 AC_CHECK_FUNC(sigprocmask,
 AC_MSG_CHECKING(for sigset_t and POSIX_SIGNALS)
 AC_CACHE_VAL(krb5_cv_type_sigset_t,
-[AC_TRY_COMPILE(
-[#include <signal.h>],
-[sigset_t x],
-krb5_cv_type_sigset_t=yes, krb5_cv_type_sigset_t=no)])
+[AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#include <signal.h>
+    ]],
+    [[sigset_t x]])],
+  [krb5_cv_type_sigset_t=yes], [krb5_cv_type_sigset_t=no])])
 AC_MSG_RESULT($krb5_cv_type_sigset_t)
 if test $krb5_cv_type_sigset_t = yes; then
   AC_DEFINE(POSIX_SIGNALS,1,[Define if POSIX signal handling is used])
 fi
 )])dnl
-dnl
-dnl check for signal type
-dnl
-dnl AC_RETSIGTYPE isn't quite right, but almost.
-AC_DEFUN(KRB5_SIGTYPE,[
-AC_MSG_CHECKING([POSIX signal handlers])
-AC_CACHE_VAL(krb5_cv_has_posix_signals,
-[AC_TRY_COMPILE(
-[#include <sys/types.h>
-#include <signal.h>
-#ifdef signal
-#undef signal
-#endif
-extern void (*signal ()) ();], [],
-krb5_cv_has_posix_signals=yes, krb5_cv_has_posix_signals=no)])
-AC_MSG_RESULT($krb5_cv_has_posix_signals)
-if test $krb5_cv_has_posix_signals = yes; then
-   stype=void
-   AC_DEFINE(POSIX_SIGTYPE, 1, [Define if POSIX signal handlers are used])
-else
-  if test $ac_cv_type_signal = void; then
-     stype=void
-  else
-     stype=int
-  fi
-fi
-AC_DEFINE_UNQUOTED(krb5_sigtype, $stype, [Define krb5_sigtype to type of signal handler])dnl
-])dnl
 dnl
 dnl check for POSIX setjmp/longjmp -- CHECK_SETJMP
 dnl
@@ -356,9 +355,12 @@ AC_DEFUN(CHECK_SETJMP,[
 AC_CHECK_FUNC(sigsetjmp,
 AC_MSG_CHECKING(for sigjmp_buf)
 AC_CACHE_VAL(krb5_cv_struct_sigjmp_buf,
-[AC_TRY_COMPILE(
-[#include <setjmp.h>],[sigjmp_buf x],
-krb5_cv_struct_sigjmp_buf=yes,krb5_cv_struct_sigjmp_buf=no)])
+[AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#include <setjmp.h>
+    ]],
+    [[sigjmp_buf x]])],
+  [krb5_cv_struct_sigjmp_buf=yes], [krb5_cv_struct_sigjmp_buf=no])])
 AC_MSG_RESULT($krb5_cv_struct_sigjmp_buf)
 if test $krb5_cv_struct_sigjmp_buf = yes; then
   AC_DEFINE(POSIX_SETJMP,1,[Define if setjmp indicates POSIX interface])
@@ -375,12 +377,15 @@ dnl under OSF/1^H^H^H^H^HDigital^H^H^H^H^H^H^HTru64 UNIX, where it's
 dnl a macro
 AC_MSG_CHECKING(for getaddrinfo)
 AC_CACHE_VAL(ac_cv_func_getaddrinfo,
-[AC_TRY_LINK([#ifdef HAVE_NETDB_H
-#include <netdb.h>
-#endif],[
-struct addrinfo *ai;
-getaddrinfo("kerberos.mit.edu", "echo", 0, &ai);
-], ac_cv_func_getaddrinfo=yes, ac_cv_func_getaddrinfo=no)])
+[AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#ifdef HAVE_NETDB_H
+      #include <netdb.h>
+      #endif
+    ]],
+    [[struct addrinfo *ai;
+      getaddrinfo("kerberos.mit.edu", "echo", 0, &ai);]])],
+  [ac_cv_func_getaddrinfo=yes], [ac_cv_func_getaddrinfo=no])])
 AC_MSG_RESULT($ac_cv_func_getaddrinfo)
 if test $ac_cv_func_getaddrinfo = yes; then
   AC_DEFINE(HAVE_GETADDRINFO,1,[Define if you have the getaddrinfo function])
@@ -392,18 +397,19 @@ AC_CACHE_VAL(krb5_cv_inet6,[
 if test "$ac_cv_func_inet_ntop" != "yes" ; then
   krb5_cv_inet6=no
 else
-AC_TRY_COMPILE([
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <netdb.h>
-],[
-  struct sockaddr_in6 in;
-  AF_INET6;
-  IN6_IS_ADDR_LINKLOCAL (&in.sin6_addr);
-],krb5_cv_inet6=yes,krb5_cv_inet6=no)])
+  AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM(
+      [[#ifdef HAVE_SYS_TYPES_H
+        #include <sys/types.h>
+        #endif
+        #include <sys/socket.h>
+        #include <netinet/in.h>
+        #include <netdb.h>
+      ]],
+      [[struct sockaddr_in6 in;
+        AF_INET6;
+        IN6_IS_ADDR_LINKLOCAL(&in.sin6_addr);]])],
+    [krb5_cv_inet6=yes], [krb5_cv_inet6=no])])
 fi
 AC_MSG_RESULT($krb5_cv_inet6)
 if test "$krb5_cv_inet6" = no && test "$ac_cv_func_inet_ntop" = yes; then
@@ -411,18 +417,19 @@ AC_MSG_CHECKING(for IPv6 compile-time support with -DINET6)
 AC_CACHE_VAL(krb5_cv_inet6_with_dinet6,[
 old_CC="$CC"
 CC="$CC -DINET6"
-AC_TRY_COMPILE([
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <netdb.h>
-],[
-  struct sockaddr_in6 in;
-  AF_INET6;
-  IN6_IS_ADDR_LINKLOCAL (&in.sin6_addr);
-],krb5_cv_inet6_with_dinet6=yes,krb5_cv_inet6_with_dinet6=no)
+AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#ifdef HAVE_SYS_TYPES_H
+      #include <sys/types.h>
+      #endif
+      #include <sys/socket.h>
+      #include <netinet/in.h>
+      #include <netdb.h>
+    ]],
+    [[struct sockaddr_in6 in;
+      AF_INET6;
+      IN6_IS_ADDR_LINKLOCAL (&in.sin6_addr);]])],
+  [krb5_cv_inet6_with_dinet6=yes], [krb5_cv_inet6_with_dinet6=no])
 CC="$old_CC"])
 AC_MSG_RESULT($krb5_cv_inet6_with_dinet6)
 fi
@@ -446,10 +453,13 @@ AC_DEFUN(TRY_WARN_CC_FLAG_1,[dnl
   cachevar=`echo "krb5_cv_cc_flag_$1" | sed -e s/=/_eq_/g -e s/-/_dash_/g -e s/[[^a-zA-Z0-9_]]/_/g`
   AC_CACHE_CHECK([if C compiler supports $1], [$cachevar],
   [# first try without, then with
-  AC_TRY_COMPILE([], 1;,
+  AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM([], [1;])],
     [old_cflags="$CFLAGS"
      CFLAGS="$CFLAGS $cflags_warning_test_flags $1"
-     AC_TRY_COMPILE([], 1;, eval $cachevar=yes, eval $cachevar=no)
+     AC_COMPILE_IFELSE(
+       [AC_LANG_PROGRAM([], [1;])],
+       [eval $cachevar=yes], [eval $cachevar=no])
      CFLAGS="$old_cflags"],
     [AC_MSG_ERROR(compiling simple test program with $CFLAGS failed)])])
   if eval test '"${'$cachevar'}"' = yes; then
@@ -638,28 +648,6 @@ AC_SUBST(WARN_CFLAGS)
 AC_SUBST(WARN_CXXFLAGS)
 ])dnl
 dnl
-dnl
-dnl check for yylineno -- HAVE_YYLINENO
-dnl
-AC_DEFUN(HAVE_YYLINENO,[dnl
-AC_REQUIRE_CPP()AC_REQUIRE([AC_PROG_LEX])dnl
-AC_MSG_CHECKING([for yylineno declaration])
-AC_CACHE_VAL(krb5_cv_type_yylineno,
-# some systems have yylineno, others don't...
-  echo '%%
-%%' | ${LEX} -t > conftest.out
-  if egrep yylineno conftest.out >/dev/null 2>&1; then
-	krb5_cv_type_yylineno=yes
-  else
-	krb5_cv_type_yylineno=no
-  fi
-  rm -f conftest.out)
-  AC_MSG_RESULT($krb5_cv_type_yylineno)
-  if test $krb5_cv_type_yylineno = no; then
-	AC_DEFINE(NO_YYLINENO, 1, [Define if lex produes code with yylineno])
-  fi
-])dnl
-dnl
 dnl K5_GEN_MAKEFILE([dir, [frags]])
 dnl
 AC_DEFUN(K5_GEN_MAKEFILE,[dnl
@@ -669,7 +657,7 @@ dnl
 dnl _K5_GEN_MAKEFILE(dir, [frags])
 dnl  dir must be present in this case
 dnl  Note: Be careful in quoting. 
-dnl        The ac_foreach generates the list of fragments to include
+dnl        The m4_foreach_w generates the list of fragments to include
 dnl        or "" if $2 is empty
 AC_DEFUN(_K5_GEN_MAKEFILE,[dnl
 AC_CONFIG_FILES([$1/Makefile:$srcdir/]K5_TOPDIR[/config/pre.in:$1/Makefile.in:$1/deps:$srcdir/]K5_TOPDIR[/config/post.in])
@@ -691,7 +679,7 @@ AC_DEFUN(V5_AC_OUTPUT_MAKEFILE,
 dnl
 define(_V5_AC_OUTPUT_MAKEFILE,
 [ifelse($2, , ,AC_CONFIG_FILES($2))
-AC_FOREACH([DIR], [$1],dnl
+m4_foreach_w([DIR], [$1],dnl
  [AC_CONFIG_FILES(DIR[/Makefile:$srcdir/]K5_TOPDIR[/config/pre.in:]DIR[/Makefile.in:]DIR[/deps:$srcdir/]K5_TOPDIR[/config/post.in])])
 K5_AC_OUTPUT])dnl
 dnl
@@ -710,7 +698,7 @@ dnl
 dnl
 AC_DEFUN(WITH_NETLIB,[
 AC_ARG_WITH([netlib],
-AC_HELP_STRING([--with-netlib=LIBS], use user defined resolver library),
+  [AS_HELP_STRING([--with-netlib=LIBS], [use user defined resolver library])],
 [  if test "$withval" = yes -o "$withval" = no ; then
 	AC_MSG_RESULT("netlib will link with C library resolver only")
   else
@@ -738,13 +726,15 @@ dnl
 dnl regcomp is present but non-functional on Solaris 2.4
 dnl
 AC_MSG_CHECKING(for working regcomp)
-AC_CACHE_VAL(ac_cv_func_regcomp,[
-AC_TRY_RUN([
-#include <sys/types.h>
-#include <regex.h>
-regex_t x; regmatch_t m;
-int main() { return regcomp(&x,"pat.*",0) || regexec(&x,"pattern",1,&m,0); }
-], ac_cv_func_regcomp=yes, ac_cv_func_regcomp=no, AC_MSG_ERROR([Cannot test regcomp when cross compiling]))])
+AC_CACHE_VAL(ac_cv_func_regcomp,
+[AC_RUN_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#include <sys/types.h>
+      #include <regex.h>
+      regex_t x; regmatch_t m;]],
+    [[return regcomp(&x,"pat.*",0) || regexec(&x,"pattern",1,&m,0);]])],
+  [ac_cv_func_regcomp=yes], [ac_cv_func_regcomp=no],
+  [AC_MSG_ERROR([Cannot test regcomp when cross compiling])])])
 AC_MSG_RESULT($ac_cv_func_regcomp)
 test $ac_cv_func_regcomp = yes && AC_DEFINE(HAVE_REGCOMP,1,[Define if regcomp exists and functions])
 dnl
@@ -829,7 +819,11 @@ if test -n "$tcl_conf" ; then
       done
       LIBS="$old_LIBS `eval echo x $TCL_LIB_SPEC $TCL_LIBS | sed 's/^x//'`"
       LDFLAGS="$old_LDFLAGS $TCL_LD_FLAGS"
-      AC_TRY_LINK([#include <tcl.h>], [Tcl_CreateInterp ();],
+      AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM(
+          [[#include <tcl.h>
+          ]],
+          [[Tcl_CreateInterp();]])],
 	tcl_ok_conf=$file
 	tcl_vers_maj=$TCL_MAJOR_VERSION
 	tcl_vers_min=$TCL_MINOR_VERSION
@@ -1002,8 +996,10 @@ dnl
 dnl WITH_HESIOD
 dnl
 AC_DEFUN(WITH_HESIOD,
-[AC_ARG_WITH(hesiod, AC_HELP_STRING(--with-hesiod[=path], compile with hesiod support @<:@omitted@:>@),
-	hesiod=$with_hesiod, with_hesiod=no)
+[AC_ARG_WITH(hesiod,
+  [AS_HELP_STRING([--with-hesiod[=path]],
+    [compile with hesiod support @<:@omitted@:>@])],
+  [hesiod=$with_hesiod], [with_hesiod=no])
 if test "$with_hesiod" != "no"; then
 	HESIOD_DEFS=-DHESIOD
 	AC_CHECK_LIB(resolv, res_send, res_lib=-lresolv)
@@ -1120,8 +1116,8 @@ if test "x$enable_static" = "x$enable_shared"; then
 fi
 
 AC_ARG_ENABLE([rpath],
-AC_HELP_STRING([--disable-rpath],[suppress run path flags in link lines]),,
-[enable_rpath=yes])
+  [AS_HELP_STRING([--disable-rpath],[suppress run path flags in link lines])],
+  [], [enable_rpath=yes])
 
 if test "x$enable_rpath" != xyes ; then
 	# Unset the rpath flag values set by shlib.conf
@@ -1285,12 +1281,12 @@ ns_initparse ns_name_uncompress dn_skipname res_search)
 	AC_CHECK_FUNC(res_search,
 	  [AC_DEFINE(HAVE_RES_SEARCH, 1,
 	    [Define to 1 if you have the `res_search' function])],
-	  [AC_ERROR([cannot find res_nsearch or res_search])])
+          [AC_MSG_ERROR([cannot find res_nsearch or res_search])])
     fi
   fi
 ])
 AC_DEFUN([_KRB5_AC_CHECK_RES_FUNCS],
-[AC_FOREACH([AC_Func], [$1],
+[m4_foreach_w([AC_Func], [$1],
   [AH_TEMPLATE(AS_TR_CPP(HAVE_[]AC_Func),
                [Define to 1 if you have the `]AC_Func[' function.])])dnl
 for krb5_func in $1; do
@@ -1302,17 +1298,20 @@ AC_DEFUN([_KRB5_AC_CHECK_RES_FUNC], [
 # doesn't export it from libresolv.so, so we use extreme paranoia here
 # and check both for the declaration and that we can link against the
 # function.
-AC_CACHE_CHECK([for $1], [krb5_cv_func_$1], [AC_TRY_LINK(
-[#include <sys/types.h>
-#include <netinet/in.h>
-#include <arpa/nameser.h>
-@%:@include <resolv.h>],
-[/*
- * Use volatile, or else optimization can cause false positives.
- */
-void (* volatile p)() = (void (*)())$1;],
-			     [AS_VAR_SET(krb5_cv_func_$1, yes)],
-			     [AS_VAR_SET(krb5_cv_func_$1, no)])])
+AC_CACHE_CHECK([for $1], [krb5_cv_func_$1],
+[AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#include <sys/types.h>
+      #include <netinet/in.h>
+      #include <arpa/nameser.h>
+      #include <resolv.h>
+    ]],
+    [[/*
+       * Use volatile, or else optimization can cause false positives.
+       */
+      void (* volatile p)() = (void (*)())$1;]])],
+    [AS_VAR_SET(krb5_cv_func_$1, yes)],
+    [AS_VAR_SET(krb5_cv_func_$1, no)])])
 AS_IF([test AS_VAR_GET(krb5_cv_func_$1) = yes],
       [AC_DEFINE_UNQUOTED(AS_TR_CPP([HAVE_$1]), 1,
 			  [Define to 1 if you have the `$1' function])])[]dnl
@@ -1347,13 +1346,14 @@ dnl
 AC_DEFUN([KRB5_NEED_PROTO], [
 ifelse([$3], ,[if test "x$ac_cv_func_$2" = xyes; then])
 AC_CACHE_CHECK([if $2 needs a prototype provided], krb5_cv_func_$2_noproto,
-AC_TRY_COMPILE([$1],
-[#undef $2
-struct k5foo {int foo; } xx;
-extern int $2 (struct k5foo*);
-$2(&xx);
-],
-krb5_cv_func_$2_noproto=yes,krb5_cv_func_$2_noproto=no))
+[AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[$1]],
+    [[#undef $2
+      struct k5foo {int foo; } xx;
+      extern int $2 (struct k5foo*);
+      $2(&xx);]])],
+  [krb5_cv_func_$2_noproto=yes], [krb5_cv_func_$2_noproto=no])])
 if test $krb5_cv_func_$2_noproto = yes; then
 	AC_DEFINE([NEED_]translit($2, [a-z], [A-Z])[_PROTO], 1, dnl
 [define if the system header files are missing prototype for $2()])
@@ -1375,12 +1375,13 @@ AC_DEFUN([TRY_GETSOCK_INT],[
 krb5_lib_var=`echo "$1 $2" | sed 'y% ./+-*%___p_p%'`
 AC_MSG_CHECKING([if getsockname() takes arguments $1 and $2])
 AC_CACHE_VAL(krb5_cv_getsockname_proto_$krb5_lib_var,
-[
-AC_TRY_COMPILE([#include <sys/types.h>
-#include <sys/socket.h>
-extern int getsockname(int, $1, $2);
-],,eval "krb5_cv_getsockname_proto_$krb5_lib_var=yes",
-    eval "krb5_cv_getsockname_proto_$krb5_lib_var=no")])
+[AC_COMPILE_IFELSE(
+  [AC_LANG_SOURCE(
+    [[#include <sys/types.h>
+      #include <sys/socket.h>
+      extern int getsockname(int, $1, $2);]])],
+  [eval "krb5_cv_getsockname_proto_$krb5_lib_var=yes"],
+  [eval "krb5_cv_getsockname_proto_$krb5_lib_var=no"])])
 if eval "test \"`echo '$krb5_cv_getsockname_proto_'$krb5_lib_var`\" = yes"; then
 	AC_MSG_RESULT(yes)
 	sock_set=yes; res1="$1"; res2="$2"
@@ -1415,7 +1416,8 @@ dnl
 dnl
 AC_DEFUN([KRB5_AC_CHOOSE_ET],[
 AC_ARG_WITH([system-et],
-AC_HELP_STRING(--with-system-et,use system compile_et and -lcom_err @<:@default: build and install a local version@:>@))
+  [AS_HELP_STRING([--with-system-et],
+    [use system compile_et and -lcom_err @<:@default: build and install a local version@:>@])])
 AC_MSG_CHECKING(which version of com_err to use)
 if test "x$with_system_et" = xyes ; then
   # This will be changed to "intlsys" if textdomain support is present.
@@ -1450,9 +1452,12 @@ EOF
   if compile_et conf$$e.et >/dev/null 2>&1 ; then true ; else
     AC_MSG_ERROR(execution failed)
   fi
-  AC_TRY_COMPILE([#include "conf$$e.h"
-      		 ],[ &et_foo_error_table; ],:,
-		 [AC_MSG_ERROR(cannot use et_foo_error_table)])
+  AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM(
+      [[#include "conf$$e.h"
+      ]],
+      [[&et_foo_error_table;]])],
+    [], [AC_MSG_ERROR(cannot use et_foo_error_table)])
   # Anything else we need to test for?
   rm -f conf$$e.c conf$$e.h
   krb5_cv_compile_et_useful=yes
@@ -1482,7 +1487,8 @@ fi
 ])
 AC_DEFUN([KRB5_AC_CHOOSE_SS],[
 AC_ARG_WITH(system-ss,
-	    AC_HELP_STRING(--with-system-ss,use system -lss and mk_cmds @<:@private version@:>@))
+  [AS_HELP_STRING([--with-system-ss],
+    [use system -lss and mk_cmds @<:@private version@:>@])])
 AC_ARG_VAR(SS_LIB,[system libraries for 'ss' package [-lss]])
 AC_MSG_CHECKING(which version of subsystem package to use)
 if test "x$with_system_ss" = xyes ; then
@@ -1493,18 +1499,20 @@ if test "x$with_system_ss" = xyes ; then
   test "x${SS_LIB+set}" = xset || SS_LIB=-lss
   old_LIBS="$LIBS"
   LIBS="$LIBS $SS_LIB"
-  AC_CACHE_CHECK(whether system ss package works, krb5_cv_system_ss_okay,[
-  AC_TRY_RUN([
-#include <ss/ss.h>
-int main(int argc, char *argv[]) {
-  if (argc == 42) {
-    int i, err;
-    i = ss_create_invocation("foo","foo","",0,&err);
-    ss_listen(i);
-  }
-  return 0;
-}], krb5_cv_system_ss_okay=yes, AC_MSG_ERROR(cannot run test program),
-  krb5_cv_system_ss_okay="assumed")])
+  AC_CACHE_CHECK(whether system ss package works, krb5_cv_system_ss_okay,
+  [AC_RUN_IFELSE(
+    [AC_LANG_SOURCE(
+      [[#include <ss/ss.h>
+        int main(int argc, char *argv[]) {
+            if (argc == 42) {
+                int i, err;
+                i = ss_create_invocation("foo","foo","",0,&err);
+                ss_listen(i);
+            }
+            return 0;
+        }]])],
+    [krb5_cv_system_ss_okay=yes], [AC_MSG_ERROR(cannot run test program)],
+    [krb5_cv_system_ss_okay=assumed])])
   LIBS="$old_LIBS"
   KRB5_NEED_PROTO([#include <ss/ss.h>],ss_execute_command,1)
 else
@@ -1517,7 +1525,8 @@ AC_SUBST(SS_VERSION)
 dnl
 AC_DEFUN([KRB5_AC_CHOOSE_DB],[
 AC_ARG_WITH(system-db,
-	    AC_HELP_STRING(--with-system-db,use system Berkeley db @<:@private version@:>@))
+  [AS_HELP_STRING([--with-system-db],
+    [use system Berkeley db @<:@private version@:>@])])
 AC_ARG_VAR(DB_HEADER,[header file for system Berkeley db package [db.h]])
 AC_ARG_VAR(DB_LIB,[library for system Berkeley db package [-ldb]])
 if test "x$with_system_db" = xyes ; then
@@ -1607,14 +1616,17 @@ fi
 a=no
 b=no
 # blindly assume we have 'unlink' and unistd.h.
-AC_TRY_RUN([#include <unistd.h>
-void foo1() __attribute__((constructor));
-void foo1() { unlink("conftest.1"); }
-void foo2() __attribute__((destructor));
-void foo2() { unlink("conftest.2"); }
-int main () { return 0; }],
-[test -r conftest.1 || a=yes
-test -r conftest.2 || b=yes], , AC_MSG_ERROR(Cannot test for constructor/destructor support when cross compiling))
+AC_RUN_IFELSE(
+  [AC_LANG_SOURCE(
+    [[#include <unistd.h>
+      void foo1() __attribute__((constructor));
+      void foo1() { unlink("conftest.1"); }
+      void foo2() __attribute__((destructor));
+      void foo2() { unlink("conftest.2"); }
+      int main () { return 0; }]])],
+    [test -r conftest.1 || a=yes
+     test -r conftest.2 || b=yes],
+  [], [AC_MSG_ERROR(Cannot test for constructor/destructor support when cross compiling)])
 case $krb5_cv_host in
 *-*-aix4.*)
 	# Under AIX 4.3.3, at least, shared library destructor functions
@@ -1647,9 +1659,12 @@ dnl KRB5_AC_PRAGMA_WEAK_REF
 AC_DEFUN([KRB5_AC_PRAGMA_WEAK_REF],
 [AC_CACHE_CHECK([whether pragma weak references are supported],
 krb5_cv_pragma_weak_ref,
-[AC_TRY_LINK([#pragma weak flurbl
-extern int flurbl(void);],[if (&flurbl != 0) return flurbl();],
-krb5_cv_pragma_weak_ref=yes,krb5_cv_pragma_weak_ref=no)])
+[AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#pragma weak flurbl
+      extern int flurbl(void);]],
+    [[if (&flurbl != 0) return flurbl();]])],
+  [krb5_cv_pragma_weak_ref=yes], [krb5_cv_pragma_weak_ref=no])])
 if test $krb5_cv_pragma_weak_ref = yes ; then
   AC_DEFINE(HAVE_PRAGMA_WEAK_REF,1,[Define if #pragma weak references work])
 fi])
@@ -1665,7 +1680,7 @@ dnl --with-ldap=value
 dnl
 AC_DEFUN(WITH_LDAP,[
 AC_ARG_WITH([ldap],
-[  --with-ldap             compile OpenLDAP database backend module],
+[AS_HELP_STRING([--with-ldap], [compile OpenLDAP database backend module])],
 [case "$withval" in
     OPENLDAP) with_ldap=yes ;;
     yes | no) ;;

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -123,8 +123,8 @@ AC_SUBST(LIBUTIL)
 # Determine if NLS is desired and supported.
 po=
 AC_ARG_ENABLE([nls],
-AC_HELP_STRING([--disable-nls], [disable native language support]),
-              [], [enable_nls=check])
+  [AS_HELP_STRING([--disable-nls], [disable native language support])],
+  [], [enable_nls=check])
 if test "$enable_nls" != no; then
   AC_CHECK_HEADER(libintl.h, [
     AC_SEARCH_LIBS(dgettext, intl, [
@@ -229,7 +229,9 @@ CHECK_SIGNALS
 # --with-vague-errors disables useful error messages.
 
 AC_ARG_WITH([vague-errors],
-AC_HELP_STRING([--with-vague-errors],[Do not @<:@do@:>@ send helpful errors to client]), , withval=no)
+  [AS_HELP_STRING([--with-vague-errors],
+    [Do not @<:@do@:>@ send helpful errors to client])],
+  [], [withval=no])
 if test "$withval" = yes; then
 	AC_MSG_NOTICE(Supplying vague error messages to KDC clients)
 	AC_DEFINE(KRBCONF_VAGUE_ERRORS,1,[Define if the KDC should return only vague error codes to clients])
@@ -238,8 +240,9 @@ fi
 # Check which (if any) audit plugin to build
 audit_plugin=""
 AC_ARG_ENABLE([audit-plugin],
-AC_HELP_STRING([--enable-audit-plugin=IMPL],
-               [use audit plugin @<:@ do not use audit @:>@]), , enableval=no)
+  [AS_HELP_STRING([--enable-audit-plugin=IMPL],
+    [use audit plugin @<:@ do not use audit @:>@])],
+  [], enableval=no)
 if test "$enableval" != no; then
     case "$enableval" in
     simple)
@@ -263,10 +266,11 @@ AC_SUBST(audit_plugin)
 
 CRYPTO_IMPL="builtin"
 AC_ARG_WITH([crypto-impl],
-AC_HELP_STRING([--with-crypto-impl=IMPL], [use specified crypto implementation @<:@builtin@:>@]),
-[CRYPTO_IMPL=$withval
-AC_MSG_NOTICE(k5crypto will use '$withval')
-], withval=builtin)
+  [AS_HELP_STRING([--with-crypto-impl=IMPL],
+    [use specified crypto implementation @<:@builtin@:>@])],
+  [CRYPTO_IMPL=$withval
+   AC_MSG_NOTICE(k5crypto will use '$withval')],
+  [withval=builtin])
 case "$withval" in
 builtin)
   ;;
@@ -283,10 +287,11 @@ AC_SUBST(CRYPTO_IMPL_CFLAGS)
 AC_SUBST(CRYPTO_IMPL_LIBS)
 
 AC_ARG_WITH([prng-alg],
-AC_HELP_STRING([--with-prng-alg=ALG], [use specified PRNG algorithm. @<:@fortuna@:>@]),
-[PRNG_ALG=$withval
-AC_MSG_NOTICE(k5crypto will use '$withval')
-], PRNG_ALG=fortuna)
+  [AS_HELP_STRING([--with-prng-alg=ALG],
+                  [use specified PRNG algorithm. @<:@fortuna@:>@])],
+  [PRNG_ALG=$withval
+   AC_MSG_NOTICE(k5crypto will use '$withval')],
+  [PRNG_ALG=fortuna])
 AC_CONFIG_COMMANDS(PRNG_ALG, , PRNG_ALG=$PRNG_ALG)
 AC_SUBST(PRNG_ALG)
 if test "$PRNG_ALG" = fortuna; then
@@ -296,9 +301,9 @@ fi
 # WITH_TLS_IMPL
 
 AC_ARG_WITH([tls-impl],
-AC_HELP_STRING([--with-tls-impl=IMPL],
-               [use specified TLS implementation @<:@auto@:>@]),
-[TLS_IMPL=$withval],[TLS_IMPL=auto])
+  [AS_HELP_STRING([--with-tls-impl=IMPL],
+    [use specified TLS implementation @<:@auto@:>@])],
+  [TLS_IMPL=$withval], [TLS_IMPL=auto])
 case "$TLS_IMPL" in
 openssl|auto)
   AC_CHECK_LIB(ssl,SSL_CTX_new,[have_lib_ssl=true],[have_lib_ssl=false],
@@ -337,8 +342,8 @@ AC_SUBST(TLS_IMPL_CFLAGS)
 AC_SUBST(TLS_IMPL_LIBS)
 
 AC_ARG_WITH([keyutils],
-AC_HELP_STRING([--without-keyutils],[do not link with libkeyutils]),
-            [], [with_keyutils=check])
+  [AS_HELP_STRING([--without-keyutils], [do not link with libkeyutils])],
+  [], [with_keyutils=check])
 if test "$with_keyutils" != no; then
   have_keyutils=false
   AC_CHECK_HEADERS([keyutils.h],
@@ -361,8 +366,9 @@ fi
 # and can support three NIST groups using OpenSSL.
 HAVE_SPAKE_OPENSSL=no
 AC_ARG_WITH([spake-openssl],
-AC_HELP_STRING([--with-spake-openssl],
-               [use OpenSSL for SPAKE preauth @<:@auto@:>@]),,[withval=auto])
+  [AS_HELP_STRING([--with-spake-openssl],
+    [use OpenSSL for SPAKE preauth @<:@auto@:>@])],
+  [], [withval=auto])
 if test "$withval" = auto -o "$withval" = yes; then
   AC_CHECK_LIB([crypto],[EC_POINT_new],[have_crypto=true],[have_crypto=false])
   if test "$have_crypto" = true; then
@@ -377,8 +383,8 @@ AC_SUBST(HAVE_SPAKE_OPENSSL)
 AC_SUBST(SPAKE_OPENSSL_LIBS)
 
 AC_ARG_ENABLE([aesni],
-AC_HELP_STRING([--disable-aesni],[Do not build with AES-NI support]), ,
-enable_aesni=check)
+  [AS_HELP_STRING([--disable-aesni], [Do not build with AES-NI support])],
+  [], [enable_aesni=check])
 if test "$CRYPTO_IMPL" = builtin -a "x$enable_aesni" != xno; then
     case "$host" in
     i686-*)
@@ -415,9 +421,9 @@ AC_SUBST(AESNI_OBJ)
 AC_SUBST(AESNI_FLAGS)
 
 AC_ARG_ENABLE([kdc-lookaside-cache],
-AC_HELP_STRING([--disable-kdc-lookaside-cache],
-               [Disable the cache which detects client retransmits]), ,
-               enableval=yes)
+  AS_HELP_STRING([--disable-kdc-lookaside-cache],
+    [Disable the cache which detects client retransmits]),
+  [], [enableval=yes])
 if test "$enableval" = no ; then
 	AC_DEFINE(NOCACHE,1,[Define if the KDC should use no lookaside cache])
 fi
@@ -428,8 +434,8 @@ KRB5_RUN_FLAGS
 # -fsanitize=address, and set ASAN=yes to suppress the undefined
 # symbols check when building shared libraries.
 AC_ARG_ENABLE([asan],
-AC_HELP_STRING([--enable-asan],[Build with asan memory checking]),[],
-               [enable_asan=no])
+  [AS_HELP_STRING([--enable-asan], [Build with asan memory checking])],
+  [], [enable_asan=no])
 if test "$enable_asan" != no; then
     if test "$enable_asan" = yes; then
         enable_asan=address
@@ -444,14 +450,11 @@ fi
 AC_SUBST(ASAN_FLAGS)
 AC_SUBST(ASAN)
 
-AC_TYPE_SIGNAL
-
 # from old include/configure.in
 AH_TEMPLATE([HAVE_STRUCT_SOCKADDR_STORAGE],
 [Define if "struct sockaddr_storage" is available.])
 
 AC_CONFIG_HEADERS(include/autoconf.h, [echo timestamp > include/autoconf.stamp])
-AC_PROG_LEX
 AC_C_CONST
 AC_HEADER_DIRENT
 AC_FUNC_STRERROR_R
@@ -513,42 +516,50 @@ CHECK_SETJMP
 
 AC_MSG_CHECKING([return type of setrpcent])
 AC_CACHE_VAL(k5_cv_type_setrpcent,
-[AC_TRY_COMPILE([#include <netdb.h>
-#ifdef __cplusplus
-extern "C"
-#endif
-extern void setrpcent();],
-[int i;], k5_cv_type_setrpcent=void, k5_cv_type_setrpcent=int)])
+[AC_COMPILE_IFELSE(
+  [AC_LANG_SOURCE([[#include <netdb.h>
+                    extern void setrpcent();]])],
+  [k5_cv_type_setrpcent=void],
+  [k5_cv_type_setrpcent=int])])
 AC_MSG_RESULT($k5_cv_type_setrpcent)
 AC_DEFINE_UNQUOTED(SETRPCENT_TYPE, $k5_cv_type_setrpcent, [Define as return type of setrpcent])
 
 AC_MSG_CHECKING([return type of endrpcent])
 AC_CACHE_VAL(k5_cv_type_endrpcent,
-[AC_TRY_COMPILE([#include <netdb.h>
-#ifdef __cplusplus
-extern "C"
-#endif
-extern void endrpcent();],
-[int i;], k5_cv_type_endrpcent=void, k5_cv_type_endrpcent=int)])
+[AC_COMPILE_IFELSE(
+  [AC_LANG_SOURCE(
+    [[#include <netdb.h>
+      extern void endrpcent();]])],
+  [k5_cv_type_endrpcent=void], [k5_cv_type_endrpcent=int])])
 AC_MSG_RESULT($k5_cv_type_endrpcent)
 AC_DEFINE_UNQUOTED(ENDRPCENT_TYPE, $k5_cv_type_endrpcent, [Define as return type of endrpcent])
 
 
 # bswap_16 is a macro in byteswap.h under GNU libc
 AC_MSG_CHECKING(for bswap_16)
-AC_CACHE_VAL(krb5_cv_bswap_16,[
-AC_TRY_LINK([#if HAVE_BYTESWAP_H
-#include <byteswap.h>
-#endif],[bswap_16(37);],krb5_cv_bswap_16=yes,krb5_cv_bswap_16=no)])
+AC_CACHE_VAL(krb5_cv_bswap_16,
+[AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#if HAVE_BYTESWAP_H
+      #include <byteswap.h>
+      #endif
+    ]],
+    [[bswap_16(37);]])],
+  [krb5_cv_bswap_16=yes], [krb5_cv_bswap_16=no])])
 AC_MSG_RESULT($krb5_cv_bswap_16)
 if test "$krb5_cv_bswap_16" = yes; then
   AC_DEFINE(HAVE_BSWAP_16,1,[Define to 1 if bswap_16 is available via byteswap.h])
 fi
 AC_MSG_CHECKING(for bswap_64)
-AC_CACHE_VAL(krb5_cv_bswap_64,[
-AC_TRY_LINK([#if HAVE_BYTESWAP_H
-#include <byteswap.h>
-#endif],[bswap_64(37);],krb5_cv_bswap_64=yes,krb5_cv_bswap_64=no)])
+AC_CACHE_VAL(krb5_cv_bswap_64,
+[AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#if HAVE_BYTESWAP_H
+      #include <byteswap.h>
+      #endif
+    ]],
+    [[bswap_64(37);]])],
+  [krb5_cv_bswap_64=yes], [krb5_cv_bswap_64=no])])
 AC_MSG_RESULT($krb5_cv_bswap_64)
 if test "$krb5_cv_bswap_64" = yes; then
   AC_DEFINE(HAVE_BSWAP_64,1,[Define to 1 if bswap_64 is available via byteswap.h])
@@ -581,18 +592,22 @@ ac_cv_func_gethostbyname_r=yes
 if test "$ac_cv_func_gethostbyname_r" = yes; then
   AC_MSG_CHECKING([if gethostbyname_r returns an int])
   AC_CACHE_VAL(krb5_cv_gethostbyname_r_returns_int,
-  [AC_TRY_COMPILE([#include <netdb.h>
-  extern int gethostbyname_r ();], [1;],
-  krb5_cv_gethostbyname_r_returns_int=yes,
-  krb5_cv_gethostbyname_r_returns_int=no)])
+  [AC_COMPILE_IFELSE(
+    [AC_LANG_SOURCE(
+      [[#include <netdb.h>
+        extern int gethostbyname_r();]])],
+    [krb5_cv_gethostbyname_r_returns_int=yes],
+    [krb5_cv_gethostbyname_r_returns_int=no])])
   AC_MSG_RESULT($krb5_cv_gethostbyname_r_returns_int)
 
   AC_MSG_CHECKING([if gethostbyname_r returns a pointer])
   AC_CACHE_VAL(krb5_cv_gethostbyname_r_returns_ptr,
-  [AC_TRY_COMPILE([#include <netdb.h>
-  extern struct hostent *gethostbyname_r ();], [1;],
-  krb5_cv_gethostbyname_r_returns_ptr=yes,
-  krb5_cv_gethostbyname_r_returns_ptr=no)])
+  [AC_COMPILE_IFELSE(
+    [AC_LANG_SOURCE(
+      [[#include <netdb.h>
+        extern struct hostent *gethostbyname_r();]])],
+    [krb5_cv_gethostbyname_r_returns_ptr=yes],
+    [krb5_cv_gethostbyname_r_returns_ptr=no])])
   AC_MSG_RESULT($krb5_cv_gethostbyname_r_returns_ptr)
 
   if test "$krb5_cv_gethostbyname_r_returns_int" = "$krb5_cv_gethostbyname_r_returns_ptr"; then
@@ -619,12 +634,16 @@ AC_CHECK_FUNC(getpwuid_r,ac_cv_func_getpwuid_r=yes,ac_cv_func_getpwuid_r=no)
 if test "$ac_cv_func_getpwnam_r" = yes; then
   AC_MSG_CHECKING([return type of getpwnam_r])
   AC_CACHE_VAL(krb5_cv_getpwnam_r_return_type,
-  [AC_TRY_COMPILE([#include <pwd.h>
-   extern int getpwnam_r();], [1;],
-   getpwnam_r_returns_int=yes,getpwnam_r_returns_int=no)
-   AC_TRY_COMPILE([#include <pwd.h>
-   extern struct passwd *getpwnam_r();], [1;],
-   getpwnam_r_returns_ptr=yes,getpwnam_r_returns_ptr=no)
+  [AC_COMPILE_IFELSE(
+    [AC_LANG_SOURCE(
+      [[#include <pwd.h>
+        extern int getpwnam_r();]])],
+    [getpwnam_r_returns_int=yes], [getpwnam_r_returns_int=no])
+   AC_COMPILE_IFELSE(
+    [AC_LANG_SOURCE(
+      [[#include <pwd.h>
+        extern struct passwd *getpwnam_r();]])],
+    [getpwnam_r_returns_ptr=yes], [getpwnam_r_returns_ptr=no])
    case "$getpwnam_r_returns_int/$getpwnam_r_returns_ptr" in
      yes/no) krb5_cv_getpwnam_r_return_type=int ;;
      no/yes) krb5_cv_getpwnam_r_return_type=ptr ;;
@@ -641,12 +660,19 @@ fi
 if test "$ac_cv_func_getpwnam_r" = yes; then
   AC_MSG_CHECKING([number of arguments to getpwnam_r])
   AC_CACHE_VAL(krb5_cv_getpwnam_r_args,
-  [AC_TRY_COMPILE([#include <pwd.h>
-   struct passwd pwx; char buf[1024];],
-   [getpwnam_r("", &pwx, buf, sizeof(buf));], args4=yes, args4=no)
-   AC_TRY_COMPILE([#include <pwd.h>
-   struct passwd pwx, *p; char buf[1024];],
-   [getpwnam_r("", &pwx, buf, sizeof(buf), &p);], args5=yes, args5=no)
+  [AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM(
+      [[#include <pwd.h>
+        struct passwd pwx; char buf[1024];]],
+      [[getpwnam_r("", &pwx, buf, sizeof(buf));]])],
+    [args4=yes], [args4=no])
+   AC_COMPILE_IFELSE(
+     [AC_LANG_PROGRAM(
+       [[#include <pwd.h>
+         struct passwd pwx, *p;
+         char buf[1024];]],
+       [[getpwnam_r("", &pwx, buf, sizeof(buf), &p);]])],
+     [args5=yes], [args5=no])
    case $args4/$args5 in
      yes/no) krb5_cv_getpwnam_r_args=4 ;;
      no/yes) krb5_cv_getpwnam_r_args=5 ;;
@@ -683,10 +709,16 @@ fi
 if test "$ac_cv_func_gmtime_r" = yes; then
   AC_MSG_CHECKING([whether gmtime_r returns int])
   AC_CACHE_VAL(krb5_cv_gmtime_r_returns_int,
-  [AC_TRY_COMPILE([#include <time.h>
-   extern int gmtime_r ();], [1;], return_int=yes, return_int=no)
-   AC_TRY_COMPILE([#include <time.h>
-   extern struct tm *gmtime_r ();], [1;], return_ptr=yes, return_ptr=no)
+  [AC_COMPILE_IFELSE(
+    [AC_LANG_SOURCE(
+      [[#include <time.h>
+        extern int gmtime_r();]])],
+    [return_int=yes], [return_int=no])
+   AC_COMPILE_IFELSE([
+     AC_LANG_SOURCE(
+       [[#include <time.h>
+         extern struct tm *gmtime_r();]])],
+     [return_ptr=yes], [return_ptr=no])
    case $return_int/$return_ptr in
      yes/no) krb5_cv_gmtime_r_returns_int=yes ;;
      no/yes) krb5_cv_gmtime_r_returns_int=no ;;
@@ -708,18 +740,22 @@ ac_cv_func_getservbyname_r=yes
 if test "$ac_cv_func_getservbyname_r" = yes; then
   AC_MSG_CHECKING([if getservbyname_r returns an int])
   AC_CACHE_VAL(krb5_cv_getservbyname_r_returns_int,
-  [AC_TRY_COMPILE([#include <netdb.h>
-  extern int getservbyname_r ();], [1;],
-  krb5_cv_getservbyname_r_returns_int=yes,
-  krb5_cv_getservbyname_r_returns_int=no)])
+  [AC_COMPILE_IFELSE(
+    [AC_LANG_SOURCE(
+      [[#include <netdb.h>
+        extern int getservbyname_r();]])],
+    [krb5_cv_getservbyname_r_returns_int=yes],
+    [krb5_cv_getservbyname_r_returns_int=no])])
   AC_MSG_RESULT($krb5_cv_getservbyname_r_returns_int)
 
   AC_MSG_CHECKING([if getservbyname_r returns a pointer])
   AC_CACHE_VAL(krb5_cv_getservbyname_r_returns_ptr,
-  [AC_TRY_COMPILE([#include <netdb.h>
-  extern struct servent *getservbyname_r ();], [1;],
-  krb5_cv_getservbyname_r_returns_ptr=yes,
-  krb5_cv_getservbyname_r_returns_ptr=no)])
+  [AC_COMPILE_IFELSE(
+    [AC_LANG_SOURCE(
+      [[#include <netdb.h>
+        extern struct servent *getservbyname_r();]])],
+    [krb5_cv_getservbyname_r_returns_ptr=yes],
+    [krb5_cv_getservbyname_r_returns_ptr=no])])
   AC_MSG_RESULT($krb5_cv_getservbyname_r_returns_ptr)
 
   if test "$krb5_cv_getservbyname_r_returns_int" = "$krb5_cv_getservbyname_r_returns_ptr"; then
@@ -736,7 +772,6 @@ if test "$ac_cv_func_getservbyname_r" = yes; then
 fi
 ])
 
-HAVE_YYLINENO
 CHECK_DIRENT
 AC_TYPE_UID_T
 
@@ -744,27 +779,27 @@ AC_CHECK_HEADER(termios.h,
 [AC_CHECK_FUNC([tcsetattr],
   AC_DEFINE(POSIX_TERMIOS,1,[Define if termios.h exists and tcsetattr exists]))])
 
-KRB5_SIGTYPE
 AC_CHECK_HEADERS(poll.h stdlib.h string.h stddef.h sys/types.h sys/file.h sys/param.h sys/stat.h sys/time.h netinet/in.h sys/uio.h sys/filio.h sys/select.h time.h paths.h errno.h)
 
 # If compiling with IPv6 support, test if in6addr_any functions.
 # Irix 6.5.16 defines it, but lacks support in the C library.
 if test $krb5_cv_inet6 = yes || test "$krb5_cv_inet6_with_dinet6" = yes ; then
-AC_CACHE_CHECK([for in6addr_any definition in library],
-  krb5_cv_var_in6addr_any,
-[AC_TRY_LINK([
-#ifdef HAVE_SYS_TYPES_H
-#include <sys/types.h>
-#endif
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <netdb.h>
-#include <stdio.h>
-],[
-  struct sockaddr_in6 in;
-  in.sin6_addr = in6addr_any;
-  printf("%x", &in);
-],krb5_cv_var_in6addr_any=yes, krb5_cv_var_in6addr_any=no)])
+  AC_CACHE_CHECK([for in6addr_any definition in library],
+  [krb5_cv_var_in6addr_any],
+  [AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM(
+      [[#ifdef HAVE_SYS_TYPES_H
+        #include <sys/types.h>
+        #endif
+        #include <sys/socket.h>
+        #include <netinet/in.h>
+        #include <netdb.h>
+        #include <stdio.h>
+      ]],
+      [[struct sockaddr_in6 in;
+        in.sin6_addr = in6addr_any;
+        printf("%x", &in);]])],
+    [krb5_cv_var_in6addr_any=yes], [krb5_cv_var_in6addr_any=no])])
   if test $krb5_cv_var_in6addr_any = no; then
     AC_DEFINE(NEED_INSIXADDR_ANY,1,[Define if in6addr_any is not defined in libc])
   fi
@@ -772,7 +807,6 @@ fi
 
 # then from osconf.h, we have
 
-AC_HEADER_TIME
 AC_CHECK_TYPE(time_t, long)
 AC_CHECK_SIZEOF(time_t)
 SIZEOF_TIME_T=$ac_cv_sizeof_time_t
@@ -799,11 +833,13 @@ AC_SUBST(KRB5_RCTMPDIR)
 
 AC_MSG_CHECKING(for socklen_t)
 AC_CACHE_VAL(krb5_cv_has_type_socklen_t,
-[AC_TRY_COMPILE(
-[#include <sys/types.h>
-#include <sys/socket.h>
-],[sizeof (socklen_t);],
-krb5_cv_has_type_socklen_t=yes,krb5_cv_has_type_socklen_t=no)])
+[AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#include <sys/types.h>
+      #include <sys/socket.h>
+    ]],
+    [[sizeof(socklen_t);]])],
+  [krb5_cv_has_type_socklen_t=yes], [krb5_cv_has_type_socklen_t=no])])
 AC_MSG_RESULT($krb5_cv_has_type_socklen_t)
 if test $krb5_cv_has_type_socklen_t = yes; then
     AC_DEFINE(HAVE_SOCKLEN_T,1,[Define if there is a socklen_t type. If not, probably use size_t])
@@ -811,11 +847,13 @@ fi
 
 AC_MSG_CHECKING(for struct lifconf)
 AC_CACHE_VAL(krb5_cv_has_struct_lifconf,
-[AC_TRY_COMPILE(
-[#include <sys/socket.h>
-#include <net/if.h>
-],[sizeof (struct lifconf);],
-krb5_cv_has_struct_lifconf=yes,krb5_cv_has_struct_lifconf=no)])
+[AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#include <sys/socket.h>
+      #include <net/if.h>
+    ]],
+    [[sizeof (struct lifconf);]])],
+  [krb5_cv_has_struct_lifconf=yes], [krb5_cv_has_struct_lifconf=no])])
 AC_MSG_RESULT($krb5_cv_has_struct_lifconf)
 if test $krb5_cv_has_struct_lifconf = yes; then
     AC_DEFINE(HAVE_STRUCT_LIFCONF,1,[Define if there is a struct lifconf.])
@@ -823,12 +861,15 @@ fi
 # HP-UX 11 uses stuct if_laddrconf
 AC_MSG_CHECKING(for struct if_laddrconf)
 AC_CACHE_VAL(krb5_cv_has_struct_if_laddrconf,
-[AC_TRY_COMPILE(
-[#include <sys/socket.h>
-#include <net/if.h>
-#include <net/if6.h>
-],[sizeof (struct if_laddrconf);],
-krb5_cv_has_struct_if_laddrconf=yes,krb5_cv_has_struct_if_laddrconf=no)])
+[AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#include <sys/socket.h>
+      #include <net/if.h>
+      #include <net/if6.h>
+    ]],
+    [[sizeof(struct if_laddrconf);]])],
+  [krb5_cv_has_struct_if_laddrconf=yes],
+  [krb5_cv_has_struct_if_laddrconf=no])])
 AC_MSG_RESULT($krb5_cv_has_struct_if_laddrconf)
 if test $krb5_cv_has_struct_if_laddrconf = yes; then
     AC_DEFINE(HAVE_STRUCT_IF_LADDRCONF,1,[Define if there is a struct if_laddrconf.])
@@ -837,10 +878,12 @@ fi
 
 AC_MSG_CHECKING([for h_errno in netdb.h])
 AC_CACHE_VAL(krb5_cv_header_netdb_h_h_errno,
-[AC_TRY_COMPILE(
-	[#include <netdb.h>],
-	[int x = h_errno;], krb5_cv_header_netdb_h_h_errno=yes,
-	krb5_cv_header_netdb_h_h_errno=no)])
+[AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#include <netdb.h>]],
+    [[int x = h_errno;]])],
+    [krb5_cv_header_netdb_h_h_errno=yes],
+    [krb5_cv_header_netdb_h_h_errno=no])])
 AC_MSG_RESULT($krb5_cv_header_netdb_h_h_errno)
 if test $krb5_cv_header_netdb_h_h_errno = yes; then
     AC_DEFINE([HAVE_NETDB_H_H_ERRNO], 1,
@@ -913,23 +956,25 @@ AC_SUBST(FCTSH)
 # to ANSI/ISO C 1999 specification).  Specifically, positional
 # specifications; not checking for other features like %zx at present.
 AC_MSG_CHECKING(for POSIX printf positional specification support)
-AC_CACHE_VAL(ac_cv_printf_positional,[
-AC_TRY_RUN([
-#include <stdio.h>
-#include <string.h>
-const char expected[] = "200 100";
-int main () {
-    char buf[30];
-    sprintf(buf, "%2\$x %1\$d", 100, 512);
-    if (strcmp(expected, buf)) {
-	fprintf(stderr,"bad result: <%s> wanted: <%s>\n", buf, expected);
-	return 1;
-    }
-    return 0;
-}],
-  ac_cv_printf_positional=yes,
-  ac_cv_printf_positional=no,
-  AC_MSG_ERROR([Cannot test for printf positional argument support when cross compiling]))])
+AC_CACHE_VAL(ac_cv_printf_positional,
+[AC_RUN_IFELSE(
+  [AC_LANG_SOURCE(
+    [[#include <stdio.h>
+      #include <string.h>
+      const char expected[] = "200 100";
+      int main()
+      {
+          char buf[30];
+          sprintf(buf, "%2\$x %1\$d", 100, 512);
+          if (strcmp(expected, buf)) {
+              fprintf(stderr, "bad result: <%s> wanted: <%s>\n",
+                      buf, expected);
+              return 1;
+          }
+          return 0;
+      }]])],
+  [ac_cv_printf_positional=yes], [ac_cv_printf_positional=no],
+  [AC_MSG_ERROR(Cannot test for printf positional argument support when cross compiling)])])
 # Nothing for autoconf.h for now.
 AC_MSG_RESULT($ac_cv_printf_positional)
 
@@ -999,19 +1044,33 @@ AC_SUBST(include_xom)
 # STRUCT_RPCENT_IN_RPC_NETDB_H anyway.
 
 AC_MSG_CHECKING([where struct rpcent is declared])
-AC_TRY_COMPILE([#include <netdb.h>],
-[struct rpcent e;
-char c = e.r_name[0];
-int i = e.r_number;],
-[AC_TRY_COMPILE([#include <rpc/netdb.h>],
-[struct rpcent e;
-char c = e.r_name[0];
-int i = e.r_number;],
-[AC_MSG_RESULT([rpc/netdb.h])
-rpcent_define='#define STRUCT_RPCENT_IN_RPC_NETDB_H'],
-[AC_MSG_RESULT([netdb.h])])],
-[AC_MSG_RESULT([nowhere])
-rpcent_define='#define STRUCT_RPCENT_IN_RPC_NETDB_H'])
+AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#include <netdb.h>
+    ]],
+    [[struct rpcent e;
+      char c = e.r_name[0];
+      int i = e.r_number;]])],
+    [netdb_rpcent=yes], [netdb_rpcent=no])
+if test "$netdb_rpcent" = yes; then
+  AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM(
+      [[#include <rpc/netdb.h>
+      ]],
+      [[struct rpcent e;
+        char c = e.r_name[0];
+        int i = e.r_number;]])],
+    [rpc_netdb_rpcent=yes], [rpc_netdb_rpcent=no])
+  if test "$rpc_netdb_rpcent" = yes; then
+    AC_MSG_RESULT([rpc/netdb.h])
+    rpcent_define='#define STRUCT_RPCENT_IN_RPC_NETDB_H'
+  else
+    AC_MSG_RESULT([netdb.h])
+  fi
+else
+  AC_MSG_RESULT([nowhere])
+  rpcent_define='#define STRUCT_RPCENT_IN_RPC_NETDB_H'
+fi
 AC_SUBST(rpcent_define)
 
 AC_CHECK_HEADERS(sys/select.h sys/time.h unistd.h)
@@ -1035,15 +1094,21 @@ fi
 AC_SUBST(GSSRPC__UNISTD_H)
 
 AC_CACHE_CHECK([for MAXHOSTNAMELEN in sys/param.h],
-  [krb5_cv_header_sys_param_h_maxhostnamelen],
-  [AC_TRY_COMPILE([#include <sys/param.h>],
-    [int i = MAXHOSTNAMELEN;],
+[krb5_cv_header_sys_param_h_maxhostnamelen],
+[AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#include <sys/param.h>
+    ]],
+    [[int i = MAXHOSTNAMELEN;]])],
     [krb5_cv_header_sys_param_h_maxhostnamelen=yes],
     [krb5_cv_header_sys_param_h_maxhostnamelen=no])])
 AC_CACHE_CHECK([for MAXHOSTNAMELEN in netdb.h],
-  [krb5_cv_header_netdb_h_maxhostnamelen],
-  [AC_TRY_COMPILE([#include <netdb.h>],
-    [int i = MAXHOSTNAMELEN;],
+[krb5_cv_header_netdb_h_maxhostnamelen],
+[AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#include <netdb.h>
+    ]],
+    [[int i = MAXHOSTNAMELEN;]])],
     [krb5_cv_header_netdb_h_maxhostnamelen=yes],
     [krb5_cv_header_netdb_h_maxhostnamelen=no])])
 
@@ -1062,14 +1127,17 @@ AC_SUBST(GSSRPC__SYS_PARAM_H)
 AC_SUBST(GSSRPC__NETDB_H)
 
 AC_CACHE_CHECK([for BSD type aliases], [krb5_cv_type_bsdaliases],
-  [AC_TRY_COMPILE(
-    [#include <sys/types.h>
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif],
-    [u_char c;
-u_int i;
-u_long l;], [krb5_cv_type_bsdaliases=yes], [krb5_cv_type_bsdaliases=no])])
+[AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[#include <sys/types.h>
+      #if HAVE_UNISTD_H
+      #include <unistd.h>
+      #endif
+    ]],
+    [[u_char c;
+      u_int i;
+      u_long l;]])],
+  [krb5_cv_type_bsdaliases=yes], [krb5_cv_type_bsdaliases=no])])
 if test $krb5_cv_type_bsdaliases = yes; then
   GSSRPC__BSD_TYPEALIASES='/* #undef GSSRPC__BSD_TYPEALIASES */'
 else
@@ -1079,23 +1147,21 @@ AC_SUBST(GSSRPC__BSD_TYPEALIASES)
 
 AC_MSG_CHECKING([return type of setrpcent])
 AC_CACHE_VAL(k5_cv_type_setrpcent,
-[AC_TRY_COMPILE([#include <netdb.h>
-#ifdef __cplusplus
-extern "C"
-#endif
-extern void setrpcent();],
-[int i;], k5_cv_type_setrpcent=void, k5_cv_type_setrpcent=int)])
+[AC_COMPILE_IFELSE(
+  [AC_LANG_SOURCE(
+    [[#include <netdb.h>
+      extern void setrpcent();]])],
+  [k5_cv_type_setrpcent=void], [k5_cv_type_setrpcent=int])])
 AC_MSG_RESULT($k5_cv_type_setrpcent)
 AC_DEFINE_UNQUOTED(SETRPCENT_TYPE, $k5_cv_type_setrpcent, [Define as return type of setrpcent])
 
 AC_MSG_CHECKING([return type of endrpcent])
 AC_CACHE_VAL(k5_cv_type_endrpcent,
-[AC_TRY_COMPILE([#include <netdb.h>
-#ifdef __cplusplus
-extern "C"
-#endif
-extern void endrpcent();],
-[int i;], k5_cv_type_endrpcent=void, k5_cv_type_endrpcent=int)])
+[AC_COMPILE_IFELSE(
+  [AC_LANG_SOURCE(
+    [[#include <netdb.h>
+      extern void endrpcent();]])],
+  [k5_cv_type_endrpcent=void], [k5_cv_type_endrpcent=int])])
 AC_MSG_RESULT($k5_cv_type_endrpcent)
 AC_DEFINE_UNQUOTED(ENDRPCENT_TYPE, $k5_cv_type_endrpcent, [Define as return type of endrpcent])
 K5_GEN_FILE(include/gssrpc/types.h:include/gssrpc/types.hin)
@@ -1200,14 +1266,9 @@ AC_SUBST(DB_EXTRA_LIBS)
 
 
 
-# Check for thread safety issues.
-# (Is there a better place for this?)
-# tsfuncs="getpwnam_r getpwuid_r gethostbyname_r getservbyname_r gmtime_r localtime_r"
-# Removed getpwnam_r and getpwuid_r because include/configure.in has some
-# more careful checks, and may decide to pretend that they're not found if
-# the function signatures can't be figured out.
-tsfuncs="gethostbyname_r getservbyname_r gmtime_r localtime_r"
-AC_CHECK_FUNCS($tsfuncs)
+# Warn about possible thread safety issues.  These functions have all
+# been checked for previously.
+tsfuncs="getpwnam_r getpwuid_r gethostbyname_r getservbyname_r gmtime_r localtime_r"
 if test "$enable_thread_support" = yes; then
   tsmissing=""
   for ts in $tsfuncs; do
@@ -1264,7 +1325,7 @@ if test -n "$OPENLDAP_PLUGIN"; then
     if test "$BER_OKAY" = "1"; then
       LDAP_LIBS='-lldap -llber'
     else
-      AC_ERROR("BER library missing - cannot build LDAP database module")
+      AC_MSG_ERROR("BER library missing - cannot build LDAP database module")
     fi
   fi
   AC_DEFINE([ENABLE_LDAP], 1, [Define if LDAP KDB support within the Kerberos library (mainly ASN.1 code) should be enabled.])
@@ -1301,9 +1362,9 @@ CFLAGS=$old_CFLAGS
 lmdb_plugin_dir=""
 HAVE_LMDB=no
 AC_ARG_WITH([lmdb],
-AC_HELP_STRING([--with-lmdb],
-	    [compile LMDB database backend module @<:@auto@:>@]),,
-	    [withval=auto])
+  [AS_HELP_STRING([--with-lmdb],
+    [compile LMDB database backend module @<:@auto@:>@])],
+  [], [withval=auto])
 if test "$withval" = auto -o "$withval" = yes; then
   AC_CHECK_LIB([lmdb],[mdb_env_create],[have_lmdb=true],[have_lmdb=false])
   if test "$have_lmdb" = true; then
@@ -1329,11 +1390,11 @@ fi
 # with readline only if asked, to avoid a default GPL dependency.
 # Building with readline also breaks the dejagnu test suite.
 AC_ARG_WITH([libedit],
-	    AC_HELP_STRING([--without-libedit], [do not compile with libedit]),
-	    [], [with_libedit=default])
+  [AS_HELP_STRING([--without-libedit], [do not compile with libedit])],
+  [], [with_libedit=default])
 AC_ARG_WITH([readline],
-	    AC_HELP_STRING([--with-readline], [compile with GNU Readline]),
-	    [], [with_readline=no])
+  [AS_HELP_STRING([--with-readline], [compile with GNU Readline])],
+  [], [with_readline=no])
 if test "x$with_readline" = xyes; then
   with_libedit=no
 fi
@@ -1365,7 +1426,7 @@ AC_SUBST([RL_CFLAGS])
 AC_SUBST([RL_LIBS])
 
 AC_ARG_WITH([system-verto],
-  [AC_HELP_STRING([--with-system-verto], [always use system verto library])],
+  [AS_HELP_STRING([--with-system-verto], [always use system verto library])],
   [], [with_system_verto=default])
 VERTO_VERSION=k5
 if test "x$with_system_verto" != xno; then
@@ -1410,9 +1471,9 @@ AC_ARG_VAR(DEFCCNAME, [Default ccache name])
 AC_ARG_VAR(DEFKTNAME, [Default keytab name])
 AC_ARG_VAR(DEFCKTNAME, [Default client keytab name])
 AC_ARG_WITH([krb5-config],
-	AC_HELP_STRING([--with-krb5-config=PATH],
-		[path to existing krb5-config program for defaults]), ,
-        [with_krb5_config=krb5-config])
+  [AS_HELP_STRING([--with-krb5-config=PATH],
+    [path to existing krb5-config program for defaults])],
+  [], [with_krb5_config=krb5-config])
 if test "x$with_krb5_config" != xno; then
 	if test "x$with_krb5_config" = xyes; then
 		with_krb5_config=krb5-config

--- a/src/include/k5-gmt_mktime.h
+++ b/src/include/k5-gmt_mktime.h
@@ -38,16 +38,6 @@
 #ifndef K5_GMT_MKTIME_H
 #define K5_GMT_MKTIME_H
 
-#include "autoconf.h"
-#ifdef HAVE_SYS_TIME_H
-#include <sys/time.h>
-#ifdef TIME_WITH_SYS_TIME
-#include <time.h>
-#endif
-#else
-#include <time.h>
-#endif
-
 time_t krb5int_gmt_mktime (struct tm *);
 
 #endif /* K5_GMT_MKTIME_H */

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -584,12 +584,8 @@ extern char *strdup (const char *);
 
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
-#ifdef TIME_WITH_SYS_TIME
-#include <time.h>
 #endif
-#else
 #include <time.h>
-#endif
 
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>                   /* struct stat, stat() */

--- a/src/kadmin/cli/getdate.y
+++ b/src/kadmin/cli/getdate.y
@@ -67,16 +67,10 @@ void *alloca ();
 
 #include <sys/types.h>
 
-#ifdef TIME_WITH_SYS_TIME
-#include <sys/time.h>
-#include <time.h>
-#else
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
-#else
+#endif
 #include <time.h>
-#endif
-#endif
 
 #ifdef timezone
 #undef timezone /* needed for sgi */

--- a/src/kadmin/cli/kadmin.h
+++ b/src/kadmin/cli/kadmin.h
@@ -67,16 +67,10 @@ randkey_princ(void *lhandle, krb5_principal princ, krb5_boolean keepold,
 
 #include "autoconf.h"
 
-#ifdef TIME_WITH_SYS_TIME
-#include <sys/time.h>
-#include <time.h>
-#else
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
-#else
+#endif
 #include <time.h>
-#endif
-#endif
 
 extern time_t get_date_rel(char *, time_t);
 

--- a/src/kdc/main.c
+++ b/src/kdc/main.c
@@ -436,28 +436,16 @@ whoops:
     return(kret);
 }
 
-static krb5_sigtype
+static void
 on_monitor_signal(int signo)
 {
     signal_received = signo;
-
-#ifdef POSIX_SIGTYPE
-    return;
-#else
-    return(0);
-#endif
 }
 
-static krb5_sigtype
+static void
 on_monitor_sighup(int signo)
 {
     sighup_received = 1;
-
-#ifdef POSIX_SIGTYPE
-    return;
-#else
-    return(0);
-#endif
 }
 
 /*

--- a/src/lib/krb5/os/prompter.c
+++ b/src/lib/krb5/os/prompter.c
@@ -16,12 +16,12 @@
 #ifdef POSIX_SIGNALS
 typedef struct sigaction osiginfo;
 #else
-typedef struct krb5_sigtype (*osiginfo)();
+typedef struct void (*osiginfo)();
 #endif
 
 static void     catch_signals(osiginfo *);
 static void     restore_signals(osiginfo *);
-static krb5_sigtype     intrfunc(int sig);
+static void     intrfunc(int sig);
 
 static krb5_error_code  setup_tty(FILE*, int, struct termios *, osiginfo *);
 static krb5_error_code  restore_tty(FILE*, struct termios *, osiginfo *);
@@ -124,7 +124,7 @@ cleanup:
     return errcode;
 }
 
-static krb5_sigtype
+static void
 intrfunc(int sig)
 {
     got_int = 1;

--- a/src/tests/dejagnu/t_inetd.c
+++ b/src/tests/dejagnu/t_inetd.c
@@ -128,7 +128,7 @@ main(argc, argv)
 
     /* Don't wait for a child signal... Otherwise dejagnu gets confused */
 #ifdef POSIX_SIGNALS
-    csig.sa_handler = (RETSIGTYPE (*)())0;
+    csig.sa_handler = SIG_IGN;
     sigemptyset(&csig.sa_mask);
     csig.sa_flags = 0;
     sigaction(SIGCHLD, &csig, (struct sigaction *)0);

--- a/src/tests/gss-threads/gss-misc.c
+++ b/src/tests/gss-threads/gss-misc.c
@@ -61,11 +61,9 @@
 #include <string.h>
 
 /* need struct timeval */
-#if HAVE_TIME_H && (!HAVE_SYS_TIME_H || TIME_WITH_SYS_TIME)
-# include <time.h>
-#endif
+#include <time.h>
 #if HAVE_SYS_TIME_H
-# include <sys/time.h>
+#include <sys/time.h>
 #endif
 
 #include <gssapi/gssapi_generic.h>

--- a/src/util/ss/list_rqs.c
+++ b/src/util/ss/list_rqs.c
@@ -44,7 +44,7 @@ ss_list_requests(argc, argv, sci_idx, info_ptr)
     sigset_t nmask, omask;
 #else
     int mask;
-    RETSIGTYPE (*func)();
+    void (*func)();
 #endif
 #ifndef WAIT_USES_INT
     union wait waitb;

--- a/src/util/ss/listen.c
+++ b/src/util/ss/listen.c
@@ -54,7 +54,7 @@ static void add_history(const char *line)
 }
 #endif
 
-static RETSIGTYPE listen_int_handler(signo)
+static void listen_int_handler(signo)
     int signo;
 {
     putc('\n', stdout);
@@ -74,8 +74,8 @@ int ss_listen (sci_idx)
     struct sigaction isig, csig, nsig, osig;
     sigset_t nmask, omask;
 #else
-    RETSIGTYPE (*sig_cont)();
-    RETSIGTYPE (*sig_int)(), (*old_sig_cont)();
+    void (*sig_cont)();
+    void (*sig_int)(), (*old_sig_cont)();
     int mask;
 #endif
 
@@ -83,12 +83,12 @@ int ss_listen (sci_idx)
     info->abort = 0;
 
 #ifdef POSIX_SIGNALS
-    csig.sa_handler = (RETSIGTYPE (*)())0;
+    csig.sa_handler = (void (*)())0;
     sigemptyset(&nmask);
     sigaddset(&nmask, SIGINT);
     sigprocmask(SIG_BLOCK, &nmask, &omask);
 #else
-    sig_cont = (RETSIGTYPE (*)())0;
+    sig_cont = (void (*)())0;
     mask = sigblock(sigmask(SIGINT));
 #endif
 
@@ -115,7 +115,7 @@ int ss_listen (sci_idx)
         nsig.sa_handler = listen_int_handler;   /* fgets is not signal-safe */
         osig = csig;
         sigaction(SIGCONT, &nsig, &csig);
-        if ((RETSIGTYPE (*)())csig.sa_handler==(RETSIGTYPE (*)())listen_int_handler)
+        if ((void (*)())csig.sa_handler==(void (*)())listen_int_handler)
             csig = osig;
 #else
         old_sig_cont = sig_cont;

--- a/src/util/support/gmt_mktime.c
+++ b/src/util/support/gmt_mktime.c
@@ -9,12 +9,8 @@
 #endif
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
-#ifdef TIME_WITH_SYS_TIME
-#include <time.h>
 #endif
-#else
 #include <time.h>
-#endif
 
 #include "k5-gmt_mktime.h"
 


### PR DESCRIPTION
In configure.ac and aclocal.m4, eliminate the use of old macros that
will generate warning from the forthcoming autoconf 2.70 release.
Specifically:

* Use AS_HELP_STRING instead of AC_HELP_STRING.

* Use AC_{COMPILE,LINK,RUN}_IFELSE and AC_LANG_{SOURCE,PROGRAM}
instead of AC_TRY_COMPILE and similar.

* Use m4_foreach_w instead of ac_foreach.

* Eliminate AC_PROG_LEX and yylineno checking, as we no longer use
  lex.

* As recommended by autoconf, assume that signal handlers return void
  as specified in C89.

* As recommmended by autoconf, assume <time.h> is present and that
  <sys/time.h>, if present, can be included alongside it.

* Don't call AC_CHECK_FUNCS with a shell variable for the thread
  safety checks.  Instead just assume (as is currently the case) that
  all of the functions have been previously checked.