### PR TITLE
Fix gss-krb5 handling of high sequence numbers

### DIFF
--- a/src/lib/gssapi/krb5/accept_sec_context.c
+++ b/src/lib/gssapi/krb5/accept_sec_context.c
@@ -982,7 +982,7 @@ kg_accept_krb5(minor_status, context_handle,
     {
         krb5_int32 seq_temp;
         krb5_auth_con_getremoteseqnumber(context, auth_context, &seq_temp);
-        ctx->seq_recv = seq_temp;
+        ctx->seq_recv = (uint32_t)seq_temp;
     }
 
     if ((code = krb5_timeofday(context, &now))) {
@@ -1065,7 +1065,7 @@ kg_accept_krb5(minor_status, context_handle,
         }
 
         krb5_auth_con_getlocalseqnumber(context, auth_context, &seq_temp);
-        ctx->seq_send = seq_temp & 0xffffffffL;
+        ctx->seq_send = (uint32_t)seq_temp;
 
         if (cfx_generate_subkey) {
             /* Get the new acceptor subkey.  With the code above, there

--- a/src/lib/gssapi/krb5/init_sec_context.c
+++ b/src/lib/gssapi/krb5/init_sec_context.c
@@ -631,7 +631,7 @@ kg_new_connection(
         }
 
         krb5_auth_con_getlocalseqnumber(context, ctx->auth_context, &seq_temp);
-        ctx->seq_send = seq_temp;
+        ctx->seq_send = (uint32_t)seq_temp;
         code = krb5_auth_con_getsendsubkey(context, ctx->auth_context,
                                            &keyblock);
         if (code != 0)


### PR DESCRIPTION
Commits abcfdaff756631d73f49103f679cafa7bc45f14e and
41ddaaeb286e8bb1bba64fb557ba0e4cff9b404d incorrectly changed the
interpretation of authenticator sequence numbers in the range
2^31..2^32-1, mapping them to sign-extended 64-bit values.  The major
Kerberos implementations do not generate sequence numbers this large,
so the changed went unnoticed.  Prevent unwanted sign extension by
casting sequence numbers retrieved from auth contexts to uint32_t
before assigning them to uint64_t fields.  Reported by Jake Scott.
