### PR TITLE
Allow kinit with keytab to defer canonicalization

### DIFF
--- a/src/clients/kinit/kinit.c
+++ b/src/clients/kinit/kinit.c
@@ -505,17 +505,6 @@ k5_begin(struct k_opts *opts, struct k5_data *k5)
                     _("when creating default server principal name"));
             goto cleanup;
         }
-        if (k5->me->realm.data[0] == 0) {
-            ret = krb5_unparse_name(k5->ctx, k5->me, &k5->name);
-            if (ret == 0) {
-                com_err(progname, KRB5_ERR_HOST_REALM_UNKNOWN,
-                        _("(principal %s)"), k5->name);
-            } else {
-                com_err(progname, KRB5_ERR_HOST_REALM_UNKNOWN,
-                        _("for local services"));
-            }
-            goto cleanup;
-        }
     } else if (k5->out_cc != NULL) {
         /* If the output ccache is initialized, use its principal. */
         if (krb5_cc_get_principal(k5->ctx, k5->out_cc, &princ) == 0)

--- a/src/lib/kadm5/clnt/client_init.c
+++ b/src/lib/kadm5/clnt/client_init.c
@@ -221,9 +221,16 @@ init_any(krb5_context context, char *client_name, enum init_type init_type,
         return KADM5_MISSING_KRB5_CONF_PARAMS;
     }
 
+    /*
+     * Parse the client name.  If it has an empty realm, it is almost certainly
+     * a host-based principal using DNS fallback processing or the referral
+     * realm, so give it the appropriate name type for canonicalization.
+     */
     code = krb5_parse_name(handle->context, client_name, &client);
     if (code)
         goto error;
+    if (init_type == INIT_SKEY && client->realm.length == 0)
+        client->type = KRB5_NT_SRV_HST;
 
     /*
      * Get credentials.  Also does some fallbacks in case kadmin/fqdn

--- a/src/lib/krb5/os/os-proto.h
+++ b/src/lib/krb5/os/os-proto.h
@@ -85,10 +85,15 @@ struct sendto_callback_info {
 
 /*
  * Initialize with all zeros except for princ.  Set no_hostrealm to disable
- * host-to-realm lookup, which ordinarily happens after canonicalizing the host
- * part.  Set subst_defrealm to substitute the default realm for the referral
- * realm after realm lookup (this has no effect if no_hostrealm is set).  Free
- * with free_canonprinc() when done.
+ * host-to-realm lookup, which ordinarily happens during fallback processing
+ * after canonicalizing the host part.  Set subst_defrealm to substitute the
+ * default realm for the referral realm after realm lookup.  Do not set both
+ * flags.  Free with free_canonprinc() when done.
+ *
+ * no_hostrealm only applies if fallback processing is in use
+ * (dns_canonicalize_hostname = fallback).  It will not remove the realm if
+ * krb5_sname_to_principal() already canonicalized the hostname and looked up a
+ * realm.  subst_defrealm applies whether or not fallback processing is in use.
  */
 struct canonprinc {
     krb5_const_principal princ;

--- a/src/tests/t_kadmin.py
+++ b/src/tests/t_kadmin.py
@@ -51,4 +51,16 @@ for i in range(200):
     realm.run_kadmin(['addprinc', '-randkey', 'foo%d' % i])
 realm.run_kadmin(['listprincs'], expected_msg='foo199')
 
+# Test kadmin -k with the default principal, with and without
+# fallback.  This operation requires canonicalization against the
+# keytab in krb5_get_init_creds_keytab() as the
+# krb5_sname_to_principal() result won't have a realm.  Try with and
+# without without fallback processing since the code paths are
+# different.
+mark('kadmin -k')
+realm.run([kadmin, '-k', 'getprinc', realm.host_princ])
+no_canon_conf = {'libdefaults': {'dns_canonicalize_hostname': 'false'}}
+no_canon = realm.special_env('no_canon', False, krb5_conf=no_canon_conf)
+realm.run([kadmin, '-k', 'getprinc', realm.host_princ], env=no_canon)
+
 success('kadmin and kpasswd tests')

--- a/src/tests/t_keytab.py
+++ b/src/tests/t_keytab.py
@@ -41,6 +41,19 @@ realm.kinit(realm.user_princ, flags=['-i'],
             expected_msg='keytab specified, forcing -k')
 realm.klist(realm.user_princ)
 
+# Test default principal for -k.  This operation requires
+# canonicalization against the keytab in krb5_get_init_creds_keytab()
+# as the krb5_sname_to_principal() result won't have a realm.  Try
+# with and without without fallback processing since the code paths
+# are different.
+mark('default principal for -k')
+realm.run([kinit, '-k'])
+realm.klist(realm.host_princ)
+no_canon_conf = {'libdefaults': {'dns_canonicalize_hostname': 'false'}}
+no_canon = realm.special_env('no_canon', False, krb5_conf=no_canon_conf)
+realm.run([kinit, '-k'], env=no_canon)
+realm.klist(realm.host_princ)
+
 # Test extracting keys with multiple key versions present.
 mark('multi-kvno extract')
 os.remove(realm.keytab)


### PR DESCRIPTION
Using `dns_canonicalize_hostname = fallback`, currently:

```
# KRB5_TRACE=/dev/stderr kinit -kt FILE:/etc/krb5.keytab
kinit: Cannot determine realm for host (principal host/kerberos.example.com@)
#
```

With changes:

```
# kinit -kt FILE:/etc/krb5.keytab
[61971] 1622750537.186595: Matching host/kerberos.example.com@ in collection with result: -1765328243/Can't find client principal host/kerberos.example.com@ in cache collection
[61971] 1622750537.186596: Getting initial credentials for host/kerberos.example.com@
[61971] 1622750537.186597: Found entries for host/kerberos.example.com@EXAMPLE.COM in keytab: aes256-cts, aes128-cts, rc4-hmac, camellia256-cts, camellia128-cts
[61971] 1622750537.186601: Sending unauthenticated request
[61971] 1622750537.186602: Sending request (211 bytes) to EXAMPLE.COM
[61971] 1622750537.186603: Resolving hostname kerberos.example.com
[61971] 1622750537.186604: Sending initial UDP request to dgram 127.0.0.1:88
[61971] 1622750537.186605: Received answer (487 bytes) from dgram 127.0.0.1:88
[61971] 1622750537.186606: Sending DNS URI query for _kerberos.EXAMPLE.COM.
[61971] 1622750537.186607: No URI records found
[61971] 1622750537.186608: Sending DNS SRV query for _kerberos-master._udp.EXAMPLE.COM.
[61971] 1622750537.186609: Sending DNS SRV query for _kerberos-master._tcp.EXAMPLE.COM.
[61971] 1622750537.186610: No SRV records found
[61971] 1622750537.186611: Response was not from primary KDC
[61971] 1622750537.186612: Received error from KDC: -1765328359/Additional pre-authentication required
[61971] 1622750537.186615: Preauthenticating using KDC method data
[61971] 1622750537.186616: Processing preauth types: PA-FX-FAST (136), PA-ETYPE-INFO2 (19), PA-SPAKE (151), PA-ENC-TIMESTAMP (2), PA-FX-COOKIE (133)
[61971] 1622750537.186617: Selected etype info: etype aes256-cts, salt "EXAMPLE.COMhostkerberos.example.com", params ""
[61971] 1622750537.186618: Received cookie: MIT1\x00\x00\x00\x01\xd0\x883\xedq\xd3\xb5\xe7\x9e\xcd\xef$\xd8\x0b\xf5\x81D\x99v(\xa3\xe8\x15n\x85B\x0a\xa3sZ\xbaT"\\x14z\x91\xda\x04\xd0c\xca\x9d,\xfe\x9d\x8f\xbd\x9e\x041\xe6\xfd,\x98\x1f}\x86\x08<K\x1dN\x94<\xb1b\x97dw\x15\xda\xa7\xce-\x8a\x12\x80]\xa5P\xae\xf5\xd2\x05\xb8YN\xc4\x82\xde\x1f\xbf\x0f\xf3\x06\xd1\xb3\xa1\x837\x85Y\xd8\x94w\xe8\xe4\xda\x9a}\x8e\xd8\x1c6\xfc\xf7\x1b\x08\xf7\xde\xc9\xaf3B\x10\xefs\xe5\xe3
[61971] 1622750537.186619: Retrieving host/kerberos.example.com@EXAMPLE.COM from FILE:/etc/krb5.keytab (vno 0, enctype aes256-cts) with result: 0/Success
[61971] 1622750537.186620: AS key obtained for encrypted timestamp: aes256-cts/89F3
[61971] 1622750537.186622: Encrypted timestamp (for 1622750537.190262): plain 301AA011180F32303231303630333230303231375AA105020302E736, encrypted 4E70B81D907C0C4B547474DD573C6CC2ACD7D43AD4ABD50C7AD06627AA0DC85512521AE3BC6FF29FA1AC222EA0A4B381258855EDD2D71FC5
[61971] 1622750537.186623: Preauth module encrypted_timestamp (2) (real) returned: 0/Success
[61971] 1622750537.186624: Produced preauth for next request: PA-FX-COOKIE (133), PA-ENC-TIMESTAMP (2)
[61971] 1622750537.186625: Sending request (447 bytes) to EXAMPLE.COM
[61971] 1622750537.186626: Resolving hostname kerberos.example.com
[61971] 1622750537.186627: Sending initial UDP request to dgram 127.0.0.1:88
[61971] 1622750537.186628: Received answer (808 bytes) from dgram 127.0.0.1:88
[61971] 1622750537.186629: Sending DNS URI query for _kerberos.EXAMPLE.COM.
[61971] 1622750537.186630: No URI records found
[61971] 1622750537.186631: Sending DNS SRV query for _kerberos-master._udp.EXAMPLE.COM.
[61971] 1622750537.186632: Sending DNS SRV query for _kerberos-master._tcp.EXAMPLE.COM.
[61971] 1622750537.186633: No SRV records found
[61971] 1622750537.186634: Response was not from primary KDC
[61971] 1622750537.186635: Processing preauth types: PA-ETYPE-INFO2 (19)
[61971] 1622750537.186636: Selected etype info: etype aes256-cts, salt "EXAMPLE.COMhostkerberos.example.com", params ""
[61971] 1622750537.186637: Produced preauth for next request: (empty)
[61971] 1622750537.186638: AS key determined by preauth: aes256-cts/89F3
[61971] 1622750537.186639: Decrypted AS reply; session key is: aes256-cts/C2FE
[61971] 1622750537.186640: FAST negotiation: available
[61971] 1622750537.186641: Initializing KCM:0 with default princ host/kerberos.example.com@EXAMPLE.COM
[61971] 1622750537.186642: Storing host/kerberos.example.com@EXAMPLE.COM -> krbtgt/EXAMPLE.COM@EXAMPLE.COM in KCM:0
[61971] 1622750537.186643: Storing config in KCM:0 for krbtgt/EXAMPLE.COM@EXAMPLE.COM: fast_avail: yes
[61971] 1622750537.186644: Storing host/kerberos.example.com@EXAMPLE.COM -> krb5_ccache_conf_data/fast_avail/krbtgt\/EXAMPLE.COM\@EXAMPLE.COM@X-CACHECONF: in KCM:0
[61971] 1622750537.186645: Storing config in KCM:0 for krbtgt/EXAMPLE.COM@EXAMPLE.COM: pa_type: 2
[61971] 1622750537.186646: Storing host/kerberos.example.com@EXAMPLE.COM -> krb5_ccache_conf_data/pa_type/krbtgt\/EXAMPLE.COM\@EXAMPLE.COM@X-CACHECONF: in KCM:0
#
```