### PR TITLE
Use typedef to define bool_t and enum_t

### DIFF
--- a/src/include/gssrpc/types.hin
+++ b/src/include/gssrpc/types.hin
@@ -95,8 +95,8 @@ typedef int32_t		rpc_inline_t;
 /* This is for rpc/netdb.h */
 @rpcent_define@
 
-#define	bool_t	int
-#define	enum_t	int
+typedef int bool_t;
+typedef int enum_t;
 #ifndef FALSE
 #	define	FALSE	(0)
 #endif


### PR DESCRIPTION
Otherwise this conflicts with bool_t and enum_t in fbthrift:
https://github.com/facebook/fbthrift/blob/main/thrift/lib/cpp2/type/Tag.h#L59