### PR TITLE
Set SSL_OP_IGNORE_UNEXPECTED_EOF for OpenSSL contexts

### DIFF
--- a/src/plugins/tls/k5tls/openssl.c
+++ b/src/plugins/tls/k5tls/openssl.c
@@ -433,7 +433,7 @@ setup(krb5_context context, SOCKET fd, const char *servername,
       char **anchors, k5_tls_handle *handle_out)
 {
     int e;
-    long options;
+    long options = SSL_OP_NO_SSLv2;
     SSL_CTX *ctx = NULL;
     SSL *ssl = NULL;
     k5_tls_handle handle = NULL;
@@ -448,8 +448,19 @@ setup(krb5_context context, SOCKET fd, const char *servername,
     ctx = SSL_CTX_new(SSLv23_client_method());
     if (ctx == NULL)
         goto error;
-    options = SSL_CTX_get_options(ctx);
-    SSL_CTX_set_options(ctx, options | SSL_OP_NO_SSLv2);
+
+#ifdef SSL_OP_IGNORE_UNEXPECTED_EOF
+    /*
+     * For OpenSSL 3 and later, mark close_notify alerts as optional.  We don't
+     * need to worry about truncation attacks because the protocols this module
+     * is used with (Kerberos and change-password) receive a single
+     * length-delimited message from the server.  For prior versions of OpenSSL
+     * we check for SSL_ERROR_SYSCALL when reading instead (this error changes
+     * to SSL_ERROR_SSL in OpenSSL 3).
+     */
+    options |= SSL_OP_IGNORE_UNEXPECTED_EOF;
+#endif
+    SSL_CTX_set_options(ctx, options);
 
     SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, verify_callback);
     X509_STORE_set_flags(SSL_CTX_get_cert_store(ctx), 0);


### PR DESCRIPTION
Starting in OpenSSL 3, connection termination without a close_notify
alert causes SSL_read() to return SSL_ERROR_SSL.  Set
SSL_OP_IGNORE_UNEXPECTED_EOF so that we get the more familiar
SSL_ERROR_ZERO_RETURN instead so that we continue working with kdcproxy.

Remove the call to SSL_CTX_get_options() since SSL_CTX_set_options()
doesn't clear existing options.

[This is not detected by openssl CI currently because openssl CI doesn't run the proxy tests.]