### PR TITLE
spnego_gss_acquire_cred_from() may attempt to free uninitialized pointer

### DIFF
--- a/src/lib/gssapi/spnego/spnego_mech.c
+++ b/src/lib/gssapi/spnego/spnego_mech.c
@@ -375,7 +375,7 @@ spnego_gss_acquire_cred_from(OM_uint32 *minor_status,
 			     OM_uint32 *time_rec)
 {
 	OM_uint32 status, tmpmin;
-	gss_OID_set amechs;
+	gss_OID_set amechs = GSS_C_NULL_OID_SET;
 	gss_cred_id_t mcred = NULL;
 	spnego_gss_cred_id_t spcred = NULL;
 	dsyslog("Entering spnego_gss_acquire_cred\n");


### PR DESCRIPTION
gss_release_iod_set() may attempt to release uninitialized pointer (`amechs`)
if earlier call to `get_available_mechs()` called earlier fails to find
a mechanism.

Initializing local variable `amechs` to `GSS_C_NULL_OID_SET` puts
sufficient mesure in.