### PR TITLE
cc: add krb5_cc_notification_path

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1485,6 +1485,15 @@ if test "x$with_krb5_config" != xno; then
 		: "${DEFCKTNAME=`$with_krb5_config --defcktname`}"
 	fi
 fi
+
+# Setup the notification path
+AC_ARG_WITH([notification-path],
+  [AS_HELP_STRING([--with-notification-path=PATH],
+   [path to the directory with user notification file])])
+if test x"$with_notification_path" != x; then
+  AC_DEFINE_UNQUOTED(NOTIFICATION_PATH, ["$with_notification_path"], [Notification path])
+fi
+
 dnl The outer brackets around the case statement prevent m4 from eating the
 dnl brackets in the glob patterns.
 if test "${DEFCCNAME+set}" != set; then

--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -4572,6 +4572,24 @@ krb5_boolean KRB5_CALLCONV
 krb5_cc_support_switch(krb5_context context, const char *type);
 
 /**
+ * Retrieve path to the ccache notification file. The file is touched everytime
+ * the ccache or the collection that the ccache is part of has changed.
+ *
+ * You can setup a file system watch (e.g. inotify) on the path and
+ * watch for the file events (IN_ATTRIB) to monitor activity of the ccache.
+ *
+ * @param [in] context          Library context
+ * @param [in] cache            Credential cache handle
+ * @param [out] path            Notification file path
+ *
+ * @retval 0              Success. Path is set to the notification file path.
+ * @retval KRB5_CC_NOSUPP Notifications are not supported by this ccache.
+ * @return Kerberos error codes
+ */
+krb5_error_code KRB5_CALLCONV
+krb5_cc_notification_path(krb5_context context, krb5_ccache cache, char **path);
+
+/**
  * Find a credential cache with a specified client principal.
  *
  * @param [in]  context         Library context

--- a/src/lib/krb5/ccache/cc-int.h
+++ b/src/lib/krb5/ccache/cc-int.h
@@ -217,6 +217,7 @@ struct _krb5_cc_ops {
     krb5_error_code (KRB5_CALLCONV *lock)(krb5_context, krb5_ccache);
     krb5_error_code (KRB5_CALLCONV *unlock)(krb5_context, krb5_ccache);
     krb5_error_code (KRB5_CALLCONV *switch_to)(krb5_context, krb5_ccache);
+    krb5_error_code (KRB5_CALLCONV *notification_file)(krb5_context, krb5_ccache, char **);
 };
 
 extern const krb5_cc_ops *krb5_cc_dfl_ops;

--- a/src/lib/krb5/ccache/cc_file.c
+++ b/src/lib/krb5/ccache/cc_file.c
@@ -1314,6 +1314,33 @@ interpret_errno(krb5_context context, int errnum)
     return ret;
 }
 
+static krb5_error_code KRB5_CALLCONV
+fcc_notification_file(krb5_context context,
+                      krb5_ccache cache,
+                      char **file)
+{
+    fcc_data *data = cache->data;
+    const char *name;
+
+    if (data == NULL || data->filename == NULL) {
+        return KRB5_CC_NOTFOUND;
+    }
+
+    /* /path/ccache -> ccache */
+
+    name = strrchr(data->filename, '/');
+    if (name == NULL || name[0] != '/') {
+        return KRB5_FCC_INTERNAL;
+    }
+
+    *file = strdup(name);
+    if (*file == NULL) {
+        return KRB5_CC_NOMEM;
+    }
+
+    return 0;
+}
+
 const krb5_cc_ops krb5_fcc_ops = {
     0,
     "FILE",
@@ -1340,6 +1367,7 @@ const krb5_cc_ops krb5_fcc_ops = {
     fcc_lock,
     fcc_unlock,
     NULL, /* switch_to */
+    fcc_notification_file,
 };
 
 #if defined(_WIN32)
@@ -1410,4 +1438,5 @@ const krb5_cc_ops krb5_cc_file_ops = {
     fcc_lock,
     fcc_unlock,
     NULL, /* switch_to */
+    NULL, /* notification_file */
 };

--- a/src/lib/krb5/ccache/cc_kcm.c
+++ b/src/lib/krb5/ccache/cc_kcm.c
@@ -1044,6 +1044,19 @@ kcm_switch_to(krb5_context context, krb5_ccache cache)
     return ret;
 }
 
+static krb5_error_code KRB5_CALLCONV
+kcm_notification_file(krb5_context context,
+                      krb5_ccache cache,
+                      char **file)
+{
+    *file = strdup("kcm");
+    if (*file == NULL) {
+        return KRB5_CC_NOMEM;
+    }
+
+    return 0;
+}
+
 const krb5_cc_ops krb5_kcm_ops = {
     0,
     "KCM",
@@ -1070,6 +1083,7 @@ const krb5_cc_ops krb5_kcm_ops = {
     kcm_lock,
     kcm_unlock,
     kcm_switch_to,
+    kcm_notification_file,
 };
 
 #endif /* not _WIN32 */

--- a/src/lib/krb5/ccache/cc_keyring.c
+++ b/src/lib/krb5/ccache/cc_keyring.c
@@ -1680,6 +1680,19 @@ cleanup:
     return ret;
 }
 
+static krb5_error_code KRB5_CALLCONV
+krcc_notification_file(krb5_context context,
+                       krb5_ccache cache,
+                       char **file)
+{
+    *file = strdup("keyring");
+    if (*file == NULL) {
+        return KRB5_CC_NOMEM;
+    }
+
+    return 0;
+}
+
 /*
  * ccache implementation storing credentials in the Linux keyring facility
  * The default is to put them at the session keyring level.
@@ -1712,6 +1725,7 @@ const krb5_cc_ops krb5_krcc_ops = {
     krcc_lock,
     krcc_unlock,
     krcc_switch_to,
+    krcc_notification_file,
 };
 
 #else /* !USE_KEYRING_CCACHE */
@@ -1737,6 +1751,7 @@ const krb5_cc_ops krb5_krcc_ops = {
     NULL,
     NULL,
     NULL,                       /* added after 1.4 release */
+    NULL,
     NULL,
     NULL,
     NULL,

--- a/src/lib/krb5/ccache/cc_memory.c
+++ b/src/lib/krb5/ccache/cc_memory.c
@@ -790,4 +790,5 @@ const krb5_cc_ops krb5_mcc_ops = {
     krb5_mcc_lock,
     krb5_mcc_unlock,
     NULL, /* switch_to */
+    NULL, /* notification_file */
 };

--- a/src/lib/krb5/ccache/cc_mslsa.c
+++ b/src/lib/krb5/ccache/cc_mslsa.c
@@ -2208,5 +2208,6 @@ const krb5_cc_ops krb5_lcc_ops = {
     NULL, /* lock */
     NULL, /* unlock */
     NULL, /* switch_to */
+    NULL, /* notification_file */
 };
 #endif /* _WIN32 */

--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -286,6 +286,7 @@ krb5_cc_start_seq_get
 krb5_cc_store_cred
 krb5_cc_support_switch
 krb5_cc_switch
+krb5_cc_notification_path
 krb5_cccol_cursor_free
 krb5_cccol_cursor_new
 krb5_cccol_cursor_next


### PR DESCRIPTION
This is a new API call to implement generic notification interface.

The function return a path to the file that can be watched for changes
through file system watchers like inotify or fswatch. The file is
created, touched and destroyed when the ccache is initialized, changed
and destroyed. The caller should setup a watch on the parent directory
and listen for the file events.

Implemented for FILE, DIR and KCM.

SSSD KCM implementation (Work in progress):
https://github.com/pbrezina/sssd/tree/kcm-notifications