### PR TITLE
Include time.h in kdb.h

### DIFF
--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -65,6 +65,7 @@
 #ifndef KRB5_KDB5__
 #define KRB5_KDB5__
 
+#include <time.h>
 #include <krb5.h>
 
 /* This version will be incremented when incompatible changes are made to the


### PR DESCRIPTION
kdb.h uses time_t, and therefore must include <time.h> to ensure its
definition.  Noticed when building t_sort_key_data.c on macOS.