### PR TITLE
Remove pre-CMS PKINIT compatibility code

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1145,7 +1145,6 @@ if test "$k5_cv_openssl_version_okay" = yes && (test "$enable_pkinit" = yes || t
   K5_GEN_MAKEFILE(plugins/preauth/pkinit)
   K5_GEN_MAKEFILE(tests/softpkcs11)
   PKINIT=yes
-  AC_CHECK_LIB(crypto, CMS_get0_content, [AC_DEFINE([HAVE_OPENSSL_CMS], 1, [Define if OpenSSL supports cms.])])
 elif test "$k5_cv_openssl_version_okay" = no && test "$enable_pkinit" = yes; then
   AC_MSG_ERROR([Version of OpenSSL is too old; cannot enable PKINIT.])
 else

--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.h
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.h
@@ -46,6 +46,7 @@
 #include <openssl/asn1.h>
 #include <openssl/pem.h>
 #include <openssl/asn1t.h>
+#include <openssl/cms.h>
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/core_names.h>
 #include <openssl/decoder.h>


### PR DESCRIPTION
CMS support is present in OpenSSL 1.0, which is the earliest supported
version.

I looked into changing cms_signeddata_create() to use CMS APIs rather than PKCS7 APIs, but it doesn't look easy.  In the PKCS11 case we need to generate the signature ourselves, and the CMS APIs appear to require that OpenSSL generate the digest and signature internally (with the caller providing the private key).  It's possible that we could do something with engines and providers for OpenSSL 1.x and 3.x respectively.

LibreSSL support isn't a priority for us, but I checked and they added CMS support in 2019.
