### PR TITLE
memory leak coming from pkinit_crypto_openssl.c pre-auth plugin

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_srv.c
+++ b/src/plugins/preauth/pkinit/pkinit_srv.c
@@ -1022,7 +1022,6 @@ pkinit_server_return_padata(krb5_context context,
     (*send_pa)->contents = (krb5_octet *) out_data->data;
 
 cleanup:
-    pkinit_fini_kdc_req_context(context, reqctx);
     free(scratch.data);
     free(out_data);
     if (encoded_dhkey_info != NULL)
@@ -1612,6 +1611,13 @@ pkinit_fini_kdc_req_context(krb5_context context, void *ctx)
     free(reqctx);
 }
 
+static void
+pkinit_free_modreq(krb5_context context, krb5_kdcpreauth_moddata moddata,
+                   krb5_kdcpreauth_modreq modreq)
+{
+    pkinit_fini_kdc_req_context(context, modreq);
+}
+
 krb5_error_code
 kdcpreauth_pkinit_initvt(krb5_context context, int maj_ver, int min_ver,
                          krb5_plugin_vtable vtable);
@@ -1633,5 +1639,6 @@ kdcpreauth_pkinit_initvt(krb5_context context, int maj_ver, int min_ver,
     vt->edata = pkinit_server_get_edata;
     vt->verify = pkinit_server_verify_padata;
     vt->return_padata = pkinit_server_return_padata;
+    vt->free_modreq = pkinit_free_modreq;
     return 0;
 }


### PR DESCRIPTION
while testing krb5-1.20-beta1 with Solaris I've found a memory
leak in krb5kdc. The libumem reports leak as follows:

```
CACHE     LEAKED   BUFCTL CALLER
0059d458      46 0075dbd0 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d458      14 008b2470 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d458      28 008b2548 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d458      15 0075cad0 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d458      15 00757098 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d458      15 0075c4e8 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d458      15 008b53b0 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d458      15 0075dca8 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d458      14 008b3700 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d458     122 0075d510 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d458      16 00757170 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d458      62 0075b840 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d458       1 00759178 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d458      15 0075e290 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d458      28 008b37d8 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d458      15 0075daf8 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d458      30 0075d948 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d458      14 008b26f8 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d858      60 00884dc0 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d858      90 0089e870 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d858      15 00882978 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d858      15 0074b7e8 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d858      15 00883548 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d858      15 008841f0 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d858      15 0074b638 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d858      30 0089e6c0 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d858      15 00883110 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d858      30 0074c208 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d858      90 00880388 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d858      15 008842c8 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d858      30 0089b5b8 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d858     150 0074b2d8 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d858      15 00883620 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d858      15 00884040 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059d858     150 0074b488 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059dc58      15 0088ca88 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059dc58      45 00752300 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059dc58     150 0088b648 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059dc58      15 00755310 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059dc58      15 0088d8e0 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059dc58      15 0088dec8 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059dc58      15 00756240 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059dc58      30 00755748 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059dc58      90 00750070 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059dc58      30 00752228 libcrypto.so.1.0.0`default_malloc_ex+0x1f
0059dc58      15 0088b2e8 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a1058      15 005f9ea0 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a1458      15 008935a0 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a1858      15 00603740 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a1c58       1 006083f0 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a1c58      14 00608828 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a1c58      15 006084c8 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a2458       1 005d64d8 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a2458      15 005d65b0 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a2458      14 005d69e8 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a2858      14 005fc2e8 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a2858       1 005fec38 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a2858      15 005fed10 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a4458      15 005da920 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a4858      14 005e8020 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a4858       1 005edda8 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a4c58      15 00604aa8 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a6058      30 00886b48 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a6058      15 008d99e0 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a6058      15 00886638 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a6058      15 008a2450 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a6058      15 008a2888 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a9c58      14 005f1110 libcrypto.so.1.0.0`default_malloc_ex+0x1f
005a1058      15 005f9558 libcrypto.so.1.0.0`default_realloc_ex+0x22
005a1058      30 005f9990 libcrypto.so.1.0.0`default_realloc_ex+0x22
0059d858      45 00883c08 libkrb5.so.3.3`decode_atype_to_ptr+0x11d
0059d858      15 00882b28 libkrb5.so.3.3`decode_atype_to_ptr+0x11d
0059dc58      15 00753158 libkrb5.so.3.3`decode_atype_to_ptr+0x11d
005a2058      15 005ef390 libkrb5.so.3.3`decode_atype_to_ptr+0x11d
0059d458      15 0075cc80 libkrb5.so.3.3`k5_asn1_decode_bytestring+0x48
0059d458      45 0075c698 libkrb5.so.3.3`k5_asn1_decode_bytestring+0x48
0059dc58      15 0088aeb0 libkrb5.so.3.3`k5_asn1_decode_bytestring+0x48
0059dc58      15 0088cde8 libkrb5.so.3.3`k5_asn1_decode_bytestring+0x48
0059d458      15 0075de58 libkrb5.so.3.3`null_terminate+0x94
0059d858      15 008858b8 libkrb5.so.3.3`null_terminate+0x94
005a9858       1 00745550 libkrb5.so.3.3`store_der+0x42
005a9858      12 00745700 libkrb5.so.3.3`store_der+0x42
0059d858      15 0089e000 pkinit.so`pkinit_init_kdc_req_context+0x2e
0059d858      15 0074b710 pkinit.so`pkinit_init_req_crypto+0x2e
------------------------------------------------------------------------
   Total    2262 buffers, 125096 bytes
```

