### PR TITLE
otp: free radius client

### DIFF
--- a/src/plugins/preauth/otp/otp_state.c
+++ b/src/plugins/preauth/otp/otp_state.c
@@ -618,6 +618,7 @@ otp_state_free(otp_state *self)
         return;
 
     krad_attrset_free(self->attrs);
+    krad_client_free(self->radius);
     token_types_free(self->types);
     free(self);
 }


### PR DESCRIPTION
The radius client is stored in otp state but never freed.