### PR TITLE
Update error codes for OpenSSL CMS_verify

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -2061,12 +2061,15 @@ cms_signeddata_verify(krb5_context context,
             goto cleanup;
         out = BIO_new(BIO_s_mem());
         if (CMS_verify(cms, NULL, store, NULL, out, flags) == 0) {
-            unsigned long err = ERR_peek_error();
+            unsigned long err = ERR_peek_last_error();
             switch(ERR_GET_REASON(err)) {
-            case PKCS7_R_DIGEST_FAILURE:
+            case RSA_R_DIGEST_NOT_ALLOWED:
+            case CMS_R_UNKNOWN_DIGEST_ALGORITHM:
+            case CMS_R_NO_MATCHING_DIGEST:
+            case CMS_R_NO_MATCHING_SIGNATURE:
                 retval = KRB5KDC_ERR_DIGEST_IN_SIGNED_DATA_NOT_ACCEPTED;
                 break;
-            case PKCS7_R_SIGNATURE_FAILURE:
+            case CMS_R_VERIFICATION_FAILURE:
             default:
                 retval = KRB5KDC_ERR_INVALID_SIG;
             }


### PR DESCRIPTION
The code for CMS data verification was initially written for OpenSSL's `PKCS7_verify()` function. It has been replaced by `CMS_verify()` but error handling is still done using `PKCS7_verify()` error identifiers. It results in the `KDC_ERR_DIGEST_IN_SIGNED_DATA_NOT_ACCEPTED` error to not be raised when it should.

This commit replaces error identifiers with CMS ones.

I also replaced the `ERR_peek_error()` call by `ERR_peek_last_error()` because the first error in OpenSSL's stack is always `CMS_R_CONTENT_TYPE_NOT_ENVELOPED_DATA` in this context. Therefore it does not allow to differentiate an error caused by an unaccepted digest algorithm and an invalid signature.

Tests confirmed the following errors to be raised in given scenarios:

* `EVP_R_INVALID_DIGEST`: The digest algorithm is recognized and compatible with PKINIT, but disallowed by OpenSSL configuration.
    * Tiggered by using SHA-1 signature against a RHEL9 KDC.
* `RSA_R_DIGEST_NOT_ALLOWED`: The digest algorithm is not supported by PKINIT (OpenSSL fails to infer a signature algorithm based on the RSA key type and the digest algorithm).
    * Triggered by setting [SM3](https://datatracker.ietf.org/doc/html/draft-oscca-cfrg-sm3-02) as digest algorithm.
    * I was rather expecting this case to raise `CMS_R_NO_MATCHING_DIGEST`.
    * I thought this one was raised because OpenSSL was failing [to infer a signature algorithm](https://github.com/openssl/openssl/blob/openssl-3.0.5/crypto/cms/cms_sd.c#L993-L1005) based on the digest algorithm and the RSA key type. However [SM3 with RSA encryption](https://github.com/openssl/openssl/blob/openssl-3.0.1/include/openssl/obj_mac.h#L1210-L1213) is supported by OpenSSL, so I don't know...
* `CMS_R_UNKNOWN_DIGEST_ALGORITHM`: The OID is not a known digest algorithm.
    * Triggered by setting a non digest/signature-related OID as algorithm.
* `CMS_R_VERIFICATION_FAILURE`: Verification of the signature value failed.
    * Triggered by putting a random value as digest.

The `CMS_R_NO_MATCHING_DIGEST` error is [part of the `SignerInfo` verification process](https://github.com/openssl/openssl/blob/openssl-3.0.5/crypto/cms/cms_sd.c#L174), but I didn't managed to have it raised.

`CMS_R_NO_MATCHING_SIGNATURE` is defined but not used in practice, I put it anyway in case is it added in the future.