### PR TITLE
Use asan in one of the CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
                       os: ubuntu-18.04
                       compiler: clang
                       makevars: CPPFLAGS=-Werror
+                      configureopts: --enable-asan
                     - name: linux-clang-openssl
                       os: ubuntu-18.04
                       compiler: clang


### PR DESCRIPTION
Now that there's no dejagnu stuff in the test suite, the Linux jobs run about twice as fast as the Windows build.  That's also the approximate penalty for enabling asan.

I chose to add asan to the existing linux-clang job instead of creating a new job.  That job will skip the test that uses resolv_wrapper, but the other two jobs will run that test so it should be fine.

The CI for this PR branch should fail until PR #1198 is merged, providing an example of what an asan failure will look like.  It looks like the runner doesn't need any explicit symbolizer configuration to produce readable stack traces.