### PR TITLE
Set SHA-2 as supportedCMSTypes instead of 3DES

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_constants.c
+++ b/src/plugins/preauth/pkinit/pkinit_constants.c
@@ -32,9 +32,14 @@
 
 #include "pkinit.h"
 
-/* statically declare OID constants for all three algorithms */
-static char sha1_oid[8] = { 0x2B, 0x06, 0x01, 0x05, 0x02, 0x03, 0x06, 0x01};
+/* RFC 8636 id-pkinit-kdf-ah-sha1: iso(1) identified-organization(3) dod(6)
+ * internet(1) security(5) kerberosv5(2) pkinit(3) kdf(6) sha1(1) */
+static char sha1_oid[8] = { 0x2B, 0x06, 0x01, 0x05, 0x02, 0x03, 0x06, 0x01 };
+/* RFC 8636 id-pkinit-kdf-ah-sha256: iso(1) identified-organization(3) dod(6)
+ * internet(1) security(5) kerberosv5(2) pkinit(3) kdf(6) sha256(2) */
 static char sha256_oid[8] = { 0x2B, 0x06, 0x01, 0x05, 0x02, 0x03, 0x06, 0x02 };
+/* RFC 8636 id-pkinit-kdf-ah-sha512: iso(1) identified-organization(3) dod(6)
+ * internet(1) security(5) kerberosv5(2) pkinit(3) kdf(6) sha512(3) */
 static char sha512_oid[8] = { 0x2B, 0x06, 0x01, 0x05, 0x02, 0x03, 0x06, 0x03 };
 
 const krb5_data sha1_id = { KV5M_DATA, sizeof(sha1_oid), sha1_oid };
@@ -45,6 +50,30 @@ krb5_data const * const supported_kdf_alg_ids[] = {
     &sha256_id,
     &sha1_id,
     &sha512_id,
+    NULL
+};
+
+/* RFC 4055 sha256WithRSAEncryption: iso(1) member-body(2) us(840)
+ * rsadsi(113549) pkcs(1) 1 11 */
+static char sha256WithRSAEncr_oid[9] = {
+    0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0b
+};
+/* RFC 4055 sha256WithRSAEncryption: iso(1) member-body(2) us(840)
+ * rsadsi(113549) pkcs(1) 1 13 */
+static char sha512WithRSAEncr_oid[9] = {
+    0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x0d
+};
+
+const krb5_data sha256WithRSAEncr_id = {
+    KV5M_DATA, sizeof(sha256WithRSAEncr_oid), sha256WithRSAEncr_oid
+};
+const krb5_data sha512WithRSAEncr_id = {
+    KV5M_DATA, sizeof(sha512WithRSAEncr_oid), sha512WithRSAEncr_oid
+};
+
+krb5_data const * const supported_cms_algs[] = {
+    &sha512WithRSAEncr_id,
+    &sha256WithRSAEncr_id,
     NULL
 };
 

--- a/src/plugins/preauth/pkinit/pkinit_crypto.h
+++ b/src/plugins/preauth/pkinit/pkinit_crypto.h
@@ -620,6 +620,10 @@ extern const krb5_data oakley_4096;
  */
 extern krb5_data const * const supported_kdf_alg_ids[];
 
+/* CMS signature algorithms supported by this implementation, in order of
+ * decreasing preference. */
+extern krb5_data const * const supported_cms_algs[];
+
 krb5_error_code
 crypto_encode_der_cert(krb5_context context, pkinit_req_crypto_context reqctx,
 		       uint8_t **der_out, size_t *der_len);


### PR DESCRIPTION
The PKINIT client uses `AuthPack.supportedCMSTypes` to let the KDC know
about the algorithms it supports for verification of CMS data signature.

This commit replaces 3DES, which is currently the only algorithm
provided in this list and could be considered outdated, by SHA-256 and
SHA-512. But more algorithms could be added. As a comparison, the [list used by Heimdal](https://github.com/heimdal/heimdal/blob/heimdal-7.7.0/lib/hx509/crypto.c#L966-L988) includes more algorithms.

This change will not affect the way the MIT KDC handles PKINIT requests because the CMS data digest (SHA-256) [is hard coded](https://github.com/krb5/krb5/blob/master/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c#L1674). However, this is important for integration with Heimdal because this KDC selects the digest algorithm [from request's `supportedCMSTypes` list](https://github.com/heimdal/heimdal/blob/heimdal-7.7.0/kdc/pkinit.c#L759).