### PR TITLE
Mark shared libraries executable during installation

### DIFF
--- a/src/config/shlib.conf
+++ b/src/config/shlib.conf
@@ -22,8 +22,10 @@ SHLIBVEXT=.so.v-nobuild
 SHLIBSEXT=.so.s-nobuild
 # Most systems support profiled libraries.
 PFLIBEXT=_p.a
-# Most systems install shared libs as mode 644, etc. while hpux wants 755
-INSTALL_SHLIB='$(INSTALL_DATA)'
+# Install libraries executable.  Some systems (e.g., RPM-based ones) require
+# this for package dependency generation, while others are ambivalent or will
+# strip it during packaging.
+INSTALL_SHLIB='$(INSTALL)'
 # Most systems use the same objects for shared libraries and dynamically
 # loadable objects.
 DYNOBJEXT='$(SHLIBEXT)'
@@ -118,7 +120,6 @@ alpha*-dec-osf*)
 # -O +dpv should display any routines eliminated as unused, but -b
 #	  apparently turns that off
 *-*-hpux*)
-	INSTALL_SHLIB='$(INSTALL)'
 	case $host_cpu in
 	hppa*)
 		SHLIBEXT=.sl


### PR DESCRIPTION
Based on a patch by Nalin Dahyabhai.

[The full patch also hardcodes PIE support and a couple other things, which I think should no longer be necessary as the distro will pass it in build flags.  Full patch for completeness: [https://github.com/frozencemetery/krb5/commit/c06693e5a17daf0fd585e608e8bfd1eb3eef447c](https://github.com/frozencemetery/krb5/commit/c06693e5a17daf0fd585e608e8bfd1eb3eef447c) ]