### PR TITLE
Use unsigned 32-bit integer for password expiry delta

### DIFF
--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -2324,6 +2324,15 @@ ts_delta(krb5_timestamp a, krb5_timestamp b)
     return (krb5_deltat)((uint32_t)a - (uint32_t)b);
 }
 
+/* Return (end - start) as an unsigned 32-bit value, or 0 if start > end. */
+static inline uint32_t
+ts_interval(krb5_timestamp start, krb5_timestamp end)
+{
+    if ((uint32_t)start > (uint32_t)end)
+        return 0;
+    return (uint32_t)end - (uint32_t)start;
+}
+
 /* Increment a timestamp by a signed 32-bit interval, without relying on
  * undefined behavior. */
 static inline krb5_timestamp

--- a/src/lib/gssapi/krb5/accept_sec_context.c
+++ b/src/lib/gssapi/krb5/accept_sec_context.c
@@ -353,8 +353,8 @@ kg_accept_dce(minor_status, context_handle, verifier_cred_handle,
         *mech_type = ctx->mech_used;
 
     if (time_rec) {
-        *time_rec = ts_delta(ctx->krb_times.endtime, now) +
-            ctx->k5_context->clockskew;
+        *time_rec = ts_interval(ts_incr(now, -ctx->k5_context->clockskew),
+                                ctx->krb_times.endtime);
     }
 
     /* Never return GSS_C_DELEG_FLAG since we don't support DCE credential
@@ -1152,8 +1152,10 @@ kg_accept_krb5(minor_status, context_handle,
 
     /* Add the maximum allowable clock skew as a grace period for context
      * expiration, just as we do for the ticket. */
-    if (time_rec)
-        *time_rec = ts_delta(ctx->krb_times.endtime, now) + context->clockskew;
+    if (time_rec) {
+        *time_rec = ts_interval(ts_incr(now, -context->clockskew),
+                                ctx->krb_times.endtime);
+    }
 
     if (ret_flags)
         *ret_flags = ctx->gss_flags;

--- a/src/lib/gssapi/krb5/acquire_cred.c
+++ b/src/lib/gssapi/krb5/acquire_cred.c
@@ -879,8 +879,7 @@ acquire_cred_context(krb5_context context, OM_uint32 *minor_status,
                                   GSS_C_NO_NAME);
             if (GSS_ERROR(ret))
                 goto error_out;
-            *time_rec = ts_after(cred->expire, now) ?
-                ts_delta(cred->expire, now) : 0;
+            *time_rec = ts_interval(now, cred->expire);
             k5_mutex_unlock(&cred->lock);
         }
     }

--- a/src/lib/gssapi/krb5/init_sec_context.c
+++ b/src/lib/gssapi/krb5/init_sec_context.c
@@ -664,7 +664,7 @@ kg_new_connection(
     if (time_rec) {
         if ((code = krb5_timeofday(context, &now)))
             goto cleanup;
-        *time_rec = ts_delta(ctx->krb_times.endtime, now);
+        *time_rec = ts_interval(now, ctx->krb_times.endtime);
     }
 
     /* set the other returns */
@@ -878,7 +878,7 @@ mutual_auth(
     if (time_rec) {
         if ((code = krb5_timeofday(context, &now)))
             goto fail;
-        *time_rec = ts_delta(ctx->krb_times.endtime, now);
+        *time_rec = ts_interval(now, ctx->krb_times.endtime);
     }
 
     if (ret_flags)

--- a/src/lib/gssapi/krb5/inq_context.c
+++ b/src/lib/gssapi/krb5/inq_context.c
@@ -95,8 +95,8 @@ krb5_gss_inquire_context(minor_status, context_handle, initiator_name,
     krb5_error_code code;
     krb5_gss_ctx_id_rec *ctx;
     krb5_gss_name_t initiator, acceptor;
-    krb5_timestamp now;
-    krb5_deltat lifetime;
+    krb5_timestamp now, start;
+    OM_uint32 lifetime;
 
     if (initiator_name)
         *initiator_name = (gss_name_t) NULL;
@@ -120,11 +120,8 @@ krb5_gss_inquire_context(minor_status, context_handle, initiator_name,
 
         /* Add the maximum allowable clock skew as a grace period for context
          * expiration, just as we do for the ticket during authentication. */
-        lifetime = ts_delta(ctx->krb_times.endtime, now);
-        if (!ctx->initiate)
-            lifetime += context->clockskew;
-        if (lifetime < 0)
-            lifetime = 0;
+        start = ctx->initiate ? now : ts_incr(now, -context->clockskew);
+        lifetime = ts_interval(start, ctx->krb_times.endtime);
 
         if (initiator_name) {
             code = kg_duplicate_name(context,

--- a/src/lib/gssapi/krb5/inq_cred.c
+++ b/src/lib/gssapi/krb5/inq_cred.c
@@ -131,7 +131,7 @@ krb5_gss_inquire_cred(minor_status, cred_handle, name, lifetime_ret,
     }
 
     if (cred->expire != 0) {
-        lifetime = ts_delta(cred->expire, now);
+        lifetime = ts_interval(now, cred->expire);
         if (lifetime < 0)
             lifetime = 0;
     }

--- a/src/lib/gssapi/krb5/s4u_gss_glue.c
+++ b/src/lib/gssapi/krb5/s4u_gss_glue.c
@@ -279,7 +279,7 @@ kg_compose_deleg_cred(OM_uint32 *minor_status,
         if (code != 0)
             goto cleanup;
 
-        *time_rec = ts_delta(cred->expire, now);
+        *time_rec = ts_interval(now, cred->expire);
     }
 
     major_status = GSS_S_COMPLETE;

--- a/src/lib/krb5/ccache/cc_keyring.c
+++ b/src/lib/krb5/ccache/cc_keyring.c
@@ -762,7 +762,7 @@ update_keyring_expiration(krb5_context context, krb5_ccache id)
 
     /* Setting the timeout to zero would reset the timeout, so we set it to one
      * second instead if creds are already expired. */
-    timeout = ts_after(endtime, now) ? ts_delta(endtime, now) : 1;
+    timeout = ts_after(endtime, now) ? ts_interval(now, endtime) : 1;
     (void)keyctl_set_timeout(data->cache_id, timeout);
 }
 
@@ -1343,7 +1343,7 @@ krcc_store(krb5_context context, krb5_ccache id, krb5_creds *creds)
 
     if (ts_after(creds->times.endtime, now)) {
         (void)keyctl_set_timeout(cred_key,
-                                 ts_delta(creds->times.endtime, now));
+                                 ts_interval(now, creds->times.endtime));
     }
 
     update_keyring_expiration(context, id);


### PR DESCRIPTION
During interactive password pre-authentication, a warning is printed in case the password expiry time delta is less than one week. However this time delta is stored as a signed 32-bit integer, while the current and expiry date times are stored as unsigned 32-bit integers (even if their declared type is signed).

As a consequence, an expiry date that is more than 2^31 - 1 seconds in the future will cause this time delta to wrap. It results in the expiry warning message "Your password will expire in less than one hour" to be displayed, while the actual expiry date is more than 68 years in the future.

This commit fixes this issue by casting the delta as unsigned after the expiry date is confirmed to be in the future.