### PR TITLE
Prevent issuance of RC4 and DES3 session keys by default

### DIFF
--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -95,6 +95,18 @@ Additionally, krb5.conf may include any of the relations described in
 
 The libdefaults section may contain any of the following relations:
 
+**allow_des3**
+    Permit the KDC to issue tickets with des3-cbc-sha1 session keys.
+    In future releases, this flag will allow des3-cbc-sha1 to be used
+    at all.  The default value for this tag is false.  (Added in
+    release 1.21.)
+
+**allow_rc4**
+    Permit the KDC to issue tickets with arcfour-hmac session keys.
+    In future releases, this flag will allow arcfour-hmac to be used
+    at all.  The default value for this tag is false.  (Added in
+    release 1.21.)
+
 **allow_weak_crypto**
     If this flag is set to false, then weak encryption types (as noted
     in :ref:`Encryption_types` in :ref:`kdc.conf(5)`) will be filtered

--- a/doc/admin/enctypes.rst
+++ b/doc/admin/enctypes.rst
@@ -48,12 +48,15 @@ Session key selection
 The KDC chooses the session key enctype by taking the intersection of
 its **permitted_enctypes** list, the list of long-term keys for the
 most recent kvno of the service, and the client's requested list of
-enctypes.
+enctypes.  Starting in krb5-1.21, all services are assumed to support
+aes256-cts-hmac-sha1-96; also, des3-cbc-sha1 and arcfour-hmac session
+keys will not be issued by default.
 
 Starting in krb5-1.11, it is possible to set a string attribute on a
 service principal to control what session key enctypes the KDC may
-issue for service tickets for that principal.  See :ref:`set_string`
-in :ref:`kadmin(1)` for details.
+issue for service tickets for that principal, overriding the service's
+long-term keys and the assumption of aes256-cts-hmac-sha1-96 support.
+See :ref:`set_string` in :ref:`kadmin(1)` for details.
 
 
 Choosing enctypes for a service
@@ -86,6 +89,20 @@ affect how enctypes are chosen.
     set this to *true* unless the use of weak enctypes is an
     acceptable risk for your environment and the weak enctypes are
     required for backward compatibility.
+
+**allow_des3**
+    was added in release 1.21 and defaults to *false*.  Unless this
+    flag is set to *true*, the KDC will not issue tickets with
+    des3-cbc-sha1 session keys.  In a future release, this flag will
+    control whether des3-cbc-sha1 is permitted in similar fashion to
+    weak enctypes.
+
+**allow_rc4**
+    was added in release 1.21 and defaults to *false*.  Unless this
+    flag is set to *true*, the KDC will not issue tickets with
+    arcfour-hmac session keys.  In a future release, this flag will
+    control whether arcfour-hmac is permitted in similar fashion to
+    weak enctypes.
 
 **permitted_enctypes**
     controls the set of enctypes that a service will permit for

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -180,6 +180,8 @@ typedef unsigned char   u_char;
  * matches the variable name.  Keep these alphabetized. */
 #define KRB5_CONF_ACL_FILE                     "acl_file"
 #define KRB5_CONF_ADMIN_SERVER                 "admin_server"
+#define KRB5_CONF_ALLOW_DES3                   "allow_des3"
+#define KRB5_CONF_ALLOW_RC4                    "allow_rc4"
 #define KRB5_CONF_ALLOW_WEAK_CRYPTO            "allow_weak_crypto"
 #define KRB5_CONF_AUTH_TO_LOCAL                "auth_to_local"
 #define KRB5_CONF_AUTH_TO_LOCAL_NAMES          "auth_to_local_names"
