### PR TITLE
kcm: improve performance

### DIFF
--- a/src/include/kcm.h
+++ b/src/include/kcm.h
@@ -51,9 +51,9 @@
  *
  * All replies begin with a 32-bit big-endian reply code.
  *
- * Parameters are appended to the request or reply with no delimiters.  Flags
- * and time offsets are stored as 32-bit big-endian integers.  Names are
- * marshalled as zero-terminated strings.  Principals and credentials are
+ * Parameters are appended to the request or reply with no delimiters.  Flags,
+ * time offsets, and lengths are stored as 32-bit big-endian integers.  Names
+ * are marshalled as zero-terminated strings.  Principals and credentials are
  * marshalled in the v4 FILE ccache format.  UUIDs are 16 bytes.  UUID lists
  * are not delimited, so nothing can come after them.
  */
@@ -89,7 +89,11 @@ typedef enum kcm_opcode {
     KCM_OP_HAVE_NTLM_CRED,
     KCM_OP_DEL_NTLM_CRED,
     KCM_OP_DO_NTLM_AUTH,
-    KCM_OP_GET_NTLM_USER_LIST
+    KCM_OP_GET_NTLM_USER_LIST,
+
+    /* MIT extensions */
+    KCM_OP_MIT_EXTENSION_BASE = 13000,
+    KCM_OP_GET_CRED_LIST,       /* (name) -> (count, count*{len, cred}) */
 } kcm_opcode;
 
 #endif /* KCM_H */

--- a/src/tests/t_ccache.py
+++ b/src/tests/t_ccache.py
@@ -125,10 +125,18 @@ def collection_test(realm, ccname):
 
 
 collection_test(realm, 'DIR:' + os.path.join(realm.testdir, 'cc'))
+
+# Test KCM without and with GET_CRED_LIST support.
 kcmserver_path = os.path.join(srctop, 'tests', 'kcmserver.py')
-realm.start_server([sys.executable, kcmserver_path, kcm_socket_path],
+kcmd = realm.start_server([sys.executable, kcmserver_path, kcm_socket_path],
+                          'starting...')
+collection_test(realm, 'KCM:')
+stop_daemon(kcmd)
+os.remove(kcm_socket_path)
+realm.start_server([sys.executable, kcmserver_path, '-c', kcm_socket_path],
                    'starting...')
 collection_test(realm, 'KCM:')
+
 if test_keyring:
     def cleanup_keyring(anchor, name):
         out = realm.run(['keyctl', 'list', anchor])


### PR DESCRIPTION
This is based on the following `krbdev` thread:
https://mailman.mit.edu/pipermail/krbdev/2021-February/013424.html

* @greghudson Is this something MIT Kerberos would accept?
* @nicowilliams Is this something that could be accepted for KCM protocol?

**kcm: use GET_CRED_LIST where available**
---
This KCM operation will returned all credentials of the selected
ccache. This change will remove unnecessary IO operations that
are a bottleneck for large ccaches, mostly for GSSAPI and
applications that iterates over credentials often. The implementation
is backwards compatible - if the call is not available or fails, it
will fallback to `GET_CRED_UUID_LIST`.

**cc: add krb5_cc_notification_path**
---
This adds new API function `krb5_cc_notification_path`. The purpose
of this call is to create a file that can be watched for events
using inotify or similar tools.

It is currently documented only in the header file and implemented only
for KCM. I will finish it once we agree on the API.

The KCM implementation introduces new operation
`GET_CACHE_NOTIFICATION_PATH (ccache) -> (path)`.