### PR TITLE
Improve daemon checking in k5test, and fix two bugs

### DIFF
--- a/src/kdc/main.c
+++ b/src/kdc/main.c
@@ -1037,7 +1037,6 @@ int main(int argc, char **argv)
     kau_kdc_start(kcontext, TRUE);
 
     verto_run(ctx);
-    loop_free(ctx);
     kau_kdc_stop(kcontext, TRUE);
     krb5_klog_syslog(LOG_INFO, _("shutting down"));
     unload_preauth_plugins(kcontext);
@@ -1051,6 +1050,7 @@ int main(int argc, char **argv)
 #ifndef NOCACHE
     kdc_free_lookaside(kcontext);
 #endif
+    loop_free(ctx);
     krb5_free_context(kcontext);
     return errout;
 }

--- a/src/plugins/preauth/otp/main.c
+++ b/src/plugins/preauth/otp/main.c
@@ -228,7 +228,7 @@ otp_edata(krb5_context context, krb5_kdc_req *request,
     krb5_pa_otp_challenge chl;
     krb5_pa_data *pa = NULL;
     krb5_error_code retval;
-    krb5_data *encoding;
+    krb5_data *encoding, nonce = empty_data();
     char *config;
 
     /* Determine if otp is enabled for the user. */
@@ -256,9 +256,10 @@ otp_edata(krb5_context context, krb5_kdc_req *request,
     ti.iteration_count = -1;
 
     /* Generate the nonce. */
-    retval = nonce_generate(context, armor_key->length, &chl.nonce);
+    retval = nonce_generate(context, armor_key->length, &nonce);
     if (retval != 0)
         goto out;
+    chl.nonce = nonce;
 
     /* Build the output pa-data. */
     retval = encode_krb5_pa_otp_challenge(&chl, &encoding);
@@ -275,6 +276,7 @@ otp_edata(krb5_context context, krb5_kdc_req *request,
     free(encoding);
 
 out:
+    krb5_free_data_contents(context, &nonce);
     (*respond)(arg, retval, pa);
 }
 


### PR DESCRIPTION
While thinking about PR #1253 I realized we could do a better job of catching asan failures in k5test.  The third commit here does that, by reworking daemon checking so that it applies to daemons we deliberately terminate.

The first two commits fix bugs detected by this change: a small but regular memory leak in OTP, and an exit-time KDC memory error relating to an interaction between OTP and KDC cleanup order.

This change also detects the PR #1253 memory leak, so the CI for this PR should initially fail--and we should be able to see that it displays the asan memory leak traces for the KDC process.