### PR TITLE
Fix meridian type in kadmin datetime parser (s390x)

### DIFF
--- a/src/kadmin/cli/getdate.y
+++ b/src/kadmin/cli/getdate.y
@@ -181,7 +181,8 @@ static time_t	yyRelSeconds;
 
 %token			tAGO tID tDST tNEVER
 %token	<Number>	tDAY tDAYZONE tMINUTE_UNIT tMONTH tMONTH_UNIT
-%token	<Number>	tSEC_UNIT tSNUMBER tUNUMBER tZONE tMERIDIAN
+%token	<Number>	tSEC_UNIT tSNUMBER tUNUMBER tZONE
+%token	<Meridian>	tMERIDIAN
 %type	<Meridian>	o_merid
 
 %%


### PR DESCRIPTION
The meridian suffix is typed as "Number" in kadmin YACC file for datetime parsing, while it should be using the "Meridian" enumeration one.

This results in invalid Meridian value on 64-bit IBM zSystems (s390x), causing core dumped errors on most kadmin commands where meridian suffices are used:

```
Hardware watchpoint 2: yyMeridian

Old value = MER24
New value = (MERpm | unknown: 0x4)
getdate_yyparse () at y.tab.c:1428
1428        break;
(gdb) l
1423                yyMinutes = (yyvsp[-1].Number);
1424                yySeconds = 0;
1425                yyMeridian = (yyvsp[0].Meridian);
1426            }
1427    #line 1428 "y.tab.c"
1428        break;
1429
1430      case 12: /* time: tUNUMBER ':' tUNUMBER tSNUMBER  */
1431    #line 231 "getdate.y"
1432                                             {
(gdb) bt
#0  getdate_yyparse () at y.tab.c:1428
#1  0x000002aa00009fc8 in get_date_rel (p=<optimized out>, nowtime=<optimized out>) at getdate.y:950
#2  0x000002aa0000acfa in parse_date (now=<optimized out>, str=0x3ffffffa24a "January 23, 2030 08:05am") at kadmin.c:162
#3  kadmin_parse_princ_args (argc=<optimized out>, argv=0x2aa000bb4e0, oprinc=0x3ffffff9320, mask=0x3ffffff9318, pass=<optimized out>, randkey=<optimized out>, nokey=<optimized out>, ks_tuple=<optimized out>, n_ks_tuple=<optimized out>, caller=<optimized out>) at kadmin.c:1039
#4  0x000002aa0000b0e8 in kadmin_addprinc (argc=<optimized out>, argv=<optimized out>) at kadmin.c:1209
#5  0x000003fff7e82922 in really_execute_command () from /lib64/libss.so.2
#6  0x000003fff7e837ba in ss_execute_line () from /lib64/libss.so.2
#7  0x000002aa00004fd4 in main (argc=<optimized out>, argv=<optimized out>) at ss_wrapper.c:66
```

This regression seems to have been introduced in d3356bc4. It may be caused by a difference in the underlying integer type GCC is using for enumeration types on s390x. The crash occurs even when turning the optimizer off, and valgrind is not reporting any memory error.

Here are the resulting changes in the generated YACC file (excluding some `#line` reference updates):

```diff
--- a/src/kadmin/cli/y.tab.c  2023-02-20 18:06:58.257363181 +0100
+++ b/src/kadmin/cli/y.tab.c  2023-02-20 19:24:57.987529072 +0100
@@ -743,11 +743,11 @@
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   189,   189,   190,   191,   202,   205,   208,   211,   214,
-     219,   225,   231,   238,   244,   254,   258,   263,   269,   273,
-     277,   283,   287,   292,   298,   304,   308,   313,   317,   324,
-     328,   331,   334,   337,   340,   343,   346,   349,   352,   355,
-     360,   363
+       0,   190,   190,   191,   192,   203,   206,   209,   212,   215,
+     220,   226,   232,   239,   245,   255,   259,   264,   270,   274,
+     278,   284,   288,   293,   299,   305,   309,   314,   318,   325,
+     329,   332,   335,   338,   341,   344,   347,   350,   353,   356,
+     361,   364
 };
 #endif

@@ -1686,9 +1686,9 @@
     break;

   case 41: /* o_merid: tMERIDIAN  */
-#line 363 "getdate.y"
+#line 364 "getdate.y"
                     {
-           (yyval.Meridian) = (yyvsp[0].Number);
+           (yyval.Meridian) = (yyvsp[0].Meridian);
        }
 #line 1694 "y.tab.c"
     break;
```
