### PR TITLE
Add additional KRB5_TRACE points

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -1964,7 +1964,7 @@ crypto_retrieve_X509_sans(krb5_context context,
     krb5_principal *princs = NULL;
     char **upns = NULL;
     unsigned char **dnss = NULL;
-    unsigned int i, num_found = 0, num_sans = 0;
+    unsigned int i, num_sans = 0;
     X509_EXTENSION *ext = NULL;
     GENERAL_NAMES *ialt = NULL;
     GENERAL_NAME *gen = NULL;
@@ -2047,7 +2047,6 @@ crypto_retrieve_X509_sans(krb5_context context,
                              __FUNCTION__);
                 } else {
                     p++;
-                    num_found++;
                 }
             } else if (upns != NULL &&
                        OBJ_cmp(plgctx->id_ms_san_upn,
@@ -2058,6 +2057,7 @@ crypto_retrieve_X509_sans(krb5_context context,
                 upns[u] = k5memdup0(name.data, name.length, &ret);
                 if (upns[u] == NULL)
                     goto cleanup;
+                u++;
             } else {
                 pkiDebug("%s: unrecognized othername oid in SAN\n",
                          __FUNCTION__);
@@ -2079,7 +2079,6 @@ crypto_retrieve_X509_sans(krb5_context context,
                              __FUNCTION__);
                 } else {
                     d++;
-                    num_found++;
                 }
             }
             break;

--- a/src/plugins/preauth/pkinit/pkinit_identity.c
+++ b/src/plugins/preauth/pkinit/pkinit_identity.c
@@ -387,8 +387,7 @@ process_option_identity(krb5_context context,
     int idtype;
     krb5_error_code retval = 0;
 
-    pkiDebug("%s: processing value '%s'\n",
-             __FUNCTION__, value ? value : "NULL");
+    TRACE_PKINIT_IDENTITY_OPTION(context, value);
     if (value == NULL)
         return EINVAL;
 

--- a/src/plugins/preauth/pkinit/pkinit_matching.c
+++ b/src/plugins/preauth/pkinit/pkinit_matching.c
@@ -448,25 +448,26 @@ cleanup:
 }
 
 static int
-regexp_match(krb5_context context, rule_component *rc, char *value)
+regexp_match(krb5_context context, rule_component *rc, char *value, int idx)
 {
     int code;
 
-    pkiDebug("%s: checking %s rule '%s' with value '%s'\n",
-             __FUNCTION__, keyword2string(rc->kw_type), rc->regsrc, value);
-
     code = regexec(&rc->regexp, value, 0, NULL, 0);
 
-    pkiDebug("%s: the result is%s a match\n", __FUNCTION__,
-             code == REG_NOMATCH ? " NOT" : "");
+    if (code == 0) {
+        TRACE_PKINIT_REGEXP_MATCH(context, keyword2string(rc->kw_type),
+                                  rc->regsrc, value, idx);
+    } else {
+        TRACE_PKINIT_REGEXP_NOMATCH(context, keyword2string(rc->kw_type),
+                                    rc->regsrc, value, idx);
+    }
 
     return (code == 0 ? 1: 0);
 }
 
 static int
-component_match(krb5_context context,
-                rule_component *rc,
-                pkinit_cert_matching_data *md)
+component_match(krb5_context context, rule_component *rc,
+                pkinit_cert_matching_data *md, int idx)
 {
     int match = 0;
     int i;
@@ -476,21 +477,21 @@ component_match(krb5_context context,
     case kwvaltype_regexp:
         switch (rc->kw_type) {
         case kw_subject:
-            match = regexp_match(context, rc, md->subject_dn);
+            match = regexp_match(context, rc, md->subject_dn, idx);
             break;
         case kw_issuer:
-            match = regexp_match(context, rc, md->issuer_dn);
+            match = regexp_match(context, rc, md->issuer_dn, idx);
             break;
         case kw_san:
             for (i = 0; md->sans != NULL && md->sans[i] != NULL; i++) {
                 krb5_unparse_name(context, md->sans[i], &princ_string);
-                match = regexp_match(context, rc, princ_string);
+                match = regexp_match(context, rc, princ_string, idx);
                 krb5_free_unparsed_name(context, princ_string);
                 if (match)
                     break;
             }
             for (i = 0; md->upns != NULL && md->upns[i] != NULL; i++) {
-                match = regexp_match(context, rc, md->upns[i]);
+                match = regexp_match(context, rc, md->upns[i], idx);
                 if (match)
                     break;
             }
@@ -574,7 +575,7 @@ check_all_certs(krb5_context context,
         pkiDebug("%s: subject: '%s'\n", __FUNCTION__, md->subject_dn);
         certs_checked++;
         for (rc = rs->crs; rc != NULL; rc = rc->next) {
-            comp_match = component_match(context, rc, md);
+            comp_match = component_match(context, rc, md, i);
             if (comp_match) {
                 pkiDebug("%s: match for keyword type %s\n",
                          __FUNCTION__, keyword2string(rc->kw_type));
@@ -600,8 +601,7 @@ check_all_certs(krb5_context context,
     nextcert:
         continue;
     }
-    pkiDebug("%s: After checking %d certs, we found %d matches\n",
-             __FUNCTION__, certs_checked, total_cert_matches);
+    TRACE_PKINIT_CERT_NUM_MATCHING(context, certs_checked, total_cert_matches);
     if (total_cert_matches == 1) {
         *match_found = 1;
         *match_index = save_index;
@@ -642,7 +642,7 @@ pkinit_cert_matching(krb5_context context,
 
     /* parse each rule line one at a time and check all the certs against it */
     for (x = 0; rules[x] != NULL; x++) {
-        pkiDebug("%s: Processing rule '%s'\n", __FUNCTION__, rules[x]);
+        TRACE_PKINIT_CERT_RULE(context, rules[x]);
 
         /* Free rules from previous time through... */
         if (rs != NULL) {
@@ -652,8 +652,7 @@ pkinit_cert_matching(krb5_context context,
         retval = parse_rule_set(context, rules[x], &rs);
         if (retval) {
             if (retval == EINVAL) {
-                pkiDebug("%s: Ignoring invalid rule pkinit_cert_match = '%s'\n",
-                         __FUNCTION__, rules[x]);
+                TRACE_PKINIT_CERT_RULE_INVALID(context, rules[x]);
                 continue;
             }
             goto cleanup;
@@ -737,7 +736,7 @@ pkinit_client_cert_match(krb5_context context,
         goto cleanup;
 
     for (rc = rs->crs; rc != NULL; rc = rc->next) {
-        comp_match = component_match(context, rc, md);
+        comp_match = component_match(context, rc, md, 0);
         if ((comp_match && rs->relation == relation_or) ||
             (!comp_match && rs->relation == relation_and)) {
             break;

--- a/src/plugins/preauth/pkinit/pkinit_trace.h
+++ b/src/plugins/preauth/pkinit/pkinit_trace.h
@@ -93,6 +93,25 @@
 #define TRACE_PKINIT_OPENSSL_ERROR(c, msg)              \
     TRACE(c, "PKINIT OpenSSL error: {str}", msg)
 
+#define TRACE_PKINIT_PKCS11_GETFLIST_FAILED(c, errstr)                  \
+    TRACE(c, "PKINIT PKCS11 C_GetFunctionList failed: {str}", errstr)
+#define TRACE_PKINIT_PKCS11_GETSYM_FAILED(c, errstr)                    \
+    TRACE(c, "PKINIT unable to find PKCS11 plugin symbol "              \
+          "C_GetFunctionList: {str}", errstr)
+#define TRACE_PKINIT_PKCS11_LOGIN_FAILED(c, errstr)             \
+    TRACE(c, "PKINIT PKCS11 C_Login failed: {str}", errstr)
+#define TRACE_PKINIT_PKCS11_NO_MATCH_TOKEN(c)                   \
+    TRACE(c, "PKINIT PKCS#11 module has no matching tokens")
+#define TRACE_PKINIT_PKCS11_NO_TOKEN(c)                                 \
+    TRACE(c, "PKINIT PKCS#11 module shows no slots with tokens")
+#define TRACE_PKINIT_PKCS11_OPEN(c, name)                       \
+    TRACE(c, "PKINIT opening PKCS#11 module \"{str}\"", name)
+#define TRACE_PKINIT_PKCS11_OPEN_FAILED(c, errstr)                      \
+    TRACE(c, "PKINIT PKCS#11 module open failed: {str}", errstr)
+#define TRACE_PKINIT_PKCS11_SLOT(c, slot, len, label)            \
+    TRACE(c, "PKINIT PKCS#11 slotid {int} token {lenstr}",       \
+          slot, len, label)
+
 #define TRACE_PKINIT_SERVER_CERT_AUTH(c, modname)                       \
     TRACE(c, "PKINIT server authorizing cert with module {str}",        \
           modname)
@@ -123,16 +142,28 @@
     TRACE(c, "PKINIT server could not parse UPN \"{str}\": {kerr}",     \
           upn, ret)
 
+#define TRACE_PKINIT_CERT_CHAIN_NAME(c, index, name)    \
+    TRACE(c, "PKINIT chain cert #{int}: {str}", index, name)
+#define TRACE_PKINIT_CERT_NUM_MATCHING(c, total, nummatch)              \
+    TRACE(c, "PKINIT client checked {int} certs, found {int} matches",  \
+          total, nummatch)
+#define TRACE_PKINIT_CERT_RULE(c, rule)                                 \
+    TRACE(c, "PKINIT client matching rule '{str}' against certificates", rule)
+#define TRACE_PKINIT_CERT_RULE_INVALID(c, rule)                         \
+    TRACE(c, "PKINIT client ignoring invalid rule '{str}'", rule)
+
 #define TRACE_PKINIT_EKU(c)                                             \
     TRACE(c, "PKINIT found acceptable EKU and digitalSignature KU")
 #define TRACE_PKINIT_EKU_NO_KU(c)                                       \
     TRACE(c, "PKINIT found acceptable EKU but no digitalSignature KU")
+#define TRACE_PKINIT_IDENTITY_OPTION(c, name)           \
+    TRACE(c, "PKINIT loading identity {str}", name)
 #define TRACE_PKINIT_LOADED_CERT(c, name)                       \
     TRACE(c, "PKINIT loaded cert and key for {str}", name)
-#define TRACE_PKINIT_LOAD_FROM_FILE(c)                          \
-    TRACE(c, "PKINIT loading CA certs and CRLs from FILE")
-#define TRACE_PKINIT_LOAD_FROM_DIR(c)                           \
-    TRACE(c, "PKINIT loading CA certs and CRLs from DIR")
+#define TRACE_PKINIT_LOAD_FROM_FILE(c, name)                            \
+    TRACE(c, "PKINIT loading CA certs and CRLs from FILE {str}", name)
+#define TRACE_PKINIT_LOAD_FROM_DIR(c, name)                             \
+    TRACE(c, "PKINIT loading CA certs and CRLs from DIR {str}", name)
 #define TRACE_PKINIT_NO_CA_ANCHOR(c, file)              \
     TRACE(c, "PKINIT no anchor CA in file {str}", file)
 #define TRACE_PKINIT_NO_CA_INTERMEDIATE(c, file)                \
@@ -162,6 +193,18 @@
     TRACE(c, "PKINIT second PKCS12_parse with password failed")
 #define TRACE_PKINIT_PKCS_PROMPT_FAIL(c)                        \
     TRACE(c, "PKINIT failed to prompt for PKCS12 password")
+#define TRACE_PKINIT_REGEXP_MATCH(c, keyword, comp, value, idx)         \
+    TRACE(c, "PKINIT matched {str} rule '{str}' with "                  \
+          "value '{str}' in cert #{int}", keyword, comp, value, (idx) + 1)
+#define TRACE_PKINIT_REGEXP_NOMATCH(c, keyword, comp, value, idx)       \
+    TRACE(c, "PKINIT didn't match {str} rule '{str}' with "             \
+          "value '{str}' in cert #{int}", keyword, comp, value, (idx) + 1)
+#define TRACE_PKINIT_SAN_CERT_COUNT(c, count, princ, upns, dns, cert)   \
+    TRACE(c, "PKINIT client found {int} SANs ({int} princs, {int} "     \
+          "UPNs, {int} DNS names) in certificate {str}", count, princ,   \
+          upns, dns, cert)
+#define TRACE_PKINIT_SAN_CERT_NONE(c, cert)                             \
+    TRACE(c, "PKINIT client found no SANs in certificate {str}", cert)
 
 #define TRACE_CERTAUTH_VTINIT_FAIL(c, ret)                              \
     TRACE(c, "certauth module failed to init vtable: {kerr}", ret)


### PR DESCRIPTION
As discussed previously, we are in the process of moving away from our own forked PKINIT plugin to the stock MIT PKINIT plugin. One thing our forked PKINIT plugin could do was conditionally enable the pkiDebug macro (this plugin fork predates the KRB5_TRACE functionality)

After observing the existing KRB5_TRACE output, our customer support staff had communicated to me that the existing trace points did not convey enough information that they could successfully debug PKINIT problems. This pull request adds additional trace points based on their feedback.

They specifically asked for more information about the following things:

- Any errors/messages regarding loading a PKCS#11 plugin
- Information about the certificates being processed from a PKCS#11 plugin
- Certificate matching (and more specifically, details about SAN matching)
- The certificate chain used to validate a selected certificate

All of those things are covered in this change request. I think nearly all of these have a corresponding pkiDebug() statement.

I attempted to conform to the recommended usage of KRB5_TRACE in this patch. Any suggested changes are welcome.