### PR TITLE
Atomic ccache refresh

### DIFF
--- a/src/clients/kvno/kvno.c
+++ b/src/clients/kvno/kvno.c
@@ -454,7 +454,7 @@ do_v5_kvno(int count, char *names[], char * ccachestr, char *etypestr,
     krb5_error_code ret;
     int i, errors, flags, initialized = 0;
     krb5_enctype etype;
-    krb5_ccache ccache, out_ccache = NULL;
+    krb5_ccache ccache, mcc, out_ccache = NULL;
     krb5_principal me;
     krb5_keytab keytab = NULL;
     krb5_principal for_user_princ = NULL;
@@ -545,6 +545,14 @@ do_v5_kvno(int count, char *names[], char * ccachestr, char *etypestr,
         exit(1);
     }
 
+    if (out_ccache != NULL) {
+        ret = krb5_cc_new_unique(context, "MEMORY", NULL, &mcc);
+        if (ret) {
+            com_err(prog, ret, _("while creating temporary output ccache"));
+            exit(1);
+        }
+    }
+
     errors = 0;
     for (i = 0; i < count; i++) {
         if (kvno(names[i], ccache, me, etype, keytab, sname, options, unknown,
@@ -552,7 +560,7 @@ do_v5_kvno(int count, char *names[], char * ccachestr, char *etypestr,
             errors++;
         } else if (out_ccache != NULL) {
             if (!initialized) {
-                ret = krb5_cc_initialize(context, out_ccache, creds->client);
+                ret = krb5_cc_initialize(context, mcc, creds->client);
                 if (ret) {
                     com_err(prog, ret, _("while initializing output ccache"));
                     exit(1);
@@ -560,9 +568,9 @@ do_v5_kvno(int count, char *names[], char * ccachestr, char *etypestr,
                 initialized = 1;
             }
             if (count == 1)
-                ret = k5_cc_store_primary_cred(context, out_ccache, creds);
+                ret = k5_cc_store_primary_cred(context, mcc, creds);
             else
-                ret = krb5_cc_store_cred(context, out_ccache, creds);
+                ret = krb5_cc_store_cred(context, mcc, creds);
             if (ret) {
                 com_err(prog, ret, _("while storing creds in output ccache"));
                 exit(1);
@@ -570,6 +578,14 @@ do_v5_kvno(int count, char *names[], char * ccachestr, char *etypestr,
         }
 
         krb5_free_creds(context, creds);
+    }
+
+    if (!errors && out_ccache != NULL) {
+        ret = krb5_cc_move(context, mcc, out_ccache);
+        if (ret) {
+            com_err(prog, ret, _("while writing output ccache"));
+            exit(1);
+        }
     }
 
     if (keytab != NULL)

--- a/src/include/kcm.h
+++ b/src/include/kcm.h
@@ -113,6 +113,8 @@ typedef enum kcm_opcode {
     /* MIT extensions */
     KCM_OP_MIT_EXTENSION_BASE = 13000,
     KCM_OP_GET_CRED_LIST,       /* (name) -> (count, count*{len, cred}) */
+    KCM_OP_REPLACE,             /* (name, offset, princ,
+                                 *  count, count*{len, cred}) -> () */
 } kcm_opcode;
 
 #endif /* KCM_H */

--- a/src/lib/krb5/ccache/cc-int.h
+++ b/src/lib/krb5/ccache/cc-int.h
@@ -51,6 +51,10 @@ krb5int_cc_initialize(void);
 void
 krb5int_cc_finalize(void);
 
+krb5_error_code
+k5_nonatomic_replace(krb5_context context, krb5_ccache ccache,
+                     krb5_principal princ, krb5_creds **creds);
+
 /*
  * Cursor for iterating over ccache types
  */
@@ -210,8 +214,8 @@ struct _krb5_cc_ops {
                                                    krb5_ccache *);
     krb5_error_code (KRB5_CALLCONV *ptcursor_free)(krb5_context,
                                                    krb5_cc_ptcursor *);
-    krb5_error_code (KRB5_CALLCONV *move)(krb5_context, krb5_ccache,
-                                          krb5_ccache);
+    krb5_error_code (KRB5_CALLCONV *replace)(krb5_context, krb5_ccache,
+                                             krb5_principal, krb5_creds **);
     krb5_error_code (KRB5_CALLCONV *wasdefault)(krb5_context, krb5_ccache,
                                                 krb5_timestamp *);
     krb5_error_code (KRB5_CALLCONV *lock)(krb5_context, krb5_ccache);

--- a/src/lib/krb5/ccache/cc_dir.c
+++ b/src/lib/krb5/ccache/cc_dir.c
@@ -692,6 +692,15 @@ dcc_ptcursor_free(krb5_context context, krb5_cc_ptcursor *cursor)
 }
 
 static krb5_error_code KRB5_CALLCONV
+dcc_replace(krb5_context context, krb5_ccache cache, krb5_principal princ,
+            krb5_creds **creds)
+{
+    dcc_data *data = cache->data;
+
+    return krb5_fcc_ops.replace(context, data->fcc, princ, creds);
+}
+
+static krb5_error_code KRB5_CALLCONV
 dcc_lock(krb5_context context, krb5_ccache cache)
 {
     dcc_data *data = cache->data;
@@ -752,7 +761,7 @@ const krb5_cc_ops krb5_dcc_ops = {
     dcc_ptcursor_new,
     dcc_ptcursor_next,
     dcc_ptcursor_free,
-    NULL, /* move */
+    dcc_replace,
     NULL, /* wasdefault */
     dcc_lock,
     dcc_unlock,

--- a/src/lib/krb5/krb/get_in_tkt.c
+++ b/src/lib/krb5/krb/get_in_tkt.c
@@ -1604,6 +1604,61 @@ warn_des3(krb5_context context, krb5_init_creds_context ctx,
     (*ctx->prompter)(context, ctx->prompter_data, NULL, banner, 0, NULL);
 }
 
+/*
+ * If ctx specifies an output ccache, create or refresh it (atomically, if
+ * possible) with the obtained credential and any appropriate ccache
+ * configuration.
+ */
+static krb5_error_code
+write_out_ccache(krb5_context context, krb5_init_creds_context ctx,
+                 krb5_boolean fast_avail)
+{
+    krb5_error_code ret;
+    krb5_ccache out_ccache = k5_gic_opt_get_out_ccache(ctx->opt);
+    krb5_ccache mcc = NULL;
+    krb5_data yes = string2data("yes");
+
+    if (out_ccache == NULL)
+        return 0;
+
+    ret = krb5_cc_new_unique(context, "MEMORY", NULL, &mcc);
+    if (ret)
+        goto cleanup;
+
+    ret = krb5_cc_initialize(context, mcc, ctx->cred.client);
+    if (ret)
+        goto cleanup;
+
+    if (fast_avail) {
+        ret = krb5_cc_set_config(context, mcc, ctx->cred.server,
+                                 KRB5_CC_CONF_FAST_AVAIL, &yes);
+        if (ret)
+            goto cleanup;
+    }
+
+    ret = save_selected_preauth_type(context, mcc, ctx);
+    if (ret)
+        goto cleanup;
+
+    ret = save_cc_config_out_data(context, mcc, ctx);
+    if (ret)
+        goto cleanup;
+
+    ret = k5_cc_store_primary_cred(context, mcc, &ctx->cred);
+    if (ret)
+        goto cleanup;
+
+    ret = krb5_cc_move(context, mcc, out_ccache);
+    if (ret)
+        goto cleanup;
+    mcc = NULL;
+
+cleanup:
+    if (mcc != NULL)
+        krb5_cc_destroy(context, mcc);
+    return ret;
+}
+
 static krb5_error_code
 init_creds_step_reply(krb5_context context,
                       krb5_init_creds_context ctx,
@@ -1618,7 +1673,6 @@ init_creds_step_reply(krb5_context context,
     krb5_keyblock *strengthen_key = NULL;
     krb5_keyblock encrypting_key;
     krb5_boolean fast_avail;
-    krb5_ccache out_ccache = k5_gic_opt_get_out_ccache(ctx->opt);
 
     encrypting_key.length = 0;
     encrypting_key.contents = NULL;
@@ -1786,30 +1840,9 @@ init_creds_step_reply(krb5_context context,
     code = stash_as_reply(context, ctx->reply, &ctx->cred, NULL);
     if (code != 0)
         goto cleanup;
-    if (out_ccache != NULL) {
-        krb5_data config_data;
-        code = krb5_cc_initialize(context, out_ccache, ctx->cred.client);
-        if (code != 0)
-            goto cc_cleanup;
-        code = k5_cc_store_primary_cred(context, out_ccache, &ctx->cred);
-        if (code != 0)
-            goto cc_cleanup;
-        if (fast_avail) {
-            config_data.data = "yes";
-            config_data.length = strlen(config_data.data);
-            code = krb5_cc_set_config(context, out_ccache, ctx->cred.server,
-                                      KRB5_CC_CONF_FAST_AVAIL, &config_data);
-            if (code != 0)
-                goto cc_cleanup;
-        }
-        code = save_selected_preauth_type(context, out_ccache, ctx);
-        if (code != 0)
-            goto cc_cleanup;
-        code = save_cc_config_out_data(context, out_ccache, ctx);
-    cc_cleanup:
-        if (code != 0)
-            k5_prependmsg(context, code, _("Failed to store credentials"));
-    }
+    code = write_out_ccache(context, ctx, fast_avail);
+    if (code)
+        k5_prependmsg(context, code, _("Failed to store credentials"));
 
     k5_preauth_request_context_fini(context, ctx);
 

--- a/src/tests/Makefile.in
+++ b/src/tests/Makefile.in
@@ -6,13 +6,13 @@ SUBDIRS = asn.1 create hammer verify gssapi shlib gss-threads misc threads \
 RUN_DB_TEST = $(RUN_SETUP) KRB5_KDC_PROFILE=kdc.conf KRB5_CONFIG=krb5.conf \
 	GSS_MECH_CONFIG=mech.conf LC_ALL=C $(VALGRIND)
 
-OBJS= adata.o etinfo.o forward.o gcred.o hist.o hooks.o hrealm.o \
+OBJS= adata.o conccache.o etinfo.o forward.o gcred.o hist.o hooks.o hrealm.o \
 	icinterleave.o icred.o kdbtest.o localauth.o plugorder.o rdreq.o \
 	replay.o responder.o s2p.o s4u2self.o s4u2proxy.o t_inetd.o \
 	unlockiter.o
-EXTRADEPSRCS= adata.c etinfo.c forward.c gcred.c hist.c hooks.c hrealm.c \
-	icinterleave.c icred.c kdbtest.c localauth.c plugorder.c rdreq.c \
-	replay.c responder.c s2p.c s4u2self.c s4u2proxy.c t_inetd.c \
+EXTRADEPSRCS= adata.c conccache.c etinfo.c forward.c gcred.c hist.c hooks.c \
+	hrealm.c icinterleave.c icred.c kdbtest.c localauth.c plugorder.c \
+	rdreq.c replay.c responder.c s2p.c s4u2self.c s4u2proxy.c t_inetd.c \
 	unlockiter.c
 
 TEST_DB = ./testdb
@@ -27,6 +27,9 @@ KTEST_OPTS= $(KADMIN_OPTS) -p $(TEST_PREFIX) -n $(TEST_NUM) -D $(TEST_DEPTH)
 
 adata: adata.o $(KRB5_BASE_DEPLIBS)
 	$(CC_LINK) -o $@ adata.o $(KRB5_BASE_LIBS)
+
+conccache: conccache.o $(KRB5_BASE_DEPLIBS)
+	$(CC_LINK) -o $@ conccache.o $(KRB5_BASE_LIBS)
 
 etinfo: etinfo.o $(KRB5_BASE_DEPLIBS)
 	$(CC_LINK) -o $@ etinfo.o $(KRB5_BASE_LIBS)
@@ -125,9 +128,9 @@ kdb_check: kdc.conf krb5.conf
 	$(RUN_DB_TEST) ../kadmin/dbutil/kdb5_util $(KADMIN_OPTS) destroy -f
 	$(RM) $(TEST_DB)* stash_file
 
-check-pytests: adata etinfo forward gcred hist hooks hrealm icinterleave icred
-check-pytests: kdbtest localauth plugorder rdreq replay responder s2p s4u2proxy
-check-pytests: unlockiter s4u2self
+check-pytests: adata conccache etinfo forward gcred hist hooks hrealm
+check-pytests: icinterleave icred kdbtest localauth plugorder rdreq replay
+check-pytests: responder s2p s4u2proxy unlockiter s4u2self
 	$(RUNPYTEST) $(srcdir)/t_general.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_hooks.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_dump.py $(PYTESTFLAGS)
@@ -190,9 +193,9 @@ check-pytests: unlockiter s4u2self
 	$(RUNPYTEST) $(srcdir)/t_replay.py $(PYTESTFLAGS)
 
 clean:
-	$(RM) adata etinfo forward gcred hist hooks hrealm icinterleave icred
-	$(RM) kdbtest localauth plugorder rdreq replay responder s2p s4u2proxy
-	$(RM) s4u2self t_inetd unlockiter
+	$(RM) adata conccache etinfo forward gcred hist hooks hrealm
+	$(RM) icinterleave icred kdbtest localauth plugorder rdreq replay
+	$(RM) responder s2p s4u2proxy s4u2self t_inetd unlockiter
 	$(RM) krb5.conf kdc.conf
 	$(RM) -rf kdc_realm/sandbox ldap
 	$(RM) au.log

--- a/src/tests/conccache.c
+++ b/src/tests/conccache.c
@@ -1,0 +1,190 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* tests/conccache.c - ccache concurrent get_creds/refresh test program */
+/*
+ * Copyright (C) 2021 by the Massachusetts Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Usage: conccache ccname clientprinc serverprinc
+ *
+ * This program spawns two subprocesses.  One repeatedly runs
+ * krb5_get_credentials() on ccname, and the other repeatedly refreshes ccname
+ * from the default keytab.  If either subprocess fails, the program exits with
+ * status 1.  The goal is to expose time windows where cache refreshes cause
+ * get_cred operations to fail.
+ */
+
+#include "k5-platform.h"
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <pthread.h>
+#include <krb5.h>
+
+/* Run this many iterations of each operation. */
+static const int iterations = 200;
+
+/* Saved command-line arguments. */
+static const char *ccname, *server_name, *client_name;
+
+static void
+check(krb5_error_code code)
+{
+    if (code)
+        abort();
+}
+
+static krb5_boolean
+get_cred(krb5_context context)
+{
+    krb5_error_code ret;
+    krb5_ccache cc;
+    krb5_principal client, server;
+    krb5_creds mcred, *cred;
+
+    check(krb5_cc_resolve(context, ccname, &cc));
+    check(krb5_parse_name(context, client_name, &client));
+    check(krb5_parse_name(context, server_name, &server));
+
+    memset(&mcred, 0, sizeof(mcred));
+    mcred.client = client;
+    mcred.server = server;
+    ret = krb5_get_credentials(context, 0, cc, &mcred, &cred);
+
+    krb5_free_creds(context, cred);
+    krb5_free_principal(context, client);
+    krb5_free_principal(context, server);
+    krb5_cc_close(context, cc);
+
+    return ret == 0;
+}
+
+static krb5_boolean
+refresh_cache(krb5_context context)
+{
+    krb5_error_code ret;
+    krb5_ccache cc;
+    krb5_principal client;
+    krb5_get_init_creds_opt *opt;
+    krb5_creds cred;
+
+    check(krb5_cc_resolve(context, ccname, &cc));
+    check(krb5_parse_name(context, client_name, &client));
+
+    check(krb5_get_init_creds_opt_alloc(context, &opt));
+    check(krb5_get_init_creds_opt_set_out_ccache(context, opt, cc));
+    ret = krb5_get_init_creds_keytab(context, &cred, client, NULL, 0, NULL,
+                                     opt);
+
+    krb5_get_init_creds_opt_free(context, opt);
+    krb5_free_cred_contents(context, &cred);
+    krb5_free_principal(context, client);
+    krb5_cc_close(context, cc);
+
+    return ret == 0;
+}
+
+static pid_t
+spawn_cred_subprocess()
+{
+    krb5_context context;
+    pid_t pid;
+    int i;
+
+    pid = fork();
+    assert(pid >= 0);
+    if (pid > 0)
+        return pid;
+
+    check(krb5_init_context(&context));
+    for (i = 0; i < iterations; i++) {
+        if (!get_cred(context)) {
+            fprintf(stderr, "cred worker failed after %d successes\n", i);
+            exit(1);
+        }
+    }
+    krb5_free_context(context);
+    exit(0);
+}
+
+static pid_t
+spawn_refresh_subprocess()
+{
+    krb5_context context;
+    pid_t pid;
+    int i;
+
+    pid = fork();
+    assert(pid >= 0);
+    if (pid > 0)
+        return pid;
+
+    check(krb5_init_context(&context));
+    for (i = 0; i < iterations; i++) {
+        if (!refresh_cache(context)) {
+            fprintf(stderr, "refresh worker failed after %d successes\n", i);
+            exit(1);
+        }
+    }
+    krb5_free_context(context);
+    exit(0);
+}
+
+int
+main(int argc, char *argv[])
+{
+    krb5_context context;
+    pid_t cred_pid, refresh_pid, pid;
+    int cstatus, rstatus;
+
+    assert(argc == 4);
+    ccname = argv[1];
+    client_name = argv[2];
+    server_name = argv[3];
+
+    /* Begin with an initialized cache. */
+    check(krb5_init_context(&context));
+    refresh_cache(context);
+    krb5_free_context(context);
+
+    cred_pid = spawn_cred_subprocess();
+    refresh_pid = spawn_refresh_subprocess();
+
+    pid = waitpid(cred_pid, &cstatus, 0);
+    if (pid == -1)
+        abort();
+    pid = waitpid(refresh_pid, &rstatus, 0);
+    if (pid == -1)
+        abort();
+
+    if (!WIFEXITED(cstatus) || WEXITSTATUS(cstatus) != 0)
+        return 1;
+    if (!WIFEXITED(rstatus) || WEXITSTATUS(rstatus) != 0)
+        return 1;
+    return 0;
+}

--- a/src/tests/t_ccache.py
+++ b/src/tests/t_ccache.py
@@ -29,6 +29,11 @@ conf = {'libdefaults': {'kcm_socket': kcm_socket_path,
                         'kcm_mach_service': '-'}}
 realm = K5Realm(krb5_conf=conf)
 
+realm.addprinc('contest')
+realm.extract_keytab('contest', realm.keytab)
+realm.run(['./conccache', realm.ccache + '.contest', 'contest',
+           realm.host_princ])
+
 keyctl = which('keyctl')
 out = realm.run([klist, '-c', 'KEYRING:process:abcd'], expected_code=1)
 test_keyring = (keyctl is not None and


### PR DESCRIPTION
Here is some work on ticket 7707, which is the long-standing problem that refreshing a ccache creates a window of time where krb5_get_credentials() will fail.  As Michael Osipov observed, this can create a problem for concurrent use of a ccache with a client keytab.

The approach here is the fourth alternative described in ticket 7707: make krb5_cc_move() atomic when possible, and make kinit-like activities write to a memory ccache.  Various complications, notes, and TBD items:

* There were some locking calls in krb5_cc_move(), but they just lock process-global mutexes, so I'm not sure what they're supposed to accomplish; anything that could happen to a ccache concurrently within a process could happen within another process.  I didn't preserve them.

* I included a test program to exercise the refresh issue using two subprocesses.  With FILE it fails pretty readily without the changes, and passes with them.  This program won't work for testing MEMORY.  I experimented with adding a threaded mode, but couldn't produce a failure with MEMORY, perhaps because there isn't much thread yielding going on without I/O operations.

* Right now there's just atomic replace support for FILE and (trivially) DIR.  MEMORY should be pretty easy, and could be important for a multithreaded process using a client keytab and a memory ccache (which is a configuration described in appl_servers.rst).  KCM support should be fairly straightforward, with the minor wrinkle that we'll need to call back into the non-atomic move implementation (currently not exported) if the KCM server doesn't support the new opcode.  KEYRING unfortunately might be difficult or impossible.

* On the kinit-like-operations side of things, right now I've only hit get_in_tkt.c which should cover kinit and client keytabs.  Other possible targets include gss_store_cred(), krb5_get_renewed_creds(), and kvno --out-cache.

* For FILE, the current strategy is to serialize the whole ccache and write it out with a single write().  I think that's fine, but we could switch to writing out each cred separately, perhaps using a stdio wrapper.

* krb5_cc_move() obeys the source-before-destination convention before copying.  However, ccache methods ordinarily put the to-be-operated-on ccache just after the context.  So I gave atomic_replace() the opposite ccache parameter order from krb5_cc_move().  Neither option feels particularly safe or right.

* I can see an argument that we should have a new API krb5_cc_replace() that doesn't delete the source ccache.  That would work better for gss_store_cred().  We could leave krb5_cc_move() alone or reimplement it on top of krb5_cc_replace().  Not sure if it's worth increasing the API surface area.
 
* The ccache vtable had an entry for move, but it wasn't used, so I repurposed that slot for atomic_replace.
