### PR TITLE
fixes keyblock leak in KDC's preauth plugin.

### DIFF
--- a/src/plugins/preauth/spake/spake_kdc.c
+++ b/src/plugins/preauth/spake/spake_kdc.c
@@ -469,6 +469,7 @@ cleanup:
     zapfree(spakeresult.data, spakeresult.length);
     krb5_free_data_contents(context, &thash);
     krb5_free_keyblock(context, k1);
+    krb5_free_keyblock(context, reply_key);
     k5_free_spake_factor(context, factor);
     (*respond)(arg, ret, NULL, NULL, NULL);
 }


### PR DESCRIPTION
leak has been noticed in krb5kdc while running unit tests
with libumem.