### PR TITLE
otp: add support for otp-challenge mechanism

### DIFF
--- a/doc/admin/otp.rst
+++ b/doc/admin/otp.rst
@@ -31,6 +31,7 @@ Token types are defined in either :ref:`krb5.conf(5)` or
             retries = <integer> (default: 3)
             strip_realm = <boolean> (default: true)
             indicator = <string> (default: none)
+            challenge = <boolean> (default: false)
         }
 
 If the server field begins with '/', it will be interpreted as a UNIX
@@ -48,6 +49,10 @@ If an indicator field is present, tickets issued using this token type
 will be annotated with the specified authentication indicator (see
 :ref:`auth_indicator`).  This key may be specified multiple times to
 add multiple indicators.
+
+If the challenge field is true then the a challenge message is obtained from the
+RADIUS server first. This message is presented to the user before asking for an
+authentication token.
 
 
 The default token type

--- a/doc/formats/cookie.rst
+++ b/doc/formats/cookie.rst
@@ -95,3 +95,13 @@ records, including none; a second-factor type need not create a state
 field if it does not need one, and no record is created for SF-NONE.
 For other cookies, there must be exactly one second-factor record
 corresponding to the factor type chosen by the client.
+
+OTP cookie format (version 1)
+-------------------------------
+
+Inside an OTP pre-authentication plugin, a data value of type 142 contains state
+of RADIUS authentication if challenge field of an OTP token type is set to true.
+This data is the concatenation of the following:
+
+* a two-byte big-endian version number with the value 1
+* a RADIUS state (rest of the cookie)

--- a/src/include/krad.h
+++ b/src/include/krad.h
@@ -57,6 +57,16 @@
 #define KRAD_SERVICE_TYPE_CALL_CHECK 10
 #define KRAD_SERVICE_TYPE_CALLBACK_ADMINISTRATIVE 11
 
+#define KRAD_CODE_ACCESS_REQUEST 1
+#define KRAD_CODE_ACCESS_ACCEPT 2
+#define KRAD_CODE_ACCESS_REJECT 3
+#define KRAD_CODE_ACCESS_CHALLENGE 11
+
+#define KRAD_ATTR_USER_NAME 1
+#define KRAD_ATTR_USER_PASSWORD 2
+#define KRAD_ATTR_SERVICE_TYPE 6
+#define KRAD_ATTR_NAS_IDENTIFIER 32
+
 typedef struct krad_attrset_st krad_attrset;
 typedef struct krad_packet_st krad_packet;
 typedef struct krad_client_st krad_client;

--- a/src/lib/krad/t_attr.c
+++ b/src/lib/krad/t_attr.c
@@ -53,26 +53,22 @@ main()
 
     noerror(krb5_init_context(&ctx));
 
-    /* Make sure User-Name is 1. */
-    insist(krad_attr_name2num("User-Name") == 1);
+    insist(krad_attr_name2num("User-Name") == KRAD_ATTR_USER_NAME);
 
-    /* Make sure 2 is User-Password. */
-    tmp = krad_attr_num2name(2);
+    tmp = krad_attr_num2name(KRAD_ATTR_USER_PASSWORD);
     insist(tmp != NULL);
     insist(strcmp(tmp, "User-Password") == 0);
 
     /* Test decoding. */
     in = make_data((void *)encoded, sizeof(encoded));
