### PR TITLE
doc: improve ktutil example keytab filename

### DIFF
--- a/doc/admin/admin_commands/ktutil.rst
+++ b/doc/admin/admin_commands/ktutil.rst
@@ -112,7 +112,7 @@ EXAMPLE
     ktutil:  add_entry -password -p alice@BLEEP.COM -k 1 -e
         aes256-cts-hmac-sha1-96
     Password for alice@BLEEP.COM:
-    ktutil:  write_kt keytab
+    ktutil:  write_kt alice.keytab
     ktutil:
 
 


### PR DESCRIPTION
The example of writing to a file named `keytab` is ambiguous. Name the file `alice.keytab` instead, to match the example user principal name.