### PR TITLE
Document -k option in kvno(1) synopsis

### DIFF
--- a/doc/user/user_commands/kvno.rst
+++ b/doc/user/user_commands/kvno.rst
@@ -9,9 +9,13 @@ SYNOPSIS
 **kvno**
 [**-c** *ccache*]
 [**-e** *etype*]
+[**-k** *keytab*]
 [**-q**]
 [**-u** | **-S** *sname*]
 [**-P**]
+[**--cached-only**]
+[**--no-store**]
+[**--out-cache** *cache*]
 [[{**-F** *cert_file* | {**-I** | **-U**} *for_user*} [**-P**]] | **--u2u** *ccache*]
 *service1 service2* ...
 

--- a/src/man/kvno.man
+++ b/src/man/kvno.man
@@ -35,9 +35,13 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 \fBkvno\fP
 [\fB\-c\fP \fIccache\fP]
 [\fB\-e\fP \fIetype\fP]
+[\fB\-k\fP \fIkeytab\fP]
 [\fB\-q\fP]
 [\fB\-u\fP | \fB\-S\fP \fIsname\fP]
 [\fB\-P\fP]
+[\fB\-\-cached\-only\fP]
+[\fB\-\-no\-store\fP]
+[\fB\-\-out\-cache\fP \fIcache\fP]
 [[{\fB\-F\fP \fIcert_file\fP | {\fB\-I\fP | \fB\-U\fP} \fIfor_user\fP} [\fB\-P\fP]] | \fB\-\-u2u\fP \fIccache\fP]
 \fIservice1 service2\fP ...
 .SH DESCRIPTION


### PR DESCRIPTION
becd1ad6830b526d08ddaf5b2b6f213154c6446c attempted to unify the
synopsis, option descriptions, and xusage(), but missed one option.