### PR TITLE
Remove include_certchain parameter in PKINIT

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_clnt.c
+++ b/src/plugins/preauth/pkinit/pkinit_clnt.c
@@ -270,7 +270,7 @@ pkinit_as_req_create(krb5_context context,
     } else {
         retval = cms_signeddata_create(context, plgctx->cryptoctx,
                                        reqctx->cryptoctx, reqctx->idctx,
-                                       CMS_SIGN_CLIENT, 1,
+                                       CMS_SIGN_CLIENT,
                                        (unsigned char *)
                                        coded_auth_pack->data,
                                        coded_auth_pack->length,

--- a/src/plugins/preauth/pkinit/pkinit_crypto.h
+++ b/src/plugins/preauth/pkinit/pkinit_crypto.h
@@ -132,9 +132,6 @@ krb5_error_code cms_signeddata_create
 	int cms_msg_type,				/* IN
 		    specifies CMS_SIGN_CLIENT for client-side CMS message
 		    and CMS_SIGN_SERVER for kdc-side */
-	int include_certchain,				/* IN
-		    specifies where certificates field in SignedData
-		    should contain certificate path */
 	unsigned char *auth_pack,			/* IN
 		    contains DER encoded AuthPack (CMS_SIGN_CLIENT)
 		    or DER encoded DHRepInfo (CMS_SIGN_SERVER) */
@@ -192,9 +189,6 @@ krb5_error_code cms_envelopeddata_create
 	pkinit_req_crypto_context req_cryptoctx,	/* IN */
 	pkinit_identity_crypto_context id_cryptoctx,	/* IN */
 	krb5_preauthtype pa_type,			/* IN */
-	int include_certchain,				/* IN
-		    specifies whether the certificates field in
-		    SignedData should contain certificate path */
 	unsigned char *key_pack,			/* IN
 		    contains DER encoded ReplyKeyPack */
 	unsigned int key_pack_len,			/* IN

--- a/src/plugins/preauth/pkinit/pkinit_srv.c
+++ b/src/plugins/preauth/pkinit/pkinit_srv.c
@@ -863,7 +863,7 @@ pkinit_server_return_padata(krb5_context context,
 
         retval = cms_signeddata_create(context, plgctx->cryptoctx,
                                        reqctx->cryptoctx, plgctx->idctx,
-                                       CMS_SIGN_SERVER, 1,
+                                       CMS_SIGN_SERVER,
                                        (unsigned char *)
                                        encoded_dhkey_info->data,
                                        encoded_dhkey_info->length,
@@ -917,7 +917,7 @@ pkinit_server_return_padata(krb5_context context,
         rep->choice = choice_pa_pk_as_rep_encKeyPack;
         retval = cms_envelopeddata_create(context, plgctx->cryptoctx,
                                           reqctx->cryptoctx, plgctx->idctx,
-                                          padata->pa_type, 1,
+                                          padata->pa_type,
                                           (unsigned char *)
                                           encoded_key_pack->data,
                                           encoded_key_pack->length,


### PR DESCRIPTION
Every caller of cms_signeddata_create() and cms_envelopeddata_create()
passes 1 for include_certchain.  Remove the parameter and
unconditionally add the certificate chain.