### PR TITLE
Fix some docs warnings

### DIFF
--- a/doc/tools/doxybuilder_types.py
+++ b/doc/tools/doxybuilder_types.py
@@ -268,38 +268,36 @@ class DoxyTypes(object):
 
     def _process_paragraph_content(self, node):
 
+        def add_text(l, s):
+            # Add a space if it wouldn't be at the start or end of a line.
+            if l and not l[-1].endswith('\n') and not s.startswith('\n'):
+                l.append(' ')
+            l.append(s)
+
         result = list()
         content = node.xpath(".//text()")
         for e in content:
-            if node is e.getparent():
-                result.append(e.strip())
+            if e.is_tail or node is e.getparent():
+                add_text(result, e.strip())
             elif e.getparent().tag == 'ref':
-                if e.is_tail:
-                    result.append(e.strip())
-                elif e.strip().find('(') > 0:
-                    result.append(':c:func:`%s`' % e.strip())
+                if e.strip().find('(') > 0:
+                    add_text(result, ':c:func:`%s`' % e.strip())
                 elif e.isupper():
-                    result.append(':c:data:`%s`' % e.strip())
+                    add_text(result, ':c:data:`%s`' % e.strip())
                 else:
-                    result.append(':c:type:`%s`' % e.strip())
+                    add_text(result, ':c:type:`%s`' % e.strip())
             elif e.getparent().tag == 'emphasis':
-                if e.is_tail:
-                    result.append(e.strip())
-                else:
-                    result.append('*%s*' % e.strip())
+                add_text(result, '*%s*' % e.strip())
             elif e.getparent().tag == 'computeroutput':
-                if e.is_tail:
-                    result.append(e.strip())
-                else:
-                    result.append('*%s*' % e.strip())
-            elif  e.getparent().tag == 'defname':
-                result.append('%s, ' % e.strip())
+                add_text(result, '*%s*' % e.strip())
+            elif e.getparent().tag == 'defname':
+                add_text(result, '%s, ' % e.strip())
             elif e.getparent().tag == 'verbatim':
-                result.append('\n::\n\n')
-                result.append(textwrap.indent(e, '    ', lambda x: True))
-                result.append('\n')
+                add_text(result, '\n::\n\n')
+                add_text(result, textwrap.indent(e, '    ', lambda x: True))
+                add_text(result, '\n')
 
-        result = ' '.join(result)
+        result = ''.join(result)
 
         return result
 

--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -3123,7 +3123,7 @@ krb5_get_credentials(krb5_context context, krb5_flags options,
  * Serialize a @c krb5_creds object.
  *
  * @param [in]  context         Library context
- * @param [in]  creds           The credentials object to serialize
+ * @param [in]  in_creds        The credentials object to serialize
  * @param [out] data_out        The serialized credentials
  *
  * Serialize @a creds in the format used by the FILE ccache format (vesion 4)
@@ -3665,12 +3665,9 @@ krb5_address_compare(krb5_context context, const krb5_address *addr1,
  * @param [in] addr1            First address
  * @param [in] addr2            Second address
  *
- * @retval
- *  0 The two addresses are the same
- * @retval
- *  \< 0 First address is less than second
- * @retval
- *  \> 0 First address is greater than second
+ * @retval 0 if The two addresses are the same
+ * @retval < 0 First address is less than second
+ * @retval > 0 First address is greater than second
  */
 int KRB5_CALLCONV
 krb5_address_order(krb5_context context, const krb5_address *addr1,
@@ -8498,14 +8495,14 @@ krb5_set_trace_filename(krb5_context context, const char *filename);
  * @param [in]  realm           The realm the message will be sent to
  * @param [in]  message         The original message to be sent to the KDC
  * @param [out] new_message_out Optional replacement message to be sent
- * @param [out] reply_out       Optional synthetic reply
+ * @param [out] new_reply_out   Optional synthetic reply
  *
  * If the hook function returns an error code, the KDC communication will be
  * aborted and the error code will be returned to the library operation which
  * initiated the communication.
  *
- * If the hook function sets @a reply_out, @a message will not be sent to the
- * KDC, and the given reply will used instead.
+ * If the hook function sets @a new_reply_out, @a message will not be sent to
+ * the KDC, and the given reply will used instead.
  *
  * If the hook function sets @a new_message_out, the given message will be sent
  * to the KDC in place of @a message.


### PR DESCRIPTION
The first commit is the impetus for the PR, though I don't have a good solution.  It seems that our docs builds fail when a literal block ends a doxygen section (trace in commit message).

Second commit fixes all (other) warnings from doxygen.  These are visible in CI, but are not currently fatal.

Note that as in 281210909beef4683be3b63bc1ac1e75c2c9c7eb , I have not addressed the sphinx 4.0 deprecations.  Right now, those are:


/home/rharwood/krb5.git/newer-sphinx/src/doc/rst_composite/conf.py:102: RemovedInSphinx40Warning: The app.add_stylesheet() is deprecated. Please use app.add_css_file() instead.
  app.add_stylesheet('kerb.css')
  /usr/lib/python3/dist-packages/docutils/parsers/rst/states.py:2147: RemovedInSphinx40Warning: highlightlang directive is deprecated. Please use highlight directive instead.
