### PR TITLE
ccselect: should not return cc_get_principal errors

### DIFF
--- a/src/lib/krb5/ccache/cc_kcm.c
+++ b/src/lib/krb5/ccache/cc_kcm.c
@@ -981,8 +981,10 @@ kcm_ptcursor_next(krb5_context context, krb5_cc_ptcursor cursor,
         k5_buf_add_len(&req.reqbuf, id, KCM_UUID_LEN);
         ret = kcmio_call(context, data->io, &req);
         /* Continue if the cache has been deleted. */
-        if (ret == KRB5_CC_END)
+        if (ret == KRB5_CC_END || ret == KRB5_FCC_NOFILE) {
+            ret = 0;
             continue;
+        }
         if (ret)
             goto cleanup;
         ret = kcmreq_get_name(&req, &name);


### PR DESCRIPTION
Before this commit, `ccselect_realm` would return the last error encountered by `krb5_cc_get_principal` ("No credential cache found", typically).
Moreover, krb5_cccol_cursor_free ret code is ignored.

With this commit, only the krb5_cccol_cursor_free return code is taken into account here.