### PR TITLE
Avoid long socket paths in KCM tests

### DIFF
--- a/src/tests/t_ccache.py
+++ b/src/tests/t_ccache.py
@@ -21,8 +21,10 @@
 # or implied warranty.
 
 from k5test import *
+import tempfile
 
-kcm_socket_path = os.path.join(os.getcwd(), 'testdir', 'kcm')
+socketdir = tempfile.TemporaryDirectory()
+kcm_socket_path = os.path.join(socketdir.name, 'kcm')
 conf = {'libdefaults': {'kcm_socket': kcm_socket_path,
                         'kcm_mach_service': '-'}}
 realm = K5Realm(krb5_conf=conf)


### PR DESCRIPTION
The build directory path may be too long for a Unix domain socket, so
use a path in a temporary directory instead.  Reported by Ryan
Schmidt.
