### PR TITLE
Omit LDFLAGS from krb5-config --libs output

### DIFF
--- a/src/build-tools/krb5-config.in
+++ b/src/build-tools/krb5-config.in
@@ -33,7 +33,6 @@ includedir=@includedir@
 libdir=@libdir@
 CC_LINK='@CC_LINK@'
 KDB5_DB_LIB=@KDB5_DB_LIB@
-LDFLAGS='@LDFLAGS@'
 RPATH_FLAG='@RPATH_FLAG@'
 PROG_RPATH_FLAGS='@PROG_RPATH_FLAGS@'
 PTHREAD_CFLAGS='@PTHREAD_CFLAGS@'
@@ -220,7 +219,7 @@ if test -n "$do_libs"; then
 	    -e 's#\$(PROG_RPATH)#'$libdir'#' \
 	    -e 's#\$(PROG_LIBPATH)#'$libdirarg'#' \
 	    -e 's#\$(RPATH_FLAG)#'"$RPATH_FLAG"'#' \
-	    -e 's#\$(LDFLAGS)#'"$LDFLAGS"'#' \
+	    -e 's#\$(LDFLAGS)##' \
 	    -e 's#\$(PTHREAD_CFLAGS)#'"$PTHREAD_CFLAGS"'#' \
 	    -e 's#\$(CFLAGS)##'`
 


### PR DESCRIPTION
Linker options supplied at configure time such as -Wl,--as-needed can
be harmful when applied to downstream users of the libraries, and in
most cases should not be necessary.
