### PR TITLE
fix coredump with unrecognized option

### DIFF
--- a/src/kprop/kpropd.c
+++ b/src/kprop/kpropd.c
@@ -1047,6 +1047,7 @@ parse_args(int argc, char **argv)
     enum { PID_FILE = 256 };
     struct option long_options[] = {
         { "pid-file", 1, NULL, PID_FILE },
+        { NULL, 0, NULL, 0 },
     };
 
     memset(&params, 0, sizeof(params));


### PR DESCRIPTION
hey，I am trying to use kpropd recently. I find coredump when enter "kpopd --help" before I read manpage.
I think this patch will fix the coredump.