### PR TITLE
Implement fallback for GSS acceptor names

### DIFF
--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -2122,6 +2122,9 @@ krb5_error_code KRB5_CALLCONV krb5_kt_register(krb5_context,
 krb5_error_code k5_kt_get_principal(krb5_context context, krb5_keytab keytab,
                                     krb5_principal *princ_out);
 
+krb5_error_code k5_kt_have_match(krb5_context context, krb5_keytab keytab,
+                                 krb5_principal mprinc);
+
 krb5_error_code krb5_principal2salt_norealm(krb5_context, krb5_const_principal,
                                             krb5_data *);
 

--- a/src/lib/krb5/krb/int-proto.h
+++ b/src/lib/krb5/krb/int-proto.h
@@ -386,4 +386,9 @@ k5_get_proxy_cred_from_kdc(krb5_context context, krb5_flags options,
                            krb5_ccache ccache, krb5_creds *in_creds,
                            krb5_creds **out_creds);
 
+/* Return true if mprinc will match any hostname in a host-based principal name
+ * (possibly due to ignore_acceptor_hostname) with krb5_sname_match(). */
+krb5_boolean
+k5_sname_wildcard_host(krb5_context context, krb5_const_principal mprinc);
+
 #endif /* KRB5_INT_FUNC_PROTO__ */

--- a/src/lib/krb5/krb/rd_req_dec.c
+++ b/src/lib/krb5/krb/rd_req_dec.c
@@ -451,10 +451,8 @@ decrypt_ticket(krb5_context context, const krb5_ap_req *req,
     struct canonprinc iter = { server, .no_hostrealm = TRUE };
     krb5_const_principal canonprinc;
 
-    /* Don't try to canonicalize if we're going to ignore the hostname, or if
-     * server is null or has a wildcard hostname. */
-    if (context->ignore_acceptor_hostname || server == NULL ||
-        (server->length == 2 && server->data[1].length == 0))
+    /* Don't try to canonicalize if we're going to ignore hostnames. */
+    if (k5_sname_wildcard_host(context, server))
         return decrypt_try_server(context, req, server, keytab, keyblock_out);
 
     /* Try each canonicalization candidate for server.  If they all fail,

--- a/src/lib/krb5/krb/sname_match.c
+++ b/src/lib/krb5/krb/sname_match.c
@@ -25,6 +25,7 @@
  */
 
 #include "k5-int.h"
+#include "int-proto.h"
 
 krb5_boolean KRB5_CALLCONV
 krb5_sname_match(krb5_context context, krb5_const_principal matching,
@@ -54,4 +55,16 @@ krb5_sname_match(krb5_context context, krb5_const_principal matching,
 
     /* All elements match. */
     return TRUE;
+}
+
+krb5_boolean
+k5_sname_wildcard_host(krb5_context context, krb5_const_principal mprinc)
+{
+    if (mprinc == NULL)
+        return TRUE;
+
+    if (mprinc->type != KRB5_NT_SRV_HST || mprinc->length != 2)
+        return FALSE;
+
+    return context->ignore_acceptor_hostname || mprinc->data[1].length == 0;
 }

--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -159,6 +159,7 @@ k5_internalize_keyblock
 k5_internalize_principal
 k5_is_string_numeric
 k5_kt_get_principal
+k5_kt_have_match
 k5_localauth_free_context
 k5_locate_kdc
 k5_marshal_cred

--- a/src/lib/krb5_32.def
+++ b/src/lib/krb5_32.def
@@ -502,3 +502,4 @@ EXPORTS
 
 ; new in 1.19
 	k5_cc_store_primary_cred			@470 ; PRIVATE
+	k5_kt_have_match				@471 ; PRIVATE GSSAPI


### PR DESCRIPTION
Commit 3fcc365a6f049730b3f47168f7112c03997c5c0b added fallback support
to krb5_rd_req(), but acquiring acceptor creds for a host-based name
could still fail within check_keytab() in the krb5 mech.

Add an internal libkrb5 API k5_kt_have_match() to check for a matching
keytab entry with canonicalization, and use it in check_keytab().  Add
a library-internal function k5_sname_wildcard_host() to share logic
between rd_req and k5_kt_have_match().

ticket: 8971 (new)