checking a callstack which leads down to default_realloc_ex() we
see this:
```
krb5kdc:core> 0075dbd0::bufctl -v
            ADDR          BUFADDR        TIMESTAMP           THREAD
                            CACHE          LASTLOG         CONTENTS
          75dbd0           758800    608d93d978349                1
                           59d458           590bb8                0
                 libumem.so.1`umem_cache_alloc_debug+0x15d
                 libumem.so.1`umem_cache_alloc+0x227
                 libumem.so.1`umem_alloc+0xc0
                 libumem.so.1`malloc+0x2d
                 libcrypto.so.1.0.0`default_malloc_ex+0x1f
                 libcrypto.so.1.0.0`CRYPTO_malloc+0x81
                 libcrypto.so.1.0.0`ASN1_STRING_set+0xcb
                 libcrypto.so.1.0.0`asn1_ex_c2i+0x141
                 libcrypto.so.1.0.0`asn1_d2i_ex_primitive+0x283
                 libcrypto.so.1.0.0`asn1_item_ex_d2i+0x7ce
                 libcrypto.so.1.0.0`asn1_template_noexp_d2i+0x24f
                 libcrypto.so.1.0.0`asn1_template_ex_d2i+0x124
                 libcrypto.so.1.0.0`asn1_item_ex_d2i+0x2ab
                 libcrypto.so.1.0.0`asn1_template_noexp_d2i+0x172
                 libcrypto.so.1.0.0`asn1_template_ex_d2i+0x124
                 libcrypto.so.1.0.0`asn1_item_ex_d2i+0x80a
                 libcrypto.so.1.0.0`asn1_template_noexp_d2i+0x172
                 libcrypto.so.1.0.0`asn1_template_ex_d2i+0x124
                 libcrypto.so.1.0.0`asn1_item_ex_d2i+0x80a
                 libcrypto.so.1.0.0`ASN1_item_ex_d2i+0x2a
                 libcrypto.so.1.0.0`x509_name_ex_d2i+0x62
                 libcrypto.so.1.0.0`asn1_item_ex_d2i+0x714
                 libcrypto.so.1.0.0`asn1_template_noexp_d2i+0x24f
                 libcrypto.so.1.0.0`asn1_template_ex_d2i+0x124
                 libcrypto.so.1.0.0`asn1_item_ex_d2i+0x2ab
                 libcrypto.so.1.0.0`asn1_template_noexp_d2i+0x24f
                 libcrypto.so.1.0.0`asn1_template_ex_d2i+0x124
                 libcrypto.so.1.0.0`asn1_item_ex_d2i+0x2ab
                 libcrypto.so.1.0.0`ASN1_item_ex_d2i+0x2a
                 libcrypto.so.1.0.0`ASN1_item_d2i+0x40
                 libcrypto.so.1.0.0`ASN1_item_dup+0x4e
                 libcrypto.so.1.0.0`X509_dup+0x24
                 pkinit.so`cms_signeddata_verify+0xf58
                 pkinit.so`pkinit_server_verify_padata+0x3db
                 next_padata+0x289
                 next_padata+0x29c
                 check_padata+0x1ba
                 process_as_req+0x12f1
                 dispatch+0x48c
                 process_tcp_connection_read+0x589
```

all stacks start at `pkinit_server_verify_padata()` doing a disassm
and finding a matching code we see this:
```
(gdb) l *(cms_signeddata_verify+0xf58)
0xf8a7f098 is in cms_signeddata_verify (/export/home/sashan/userland/components/krb5/krb5-1.20-beta1/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c:2153).
2148                size += remain;
2149        }
2150        *data_len = size;
2151
2152        if (x) {
2153            reqctx->received_cert = X509_dup(x);
2154
2155            /* generate authorization data */
2156            if (cms_msg_type == CMS_SIGN_CLIENT) {
2157
(gdb) l *(pkinit_server_verify_padata+0x3db)
0xf8a5bb9b is in pkinit_server_verify_padata (/export/home/sashan/userland/components/krb5/krb5-1.20-beta1/src/plugins/preauth/pkinit/pkinit_srv.c:496).
491                                        (unsigned char *)reqp->signedAuthPack.data,
492                                        reqp->signedAuthPack.length,
493                                        (unsigned char **)&authp_data.data,
494                                        &authp_data.length,
495                                        (unsigned char **)&krb5_authz.data,
496                                        &krb5_authz.length, &is_signed);
497         if (retval) {
498             TRACE_PKINIT_SERVER_PADATA_VERIFY_FAIL(context);
499             goto cleanup;
500         }
```

