### PR TITLE
Fix ASN.1 test memory leak

### DIFF
--- a/src/tests/asn.1/krb5_decode_test.c
+++ b/src/tests/asn.1/krb5_decode_test.c
@@ -104,6 +104,7 @@ int main(argc, argv)
     }                                                                   \
     test(1,typestring);                                                 \
     printf("%s\n",description);                                         \
+    krb5_free_data_contents(test_context, &code);                       \
 } while (0)
 
     /****************************************************************/


### PR DESCRIPTION
Commit d9443a58cd364349b7d764f4e997f3af7d979a87 introduced a leak in
krb5_decode_test.c with its new decode_fail macro.