### PR TITLE
Allow multiple pkinit_anchor and pkinit_pool lines

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_clnt.c
+++ b/src/plugins/preauth/pkinit/pkinit_clnt.c
@@ -1101,6 +1101,11 @@ pkinit_client_process(krb5_context context, krb5_clpreauth_moddata moddata,
     }
 
     if (processing_request) {
+        if (reqctx->idopts->anchors == NULL) {
+            krb5_set_error_message(context, KRB5_PREAUTH_FAILED,
+                                   _("No pkinit_anchors supplied"));
+            return KRB5_PREAUTH_FAILED;
+        }
         pkinit_client_profile(context, plgctx, reqctx, cb, rock,
                               &request->server->realm);
         /* Pull in PINs and passwords for identities which we deferred


### PR DESCRIPTION
As discussed on krbdev, this allows multiple pkinit_anchor and pkinit_pool lines in krb5.conf.

To expand on this a bit; it is true that the existing code allows multiple anchor/pool lines.  But if any of the entries fail to process (e.g., file not found), then an error is returned from pkinit_identity_prompt() and pkinit ends up failing.

We've found during our PKINIT deployment that it was useful to list multiple locations in pkinit_anchors and pkinit_pool because certificate locations can vary across systems. This change weakens the error checking for the pkinit_anchors and pkinit_pool lines; if those configuration entries are specified, only one working entry is required.