@@ -1238,6 +1240,8 @@ struct _krb5_context {
     struct _kdb_log_context *kdblog_context;
 
     krb5_boolean allow_weak_crypto;
+    krb5_boolean allow_des3;
+    krb5_boolean allow_rc4;
     krb5_boolean ignore_acceptor_hostname;
     krb5_boolean enforce_ok_as_delegate;
     enum dns_canonhost dns_canonicalize_hostname;

--- a/src/kdc/kdc_util.c
+++ b/src/kdc/kdc_util.c
@@ -1006,6 +1006,10 @@ dbentry_supports_enctype(krb5_context context, krb5_db_entry *server,
     free(etypes_str);
     free(etypes);
 
+    /* Assume every server without a session_enctypes attribute supports
+     * aes256-cts-hmac-sha1-96. */
+    if (enctype == ENCTYPE_AES256_CTS_HMAC_SHA1_96)
+        return TRUE;
     /* Assume the server supports any enctype it has a long-term key for. */
     return !krb5_dbe_find_enctype(context, server, enctype, -1, 0, &datap);
 }

--- a/src/kdc/kdc_util.c
+++ b/src/kdc/kdc_util.c
@@ -1032,6 +1032,16 @@ select_session_keytype(krb5_context context, krb5_db_entry *server,
         if (!krb5_is_permitted_enctype(context, ktype[i]))
             continue;
 
+        /*
+         * Prevent these deprecated enctypes from being used as session keys
+         * unless they are explicitly allowed.  In the future they will be more
+         * comprehensively disabled and eventually removed.
+         */
+        if (ktype[i] == ENCTYPE_DES3_CBC_SHA1 && !context->allow_des3)
+            continue;
+        if (ktype[i] == ENCTYPE_ARCFOUR_HMAC && !context->allow_rc4)
+            continue;
+
         if (dbentry_supports_enctype(context, server, ktype[i]))
             return ktype[i];
     }

--- a/src/lib/krb5/krb/init_ctx.c
+++ b/src/lib/krb5/krb/init_ctx.c
@@ -221,6 +221,16 @@ krb5_init_context_profile(profile_t profile, krb5_flags flags,
         goto cleanup;
     ctx->allow_weak_crypto = tmp;
 
+    retval = get_boolean(ctx, KRB5_CONF_ALLOW_DES3, 0, &tmp);
+    if (retval)
+        goto cleanup;
+    ctx->allow_des3 = tmp;
+
+    retval = get_boolean(ctx, KRB5_CONF_ALLOW_RC4, 0, &tmp);
+    if (retval)
+        goto cleanup;
+    ctx->allow_rc4 = tmp;
+
     retval = get_boolean(ctx, KRB5_CONF_IGNORE_ACCEPTOR_HOSTNAME, 0, &tmp);
     if (retval)
         goto cleanup;

--- a/src/tests/gssapi/t_enctypes.py
+++ b/src/tests/gssapi/t_enctypes.py
@@ -18,7 +18,8 @@ d_rc4 = 'DEPRECATED:arcfour-hmac'
 # These tests make assumptions about the default enctype lists, so set
 # them explicitly rather than relying on the library defaults.
 supp='aes256-cts:normal aes128-cts:normal des3-cbc-sha1:normal rc4-hmac:normal'
-conf = {'libdefaults': {'permitted_enctypes': 'aes des3 rc4'},
+conf = {'libdefaults': {'permitted_enctypes': 'aes des3 rc4',
+                        'allow_des3': 'true', 'allow_rc4': 'true'},
         'realms': {'$realm': {'supported_enctypes': supp}}}
 realm = K5Realm(krb5_conf=conf)
 shutil.copyfile(realm.ccache, os.path.join(realm.testdir, 'save'))

--- a/src/tests/t_etype_info.py
+++ b/src/tests/t_etype_info.py
@@ -1,7 +1,7 @@
 from k5test import *
 
 supported_enctypes = 'aes128-cts des3-cbc-sha1 rc4-hmac'
-conf = {'libdefaults': {'allow_weak_crypto': 'true'},
+conf = {'libdefaults': {'allow_des3': 'true', 'allow_rc4': 'true'},
         'realms': {'$realm': {'supported_enctypes': supported_enctypes}}}
 realm = K5Realm(create_host=False, get_creds=False, krb5_conf=conf)
 

--- a/src/tests/t_keyrollover.py
+++ b/src/tests/t_keyrollover.py
@@ -22,9 +22,9 @@ realm.run([kvno, princ1])
 realm.run([kadminl, 'purgekeys', realm.krbtgt_princ])
 # Make sure an old TGT fails after purging old TGS key.
 realm.run([kvno, princ2], expected_code=1)
-et = "aes128-cts-hmac-sha256-128"
-msg = 'krbtgt/%s@%s\n\tEtype (skey, tkt): %s, %s' % \
-    (realm.realm, realm.realm, et, et)
+msg = 'krbtgt/%s@%s\n\tEtype (skey, tkt): ' \
+    'aes256-cts-hmac-sha1-96, aes128-cts-hmac-sha256-128' % \
+    (realm.realm, realm.realm)
 realm.run([klist, '-e'], expected_msg=msg)
 
 # Check that new key actually works.

--- a/src/util/k5test.py
+++ b/src/util/k5test.py
@@ -1340,14 +1340,14 @@ _passes = [
 
     # Exercise the DES3 enctype.
     ('des3', None,
-     {'libdefaults': {'permitted_enctypes': 'des3'}},
+     {'libdefaults': {'permitted_enctypes': 'des3 aes256-sha1'}},
      {'realms': {'$realm': {
                     'supported_enctypes': 'des3-cbc-sha1:normal',
                     'master_key_type': 'des3-cbc-sha1'}}}),
 
     # Exercise the arcfour enctype.
     ('arcfour', None,
-     {'libdefaults': {'permitted_enctypes': 'rc4'}},
+     {'libdefaults': {'permitted_enctypes': 'rc4 aes256-sha1'}},
      {'realms': {'$realm': {
                     'supported_enctypes': 'arcfour-hmac:normal',
                     'master_key_type': 'arcfour-hmac'}}}),


### PR DESCRIPTION
This is prompted by https://i.blackhat.com/EU-22/Thursday-Briefings/EU-22-Tervoort-Breaking-Kerberos-RC4-Cipher-and-Spoofing-Windows-PACs-wp.pdf which observes that rc4-hmac pre-hashes the input string before applying HMAC in its checksum and GSS algorithms, and is therefore vulnerable to spoofing via collision attacks (as opposed to just second preimage attacks as it would be if HMAC were properly applied).  The paper concludes that:

* There isn't a current reason to be concerned about the RC4 encryption algorithm, as it properly uses HMAC for the authentication tag.  (RC4's weaknesses might be an issue if lots of data is encrypted with the same key, but that is not common in Kerberos.)
* There is a concrete vulnerability in PACs, but a similar vulnerability is present for almost any checksum type due to the relatively short tag size.
* There might be vulnerabilities in Kerberos-using protocols if they use RC4 session keys.

Microsoft's response has two parts: introduce a new PAC KDC signature over the whole PAC and not just the server checksum, and prevent (at least in large part) the use of RC4 for session keys, making an effort to use AES instead.  Samba is doing the same.  This PR addresses the second part, with the following changes:

* Assume that services support aes256-cts even if they don't have a long-term key of that type.  This can be overridden on a per-service basis with the session_enctypes string attribute.

* Refuse to issue tickets with DES3 or RC4 session keys by default.  While there is no new information about DES3 vulnerabilities, we are already in the midst of a deprecation process for that enctype, and combined with the previous change, this is a fairly non-disruptive measure along that path.  (A full weak-enctype deprecation of 3DES needs to address that it was the default master key type for new databases in several releases.)

* Add allow_des3 and allow_rc4 profile flags.  Currently these override the previous change and allow the use of those enctypes as session keys, but in the future they will prevent those enctypes from being filtered out of permitted_enctypes et al.

* Warn if RC4 is used as the encryption key or session key when getting initial tickets, as we already do for 3DES.