### PR TITLE
aclocal: remove unnecessary -search_paths_first flag on Darwin

### DIFF
--- a/src/aclocal.m4
+++ b/src/aclocal.m4
@@ -595,10 +595,6 @@ if test "$GCC" = yes ; then
       CFLAGS="$CFLAGS -fno-common"
       ;;
     esac
-    case "$LD $LDFLAGS" in
-    *-Wl,-search_paths_first*) ;;
-    *) LDFLAGS="${LDFLAGS} -Wl,-search_paths_first" ;;
-    esac
   fi
 else
   if test "`uname -s`" = AIX ; then


### PR DESCRIPTION
The configure machinery for adding the `-search_paths_first` linker flag
on Darwin does not correctly handle cross compilation. (It should
condition the value of `krb5_cv_host` rather than `uname -s` to detect
when the compilation target is Darwin, rather than the build machine.)

It turns out `-search_paths_first` has been the default behavior of ld
on macOS since XCode 4 (see `man ld`). So this commit just removes that
big of configury entirely. That neatly fixes cross compiling from macOS
to Linux without impacting native macOS builds.

(The history checks out here too: the flag was added way back in 2004,
but XCode 4 wasn't released until 2010.)