### PR TITLE
Improve anonymous cache behavior by adding start_realm support

### DIFF
--- a/doc/formats/ccache_file_format.rst
+++ b/doc/formats/ccache_file_format.rst
@@ -174,3 +174,9 @@ refresh_time
     decimal representation of a timestamp at which the GSS mechanism
     should attempt to refresh the credential cache from the client
     keytab.
+
+start_realm
+    This key indicates the realm of the ticket-granting ticket to be
+    used for TGS requests, when making a referrals request or
+    beginning a cross-realm request.  If it is not present, the client
+    realm is used.

--- a/src/clients/kinit/kinit.c
+++ b/src/clients/kinit/kinit.c
@@ -828,7 +828,7 @@ k5_kinit(struct k_opts *opts, struct k5_data *k5)
         if (opts->verbose)
             fprintf(stderr, _("Initialized cache\n"));
 
-        ret = krb5_cc_store_cred(k5->ctx, k5->out_cc, &my_creds);
+        ret = k5_cc_store_primary_cred(k5->ctx, k5->out_cc, &my_creds);
         if (ret) {
             com_err(progname, ret, _("while storing credentials"));
             goto cleanup;

--- a/src/clients/kvno/kvno.c
+++ b/src/clients/kvno/kvno.c
@@ -561,7 +561,10 @@ do_v5_kvno(int count, char *names[], char * ccachestr, char *etypestr,
                 }
                 initialized = 1;
             }
-            ret = krb5_cc_store_cred(context, out_ccache, creds);
+            if (count == 1)
+                ret = k5_cc_store_primary_cred(context, out_ccache, creds);
+            else
+                ret = krb5_cc_store_cred(context, out_ccache, creds);
             if (ret) {
                 com_err(prog, ret, _("while storing creds in output ccache"));
                 exit(1);

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -308,6 +308,7 @@ typedef unsigned char   u_char;
 #define KRB5_CC_CONF_PA_TYPE                   "pa_type"
 #define KRB5_CC_CONF_PROXY_IMPERSONATOR        "proxy_impersonator"
 #define KRB5_CC_CONF_REFRESH_TIME              "refresh_time"
+#define KRB5_CC_CONF_START_REALM               "start_realm"
 
 /* Error codes used in KRB_ERROR protocol messages.
    Return values of library routines are based on a different error table
@@ -1905,6 +1906,9 @@ krb5_ser_unpack_bytes(krb5_octet *, size_t, krb5_octet **, size_t *);
 
 krb5_error_code KRB5_CALLCONV
 krb5int_cc_default(krb5_context, krb5_ccache *);
+
+krb5_error_code
+k5_cc_store_primary_cred(krb5_context, krb5_ccache, krb5_creds *);
 
 /* Fill in the buffer with random alphanumeric data. */
 krb5_error_code

--- a/src/lib/gssapi/krb5/accept_sec_context.c
+++ b/src/lib/gssapi/krb5/accept_sec_context.c
@@ -216,7 +216,7 @@ rd_and_store_for_creds(context, auth_context, inbuf, out_cred)
     if ((retval = krb5_cc_initialize(context, ccache, creds[0]->client)))
         goto cleanup;
 
-    if ((retval = krb5_cc_store_cred(context, ccache, creds[0])))
+    if ((retval = k5_cc_store_primary_cred(context, ccache, creds[0])))
         goto cleanup;
 
     /* generate a delegated credential handle */

--- a/src/lib/krb5/ccache/ccfns.c
+++ b/src/lib/krb5/ccache/ccfns.c
@@ -298,3 +298,23 @@ krb5_cc_switch(krb5_context context, krb5_ccache cache)
         return 0;
     return cache->ops->switch_to(context, cache);
 }
+
+krb5_error_code
+k5_cc_store_primary_cred(krb5_context context, krb5_ccache cache,
+                         krb5_creds *creds)
+{
+    krb5_error_code ret;
+
+    /* Write a start realm if we're writing a TGT and the client realm isn't
+     * the same as the TGS realm. */
+    if (IS_TGS_PRINC(creds->server) &&
+        !data_eq(creds->client->realm, creds->server->data[1])) {
+        ret = krb5_cc_set_config(context, cache, NULL,
+                                 KRB5_CC_CONF_START_REALM,
+                                 &creds->server->data[1]);
+        if (ret)
+            return ret;
+    }
+
+    return krb5_cc_store_cred(context, cache, creds);
+}

