### PR TITLE
Use krb5int_open_plugin for PKCS#11 module

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_clnt.c
+++ b/src/plugins/preauth/pkinit/pkinit_clnt.c
@@ -34,7 +34,6 @@
 #include "k5-json.h"
 
 #include <unistd.h>
-#include <dlfcn.h>
 #include <sys/stat.h>
 
 /**

--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.h
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.h
@@ -84,7 +84,7 @@ struct _pkinit_identity_crypto_context {
     char *token_label;
     char *cert_label;
     /* These are crypto-specific */
-    void *p11_module;
+    struct plugin_file_handle *p11_module;
     CK_SESSION_HANDLE session;
     CK_FUNCTION_LIST_PTR p11;
     uint8_t *cert_id;

--- a/src/plugins/preauth/pkinit/pkinit_identity.c
+++ b/src/plugins/preauth/pkinit/pkinit_identity.c
@@ -30,7 +30,6 @@
  */
 
 #include "pkinit.h"
-#include <dlfcn.h>
 #include <dirent.h>
 
 static void


### PR DESCRIPTION
Instead of calling dlopen() directly, use the krb5 cross-platform interfaces (krb5int_open_plugin()).

The goal here is to eventually support pkinit on Windows; this is just the first small step in that direction. We had talked about this change a while back on krbdev; the reason I am submitting a pull request now is I would like to submit a pull request soon to include a lot of extra trace points in the pkinit plugin, and this is a small piece of that.

This patch also removes the include of dlfcn.h in pkinit_clnt.c and pkinit_identity.c; that file doesn't exist on Windows and I am not sure why those files include that header as they don't call dlopen(). It looks like it's been that way since the beginning.