### PR TITLE
Fix argument type errors on Windows

### DIFF
--- a/src/clients/kpasswd/kpasswd.c
+++ b/src/clients/kpasswd/kpasswd.c
@@ -37,7 +37,8 @@ get_name_from_passwd_file(char *program_name, krb5_context context,
 }
 #else /* HAVE_PWD_H */
 static void
-get_name_from_passwd_file(krb5_context context, krb5_principal *me)
+get_name_from_passwd_file(char *program_name, krb5_context context,
+                          krb5_principal *me)
 {
     fprintf(stderr, _("Unable to identify user\n"));
     exit(1);

--- a/src/config/win-pre.in
+++ b/src/config/win-pre.in
@@ -118,7 +118,11 @@ CC=cl
 
 PDB_OPTS=-Fd$(OUTPRE)\ -FD
 CPPFLAGS=-I$(top_srcdir)\include -I$(top_srcdir)\include\krb5 $(DNSFLAGS) -DWIN32_LEAN_AND_MEAN -DKRB5_DEPRECATED=1 -DKRB5_PRIVATE -D_CRT_SECURE_NO_DEPRECATE $(KFWFLAGS) $(TIME_T_FLAGS)
-CCOPTS=-nologo /EHsc /W3 $(PDB_OPTS) $(DLL_FILE_DEF)
+# Treat the following warnings as errors:
+#  4020: too many actual parameters
+#  4024: different types for formal and actual parameter
+#  4047: different levels of indirection
+CCOPTS=-nologo /EHsc /W3 /we4020 /we4024 /we4047 $(PDB_OPTS) $(DLL_FILE_DEF)
 LOPTS=-nologo -incremental:no -manifest
 
 !if  ("$(BITS)" == "64" )

--- a/src/lib/krb5/rcache/rc_dfl.c
+++ b/src/lib/krb5/rcache/rc_dfl.c
@@ -67,7 +67,7 @@ open_file(krb5_context context, int *fd_out)
             return ret;
     }
 
-    *fd_out = open(O_CREAT | O_RDWR | O_BINARY, 0600);
+    *fd_out = open(fname, O_CREAT | O_RDWR | O_BINARY, 0600);
     ret = (*fd_out < 0) ? errno : 0;
     if (ret) {
         k5_setmsg(context, ret, "%s (filename: %s)",

--- a/src/util/support/dir_filenames.c
+++ b/src/util/support/dir_filenames.c
@@ -87,7 +87,7 @@ k5_dir_filenames(const char *dirname, char ***fnames_out)
         return ENOENT;
 
     do {
-        if (add_filename(&fnames, &n_fnames, &ffd.cFileName) != 0) {
+        if (add_filename(&fnames, &n_fnames, ffd.cFileName) != 0) {
             k5_free_filenames(fnames);
             FindClose(handle);
             return ENOMEM;


### PR DESCRIPTION
Fix three Windows-specific argument type errors, including a crash bug
in the default replay cache type.  Change the compiler flags to treat
several argument type warnings as errors.

The replay cache bug was reported by Thomas Wagner.

[Side note, not in the commit message: I had considered flagging "incompatible types" (C4133) as an error, but we have eleven harmless instances of that warning in the build, all stemming from Windows/POSIX disagreements about pointer types in socket-layer functions like setsockopt().]
