### PR TITLE
krb5_32.def: export encode/decode_krb5_enc_tkt_part

### DIFF
--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -1378,9 +1378,6 @@ krb5_error_code
 encode_krb5_ticket(const krb5_ticket *rep, krb5_data **code);
 
 krb5_error_code
-encode_krb5_enc_tkt_part(const krb5_enc_tkt_part *rep, krb5_data **code);
-
-krb5_error_code
 encode_krb5_enc_kdc_rep_part(const krb5_enc_kdc_rep_part *rep,
                              krb5_data **code);
 
@@ -1587,9 +1584,6 @@ decode_krb5_ticket(const krb5_data *code, krb5_ticket **rep);
 
 krb5_error_code
 decode_krb5_encryption_key(const krb5_data *output, krb5_keyblock **rep);
-
-krb5_error_code
-decode_krb5_enc_tkt_part(const krb5_data *output, krb5_enc_tkt_part **rep);
 
 krb5_error_code
 decode_krb5_enc_kdc_rep_part(const krb5_data *output,

--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -8597,6 +8597,13 @@ void KRB5_CALLCONV
 krb5_set_kdc_recv_hook(krb5_context context, krb5_post_recv_fn recv_hook,
                        void *data);
 
+krb5_error_code KRB5_CALLCONV
+encode_krb5_enc_tkt_part(const krb5_enc_tkt_part *rep, krb5_data **code);
+
+krb5_error_code KRB5_CALLCONV
+decode_krb5_enc_tkt_part(const krb5_data *output, krb5_enc_tkt_part **rep);
+
+
 #if defined(__APPLE__) && (defined(__ppc__) || defined(__ppc64__) || defined(__i386__) || defined(__x86_64__))
 #pragma pack(pop)
 #endif

--- a/src/lib/krb5_32.def
+++ b/src/lib/krb5_32.def
@@ -133,6 +133,7 @@ EXPORTS
 	krb5_free_data				@129
 	krb5_free_data_contents			@130
 	krb5_free_default_realm			@131
+	krb5_free_enc_tkt_part			@132
 	krb5_free_error				@133
 	krb5_free_host_realm			@135
 	krb5_free_keyblock			@136
@@ -270,7 +271,6 @@ EXPORTS
 	krb5_auth_con_set_req_cksumtype		@36	; PRIVATE GSSAPI krb5.hin
 	krb5_kt_free_entry			@192	; PRIVATE GSSAPI krb5.hin
 	k5_rc_close				@217	; PRIVATE GSSAPI krb5.hin
-	krb5_free_enc_tkt_part			@132	; PRIVATE GSSAPI krb5.hin
 	krb5_decrypt_tkt_part			@108	; PRIVATE GSSAPI krb5.hin
 
 	krb5_set_error_message			@242
@@ -508,3 +508,7 @@ EXPORTS
 	krb5_marshal_credentials			@472
 	krb5_unmarshal_credentials			@473
 	k5_sname_compare				@474 ; PRIVATE GSSAPI
+
+;
+	encode_krb5_enc_tkt_part			@475
+	decode_krb5_enc_tkt_part			@476


### PR DESCRIPTION
This seem to help for wireshark pac ticket signature verification to work on Windows, see discussion at:
https://gitlab.com/wireshark/wireshark/-/merge_requests/3570