### PR TITLE
Simplify krb5_cccol_have_content()

### DIFF
--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -2667,14 +2667,14 @@ krb5_error_code KRB5_CALLCONV
 krb5_cccol_cursor_free(krb5_context context, krb5_cccol_cursor *cursor);
 
 /**
- * Check if the credential cache collection contains any credentials.
+ * Check if the credential cache collection contains any initialized caches.
  *
  * @param [in]  context         Library context
  *
  * @version New in 1.11
  *
- * @retval 0 Credentials are available in the collection
- * @retval KRB5_CC_NOTFOUND The collection contains no credentials
+ * @retval 0 At least one initialized cache is present in the collection
+ * @retval KRB5_CC_NOTFOUND The collection contains no caches
  */
 krb5_error_code KRB5_CALLCONV
 krb5_cccol_have_content(krb5_context context);

--- a/src/lib/krb5/ccache/cccursor.c
+++ b/src/lib/krb5/ccache/cccursor.c
@@ -224,33 +224,8 @@ static void
 save_first_error(krb5_context context, krb5_error_code code,
                  struct errinfo *errsave)
 {
-    if (code && code != KRB5_CC_END && !errsave->code)
+    if (code && code != KRB5_FCC_NOFILE && !errsave->code)
         k5_save_ctx_error(context, code, errsave);
-}
-
-/* Return 0 if cache contains any non-config credentials.  Return KRB5_CC_END
- * if it does not, or another error if we failed to read through it. */
-static krb5_error_code
-has_content(krb5_context context, krb5_ccache cache)
-{
-    krb5_error_code ret;
-    krb5_boolean found = FALSE;
-    krb5_cc_cursor cache_cursor;
-    krb5_creds creds;
-
-    ret = krb5_cc_start_seq_get(context, cache, &cache_cursor);
-    if (ret)
-        return ret;
-    while (!found) {
-        ret = krb5_cc_next_cred(context, cache, &cache_cursor, &creds);
-        if (ret)
-            break;
-        if (!krb5_is_config_principal(context, creds.server))
-            found = TRUE;
-        krb5_free_cred_contents(context, &creds);
-    }
-    krb5_cc_end_seq_get(context, cache, &cache_cursor);
-    return ret;
 }
 
 krb5_error_code KRB5_CALLCONV
@@ -259,6 +234,7 @@ krb5_cccol_have_content(krb5_context context)
     krb5_error_code ret;
     krb5_cccol_cursor col_cursor;
     krb5_ccache cache;
+    krb5_principal princ;
     krb5_boolean found = FALSE;
     struct errinfo errsave = EMPTY_ERRINFO;
     const char *defname;
@@ -273,15 +249,18 @@ krb5_cccol_have_content(krb5_context context)
         save_first_error(context, ret, &errsave);
         if (ret || cache == NULL)
             break;
-        ret = has_content(context, cache);
+        ret = krb5_cc_get_principal(context, cache, &princ);
         save_first_error(context, ret, &errsave);
         if (!ret)
             found = TRUE;
+        krb5_free_principal(context, princ);
         krb5_cc_close(context, cache);
     }
     krb5_cccol_cursor_free(context, &col_cursor);
-    if (found)
+    if (found) {
+        k5_clear_error(&errsave);
         return 0;
+    }
 
 no_entries:
     if (errsave.code) {


### PR DESCRIPTION
For the purposes of determining whether Kerberos credentials are
present, just check for an initialized ccache (as detected by
krb5_cc_get_principal()), not one with credentials in it.  For KCM
caches in particular, this changes avoids the O(n) expense of starting
an iteration.

Also fix a potential memory leak if a cache is found after an error is
saved.
