### PR TITLE
kr_attrset_decode: make sure length byte is unsigned

### DIFF
--- a/src/lib/krad/attrset.c
+++ b/src/lib/krad/attrset.c
@@ -217,7 +217,7 @@ kr_attrset_decode(krb5_context ctx, const krb5_data *in, const char *secret,
 
     for (i = 0; i + 2 < in->length; ) {
         type = in->data[i++];
-        tmp = make_data(&in->data[i + 1], in->data[i] - 2);
+        tmp = make_data(&in->data[i + 1], (uint8_t)in->data[i] - 2);
         i += tmp.length + 1;
 
         retval = (in->length < i) ? EBADMSG : 0;

--- a/src/lib/krad/t_packet.c
+++ b/src/lib/krad/t_packet.c
@@ -57,6 +57,14 @@ make_packet(krb5_context ctx, const krb5_data *username,
     krb5_error_code retval;
     const krb5_data *data;
     int i = 0;
+    krb5_data nas_id;
+
+    nas_id = string2data("12345678901234567890123456789012345678901234567890"
+                         "12345678901234567890123456789012345678901234567890"
+                         "12345678901234567890123456789012345678901234567890"
+                         "12345678901234567890123456789012345678901234567890"
+                         "12345678901234567890123456789012345678901234567890"
+                         "123");
 
     retval = krad_attrset_new(ctx, &set);
     if (retval != 0)
@@ -68,6 +76,11 @@ make_packet(krb5_context ctx, const krb5_data *username,
 
     retval = krad_attrset_add(set, krad_attr_name2num("User-Password"),
                               password);
+    if (retval != 0)
+        goto out;
+
+    retval = krad_attrset_add(set, krad_attr_name2num("NAS-Identifier"),
+                              &nas_id);
     if (retval != 0)
         goto out;
 


### PR DESCRIPTION
To avoid ambiguity the length byte in the Radius attribute is should be treated as unsigned explicitly. Otherwise it might be possible that attributes longer than 125 characters will be rejected with EBADMSG.

A 253 characters long NAS-Identifier attribute is added to the tests to make sure that attributes with the maximal number of characters are working as expected.