### PR TITLE
Revert dns_canonicalize_hostname default to true

### DIFF
--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -191,7 +191,7 @@ The libdefaults section may contain any of the following relations:
     fully-qualified hostnames.  If this option is set to ``fallback`` (new
     in release 1.18), DNS canonicalization will only be performed the
     server hostname is not found with the original name when
-    requesting credentials.  The default value is ``fallback``.
+    requesting credentials.  The default value is true.
 
 **dns_lookup_kdc**
     Indicate whether DNS SRV records should be used to locate the KDCs

--- a/doc/admin/princ_dns.rst
+++ b/doc/admin/princ_dns.rst
@@ -35,14 +35,14 @@ In the MIT krb5 client library, canonicalization of host-based service
 principals is controlled by the **dns_canonicalize_hostname**,
 **rnds**, and **qualify_shortname** variables in :ref:`libdefaults`.
 
-If **dns_canonicalize_hostname** is set to ``true`` (the default value
-before release 1.19), the client performs forward resolution by
-looking up the IPv4 and/or IPv6 addresses of the hostname using
-``getaddrinfo()``.  This process will typically add a domain suffix to
-the hostname if needed, and follow CNAME records in the DNS.  If
-**rdns** is also set to ``true`` (the default), the client will then
-perform a reverse lookup of the first returned Internet address using
-``getnameinfo()``, finding the name associated with the PTR record.
+If **dns_canonicalize_hostname** is set to ``true`` (the default
+value), the client performs forward resolution by looking up the IPv4
+and/or IPv6 addresses of the hostname using ``getaddrinfo()``.  This
+process will typically add a domain suffix to the hostname if needed,
+and follow CNAME records in the DNS.  If **rdns** is also set to
+``true`` (the default), the client will then perform a reverse lookup
+of the first returned Internet address using ``getnameinfo()``,
+finding the name associated with the PTR record.
 
 If **dns_canonicalize_hostname** is set to ``false``, the hostname is
 not canonicalized using DNS.  If the hostname has only one component
@@ -50,11 +50,11 @@ not canonicalized using DNS.  If the hostname has only one component
 domain will be appended, if there is one.  The **qualify_shortname**
 variable can be used to override or disable this suffix.
 
-If **dns_canonicalize_hostname** is set to ``fallback`` (the default
-value in release 1.19 and later), the hostname is initially treated
-according to the rules for ``dns_canonicalize_hostname=false``.  If a
-ticket request fails because the service principal is unknown, it the
-hostname will be canonicalized according to the rules for
+If **dns_canonicalize_hostname** is set to ``fallback`` (added in
+release 1.18), the hostname is initially treated according to the
+rules for ``dns_canonicalize_hostname=false``.  If a ticket request
+fails because the service principal is unknown, the hostname will be
+canonicalized according to the rules for
 ``dns_canonicalize_hostname=true`` and the request will be retried.
 
 In all cases, the hostname is converted to lowercase, and any trailing

--- a/src/kadmin/testing/proto/krb5.conf.proto
+++ b/src/kadmin/testing/proto/krb5.conf.proto
@@ -2,6 +2,7 @@
 	default_realm = __REALM__
 	default_keytab_name = FILE:__K5ROOT__/keytab
 	dns_fallback = no
+	dns_canonicalize_hostname = fallback
 	qualify_shortname = ""
 	plugin_base_dir = __PLUGIN_DIR__
 	allow_weak_crypto = true

--- a/src/lib/krb5/krb/init_ctx.c
+++ b/src/lib/krb5/krb/init_ctx.c
@@ -238,7 +238,7 @@ krb5_init_context_profile(profile_t profile, krb5_flags flags,
     ctx->enforce_ok_as_delegate = tmp;
 
     retval = get_tristate(ctx, KRB5_CONF_DNS_CANONICALIZE_HOSTNAME, "fallback",
-                          CANONHOST_FALLBACK, CANONHOST_FALLBACK, &tmp);
+                          CANONHOST_FALLBACK, 1, &tmp);
     if (retval)
         goto cleanup;
     ctx->dns_canonicalize_hostname = tmp;

--- a/src/tests/dejagnu/config/default.exp
+++ b/src/tests/dejagnu/config/default.exp
@@ -743,6 +743,7 @@ proc setup_krb5_conf { {type client} } {
 	puts $conffile "\[libdefaults\]"
 	puts $conffile "	default_realm = $REALMNAME"
 	puts $conffile "	dns_lookup_kdc = false"
+	puts $conffile "        dns_canonicalize_hostname = fallback"
 	puts $conffile "	qualify_shortname = \"\""
 	if [info exists allow_weak_crypto($type)] {
 	    puts $conffile "	allow_weak_crypto = $allow_weak_crypto($type)"

--- a/src/util/k5test.py
+++ b/src/util/k5test.py
@@ -1240,6 +1240,7 @@ _default_krb5_conf = {
     'libdefaults': {
         'default_realm': '$realm',
         'dns_lookup_kdc': 'false',
+        'dns_canonicalize_hostname': 'fallback',
         'qualify_shortname': '',
         'plugin_base_dir': '$plugins'},
     'realms': {'$realm': {


### PR DESCRIPTION
Field testing of dns_canonicalize_hostname=fallback (ticket 8911)
revealed more disruptive edge cases than anticipated.  Many were fixed
by ticket 8930, but host-based GSS initiator names were recently
discovered to not work, and one other edge case could not be resolved
without a change to external code.

Restore the default to true for now.  Set the value to fallback in the
test suite, to continue testing the desired configuration and to avoid
restoring tests/resolve.

ticket: 8973 (new)
tags: pullup
target_version: 1.19