taking a closer look at how we handle `->received_cert` we obtained at line 2153
in `pkinit_server_verify_padata()` reveals this:
```
 463     /* create a per-request context */
 464     retval = pkinit_init_kdc_req_context(context, &reqctx);
 465     if (retval)
 466         goto cleanup;
 467     reqctx->pa_type = data->pa_type;
 468
 ...
 487     retval = cms_signeddata_verify(context, plgctx->cryptoctx,
 488                                    reqctx->cryptoctx, plgctx->idctx,
 489                                    CMS_SIGN_CLIENT,
 490                                    plgctx->opts->require_crl_checking,
 491                                    (unsigned char *)reqp->signedAuthPack.data,
 492                                    reqp->signedAuthPack.length,
 493                                    (unsigned char **)&authp_data.data,
 494                                    &authp_data.length,
 495                                    (unsigned char **)&krb5_authz.data,
 496                                    &krb5_authz.length, &is_signed);
 497     if (retval) {
 498         TRACE_PKINIT_SERVER_PADATA_VERIFY_FAIL(context);
 499         goto cleanup;
 ...
 500     }
 620     /* remember to set the PREAUTH flag in the reply */
 621     enc_tkt_reply->flags |= TKT_FLG_PRE_AUTH;
 622     if (hwauth)
 623         enc_tkt_reply->flags |= TKT_FLG_HW_AUTH;
 624     modreq = (krb5_kdcpreauth_modreq)reqctx;
 625     reqctx = NULL;
 626
 627 cleanup:
 628     if (retval && data->pa_type == KRB5_PADATA_PK_AS_REQ) {
 629         pkiDebug("pkinit_verify_padata failed: creating e-data\n");
 630         if (pkinit_create_edata(context, plgctx->cryptoctx, reqctx->cryptoctx,
 631                                 plgctx->idctx, plgctx->opts, retval, &e_data))
 632             pkiDebug("pkinit_create_edata failed\n");
 633     }
 634
 635     free_krb5_pa_pk_as_req(&reqp);
 636     free(cksum.contents);
 637     free(authp_data.data);
 638     free(krb5_authz.data);
 639     if (reqctx != NULL)
 640         pkinit_fini_kdc_req_context(context, reqctx);
 641     free_krb5_auth_pack(&auth_pack);
 642
 643     (*respond)(arg, retval, modreq, e_data, NULL);
```
we've just learned the data we obtained are passed as `modreq`
argument to `(*respond)` handler, which according to disassm is
`finish_verify_padata`:
```
(gdb) l *(next_padata+0x289)
0xf999fa09 is in next_padata (/export/home/sashan/userland/components/krb5/krb5-1.20-beta1/src/kdc/kdc_preauth.c:1321).
1316        state->pa_found++;
1317        state->pa_sys->verify_padata(state->context, state->req_pkt,
1318                                     state->request, state->enc_tkt_reply,
1319                                     *state->padata, &callbacks, state->rock,
1320                                     state->pa_sys->moddata, finish_verify_padata,
1321                                     state);
1322        return;
1323
1324    next:
1325        next_padata(state);
```
the relevant part of function finish_verify_padata() reads as follows:
```
1212 static void
1213 finish_verify_padata(void *arg, krb5_error_code code,
1214                      krb5_kdcpreauth_modreq modreq, krb5_pa_data **e_data,
1215                      krb5_authdata **authz_data)
1216 {
1217     struct padata_state *state = arg;
1218     const char *emsg;
1219     krb5_boolean typed_e_data_flag;
1220
1221     assert(state);
1222     *state->modreq_ptr = modreq;
1223
```
so it looks like tha data we got from librcrypto are supposed to be freed
when we will be done with pre-auth request processing. After sepnding
few days with kdc code and plugins I came to conclusion the pkinit
does not set free modreq handler. The changed prpoosed in this pull
request adds a `pkinit_free_modreq()` function to pkinit plugin.
the function releases `state->modreq_ptr` data when state is
destroyed.

The change was tested with all unit test which come which come with
kerberos sources. All tests I could run pass. Also libumem confirms
memory leak is gone.