### PR TITLE
Two small libkadm5srv policy fixes

### DIFF
--- a/src/lib/kadm5/server_internal.h
+++ b/src/lib/kadm5/server_internal.h
@@ -139,7 +139,9 @@ extern  krb5_principal  current_caller;
     (KADM5_POLICY | KADM5_PW_MAX_LIFE | KADM5_PW_MIN_LIFE |             \
      KADM5_PW_MIN_LENGTH | KADM5_PW_MIN_CLASSES | KADM5_PW_HISTORY_NUM | \
      KADM5_REF_COUNT | KADM5_PW_MAX_FAILURE | KADM5_PW_FAILURE_COUNT_INTERVAL | \
-     KADM5_PW_LOCKOUT_DURATION )
+     KADM5_PW_LOCKOUT_DURATION | KADM5_POLICY_ATTRIBUTES |              \
+     KADM5_POLICY_MAX_LIFE | KADM5_POLICY_MAX_RLIFE |                   \
+     KADM5_POLICY_ALLOWED_KEYSALTS | KADM5_POLICY_TL_DATA)
 
 #define SERVER_CHECK_HANDLE(handle)             \
     {                                           \

--- a/src/lib/kadm5/srv/svr_policy.c
+++ b/src/lib/kadm5/srv/svr_policy.c
@@ -59,7 +59,7 @@ kadm5_ret_t
 kadm5_create_policy(void *server_handle, kadm5_policy_ent_t entry, long mask)
 {
     kadm5_server_handle_t handle = server_handle;
-    osa_policy_ent_rec  pent;
+    osa_policy_ent_rec  pent, *check_pol;
     int                 ret;
     char                *p;
 
@@ -78,6 +78,14 @@ kadm5_create_policy(void *server_handle, kadm5_policy_ent_t entry, long mask)
         ret = validate_allowed_keysalts(entry->allowed_keysalts);
         if (ret)
             return ret;
+    }
+
+    ret = krb5_db_get_policy(handle->context, entry->policy, &check_pol);
+    if (!ret) {
+        krb5_db_free_policy(handle->context, check_pol);
+        return KADM5_DUP;
+    } else if (ret != KRB5_KDB_NOENTRY) {
+        return ret;
     }
 
     memset(&pent, 0, sizeof(pent));

--- a/src/lib/kadm5/srv/svr_policy.c
+++ b/src/lib/kadm5/srv/svr_policy.c
@@ -71,7 +71,7 @@ kadm5_create_policy(void *server_handle, kadm5_policy_ent_t entry, long mask)
         return EINVAL;
     if(strlen(entry->policy) == 0)
         return KADM5_BAD_POLICY;
-    if (!(mask & KADM5_POLICY))
+    if (!(mask & KADM5_POLICY) || (mask & ~ALL_POLICY_MASK))
         return KADM5_BAD_MASK;
     if ((mask & KADM5_POLICY_ALLOWED_KEYSALTS) &&
         entry->allowed_keysalts != NULL) {
@@ -258,7 +258,7 @@ kadm5_modify_policy(void *server_handle, kadm5_policy_ent_t entry, long mask)
         return EINVAL;
     if(strlen(entry->policy) == 0)
         return KADM5_BAD_POLICY;
-    if((mask & KADM5_POLICY))
+    if ((mask & KADM5_POLICY) || (mask & ~ALL_POLICY_MASK))
         return KADM5_BAD_MASK;
     if ((mask & KADM5_POLICY_ALLOWED_KEYSALTS) &&
         entry->allowed_keysalts != NULL) {


### PR DESCRIPTION
While working on converting the libkadm5 unit tests away from TCL, I noticed two policy error-handling foibles which seemed (a) asymmetric with the corresponding principal handling functions, and (b) counter to the intent of the TCL tests, although the tests passed (one because it just looked for "DUP" in the error code name, the other because it used an undefined mask bit but also a defined-but-prohibited mask bit).
