### PR TITLE
Using locking in MEMORY krb5_cc_get_principal()

### DIFF
--- a/src/lib/krb5/ccache/cc_memory.c
+++ b/src/lib/krb5/ccache/cc_memory.c
@@ -578,12 +578,17 @@ krb5_mcc_get_name (krb5_context context, krb5_ccache id)
 krb5_error_code KRB5_CALLCONV
 krb5_mcc_get_principal(krb5_context context, krb5_ccache id, krb5_principal *princ)
 {
-    krb5_mcc_data *ptr = (krb5_mcc_data *)id->data;
-    if (!ptr->prin) {
-        *princ = 0L;
-        return KRB5_FCC_NOFILE;
-    }
-    return krb5_copy_principal(context, ptr->prin, princ);
+    krb5_error_code ret;
+    krb5_mcc_data *d = id->data;
+
+    *princ = NULL;
+    k5_cc_mutex_lock(context, &d->lock);
+    if (d->prin == NULL)
+        ret = KRB5_FCC_NOFILE;
+    else
+        ret = krb5_copy_principal(context, d->prin, princ);
+    k5_cc_mutex_unlock(context, &d->lock);
+    return ret;
 }
 
 krb5_error_code KRB5_CALLCONV


### PR DESCRIPTION
Without locking, the principal pointer could be freed out from under
krb5_copy_principal() by another thread calling krb5_cc_initialize()
or krb5_cc_destroy().

[This seems likely to be the cause of the crash mentioned in https://mailman.mit.edu/pipermail/krbdev/2021-May/013462.html now that I have looked at a stack trace provided by Thomas.]
