### PR TITLE
Enable LFS on 32-bit platforms

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -27,6 +27,8 @@ PKG_PROG_PKG_CONFIG
 AC_CHECK_HEADER([stdint.h], [],
   [AC_MSG_ERROR([stdint.h is required])])
 
+AC_SYS_LARGEFILE
+
 AC_CACHE_CHECK([whether integers are two's complement],
   [krb5_cv_ints_twos_compl],
   [AC_COMPILE_IFELSE(


### PR DESCRIPTION
* required to support 64-bit filesystems (inodes) on 32-bit platforms: https://flameeyes.blog/2010/12/15/another-good-reason-to-use-64-bit-installations-large-file-support-headaches/