### PR TITLE
Allow kprop over more types of NATs

### DIFF
--- a/src/kprop/kprop.c
+++ b/src/kprop/kprop.c
@@ -60,7 +60,6 @@ static krb5_principal my_principal;
 
 static krb5_creds creds;
 static krb5_address *sender_addr;
-static krb5_address *receiver_addr;
 static const char *port = KPROP_SERVICE;
 static char *dbpathname;
 
@@ -251,12 +250,6 @@ open_connection(krb5_context context, char *host, int *fd_out)
 
         /* We successfully connect()ed */
         *fd_out = s;
-        retval = sockaddr2krbaddr(context, res->ai_family, res->ai_addr,
-                                  &receiver_addr);
-        if (retval != 0) {
-            com_err(progname, retval, _("while converting server address"));
-            exit(1);
-        }
 
         break;
     }
@@ -296,8 +289,7 @@ kerberos_authenticate(krb5_context context, krb5_auth_context *auth_context,
     krb5_auth_con_setflags(context, *auth_context,
                            KRB5_AUTH_CONTEXT_DO_SEQUENCE);
 
-    retval = krb5_auth_con_setaddrs(context, *auth_context, sender_addr,
-                                    receiver_addr);
+    retval = krb5_auth_con_setaddrs(context, *auth_context, sender_addr, NULL);
     if (retval) {
         com_err(progname, retval, _("in krb5_auth_con_setaddrs"));
         exit(1);


### PR DESCRIPTION
Do not send an r-address in messages from kprop, so that kpropd will
not check it against the receiver address.  This change allows kprop
to work when a NAT changes the destination address.  (Commit
775e496aac2650343ec20826b1ba7f6306a12f3c allows kprop to work when a
NAT changes the source address.)  Reported by Jorj Bauer.
