### PR TITLE
fix coredump in db null

### DIFF
--- a/src/plugins/kdb/db2/kdb_db2.c
+++ b/src/plugins/kdb/db2/kdb_db2.c
@@ -390,7 +390,7 @@ open_db(krb5_context context, krb5_db2_context *dbc, int flags, int mode,
 
     *db_out = db;
     free(fname);
-    return (db == NULL) ? errno : 0;
+    return (db == NULL) ? (errno == 0 ? ENOMEM : errno) : 0;
 }
 
 static krb5_error_code


### PR DESCRIPTION
Hi @greghudson, It's another core dump in the test, The following is the full stack trace
```
Using host libthread_db library "/usr/lib64/libthread_db.so.1".
Core was generated by `/usr/sbin/kadmin.local delstr testprinc key_name'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0 0x00007f93ca92cf09 in check_openable (context=0x55e11bbbbea0) at kdb_db2.c:556
556 db->close(db);
Missing separate debuginfos, use: dnf debuginfo-install e2fsprogs-1.46.4-7.h12.eulerosv2r11.x86_64 gssproxy-0.8.4-1.eulerosv2r11.x86_64 keyutils-libs-1.6.3-3.h3.eulerosv2r11.x86_64 openssl-libs-1.1.1m-2.h19.eulerosv2r11.x86_64 pcre2-10.39-1.h3.eulerosv2r11.x86_64 zlib-1.2.11-19.h5.eulerosv2r11.x86_64
(gdb) bt
#0 0x00007f93ca92cf09 in check_openable (context=0x55e11bbbbea0) at kdb_db2.c:556
#1 krb5_db2_open (context=context@entry=0x55e11bbbbea0, conf_section=conf_section@entry=0x55e11bbbed40 "KRBTEST.COM", db_args=db_args@entry=0x0,
mode=mode@entry=512) at kdb_db2.c:1195
#2 0x00007f93ca92e228 in wrap_krb5_db2_open (kcontext=0x55e11bbbbea0, conf_section=0x55e11bbbed40 "KRBTEST.COM", db_args=0x0, mode=512) at db2_exp.c:89
#3 0x00007f93d860bd25 in krb5_db_open (kcontext=0x55e11bbbbea0, db_args=db_args@entry=0x0, mode=mode@entry=512) at kdb5.c:676
#4 0x00007f93d86304ca in kadm5_init (pass=, service_name=, struct_version=305419777, server_handle=0x55e11a428098 ,
db_args=0x0, api_version=305420036, params_in=0x7ffc870cf420, client_name=0x55e11bbbced0 "user/admin@KRBTEST.COM", context=0x55e11bbbbea0)
at server_init.c:234
#5 kadm5_init (context=0x55e11bbbbea0, client_name=0x55e11bbbced0 "user/admin@KRBTEST.COM", pass=, service_name=,
params_in=0x7ffc870cf420, struct_version=, api_version=305420036, db_args=0x0, server_handle=0x55e11a428098 ) at server_init.c:158
#6 0x000055e11a41a876 in kadmin_startup (argc=, argv=0x7ffc870cf688, request_out=, args_out=) at kadmin.c:574
#7 0x000055e11a4187ec in main (argc=4, argv=0x7ffc870cf688) at ss_wrapper.c:50

```