### PR TITLE
Use KCM_OP_RETRIEVE in KCM client

### DIFF
--- a/src/include/kcm.h
+++ b/src/include/kcm.h
@@ -87,7 +87,7 @@ typedef enum kcm_opcode {
     KCM_OP_INITIALIZE,          /*          (name, princ) -> ()          */
     KCM_OP_DESTROY,             /*                 (name) -> ()          */
     KCM_OP_STORE,               /*           (name, cred) -> ()          */
-    KCM_OP_RETRIEVE,
+    KCM_OP_RETRIEVE,            /* (name, flags, credtag) -> (cred)      */
     KCM_OP_GET_PRINCIPAL,       /*                 (name) -> (princ)     */
     KCM_OP_GET_CRED_UUID_LIST,  /*                 (name) -> (uuid, ...) */
     KCM_OP_GET_CRED_BY_UUID,    /*           (name, uuid) -> (cred)      */

--- a/src/tests/t_ccache.py
+++ b/src/tests/t_ccache.py
@@ -25,7 +25,7 @@ from k5test import *
 kcm_socket_path = os.path.join(os.getcwd(), 'testdir', 'kcm')
 conf = {'libdefaults': {'kcm_socket': kcm_socket_path,
                         'kcm_mach_service': '-'}}
-realm = K5Realm(create_host=False, krb5_conf=conf)
+realm = K5Realm(krb5_conf=conf)
 
 keyctl = which('keyctl')
 out = realm.run([klist, '-c', 'KEYRING:process:abcd'], expected_code=1)
@@ -71,6 +71,11 @@ def collection_test(realm, ccname):
     realm.kinit('alice', password('alice'))
     realm.run([klist], expected_msg='Default principal: alice@')
     realm.run([klist, '-A', '-s'])
+    realm.run([kvno, realm.host_princ], expected_msg = 'kvno = 1')
+    realm.run([kvno, realm.host_princ], expected_msg = 'kvno = 1')
+    out = realm.run([klist])
+    if out.count(realm.host_princ) != 1:
+        fail('Wrong number of service tickets in cache')
     realm.run([kdestroy])
     output = realm.run([klist], expected_code=1)
     if 'No credentials cache' not in output and 'not found' not in output:
@@ -126,14 +131,14 @@ def collection_test(realm, ccname):
 
 collection_test(realm, 'DIR:' + os.path.join(realm.testdir, 'cc'))
 
-# Test KCM without and with GET_CRED_LIST support.
+# Test KCM with and without RETRIEVE and GET_CRED_LIST support.
 kcmserver_path = os.path.join(srctop, 'tests', 'kcmserver.py')
 kcmd = realm.start_server([sys.executable, kcmserver_path, kcm_socket_path],
                           'starting...')
 collection_test(realm, 'KCM:')
 stop_daemon(kcmd)
 os.remove(kcm_socket_path)
-realm.start_server([sys.executable, kcmserver_path, '-c', kcm_socket_path],
+realm.start_server([sys.executable, kcmserver_path, '-f', kcm_socket_path],
                    'starting...')
 collection_test(realm, 'KCM:')
 


### PR DESCRIPTION
In kcm_retrieve(), try KCM_OP_RETRIEVE.  Fall back to iteration if the
server doesn't implement it, or if we can an answer incompatible with
KRB5_TC_SUPPORTED_KTYPES.

In kcmserver.py, implement partial decoding for creds and cred tags so
that we can do a basic principal name match.
