### PR TITLE
include:gssrpc: Fix prototype definitions

### DIFF
--- a/src/include/gssrpc/auth.h
+++ b/src/include/gssrpc/auth.h
@@ -190,7 +190,6 @@ extern AUTH *authunix_create(char *machname, int uid, int gid, int len,
 			     int *aup_gids);
 extern AUTH *authunix_create_default(void);	/* takes no parameters */
 extern AUTH *authnone_create(void);		/* takes no parameters */
-extern AUTH *authdes_create();
 extern bool_t xdr_opaque_auth(XDR *, struct opaque_auth *);
 
 #define AUTH_NONE	0		/* no authentication */

--- a/src/include/gssrpc/rename.h
+++ b/src/include/gssrpc/rename.h
@@ -60,13 +60,9 @@
 
 #define xdr_des_block		gssrpc_xdr_des_block
 
-#define authany_wrap		gssrpc_authany_wrap
-#define authany_unwrap		gssrpc_authany_unwrap
-
 #define authunix_create		gssrpc_authunix_create
 #define authunix_create_default	gssrpc_authunix_create_default
 #define authnone_create		gssrpc_authnone_create
-#define authdes_create		gssrpc_authdes_create
 #define xdr_opaque_auth		gssrpc_xdr_opaque_auth
 
 /* auth_gss.c */
@@ -203,11 +199,8 @@
 #define svc_fdset		gssrpc_svc_fdset
 #define svc_fds			gssrpc_svc_fds
 
-#define rpctest_service		gssrpc_rpctest_service
-
 #define svc_getreq		gssrpc_svc_getreq
 #define svc_getreqset		gssrpc_svc_getreqset
-#define svc_getreqset2		gssrpc_svc_getreqset2
 #define svc_run			gssrpc_svc_run
 
 #define svcraw_create		gssrpc_svcraw_create

--- a/src/include/gssrpc/svc.h
+++ b/src/include/gssrpc/svc.h
@@ -289,16 +289,9 @@ extern int svc_fds;
 #endif /* def FD_SETSIZE */
 extern int svc_maxfd;
 
-/*
- * a small program implemented by the svc_rpc implementation itself;
- * also see clnt.h for protocol numbers.
- */
-extern void rpctest_service();
-
 extern void	svc_getreq(int);
 #ifdef FD_SETSIZE
 extern void	svc_getreqset(fd_set *);/* takes fdset instead of int */
-extern void	svc_getreqset2(fd_set *, int);
 #else
 extern void	svc_getreqset(int *);
 #endif


### PR DESCRIPTION
```
gssrpc/svc.h:296:1: error: function declaration isn’t a prototype
[-Werror=strict-prototypes]
  296 | extern void rpctest_service();
```

The Samba developer build is setting `-Werror=strict-prototypes` and fails to build with mit-krb5 master.