### PR TITLE
gss-server: Avoid calling listen(2) with zero backlog

### DIFF
--- a/src/appl/gss-sample/gss-server.c
+++ b/src/appl/gss-sample/gss-server.c
@@ -766,8 +766,6 @@ main(int argc, char **argv)
         int     stmp;
 
         if ((stmp = create_socket(port)) >= 0) {
-            if (listen(stmp, max_threads == 1 ? 0 : max_threads) < 0)
-                perror("listening on socket");
             fprintf(stderr, "starting...\n");
 
             do {

--- a/src/tests/gss-threads/gss-server.c
+++ b/src/tests/gss-threads/gss-server.c
@@ -782,9 +782,6 @@ main(int argc, char **argv)
 
         stmp = create_socket(port);
         if (stmp >= 0) {
-            if (listen(stmp, max_threads == 1 ? 0 : max_threads) < 0)
-                perror("listening on socket");
-
             do {
                 struct _work_plan * work = malloc(sizeof(struct _work_plan));
 


### PR DESCRIPTION
Calling listen system call with zero backlog makes gss-server execution (and tests) racy on slower and busy systems.