### PR TITLE
Canonicalize user realm for S4U2Self queries

### DIFF
--- a/src/lib/krb5/krb/s4u_creds.c
+++ b/src/lib/krb5/krb/s4u_creds.c
@@ -482,8 +482,18 @@ krb5_get_self_cred_from_kdc(krb5_context context,
     code = krb5_get_credentials(context, options, ccache, &tgtq, &tgt);
     if (code != 0)
         goto cleanup;
-
     tgtptr = tgt;
+
+    /* Canonicalize the user's realm name using the obtained TGT. */
+    if (tgt->server->length != 2) {
+        code = KRB5KRB_AP_ERR_MODIFIED;
+        goto cleanup;
+    }
+    krb5_free_data_contents(context, &s4u_user.user_id.user->realm);
+    code = krb5int_copy_data_contents(context, &tgt->server->data[1],
+                                      &s4u_user.user_id.user->realm);
+    if (code != 0)
+        goto cleanup;
 
     /* Convert the server principal to an enterprise principal, for use with
      * foreign realms. */


### PR DESCRIPTION
Based on a trace provided by Jacob Shivers from Red Hat, Active Directory 2016 does not canonicalize the user realm in S4U2Self queries, and adds a transited field to a cross-realm S4U2Self ticket if the user realm is an alias, causing MIT krb5 to fail a transited check on the ticket.

In krb5_get_self_cred_from_kdc(), after obtaining a TGT for the user realm, replace the realm for the S4U2Self request with the realm in the TGT.

ticket: 9070