### PR TITLE
gss_add_cred_from() does not check for duplicates, when caller passes…

### DIFF
--- a/src/lib/gssapi/mechglue/g_acquire_cred.c
+++ b/src/lib/gssapi/mechglue/g_acquire_cred.c
@@ -480,7 +480,13 @@ gss_add_cred_from(minor_status, input_cred_handle,
     else if (!mech->gss_acquire_cred)
 	return (GSS_S_UNAVAILABLE);
 
-    if (input_cred_handle == GSS_C_NO_CREDENTIAL) {
+    union_cred = (gss_union_cred_t)input_cred_handle;
+    if (union_cred != NULL &&
+	gssint_get_mechanism_cred(union_cred,
+				  selected_mech) != GSS_C_NO_CREDENTIAL)
+	return (GSS_S_DUPLICATE_ELEMENT);
+
+    if (union_cred == NULL) {
 	/* Create a new credential handle. */
 	union_cred = malloc(sizeof (gss_union_cred_desc));
 	if (union_cred == NULL)
@@ -488,13 +494,7 @@ gss_add_cred_from(minor_status, input_cred_handle,
 
 	(void) memset(union_cred, 0, sizeof (gss_union_cred_desc));
 	union_cred->loopback = union_cred;
-    } else if (output_cred_handle == NULL) {
-	/* Add to the existing handle. */
-	union_cred = (gss_union_cred_t)input_cred_handle;
-	if (gssint_get_mechanism_cred(union_cred, selected_mech) !=
-	    GSS_C_NO_CREDENTIAL)
-	    return (GSS_S_DUPLICATE_ELEMENT);
-    } else {
+    } else if (output_cred_handle != NULL) {
 	/* Create a new credential handle with the mechanism credentials of the
 	 * input handle plus the acquired mechanism credential. */
 	status = copy_union_cred(minor_status, input_cred_handle, &union_cred);


### PR DESCRIPTION
… output handle

the glitch is reported by unit-test we use on Solaris. The code reads as follows
```
        for (i = 0; i < NUM_MECHS_TO_TEST; i++) {
                major_status = gss_add_cred(&minor_status, GSS_C_NO_CREDENTIAL,
                        good_name1, mechs[i].oid, cred_usage,
                        GSS_C_INDEFINITE, GSS_C_INDEFINITE, &new_cred_handle,
                        NULL, NULL, NULL);
                if (major_status != GSS_S_COMPLETE) {
                        print_status_mech(major_status, minor_status,
                                mechs[i].oid, "gss_add_cred(1)");
                        exit(FAIL);
                }
        }

        /*
         * To test whether credentials are really added
         * Note that after the loop above, what new_cred_handle points to
         * a union credential contains only credential for the last mech
         */
        i = NUM_MECHS_TO_TEST - 1;
        major_status = gss_add_cred(&minor_status, new_cred_handle,
                good_name1, mechs[i].oid, cred_usage, GSS_C_INDEFINITE,
                GSS_C_INDEFINITE, &new_cred_handle2, NULL, NULL, NULL);
        if (major_status != GSS_S_DUPLICATE_ELEMENT) {
                print_status_mech(major_status, minor_status,
                        mechs[i].oid, "gss_add_cred(2)");
                exit(FAIL);
        }
```

the snippet above attempts to add mechanism, which is present already.
the &new_cred_handle2 is a local variable. Test expects GSS_S_DUPLICATE_ELEMENT,
while code actually succeeds.

The proposed change makes our Solaris test happy.  Also all tests
which come with MIT kerberos do pass with the proposed fix. The
tests were performed on 1.18.3