### PR TITLE
Get CI working again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,9 @@ jobs:
                 sudo apt-get update -qq
                 sudo apt-get install -y bison dejagnu gettext keyutils ldap-utils libcmocka-dev libldap2-dev libkeyutils-dev libresolv-wrapper libsasl2-dev libssl-dev python3-kdcproxy python3-pip slapd tcl-dev tcsh
                 pip3 install pyrad
+                # Temporary workaround for:
+                # https://github.com/actions/virtual-environments/issues/3185
+                sudo hostname localhost
             - name: Build
               env:
                 CC: ${{ matrix.compiler }}


### PR DESCRIPTION
For a few weeks I started seeing occasional test failures where the first test involving a KDC would fail with a "Cannot contact any KDC for realm" error.  Now it happens all the time.  I assume Github Actions made a change to their runners and started with only some of them.

For the moment this PR switches the Unix build and tests back to Travis, but I will see if I can figure out the root cause and a workaround with Github Actions.
