### PR TITLE
fix coredump when db->db is null

### DIFF
--- a/src/plugins/kdb/db2/adb_policy.c
+++ b/src/plugins/kdb/db2/adb_policy.c
@@ -58,7 +58,7 @@ osa_adb_create_policy(osa_adb_policy_t db, osa_policy_ent_t entry)
 
     OPENLOCK(db, KRB5_DB_LOCKMODE_EXCLUSIVE);
 
-    if(entry->name == NULL) {
+    if(entry->name == NULL || db->db == NULL) {
         ret = EINVAL;
         goto error;
     }
@@ -131,7 +131,7 @@ osa_adb_destroy_policy(osa_adb_policy_t db, char *name)
 
     OPENLOCK(db, KRB5_DB_LOCKMODE_EXCLUSIVE);
 
-    if(name == NULL) {
+    if(name == NULL || db->db == NULL) {
         ret = EINVAL;
         goto error;
     }
@@ -190,7 +190,7 @@ osa_adb_get_policy(osa_adb_policy_t db, char *name,
     *entry_ptr = NULL;
     OPENLOCK(db, KRB5_DB_LOCKMODE_SHARED);
 
-    if(name == NULL) {
+    if(name == NULL || db->db == NULL) {
         ret = EINVAL;
         goto error;
     }
@@ -262,7 +262,7 @@ osa_adb_put_policy(osa_adb_policy_t db, osa_policy_ent_t entry)
 
     OPENLOCK(db, KRB5_DB_LOCKMODE_EXCLUSIVE);
 
-    if(entry->name == NULL) {
+    if(entry->name == NULL || db->db == NULL) {
         ret = EINVAL;
         goto error;
     }
@@ -330,6 +330,10 @@ osa_adb_iter_policy(osa_adb_policy_t db, osa_adb_iter_policy_func func,
     char                    *aligned_data;
 
     OPENLOCK(db, KRB5_DB_LOCKMODE_EXCLUSIVE); /* hmmm */
+    if (db->db == NULL) {
+        ret = EINVAL;
+        goto error;
+    }
 
     if((ret = db->db->seq(db->db, &dbkey, &dbdata, R_FIRST)) == -1) {
         ret = errno;


### PR DESCRIPTION
Hi @greghudson, It's another core dump in the test, The following is the full stack trace
```
Reading symbols from kadmin.local...
Reading symbols from /usr/lib/debug//usr/sbin/kadmin.local-1.19.2-2.h10.eulerosv2r11.x86_64.debug...
[New LWP 404715]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/usr/lib64/libthread_db.so.1".
Core was generated by `/usr/sbin/kadmin.local getpol policy_self'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0 0x00007f69813a2a10 in osa_adb_get_policy (db=0x557e48b49c00, name=name@entry=0x7ffcf687c19d "policy_self", entry_ptr=entry_ptr@entry=0x7ffcf687a750)
at adb_policy.c:201
201 switch((db->db->get(db->db, &dbkey, &dbdata, 0))) {
Missing separate debuginfos, use: dnf debuginfo-install e2fsprogs-1.46.4-7.h12.eulerosv2r11.x86_64 gssproxy-0.8.4-1.eulerosv2r11.x86_64 keyutils-libs-1.6.3-3.h3.eulerosv2r11.x86_64 ncurses-libs-6.3-2.h2.eulerosv2r11.x86_64 openssl-libs-1.1.1m-2.h19.eulerosv2r11.x86_64 pcre2-10.39-1.h3.eulerosv2r11.x86_64 readline-8.1-1.eulerosv2r11.x86_64 zlib-1.2.11-19.h5.eulerosv2r11.x86_64
(gdb) bt
#0 0x00007f69813a2a10 in osa_adb_get_policy (db=0x557e48b49c00, name=name@entry=0x7ffcf687c19d "policy_self", entry_ptr=entry_ptr@entry=0x7ffcf687a750)
at adb_policy.c:201
#1 0x00007f69813a51f8 in krb5_db2_get_policy (context=context@entry=0x557e48ac7ea0, name=name@entry=0x7ffcf687c19d "policy_self",
policy=policy@entry=0x7ffcf687a750) at kdb_db2.c:1289
#2 0x00007f69813a5cd0 in wrap_krb5_db2_get_policy (kcontext=0x557e48ac7ea0, name=0x7ffcf687c19d "policy_self", policy=0x7ffcf687a750) at db2_exp.c:140
#3 0x00007f698f0a2cc7 in kadm5_get_policy (server_handle=0x557e48aca810, name=, entry=entry@entry=0x7ffcf687a7a0) at svr_policy.c:375
#4 0x0000557e486ca7de in kadmin_getpol (argc=, argv=0x557e48b36660) at kadmin.c:1739
#5 0x00007f698f0b5ded in ?? () from /usr/lib64/libss.so.2
#6 0x00007f698f0b5ee3 in ss_execute_command () from /usr/lib64/libss.so.2
#7 0x0000557e486c5829 in main (argc=3, argv=) at ss_wrapper.c:59
```