### PR TITLE
ACE library defines MAXHOSTNAMELEN macro, adding check for the same.

### DIFF
--- a/src/include/win-mac.h
+++ b/src/include/win-mac.h
@@ -101,7 +101,10 @@ typedef _W64 int         ssize_t;
 #endif
 #endif /* KRB5_SYSTYPES__ */
 
+#ifndef MAXHOSTNAMELEN
 #define MAXHOSTNAMELEN  512
+#endif
+
 #ifndef MAXPATHLEN
 #define MAXPATHLEN      256            /* Also for Windows temp files */
 #endif


### PR DESCRIPTION
ACE library defines MAXHOSTNAMELEN macro - http://www.aoc.nrao.edu/php/tjuerges/ALMA/ACE-5.5.2/html/ace/os__netdb_8h-source.html#l00072

If project uses both ACE and MIT Kerberos then it conflicts and gives compilation error.

Adding a check to prevent macro redefinition.