--- a/src/lib/krb5/krb/get_in_tkt.c
+++ b/src/lib/krb5/krb/get_in_tkt.c
@@ -1796,7 +1796,7 @@ init_creds_step_reply(krb5_context context,
         code = krb5_cc_initialize(context, out_ccache, ctx->cred.client);
         if (code != 0)
             goto cc_cleanup;
-        code = krb5_cc_store_cred(context, out_ccache, &ctx->cred);
+        code = k5_cc_store_primary_cred(context, out_ccache, &ctx->cred);
         if (code != 0)
             goto cc_cleanup;
         if (fast_avail) {

--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -125,6 +125,7 @@ k5_add_pa_data_from_data
 k5_alloc_pa_data
 k5_authind_decode
 k5_build_conf_principals
+k5_cc_store_primary_cred
 k5_ccselect_free_context
 k5_change_error_message_code
 k5_etypes_contains

--- a/src/lib/krb5_32.def
+++ b/src/lib/krb5_32.def
@@ -499,3 +499,6 @@ EXPORTS
 	k5_size_context					@467 ; PRIVATE GSSAPI
 	k5_size_keyblock				@468 ; PRIVATE GSSAPI
 	k5_size_principal				@469 ; PRIVATE GSSAPI
+
+; new in 1.19
+	k5_cc_store_primary_cred			@470 ; PRIVATE

--- a/src/tests/t_crossrealm.py
+++ b/src/tests/t_crossrealm.py
@@ -77,6 +77,14 @@ r1, r2, r3 = cross_realms(3, xtgts=((0,1), (1,2)),
                                 {'realm': 'B.X'}))
 test_kvno(r1, r3.host_princ, 'KDC domain walk')
 check_klist(r1, (tgt(r1, r1), r3.host_princ))
+
+# Test start_realm in this setup.
+r1.run([kvno, '--out-cache', r1.ccache, r2.krbtgt_princ])
+r1.run([klist, '-C'], expected_msg='config: start_realm = X')
+msgs = ('Requesting TGT krbtgt/B.X@X using TGT krbtgt/X@X',
+        'Received TGT for service realm: krbtgt/B.X@X')
+r1.run([kvno, r3.host_princ], expected_trace=msgs)
+
 stop(r1, r2, r3)
 
 # Test client capaths.  The client in A will ask for a cross TGT to D,

--- a/src/tests/t_pkinit.py
+++ b/src/tests/t_pkinit.py
@@ -130,6 +130,9 @@ realm.run([kvno, realm.host_princ])
 out = realm.run(['./adata', realm.host_princ])
 if '97:' in out:
     fail('auth indicators seen in anonymous PKINIT ticket')
+# Verify start_realm setting and test referrals TGS request.
+realm.run([klist, '-C'], expected_msg='start_realm = KRBTEST.COM')
+realm.run([kvno, '-S', 'host', hostname])
 
 # Test anonymous kadmin.
 mark('anonymous kadmin')


### PR DESCRIPTION
Currently anonymous caches don't work for referrals or cross-realm TGS requests; they only work as FAST armor or for services in the local realm (and marked as such in the server field).

This PR implements one possible solution, which is to add support for Heimdal's start_realm feature.  Heimdal sets start_realm automatically in the cache dispatch layer, which I do not like; I feel like logic implemented at the ccache dispatch layer generally comes back to bite us later.  Right now the PR is setting it for initial creds acquisition when an output cache is specified, as is done for both kinit -n and kadmin -n.  That's elegant but not totally satisfying; it won't work for "kvno --out-cache=... krbtgt/REALM@REALM" and it won't work if you delegate a different-realm TGT over ssh (as twosigma does).

In general I'm not fond of start_realm because it seems incomplete.  Heimdal more recently implemented a second "anon_pkinit_realm" key within kinit to allow renewal of anonymous caches.  I pointed out that this seemed redundant with start_realm, and Jeff noted that the issuing realm of the TGT isn't necessarily the same as the service realm, as you could have a cache whose primary cred is a cross-TGT.  (Heimdal's ccache dispatch layer only sets start_realm for a local TGT, so it doesn't really support that scenario.  Its get_cred.c implementation of start_realm should work for a cross TGT as it ignores the issuing realm when fetching the initial TGT.  We currently do not, and I'm not sure if we should.)

What I'd really like is for the ccache model to include the concept of a primary cred.  There would be a number of benefits: the caller wouldn't need to identify any particular service principal to renew a cache; a starting cross-TGT would work without needing to ignore the issuing realm; we might not need to scan the ccache in the GSS krb5 mech to determine the cache expiration time.  But that's a big can of worms; every ccache type would need a way to identify the primary cred, and third-party code that interacts with caches might not behave properly without heuristics.