### PR TITLE
Fix gettext extraction of usage messages

### DIFF
--- a/src/clients/kinit/kinit.c
+++ b/src/clients/kinit/kinit.c
@@ -141,18 +141,13 @@ usage()
 {
     fprintf(stderr,
             _("Usage: %s [-V] [-l lifetime] [-s start_time] "
-              "[-r renewable_life]"
-              USAGE_BREAK
-              "[-f | -F] [-p | -P] [-n] [-a | -A] [-C] [-E]"
-              USAGE_BREAK
-              "[--request-pac | --no-request-pac] "
-              USAGE_BREAK
-              "[-v] [-R] [-k [-i|-t keytab_file]] [-c cachename]"
-              USAGE_BREAK
-              "[-S service_name] [-I input_ccache] [-T ticket_armor_cache]"
-              USAGE_BREAK
-              "[-X <attribute>[=<value>]] [principal]"
-              "\n\n"), progname);
+              "[-r renewable_life]\n"
+              "\t[-f | -F] [-p | -P] [-n] [-a | -A] [-C] [-E]\n"
+              "\t[--request-pac | --no-request-pac]\n"
+              "\t[-v] [-R] [-k [-i|-t keytab_file]] [-c cachename]\n"
+              "\t[-S service_name] [-I input_ccache] [-T ticket_armor_cache]\n"
+              "\t[-X <attribute>[=<value>]] [principal]\n"
+              "\n"), progname);
 
     fprintf(stderr, "    options:\n");
     fprintf(stderr, _("\t-V verbose\n"));

--- a/src/clients/kvno/kvno.c
+++ b/src/clients/kvno/kvno.c
@@ -38,16 +38,14 @@
 static char *prog;
 static int quiet = 0;
 
-#define XUSAGE_BREAK "\n\t"
-
 static void
 xusage()
 {
     fprintf(stderr, _("usage: %s [-c ccache] [-e etype] [-k keytab] [-q] "
-                      "[-u | -S sname]" XUSAGE_BREAK
-                      "[[{-F cert_file | {-I | -U} for_user} [-P]] | "
-                      "--u2u ccache]" XUSAGE_BREAK
-                      "[--cached-only] [--no-store] [--out-cache] "
+                      "[-u | -S sname]\n"
+                      "\t[[{-F cert_file | {-I | -U} for_user} [-P]] | "
+                      "--u2u ccache]\n"
+                      "\t[--cached-only] [--no-store] [--out-cache] "
                       "service1 service2 ...\n"),
             prog);
     exit(1);


### PR DESCRIPTION
Stop using macros for the newline and tab dividers between lines of
usage messages in kinit and kvno, so that gettext can extract the full
string.