### PR TITLE
Fix PKINIT memory leaks

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_clnt.c
+++ b/src/plugins/preauth/pkinit/pkinit_clnt.c
@@ -1105,8 +1105,6 @@ pkinit_client_process(krb5_context context, krb5_clpreauth_moddata moddata,
                                    _("No pkinit_anchors supplied"));
             return KRB5_PREAUTH_FAILED;
         }
-        pkinit_client_profile(context, plgctx, reqctx, cb, rock,
-                              &request->server->realm);
         /* Pull in PINs and passwords for identities which we deferred
          * loading earlier. */
         retval = pkinit_client_parse_answers(context, moddata, modreq,

--- a/src/plugins/preauth/pkinit/pkinit_identity.c
+++ b/src/plugins/preauth/pkinit/pkinit_identity.c
@@ -333,6 +333,8 @@ parse_fs_options(krb5_context context,
     if (key_filename == NULL)
         goto cleanup;
 
+    free(idopts->cert_filename);
+    free(idopts->key_filename);
     idopts->cert_filename = cert_filename;
     idopts->key_filename = key_filename;
     cert_filename = key_filename = NULL;
@@ -355,10 +357,12 @@ parse_pkcs12_options(krb5_context context,
     if (residual == NULL || residual[0] == '\0')
         return 0;
 
+    free(idopts->cert_filename);
     idopts->cert_filename = strdup(residual);
     if (idopts->cert_filename == NULL)
         goto cleanup;
 
+    free(idopts->key_filename);
     idopts->key_filename = strdup(residual);
     if (idopts->key_filename == NULL)
         goto cleanup;
@@ -438,6 +442,7 @@ process_option_identity(krb5_context context,
         break;
 #endif
     case IDTYPE_DIR:
+        free(idopts->cert_filename);
         idopts->cert_filename = strdup(residual);
         if (idopts->cert_filename == NULL)
             retval = ENOMEM;


### PR DESCRIPTION
pkinit_client_process() calls pkinit_client_profile() a second time,
leaking the values obtained the first time.  Remove the call.

Commit 13ae08e70a05768d4f65978ce1a8d4e16fec0d35 introduced more
possibilities for process_option_identity() to return failure after it
filled in some fields.  PKCS11 option parsing already prevents leaks
by freeing old values before setting new ones; do so in the other
option-parsing functions as well.
