### PR TITLE
fix core dump get as key keytab

### DIFF
--- a/src/lib/krb5/krb/gic_keytab.c
+++ b/src/lib/krb5/krb/gic_keytab.c
@@ -45,7 +45,6 @@ get_as_key_keytab(krb5_context context,
     krb5_keytab keytab = (krb5_keytab) gak_data;
     krb5_error_code ret;
     krb5_keytab_entry kt_ent;
-    krb5_keyblock *kt_key;
 
     /* We don't need the password from the responder to create the AS key. */
     if (as_key == NULL)
@@ -71,16 +70,13 @@ get_as_key_keytab(krb5_context context,
                                  etype, &kt_ent)))
         return(ret);
 
-    ret = krb5_copy_keyblock(context, &kt_ent.key, &kt_key);
-
-    /* again, krb5's memory management is lame... */
-
-    *as_key = *kt_key;
-    free(kt_key);
+    /* Steal the keyblock from kt_ent for the caller. */
+    *as_key = kt_ent.key;
+    memset(&kt_ent.key, 0, sizeof(kt_ent.key));
 
     (void) krb5_kt_free_entry(context, &kt_ent);
 
-    return(ret);
+    return 0;
 }
 
 /* Return the list of etypes available for client in keytab. */


### PR DESCRIPTION
Hi @greghudson 
I found another core dump in the test, The following is the full core dump
```
Type "apropos word" to search for commands related to "word"...
Reading symbols from kinit...
Reading symbols from /usr/lib/debug//usr/bin/kinit-1.19.2-2.h9.eulerosv2r11.x86_64.debug...
[New LWP 3844944]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib64/libthread_db.so.1".
Core was generated by `/usr/bin/kinit -kt /etc/key.keytab user'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  get_as_key_keytab (prompter=<optimized out>, prompter_data=<optimized out>, salt=<optimized out>, params=0x55abc3c5b098, ritems=0x55abc3c5b1b0,
    gak_data=0x55abc3c5a7e0, as_key=0x55abc3c5b0a8, etype=18, client=0x55abc3c5adb0, context=0x55abc3c57ba0) at gic_keytab.c:78
78          *as_key = *kt_key;
Missing separate debuginfos, use: dnf debuginfo-install e2fsprogs-1.46.4-7.h12.eulerosv2r11.x86_64 keyutils-libs-1.6.3-3.h3.eulerosv2r11.x86_64 libgcc-10.3.1-10.h13.eulerosv2r11.x86_64 openssl-libs-1.1.1m-2.h19.eulerosv2r11.x86_64 pcre2-10.39-1.h3.eulerosv2r11.x86_64 sssd-2.6.1-1.h8.eulerosv2r11.x86_64 zlib-1.2.11-19.h5.eulerosv2r11.x86_64
(gdb) bt
#0  get_as_key_keytab (prompter=<optimized out>, prompter_data=<optimized out>, salt=<optimized out>, params=0x55abc3c5b098, ritems=0x55abc3c5b1b0,
    gak_data=0x55abc3c5a7e0, as_key=0x55abc3c5b0a8, etype=18, client=0x55abc3c5adb0, context=0x55abc3c57ba0) at gic_keytab.c:78
#1  get_as_key_keytab (context=0x55abc3c57ba0, client=0x55abc3c5adb0, etype=18, prompter=<optimized out>, prompter_data=<optimized out>, salt=<optimized out>,
    params=0x55abc3c5b098, as_key=0x55abc3c5b0a8, gak_data=0x55abc3c5a7e0, ritems=0x55abc3c5b1b0) at gic_keytab.c:34
#2  0x00007fe5f45ed989 in decrypt_as_reply (key_out=0x7ffd6b4c94d0, strengthen_key=0x0, ctx=0x55abc3c5aef0, context=0x55abc3c57ba0) at get_in_tkt.c:118
#3  init_creds_step_reply (in=<optimized out>, ctx=0x55abc3c5aef0, context=0x55abc3c57ba0) at get_in_tkt.c:1772
#4  krb5_init_creds_step (flags=0x7ffd6b4c9568, realm=0x7ffd6b4c9590, out=0x7ffd6b4c9570, in=<optimized out>, ctx=0x55abc3c5aef0, context=0x55abc3c57ba0)
    at get_in_tkt.c:1867
#5  krb5_init_creds_step (context=0x55abc3c57ba0, ctx=0x55abc3c5aef0, in=<optimized out>, out=0x7ffd6b4c9570, realm=0x7ffd6b4c9590, flags=0x7ffd6b4c9568)
    at get_in_tkt.c:1842
#6  0x00007fe5f45ef8ef in k5_init_creds_get (context=context@entry=0x55abc3c57ba0, ctx=0x55abc3c5aef0, use_primary=use_primary@entry=0x7ffd6b4c9674)
    at get_in_tkt.c:569
#7  0x00007fe5f45f055f in get_init_creds_keytab (context=context@entry=0x55abc3c57ba0, creds=creds@entry=0x7ffd6b4c9770, client=client@entry=0x55abc3c5a820,
    keytab=keytab@entry=0x55abc3c5a7e0, start_time=start_time@entry=0, in_tkt_service=in_tkt_service@entry=0x0, options=0x55abc3c5ae40,
    use_primary=0x7ffd6b4c9674) at gic_keytab.c:262
#8  0x00007fe5f45f05f6 in krb5_get_init_creds_keytab (context=0x55abc3c57ba0, creds=0x7ffd6b4c9770, client=0x55abc3c5a820, arg_keytab=0x55abc3c5a7e0,
    start_time=0, in_tkt_service=0x0, options=0x55abc3c5ae40) at gic_keytab.c:301
#9  0x000055abc2a10cc4 in k5_kinit (k5=0x7ffd6b4c9740, opts=0x7ffd6b4c97f0) at kinit.c:770
#10 main (argc=<optimized out>, argv=<optimized out>) at kinit.c:886

```