### PR TITLE
Make name in plugin's vtable const

### DIFF
--- a/src/include/krb5/audit_plugin.h
+++ b/src/include/krb5/audit_plugin.h
@@ -255,7 +255,7 @@ typedef krb5_error_code
 /* vtable declaration */
 typedef struct krb5_audit_vtable_st {
     /* Mandatory: name of module. */
-    char                   *name;
+    const char             *name;
     krb5_audit_open_fn      open;
     krb5_audit_close_fn     close;
     krb5_audit_kdc_start_fn kdc_start;

--- a/src/include/krb5/authdata_plugin.h
+++ b/src/include/krb5/authdata_plugin.h
@@ -191,7 +191,7 @@ typedef krb5_error_code
                              void *dst_request_context);
 
 typedef struct krb5plugin_authdata_client_ftable_v0 {
-    char *name;
+    const char *name;
     krb5_authdatatype *ad_type_list;
     authdata_client_plugin_init_proc init;
     authdata_client_plugin_fini_proc fini;

--- a/src/include/krb5/clpreauth_plugin.h
+++ b/src/include/krb5/clpreauth_plugin.h
@@ -299,7 +299,7 @@ typedef krb5_error_code
 
 typedef struct krb5_clpreauth_vtable_st {
     /* Mandatory: name of module. */
-    char *name;
+    const char *name;
 
     /* Mandatory: pointer to zero-terminated list of pa_types which this module
      * can provide services for. */

--- a/src/include/krb5/kdcpreauth_plugin.h
+++ b/src/include/krb5/kdcpreauth_plugin.h
@@ -380,7 +380,7 @@ typedef krb5_error_code
 
 typedef struct krb5_kdcpreauth_vtable_st {
     /* Mandatory: name of module. */
-    char *name;
+    const char *name;
 
     /* Mandatory: pointer to zero-terminated list of pa_types which this module
      * can provide services for. */


### PR DESCRIPTION
Internal krb5 plugins passes const string to the plugin's vtable
name field, most of the available vtables already declare the name
as const char *.