### PR TITLE
Expose krb5 functions for serialization of credentials

### DIFF
--- a/doc/appdev/refs/api/index.rst
+++ b/doc/appdev/refs/api/index.rst
@@ -232,6 +232,7 @@ Rarely used public interfaces
    krb5_kt_remove_entry.rst
    krb5_kt_start_seq_get.rst
    krb5_make_authdata_kdc_issued.rst
+   krb5_marshal_credentials.rst
    krb5_merge_authdata.rst
    krb5_mk_1cred.rst
    krb5_mk_error.rst
@@ -285,6 +286,7 @@ Rarely used public interfaces
    krb5_tkt_creds_get_times.rst
    krb5_tkt_creds_init.rst
    krb5_tkt_creds_step.rst
+   krb5_unmarshal_credentials.rst
    krb5_verify_init_creds.rst
    krb5_verify_init_creds_opt_init.rst
    krb5_verify_init_creds_opt_set_ap_req_nofail.rst

--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -3119,6 +3119,42 @@ krb5_get_credentials(krb5_context context, krb5_flags options,
                      krb5_ccache ccache, krb5_creds *in_creds,
                      krb5_creds **out_creds);
 
+/**
+ * Serialize a @c krb5_creds object.
+ *
+ * @param [in]  context         Library context
+ * @param [in]  creds           The credentials object to serialize
+ * @param [out] data_out        The serialized credentials
+ *
+ * Serialize @a creds in the format used by the FILE ccache format (vesion 4)
+ * and KCM ccache protocol.
+ *
+ * Use krb5_free_data() to free @a data_out when it is no longer needed.
+ *
+ * @retval 0 Success; otherwise - Kerberos error codes
+ */
+krb5_error_code KRB5_CALLCONV
+krb5_marshal_credentials(krb5_context context, krb5_creds *in_creds,
+                         krb5_data **data_out);
+
+/**
+ * Deserialize a @c krb5_creds object.
+ *
+ * @param [in]  context         Library context
+ * @param [in]  data            The serialized credentials
+ * @param [out] creds_out       The resulting creds object
+ *
+ * Deserialize @a data to credentials in the format used by the FILE ccache
+ * format (vesion 4) and KCM ccache protocol.
+ *
+ * Use krb5_free_creds() to free @a creds_out when it is no longer needed.
+ *
+ * @retval 0 Success; otherwise - Kerberos error codes
+ */
+krb5_error_code KRB5_CALLCONV
+krb5_unmarshal_credentials(krb5_context context, const krb5_data *data,
+                           krb5_creds **creds_out);
+
 /** @deprecated Replaced by krb5_get_validated_creds. */
 krb5_error_code KRB5_CALLCONV
 krb5_get_credentials_validate(krb5_context context, krb5_flags options,

--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -490,6 +490,7 @@ krb5_lock_file
 krb5_make_authdata_kdc_issued
 krb5_make_full_ipaddr
 krb5_make_fulladdr
+krb5_marshal_credentials
 krb5_mcc_ops
 krb5_merge_authdata
 krb5_mk_1cred
@@ -592,6 +593,7 @@ krb5_timeofday
 krb5_timestamp_to_sfstring
 krb5_timestamp_to_string
 krb5_unlock_file
+krb5_unmarshal_credentials
 krb5_unpack_full_ipaddr
 krb5_unparse_name
 krb5_unparse_name_ext

--- a/src/lib/krb5_32.def
+++ b/src/lib/krb5_32.def
@@ -503,3 +503,7 @@ EXPORTS
 ; new in 1.19
 	k5_cc_store_primary_cred			@470 ; PRIVATE
 	k5_kt_have_match				@471 ; PRIVATE GSSAPI
+
+; new in 1.20
+	krb5_marshal_credentials			@472
+	krb5_unmarshal_credentials			@473


### PR DESCRIPTION
In KCM, the responder will receive a serialized krb5_creds object.
Should it wish to perform any operations on this object, it needs to
deserialize and reserialize it.