-    noerror(kr_attr_decode(ctx, secret, auth,
-                           krad_attr_name2num("User-Password"),
+    noerror(kr_attr_decode(ctx, secret, auth, KRAD_ATTR_USER_PASSWORD,
                            &in, outbuf, &len));
     insist(len == strlen(decoded));
     insist(memcmp(outbuf, decoded, len) == 0);
 
     /* Test encoding. */
     in = string2data((char *)decoded);
-    retval = kr_attr_encode(ctx, secret, auth,
-                            krad_attr_name2num("User-Password"),
+    retval = kr_attr_encode(ctx, secret, auth, KRAD_ATTR_USER_PASSWORD,
                             &in, outbuf, &len);
     insist(retval == 0);
     insist(len == sizeof(encoded));
@@ -80,9 +76,9 @@ main()
 
     /* Test constraint. */
     in.length = 100;
-    insist(kr_attr_valid(krad_attr_name2num("User-Password"), &in) == 0);
+    insist(kr_attr_valid(KRAD_ATTR_USER_PASSWORD, &in) == 0);
     in.length = 200;
-    insist(kr_attr_valid(krad_attr_name2num("User-Password"), &in) != 0);
+    insist(kr_attr_valid(KRAD_ATTR_USER_PASSWORD, &in) != 0);
 
     krb5_free_context(ctx);
     return 0;

--- a/src/lib/krad/t_attrset.c
+++ b/src/lib/krad/t_attrset.c
@@ -55,24 +55,24 @@ main()
 
     /* Add username. */
     tmp = string2data((char *)username);
-    noerror(krad_attrset_add(set, krad_attr_name2num("User-Name"), &tmp));
+    noerror(krad_attrset_add(set, KRAD_ATTR_USER_NAME, &tmp));
 
     /* Add password. */
     tmp = string2data((char *)password);
-    noerror(krad_attrset_add(set, krad_attr_name2num("User-Password"), &tmp));
+    noerror(krad_attrset_add(set, KRAD_ATTR_USER_PASSWORD, &tmp));
 
     /* Encode attrset. */
     noerror(kr_attrset_encode(set, "foo", auth, buffer, &encode_len));
     krad_attrset_free(set);
 
     /* Manually encode User-Name. */
-    encoded[len + 0] = krad_attr_name2num("User-Name");
+    encoded[len + 0] = KRAD_ATTR_USER_NAME;
     encoded[len + 1] = strlen(username) + 2;
     memcpy(encoded + len + 2, username, strlen(username));
     len += encoded[len + 1];
 
     /* Manually encode User-Password. */
-    encoded[len + 0] = krad_attr_name2num("User-Password");
+    encoded[len + 0] = KRAD_ATTR_USER_PASSWORD;
     encoded[len + 1] = sizeof(encpass) + 2;
     memcpy(encoded + len + 2, encpass, sizeof(encpass));
     len += encoded[len + 1];
@@ -87,7 +87,7 @@ main()
 
     /* Test getting an attribute. */
     tmp = string2data((char *)username);
-    tmpp = krad_attrset_get(set, krad_attr_name2num("User-Name"), 0);
+    tmpp = krad_attrset_get(set, KRAD_ATTR_USER_NAME, 0);
     insist(tmpp != NULL);
     insist(tmpp->length == tmp.length);
     insist(strncmp(tmpp->data, tmp.data, tmp.length) == 0);

--- a/src/lib/krad/t_client.c
+++ b/src/lib/krad/t_client.c
@@ -74,33 +74,31 @@ main(int argc, const char **argv)
 
     tmp = string2data("testUser");
     noerror(krad_attrset_new(kctx, &attrs));
-    noerror(krad_attrset_add(attrs, krad_attr_name2num("User-Name"), &tmp));
+    noerror(krad_attrset_add(attrs, KRAD_ATTR_USER_NAME, &tmp));
 
     /* Test accept. */
     tmp = string2data("accept");
-    noerror(krad_attrset_add(attrs, krad_attr_name2num("User-Password"),
-                             &tmp));
-    noerror(krad_client_send(rc, krad_code_name2num("Access-Request"), attrs,
+    noerror(krad_attrset_add(attrs, KRAD_ATTR_USER_PASSWORD, &tmp));
+    noerror(krad_client_send(rc, KRAD_CODE_ACCESS_REQUEST, attrs,
                              "localhost", "foo", 1000, 3, callback, NULL));
     verto_run(vctx);
 
     /* Test reject. */
     tmp = string2data("reject");
-    krad_attrset_del(attrs, krad_attr_name2num("User-Password"), 0);
-    noerror(krad_attrset_add(attrs, krad_attr_name2num("User-Password"),
-                             &tmp));
-    noerror(krad_client_send(rc, krad_code_name2num("Access-Request"), attrs,
+    krad_attrset_del(attrs, KRAD_ATTR_USER_PASSWORD, 0);
+    noerror(krad_attrset_add(attrs, KRAD_ATTR_USER_PASSWORD, &tmp));
+    noerror(krad_client_send(rc, KRAD_CODE_ACCESS_REQUEST, attrs,
                              "localhost", "foo", 1000, 3, callback, NULL));
     verto_run(vctx);
 
     /* Test timeout. */
     daemon_stop();
-    noerror(krad_client_send(rc, krad_code_name2num("Access-Request"), attrs,
+    noerror(krad_client_send(rc, KRAD_CODE_ACCESS_REQUEST, attrs,
                              "localhost", "foo", 1000, 3, callback, NULL));
     verto_run(vctx);
 
     /* Test outstanding packet freeing. */
-    noerror(krad_client_send(rc, krad_code_name2num("Access-Request"), attrs,
+    noerror(krad_client_send(rc, KRAD_CODE_ACCESS_REQUEST, attrs,
                              "localhost", "foo", 1000, 3, callback, NULL));
     krad_client_free(rc);
     rc = NULL;
@@ -108,11 +106,9 @@ main(int argc, const char **argv)
     /* Verify the results. */
     insist(record.count == EVENT_COUNT);
     insist(record.events[0].error == FALSE);
-    insist(record.events[0].result.code ==
-           krad_code_name2num("Access-Accept"));
+    insist(record.events[0].result.code == KRAD_CODE_ACCESS_ACCEPT);
     insist(record.events[1].error == FALSE);
-    insist(record.events[1].result.code ==
-           krad_code_name2num("Access-Reject"));
+    insist(record.events[1].result.code == KRAD_CODE_ACCESS_REJECT);
     insist(record.events[2].error == TRUE);
     insist(record.events[2].result.retval == ETIMEDOUT);
     insist(record.events[3].error == TRUE);

--- a/src/lib/krad/t_code.c
+++ b/src/lib/krad/t_code.c
@@ -34,19 +34,19 @@ main()
 {
     const char *tmp;
 
-    insist(krad_code_name2num("Access-Request") == 1);
-    insist(krad_code_name2num("Access-Accept") == 2);
-    insist(krad_code_name2num("Access-Reject") == 3);
+    insist(krad_code_name2num("Access-Request") == KRAD_CODE_ACCESS_REQUEST);
+    insist(krad_code_name2num("Access-Accept") == KRAD_CODE_ACCESS_ACCEPT);
+    insist(krad_code_name2num("Access-Reject") == KRAD_CODE_ACCESS_REJECT);
 
-    tmp = krad_code_num2name(1);
+    tmp = krad_code_num2name(KRAD_CODE_ACCESS_REQUEST);
     insist(tmp != NULL);
     insist(strcmp(tmp, "Access-Request") == 0);
 
-    tmp = krad_code_num2name(2);
+    tmp = krad_code_num2name(KRAD_CODE_ACCESS_ACCEPT);
     insist(tmp != NULL);
     insist(strcmp(tmp, "Access-Accept") == 0);
 
-    tmp = krad_code_num2name(3);
+    tmp = krad_code_num2name(KRAD_CODE_ACCESS_REJECT);
     insist(tmp != NULL);
     insist(strcmp(tmp, "Access-Reject") == 0);
 

--- a/src/lib/krad/t_packet.c
+++ b/src/lib/krad/t_packet.c
@@ -62,22 +62,20 @@ make_packet(krb5_context ctx, const krb5_data *username,
     if (retval != 0)
         goto out;
 
-    retval = krad_attrset_add(set, krad_attr_name2num("User-Name"), username);
+    retval = krad_attrset_add(set, KRAD_ATTR_USER_NAME, username);
     if (retval != 0)
         goto out;
 
-    retval = krad_attrset_add(set, krad_attr_name2num("User-Password"),
-                              password);
+    retval = krad_attrset_add(set, KRAD_ATTR_USER_PASSWORD, password);
     if (retval != 0)
         goto out;
 
-    retval = krad_packet_new_request(ctx, "foo",
-                                     krad_code_name2num("Access-Request"),
+    retval = krad_packet_new_request(ctx, "foo", KRAD_CODE_ACCESS_REQUEST,
                                      set, iterator, &i, &tmp);
     if (retval != 0)
         goto out;
 
-    data = krad_packet_get_attr(tmp, krad_attr_name2num("User-Name"), 0);
+    data = krad_packet_get_attr(tmp, KRAD_ATTR_USER_NAME, 0);
     if (data == NULL) {
         retval = ENOENT;
         goto out;
@@ -143,7 +141,7 @@ do_auth(krb5_context ctx, struct addrinfo *ai, const char *secret,
         goto out;
     }
 
-    *auth = krad_packet_get_code(rsp) == krad_code_name2num("Access-Accept");
+    *auth = krad_packet_get_code(rsp) == KRAD_CODE_ACCESS_ACCEPT;
 
 out:
     krad_packet_free(rsp);

--- a/src/lib/krad/t_remote.c
+++ b/src/lib/krad/t_remote.c
@@ -78,13 +78,13 @@ do_auth(const char *password, const krad_packet **pkt)
     krb5_error_code retval;
     krb5_data tmp = string2data((char *)password);
 
-    retval = krad_attrset_add(set, krad_attr_name2num("User-Password"), &tmp);
+    retval = krad_attrset_add(set, KRAD_ATTR_USER_PASSWORD, &tmp);
     if (retval != 0)
         return retval;
 
-    retval = kr_remote_send(rr, krad_code_name2num("Access-Request"), set,
+    retval = kr_remote_send(rr, KRAD_CODE_ACCESS_REQUEST, set,
                             callback, NULL, 1000, 3, &tmppkt);
-    krad_attrset_del(set, krad_attr_name2num("User-Password"), 0);
+    krad_attrset_del(set, KRAD_ATTR_USER_PASSWORD, 0);
     if (retval != 0)
         return retval;
 
@@ -122,7 +122,7 @@ main(int argc, const char **argv)
     /* Create attribute set. */
     noerror(krad_attrset_new(kctx, &set));
     tmp = string2data("testUser");
-    noerror(krad_attrset_add(set, krad_attr_name2num("User-Name"), &tmp));
+    noerror(krad_attrset_add(set, KRAD_ATTR_USER_NAME, &tmp));
 
     /* Send accept packet. */
     noerror(do_auth("accept", NULL));
@@ -150,11 +150,9 @@ main(int argc, const char **argv)
     /* Verify the results. */
     insist(record.count == EVENT_COUNT);
     insist(record.events[0].error == FALSE);
-    insist(record.events[0].result.code ==
-           krad_code_name2num("Access-Accept"));
+    insist(record.events[0].result.code == KRAD_CODE_ACCESS_ACCEPT);
     insist(record.events[1].error == FALSE);
-    insist(record.events[1].result.code ==
-           krad_code_name2num("Access-Reject"));
+    insist(record.events[1].result.code == KRAD_CODE_ACCESS_REJECT);
     insist(record.events[2].error == TRUE);
     insist(record.events[2].result.retval == ECANCELED);
     insist(record.events[3].error == TRUE);

--- a/src/plugins/preauth/otp/otp_state.c
+++ b/src/plugins/preauth/otp/otp_state.c
@@ -591,13 +591,11 @@ otp_state_new(krb5_context ctx, otp_state **out)
         goto error;
 
     hndata = make_data(hostname, strlen(hostname));
-    retval = krad_attrset_add(self->attrs,
-                              krad_attr_name2num("NAS-Identifier"), &hndata);
+    retval = krad_attrset_add(self->attrs, KRAD_ATTR_NAS_IDENTIFIER, &hndata);
     if (retval != 0)
         goto error;
 
-    retval = krad_attrset_add_number(self->attrs,
-                                     krad_attr_name2num("Service-Type"),
+    retval = krad_attrset_add_number(self->attrs, KRAD_ATTR_SERVICE_TYPE,
                                      KRAD_SERVICE_TYPE_AUTHENTICATE_ONLY);
     if (retval != 0)
         goto error;
@@ -636,8 +634,7 @@ callback(krb5_error_code retval, const krad_packet *rqst,
         goto error;
 
     /* If we received an accept packet, success! */
-    if (krad_packet_get_code(resp) ==
-        krad_code_name2num("Access-Accept")) {
+    if (krad_packet_get_code(resp) == KRAD_CODE_ACCESS_ACCEPT) {
         indicators = tok->indicators;
         if (indicators == NULL)
             indicators = tok->type->indicators;
@@ -666,16 +663,14 @@ request_send(request *req)
     token *tok = &req->tokens[req->index];
     const token_type *t = tok->type;
 
-    retval = krad_attrset_add(req->attrs, krad_attr_name2num("User-Name"),
-                              &tok->username);
+    retval = krad_attrset_add(req->attrs, KRAD_ATTR_USER_NAME, &tok->username);
     if (retval != 0)
         goto error;
 
-    retval = krad_client_send(req->state->radius,
-                              krad_code_name2num("Access-Request"), req->attrs,
-                              t->server, t->secret, t->timeout, t->retries,
-                              callback, req);
-    krad_attrset_del(req->attrs, krad_attr_name2num("User-Name"), 0);
+    retval = krad_client_send(req->state->radius, KRAD_CODE_ACCESS_REQUEST,
+                              req->attrs, t->server, t->secret, t->timeout,
+                              t->retries, callback, req);
+    krad_attrset_del(req->attrs, KRAD_ATTR_USER_NAME, 0);
     if (retval != 0)
         goto error;
 
@@ -714,7 +709,7 @@ otp_state_verify(otp_state *state, verto_ctx *ctx, krb5_const_principal princ,
     if (retval != 0)
         goto error;
 
-    retval = krad_attrset_add(rqst->attrs, krad_attr_name2num("User-Password"),
+    retval = krad_attrset_add(rqst->attrs, KRAD_ATTR_USER_PASSWORD,
                               &req->otp_value);
     if (retval != 0)
         goto error;

--- a/src/plugins/preauth/otp/otp_state.h
+++ b/src/plugins/preauth/otp/otp_state.h
@@ -46,6 +46,7 @@ typedef struct otp_state_st otp_state;
 typedef struct token_st token;
 
 /* Opaque to otp_state.c, visible to main.c */
+struct challenge_state;
 struct verify_state;
 
 krb5_error_code
@@ -61,14 +62,27 @@ otp_state_parse_config(otp_state *state, const char *config_str,
 void
 otp_state_free_config(token *config);
 
+krb5_boolean
+otp_state_challenge_required(token *config);
+
+/* On success and some failures, takes ownership of *config and *cstate and
+ * sets them to NULL.  Asynchronously calls otp_verify_done() when complete. */
+void
+otp_state_challenge(otp_state *state, verto_ctx *ctx, token **config,
+                    struct challenge_state **cstate);
+
 /* On success and some failures, takes ownership of *config and *vstate and
  * sets them to NULL.  Asynchronously calls otp_verify_done() when complete. */
 void
-otp_state_verify(otp_state *state, verto_ctx *ctx,
-                 const krb5_pa_otp_req *request, token **config,
+otp_state_verify(otp_state *state, verto_ctx *ctx, const krb5_pa_otp_req *req,
+                 krb5_data *radius_state, token **config,
                  struct verify_state **vstate);
 
-/* Provided by main.c.  Must free vstate. */
+/* Provided by main.c.  Must free cstate and vstate respectively. */
+void
+otp_challenge_done(krb5_error_code retval, struct challenge_state *cstate,
+                   otp_response response, const krb5_data *radius_state,
+                   const krb5_data *message);
 void
 otp_verify_done(krb5_error_code retval, struct verify_state *vstate,
                 otp_response response, char *const *indicators);


### PR DESCRIPTION
otp-challenge flag requires edata to obtain a challenge message from the
server that must be presented to the user in order to authenticate 
correctly.

In order to do so, otp_edata sends a password-less Access-Request and 
expects Access-Challenge in reply. Then reads the challenge from 
Reply-Message attribute and remembers the State attribute inside a cookie.

Then it reads the cookie in otp_verify flow and appends it to the next 
Access-Request together with the authentication token so the RADIUS server
can match the second message with the initial one.

---

This implements external challenge functionality that is required for OAuth2
authentication via RADIUS protocol and FreeIPA as discussed here:

* http://mailman.mit.edu/pipermail/krbdev/2021-June/013469.html

The functionality is not yet implemented in FreeIPA, therefore it requires a special
FreeIPA patch and a mocked RADIUS server for testing. The Kerberos code is completed
and ready for review, I would like to wait hovewer for FreeIPA side to be finished
before merging. Please, review.

## How to test:

On server:
1. Install https://github.com/pbrezina/freeipa/tree/otp (enables challenge flag for tuser)
2. Clone and run https://github.com/pbrezina/mock-radius on IPA server
3. Create RADIUS proxy config “localhost/127.0.0.1/Secret123” in IPA
4. Create user “tuser” with RADIUS proxy set to localhost in IPA
5. In kadmin.local > getstrs tuser > you should see challenge flag set to true

On client:
```
kinit -n @IPA.VM -c FILE:armor.ccache
kinit -T FILE:armor.ccache tuser@IPA.VM
```

Note: challenge=true is set only for tuser, other RADIUS proxy users will have challenge=false