### PR TITLE
Allow multiple pkinit_identities lines

### DIFF
--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -1123,10 +1123,9 @@ PKINIT krb5.conf options
 **pkinit_identities**
     Specifies the location(s) to be used to find the user's X.509
     identity information.  If this option is specified multiple times,
-    the first valid value is used; this can be used to specify an
-    environment variable (with **ENV:**\ *envvar*) followed by a
-    default value.  Note that these values are not used if the user
-    specifies **X509_user_identity** on the command line.
+    each value is attempted in order until certificates are found.
+    Note that these values are not used if the user specifies
+    **X509_user_identity** on the command line.
 
 **pkinit_kdc_hostname**
     The presence of this option indicates that the client is willing

--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -3748,7 +3748,7 @@ pkinit_open_session(krb5_context context,
             pkinit_set_deferred_id(&cctx->deferred_ids,
                                    p11name, tinfo.flags, NULL);
             free(p11name);
-            return KRB5KRB_ERR_GENERIC;
+            return 0;
         }
         /* Look up a responder-supplied password for the token. */
         password = pkinit_find_deferred_id(cctx->deferred_ids, p11name);
@@ -4552,11 +4552,9 @@ pkinit_get_certs_pkcs11(krb5_context context,
     id_cryptoctx->slotid = idopts->slotid;
     id_cryptoctx->pkcs11_method = 1;
 
-    if (pkinit_open_session(context, id_cryptoctx)) {
-        pkiDebug("can't open pkcs11 session\n");
-        if (!id_cryptoctx->defer_id_prompt)
-            return KRB5KDC_ERR_PREAUTH_FAILED;
-    }
+    r = pkinit_open_session(context, id_cryptoctx);
+    if (r != 0)
+        return r;
     if (id_cryptoctx->defer_id_prompt) {
         /*
          * We need to reset all of the PKCS#11 state, so that the next time we

--- a/src/tests/t_pkinit.py
+++ b/src/tests/t_pkinit.py
@@ -183,6 +183,13 @@ realm.kinit(realm.user_princ,
 realm.klist(realm.user_princ)
 realm.run([kvno, realm.host_princ])
 
+# Try using multiple configured pkinit_identities, to make sure we
+# fall back to the second one when the first one cannot be read.
+id_conf = {'realms': {'$realm': {'pkinit_identities': [file_identity + 'X',
+                                                       file_identity]}}}
+id_env = realm.special_env('idconf', False, krb5_conf=id_conf)
+realm.kinit(realm.user_princ, expected_trace=msgs, env=id_env)
+
 # Try again using RSA instead of DH.
 mark('FILE identity, no password, RSA')
 realm.kinit(realm.user_princ,


### PR DESCRIPTION
This patch permits the use of multiple pkinit_identities lines in
krb5.conf.  This patch has two components:

Move the call to crypto_load_certs() in pkinit_identity_initialize()
inside of the same loop as process_option_identity().  This will
attempt to load a certificate from each pkinit_identities line in
the configuration, and if the certificate load fails to move to
the next line.

In pkinit_get_certs_pkcs11(), if pkinit_open_session() fails (for
example, if the specified library does not exist) then return an error.
Previously if defer_id_prompts was set an error was NOT returned.
This makes pkinit_get_certs_pkcs11() behave like all other certificate
loading functions called by crypto_load_certs(), and is required if you
want to be able to specify multiple PKCS#11 libraries on pkinit_identities
configuration lines.

Additionally, if pkinit_open_session has defer_id_prompt set, then make
it so it will return 0 (success) if the module finds an ID successfully.
Previously it would not (but this didn't matter because the error was
ignored by the caller when defer_id_prompt was set).

The resulting semantics is that the PKINT plugin will try multiple
identities until it can successfully load a matching identity.  This
seems like a reasonable combination of useful functionality easy
to implement.

This patch also reverts the change to the krb5 documentation for
pkinit_identities made in commit 456e41f848861217ddf5149b9e52e3ba6d42947c.