### PR TITLE
Hostbased initiator name support

### DIFF
--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -2406,4 +2406,13 @@ void k5_change_error_message_code(krb5_context ctx, krb5_error_code oldcode,
 #define k5_prependmsg krb5_prepend_error_message
 #define k5_wrapmsg krb5_wrap_error_message
 
+/*
+ * Like krb5_principal_compare(), but with canonicalization of sname if
+ * fallback is enabled.  This function should be avoided if multiple matches
+ * are required, since repeated canonicalization is inefficient.
+ */
+krb5_boolean
+k5_sname_compare(krb5_context context, krb5_const_principal sname,
+                 krb5_const_principal princ);
+
 #endif /* _KRB5_INT_H */

--- a/src/include/k5-trace.h
+++ b/src/include/k5-trace.h
@@ -105,6 +105,9 @@ void krb5int_trace(krb5_context context, const char *fmt, ...);
 
 #endif /* DISABLE_TRACING */
 
+#define TRACE_CC_CACHE_MATCH(c, princ, ret)                             \
+    TRACE(c, "Matching {princ} in collection with result: {kerr}",      \
+          princ, ret)
 #define TRACE_CC_DESTROY(c, cache)                      \
     TRACE(c, "Destroying ccache {ccache}", cache)
 #define TRACE_CC_GEN_NEW(c, cache)                                      \

--- a/src/lib/gssapi/krb5/accept_sec_context.c
+++ b/src/lib/gssapi/krb5/accept_sec_context.c
@@ -683,7 +683,6 @@ kg_accept_krb5(minor_status, context_handle,
     krb5_flags ap_req_options = 0;
     krb5_enctype negotiated_etype;
     krb5_authdata_context ad_context = NULL;
-    krb5_principal accprinc = NULL;
     krb5_ap_req *request = NULL;
 
     code = krb5int_accessor (&kaccess, KRB5INT_ACCESS_VERSION);
@@ -849,17 +848,9 @@ kg_accept_krb5(minor_status, context_handle,
         }
     }
 
-    if (!cred->default_identity) {
-        if ((code = kg_acceptor_princ(context, cred->name, &accprinc))) {
-            major_status = GSS_S_FAILURE;
-            goto fail;
-        }
-    }
-
-    code = krb5_rd_req_decoded(context, &auth_context, request, accprinc,
-                               cred->keytab, &ap_req_options, NULL);
-
-    krb5_free_principal(context, accprinc);
+    code = krb5_rd_req_decoded(context, &auth_context, request,
+                               cred->acceptor_mprinc, cred->keytab,
+                               &ap_req_options, NULL);
     if (code) {
         major_status = GSS_S_FAILURE;
         goto fail;

--- a/src/lib/gssapi/krb5/gssapiP_krb5.h
+++ b/src/lib/gssapi/krb5/gssapiP_krb5.h
@@ -175,6 +175,7 @@ typedef struct _krb5_gss_cred_id_rec {
     /* name/type of credential */
     gss_cred_usage_t usage;
     krb5_gss_name_t name;
+    krb5_principal acceptor_mprinc;
     krb5_principal impersonator;
     unsigned int default_identity : 1;
     unsigned int iakerb_mech : 1;

--- a/src/lib/gssapi/krb5/rel_cred.c
+++ b/src/lib/gssapi/krb5/rel_cred.c
@@ -72,6 +72,7 @@ krb5_gss_release_cred(minor_status, cred_handle)
     if (cred->name)
         kg_release_name(context, &cred->name);
 
+    krb5_free_principal(context, cred->acceptor_mprinc);
     krb5_free_principal(context, cred->impersonator);
 
     if (cred->req_enctypes)

--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -182,6 +182,7 @@ k5_size_authdata_context
 k5_size_context
 k5_size_keyblock
 k5_size_principal
+k5_sname_compare
 k5_unmarshal_cred
 k5_unmarshal_princ
 k5_unwrap_cammac_svc

--- a/src/lib/krb5_32.def
+++ b/src/lib/krb5_32.def
@@ -507,3 +507,4 @@ EXPORTS
 ; new in 1.20
 	krb5_marshal_credentials			@472
 	krb5_unmarshal_credentials			@473
+	k5_sname_compare				@474 ; PRIVATE GSSAPI

--- a/src/tests/gssapi/t_gssapi.py
+++ b/src/tests/gssapi/t_gssapi.py
@@ -8,7 +8,7 @@ for realm in multipass_realms():
     realm.run(['./t_iov', '-s', 'p:' + realm.host_princ])
     realm.run(['./t_pcontok', 'p:' + realm.host_princ])
 
-realm = K5Realm(krb5_conf={'libdefaults': {'rdns': 'false'}})
+realm = K5Realm()
 
 # Test gss_add_cred().
 realm.run(['./t_add_cred'])
@@ -62,13 +62,8 @@ realm.run(['./t_accname', 'p:host/-nomatch-',
           expected_msg=' not found in keytab')
 
 # If possible, test with an acceptor name requiring fallback to match
-# against a keytab entry.  Forward-canonicalize the hostname, relying
-# on the rdns=false realm setting.
-try:
-    ai = socket.getaddrinfo(hostname, None, 0, 0, 0, socket.AI_CANONNAME)
-    (family, socktype, proto, canonname, sockaddr) = ai[0]
-except socket.gaierror:
-    canonname = hostname
+# against a keytab entry.
+canonname = canonicalize_hostname(hostname)
 if canonname != hostname:
     os.rename(realm.keytab, realm.keytab + '.save')
     canonprinc = 'host/' + canonname


### PR DESCRIPTION
Having tried a couple of approaches to this problem, I'm putting this up to keep a record of my design notes.

Hostbased initiator names are not currently supported very well; even without dns_canonicalize_hostname=fallback, they fail if there is no [domain_realm] entry supplying a realm name.  But apparently FreeIPA uses them, and there is no conceptual reason why they shouldn't work on a best-effort basis.

gic_keytab does not support wildcarding like krb5_rd_req() does.  At this time I think that's inherent to the nature of the initiator: we need to pick a concrete principal to authenticate as, and there might be multiple matches for a wildcard in the keytab or cache collection.  By contrast, the acceptor has the ticket encryption key to use as an authority.  For this reason, I think it makes sense that a GSS host-based name like "host" can only match the local host, and if the realm can't be determined with [domain_realm] then we can only match the default realm.

The current implementation approach is to rewrite cred->name->princ after we match a ccache in the collection or acquire creds from the client keytab.  This is much simpler than adding a new field to the cred (we create credentials and use cred->name->princ in many places), but unfortunately it creates a corner case for GSS_C_BOTH credentials, because cred->name->princ->data[1] is now post-canonicalization but kg_rd_req() thinks it is pre-canonicalization.

The mere possibility of this situation is a result of the krb5_sname_to_principal() fallback design.  When we see a host-based krb5_principal, we currently have to deduce from the call graph whether it's pre-canonical or post-canonical.  Heimdal uses a fake name type (KRB5_NT_SRV_HST_NEEDS_CANON) to make this explicit, but that leaves open the possibility of the fake name type leaking out onto the wire.
  
I currently think the safe solution is to create a new (internal) "principal description" type which can contain a service, hostname, iteration state, and (once known) canonical principal name.  (For non-hostbased names it would just contain a fixed canonical principal name.)  I will investigate that approach.

The PR currently reuses reuses krb5_kt_have_match() to match against the client keytab when checking whether we can acquire initial creds.  This is a bit overly permissive because that function uses wildcarding rules and obeys ignore_acceptor_hostname.  Being a little too permissive isn't necessarily a big problem, though.
