### PR TITLE
Restore OpenSSL 1.0 compatibility in softpkcs11

### DIFF
--- a/src/tests/softpkcs11/main.c
+++ b/src/tests/softpkcs11/main.c
@@ -1590,7 +1590,8 @@ C_Encrypt(CK_SESSION_HANDLE hSession,
 
     ret = CKR_OK;
 out:
-    OPENSSL_clear_free(buffer, buffer_len);
+    OPENSSL_cleanse(buffer, buffer_len);
+    OPENSSL_free(buffer);
     EVP_PKEY_CTX_free(ctx);
     return ret;
 }
@@ -1732,7 +1733,8 @@ C_Decrypt(CK_SESSION_HANDLE hSession,
 
     ret = CKR_OK;
 out:
-    OPENSSL_clear_free(buffer, buffer_len);
+    OPENSSL_cleanse(buffer, buffer_len);
+    OPENSSL_free(buffer);
     EVP_PKEY_CTX_free(ctx);
     return ret;
 }
@@ -1879,7 +1881,8 @@ C_Sign(CK_SESSION_HANDLE hSession,
 
     ret = CKR_OK;
 out:
-    OPENSSL_clear_free(buffer, buffer_len);
+    OPENSSL_cleanse(buffer, buffer_len);
+    OPENSSL_free(buffer);
     EVP_PKEY_CTX_free(ctx);
     return ret;
 }


### PR DESCRIPTION
Commit 00de1aad7b3647b91017c7009b0bc65cd0c8b2e0 used
OPENSSL_clear_free(), which was added in OpenSSL 1.1.  Use
OPENSSL_cleanse() and OPENSSL_free() instead.