### PR TITLE
Use k5input for SPNEGO token processing

### DIFF
--- a/src/clients/ksu/authorization.c
+++ b/src/clients/ksu/authorization.c
@@ -501,11 +501,11 @@ krb5_boolean find_first_cmd_that_exists(fcmd_arr, cmd_out, err_out)
         for(j= 0; j < i; j ++)
             k5_buf_add_fmt(&buf, " %s ", fcmd_arr[j]);
         k5_buf_add(&buf, "\n");
-        if (k5_buf_status(&buf) != 0) {
+        *err_out = k5_buf_cstring(&buf);
+        if (*err_out == NULL) {
             perror(prog_name);
             exit(1);
         }
-        *err_out = buf.data;
     }
 
 

--- a/src/clients/kvno/kvno.c
+++ b/src/clients/kvno/kvno.c
@@ -222,7 +222,7 @@ read_pem_file(char *file_name, krb5_data *der_out)
     FILE *fp = NULL;
     const char *begin_line = "-----BEGIN CERTIFICATE-----";
     const char *end_line = "-----END ", *line;
-    char linebuf[256];
+    char linebuf[256], *b64;
     struct k5buf buf = EMPTY_K5BUF;
     uint8_t *der_cert;
     size_t dlen;
@@ -267,7 +267,12 @@ read_pem_file(char *file_name, krb5_data *der_out)
         k5_buf_add(&buf, line);
     }
 
-    der_cert = k5_base64_decode(buf.data, &dlen);
+    b64 = k5_buf_cstring(&buf);
+    if (b64 == NULL) {
+        ret = ENOMEM;
+        goto cleanup;
+    }
+    der_cert = k5_base64_decode(b64, &dlen);
     if (der_cert == NULL) {
         ret = EINVAL;
         k5_setmsg(context, ret, _("Invalid base64"));

--- a/src/include/k5-buf.h
+++ b/src/include/k5-buf.h
@@ -35,8 +35,9 @@
  * fixed or dynamic buffer without the need to check for a failure at each step
  * (and without aborting on malloc failure).  If an allocation failure occurs
  * or the fixed buffer runs out of room, the buffer will be set to an error
- * state which can be detected with k5_buf_status.  Data in a buffer is
- * terminated with a zero byte so that it can be used as a C string.
+ * state which can be detected with k5_buf_status.  Data in a buffer is not
+ * automatically terminated with a zero byte; call k5_buf_cstring() to use the
+ * contents as a C string.
  *
  * k5buf structures are usually stack-allocated.  Do not put k5buf structure
  * pointers into public APIs.  It is okay to reference the data and len fields
@@ -58,7 +59,7 @@ struct k5buf {
 
 /* Initialize a k5buf using a fixed-sized, existing buffer.  SPACE must be
  * more than zero, or an assertion failure will result. */
-void k5_buf_init_fixed(struct k5buf *buf, char *data, size_t space);
+void k5_buf_init_fixed(struct k5buf *buf, void *data, size_t space);
 
 /* Initialize a k5buf using an internally allocated dynamic buffer. */
 void k5_buf_init_dynamic(struct k5buf *buf);
@@ -73,7 +74,8 @@ void k5_buf_add(struct k5buf *buf, const char *data);
 /* Add a counted series of bytes to BUF. */
 void k5_buf_add_len(struct k5buf *buf, const void *data, size_t len);
 
-/* Add sprintf-style formatted data to BUF. */
+/* Add sprintf-style formatted data to BUF.  For a fixed-length buffer this
+ * operation will fail if there isn't room for a zero terminator. */
 void k5_buf_add_fmt(struct k5buf *buf, const char *fmt, ...)
 #if !defined(__cplusplus) && (__GNUC__ > 2)
     __attribute__((__format__(__printf__, 2, 3)))
@@ -87,6 +89,10 @@ void k5_buf_add_vfmt(struct k5buf *buf, const char *fmt, va_list ap)
     __attribute__((__format__(__printf__, 2, 0)))
 #endif
     ;
+
+/* Without changing the length of buf, ensure that there is a zero byte after
+ * buf.data and return it.  Return NULL on error. */
+char *k5_buf_cstring(struct k5buf *buf);
 
 /* Extend the length of buf by len and return a pointer to the reserved space,
  * to be filled in by the caller.  Return NULL on error. */
@@ -107,6 +113,12 @@ int k5_buf_status(struct k5buf *buf);
  * or a zeroed k5buf structure is a no-op.
  */
 void k5_buf_free(struct k5buf *buf);
+
+static inline void
+k5_buf_add_byte(struct k5buf *buf, uint8_t val)
+{
+    k5_buf_add_len(buf, &val, 1);
+}
 
 static inline void
 k5_buf_add_uint16_be(struct k5buf *buf, uint16_t val)

--- a/src/include/k5-der.h
+++ b/src/include/k5-der.h
@@ -1,0 +1,149 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* include/k5-der.h - Distinguished Encoding Rules (DER) declarations */
+/*
+ * Copyright (C) 2023 by the Massachusetts Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Most ASN.1 encoding and decoding is done using the table-driven framework in
+ * libkrb5.  When that is not an option, these helpers can be used to encode
+ * and decode simple types.
+ */
+
+#ifndef K5_DER_H
+#define K5_DER_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "k5-buf.h"
+#include "k5-input.h"
+
+/* Return the number of bytes needed to encode len as a DER encoding length. */
+static inline size_t
+k5_der_len_len(size_t len)
+{
+    size_t llen;
+
+    if (len < 128)
+        return 1;
+    llen = 1;
+    while (len > 0) {
+        len >>= 8;
+        llen++;
+    }
+    return llen;
+}
+
+/* Return the number of bytes needed to encode a DER value (with identifier
+ * byte and length) for a given contents length. */
+static inline size_t
+k5_der_value_len(size_t contents_len)
+{
+    return 1 + k5_der_len_len(contents_len) + contents_len;
+}
+
+/* Add a DER identifier byte (composed by the caller, including the ASN.1
+ * class, tag, and constructed bit) and length. */
+static inline void
+k5_der_add_taglen(struct k5buf *buf, uint8_t idbyte, size_t len)
+{
+    uint8_t *p;
+    size_t llen = k5_der_len_len(len);
+
+    p = k5_buf_get_space(buf, 1 + llen);
+    if (p == NULL)
+        return;
+    *p++ = idbyte;
+    if (len < 128) {
+        *p = len;
+    } else {
+        *p = 0x80 | (llen - 1);
+        /* Encode the length bytes backwards so the most significant byte is
+         * first. */
+        p += llen;
+        while (len > 0) {
+            *--p = len & 0xFF;
+            len >>= 8;
+        }
+    }
+}
+
+/* Add a DER value (identifier byte, length, and contents). */
+static inline void
+k5_der_add_value(struct k5buf *buf, uint8_t idbyte, const void *contents,
+                 size_t len)
+{
+    k5_der_add_taglen(buf, idbyte, len);
+    k5_buf_add_len(buf, contents, len);
+}
+
+/*
+ * If the next byte in in matches idbyte and the subsequent DER length is
+ * valid, advance in past the value, set *contents_out to the value contents,
+ * and return true.  Otherwise return false.  Only set an error on in if the
+ * next bytes matches idbyte but the ensuing length is invalid.  contents_out
+ * may be aliased to in; it will only be written to on successful decoding of a
+ * value.
+ */
+static inline bool
+k5_der_get_value(struct k5input *in, uint8_t idbyte,
+                 struct k5input *contents_out)
+{
+    uint8_t lenbyte, i;
+    size_t len;
+    const void *bytes;
+
+    /* Do nothing if in is empty or the next byte doesn't match idbyte. */
+    if (in->status || in->len == 0 || *in->ptr != idbyte)
+        return false;
+
+    /* Advance past the identifier byte and decode the length. */
+    (void)k5_input_get_byte(in);
+    lenbyte = k5_input_get_byte(in);
+    if (lenbyte < 128) {
+        len = lenbyte;
+    } else {
+        len = 0;
+        for (i = 0; i < (lenbyte & 0x7F); i++) {
+            if (len > (SIZE_MAX >> 8)) {
+                k5_input_set_status(in, EOVERFLOW);
+                return false;
+            }
+            len = (len << 8) | k5_input_get_byte(in);
+        }
+    }
+
+    bytes = k5_input_get_bytes(in, len);
+    if (bytes == NULL)
+        return false;
+    k5_input_init(contents_out, bytes, len);
+    return true;
+}
+
+#endif /* K5_DER_H */

--- a/src/kadmin/dbutil/tdumputil.c
+++ b/src/kadmin/dbutil/tdumputil.c
@@ -92,7 +92,7 @@ qquote(struct flavor *fl, const char *s)
         if (*sp == fl->quotechar)
             k5_buf_add_len(&buf, sp, 1);
     }
-    return buf.data;
+    return k5_buf_cstring(&buf);
 }
 
 /*

--- a/src/kadmin/server/auth_acl.c
+++ b/src/kadmin/server/auth_acl.c
@@ -146,7 +146,7 @@ get_line(FILE *fp, const char *fname, int *lineno, int *incr)
                 *incr = 0;
                 k5_buf_truncate(&buf, 0);
             } else {
-                return buf.data;
+                return k5_buf_cstring(&buf);
             }
         }
     }

--- a/src/kdc/kdc_util.c
+++ b/src/kdc/kdc_util.c
@@ -1135,7 +1135,7 @@ ktypes2str(krb5_enctype *ktype, int nktypes)
         k5_buf_add_fmt(&buf, "%s%s(%ld)", i ? ", " : "", name, (long)ktype[i]);
     }
     k5_buf_add(&buf, "}");
-    return buf.data;
+    return k5_buf_cstring(&buf);
 }
 
 char *
@@ -1164,7 +1164,7 @@ rep_etypes2str(krb5_kdc_rep *rep)
     }
 
     k5_buf_add(&buf, "}");
-    return buf.data;
+    return k5_buf_cstring(&buf);
 }
 
 static krb5_error_code

--- a/src/lib/gssapi/generic/gssapiP_generic.h
+++ b/src/lib/gssapi/generic/gssapiP_generic.h
@@ -54,38 +54,6 @@
         (((o1)->length == (o2)->length) &&                              \
         (memcmp((o1)->elements, (o2)->elements, (o1)->length) == 0))
 
-/* this code knows that an int on the wire is 32 bits.  The type of
-   num should be at least this big, or the extra shifts may do weird
-   things */
-
-#define TWRITE_INT(ptr, num, bigend)                                    \
-   if (bigend) store_32_be(num, ptr); else store_32_le(num, ptr);       \
-   (ptr) += 4;
-
-#define TWRITE_INT16(ptr, num, bigend)                                  \
-   if (bigend) store_16_be((num)>>16, ptr); else store_16_le(num, ptr); \
-   (ptr) += 2;
-
-#define TREAD_INT(ptr, num, bigend)                        \
-   (num) = ((bigend) ? load_32_be(ptr) : load_32_le(ptr)); \
-   (ptr) += 4;
-
-#define TREAD_INT16(ptr, num, bigend)                              \
-   (num) = ((bigend) ? (load_16_be(ptr) << 16) : load_16_le(ptr)); \
-   (ptr) += 2;
-
-#define TWRITE_STR(ptr, str, len)               \
-   memcpy((ptr), (str), (len));                 \
-   (ptr) += (len);
-
-#define TREAD_STR(ptr, str, len)                \
-   (str) = (ptr);                               \
-   (ptr) += (len);
-
-#define TWRITE_BUF(ptr, buf, bigend)                    \
-   TWRITE_INT((ptr), (buf).length, (bigend));           \
-   TWRITE_STR((ptr), (buf).value, (buf).length);
-
 /** malloc wrappers; these may actually do something later */
 
 #define xmalloc(n) malloc(n)

--- a/src/lib/gssapi/generic/gssapiP_generic.h
+++ b/src/lib/gssapi/generic/gssapiP_generic.h
@@ -153,8 +153,8 @@ int g_make_string_buffer (const char *str, gss_buffer_t buffer);
 
 unsigned int g_token_size (const gss_OID_desc * mech, unsigned int body_size);
 
-void g_make_token_header (const gss_OID_desc * mech, unsigned int body_size,
-                          unsigned char **buf, int tok_type);
+void g_make_token_header (struct k5buf *buf, const gss_OID_desc *mech,
+                          size_t body_size, int tok_type);
 
 /* flags for g_verify_token_header() */
 #define G_VFY_TOKEN_HDR_WRAPPER_REQUIRED        0x01

--- a/src/lib/gssapi/generic/util_token.c
+++ b/src/lib/gssapi/generic/util_token.c
@@ -22,6 +22,7 @@
  */
 
 #include "gssapiP_generic.h"
+#include "k5-der.h"
 #ifdef HAVE_MEMORY_H
 #include <memory.h>
 #endif
@@ -31,131 +32,33 @@
  * $Id$
  */
 
-/* XXXX this code currently makes the assumption that a mech oid will
-   never be longer than 127 bytes.  This assumption is not inherent in
-   the interfaces, so the code can be fixed if the OSI namespace
-   balloons unexpectedly. */
-
-/*
- * Each token looks like this:
- * 0x60                 tag for APPLICATION 0, SEQUENCE
- *                              (constructed, definite-length)
- * <length>             possible multiple bytes, need to parse/generate
- * 0x06                 tag for OBJECT IDENTIFIER
- * <moid_length>        compile-time constant string (assume 1 byte)
- * <moid_bytes>         compile-time constant string
- * <inner_bytes>        the ANY containing the application token
- * bytes 0,1 are the token type
- * bytes 2,n are the token data
- *
- * Note that the token type field is a feature of RFC 1964 mechanisms and
- * is not used by other GSSAPI mechanisms.  As such, a token type of -1
- * is interpreted to mean that no token type should be expected or
- * generated.
- *
- * For the purposes of this abstraction, the token "header" consists of
- * the sequence tag and length octets, the mech OID DER encoding, and the
- * first two inner bytes, which indicate the token type.  The token
- * "body" consists of everything else.
- */
-static unsigned int
-der_length_size(int length)
-{
-    if (length < (1<<7))
-        return(1);
-    else if (length < (1<<8))
-        return(2);
-#if INT_MAX == 0x7fff
-    else
-        return(3);
-#else
-    else if (length < (1<<16))
-        return(3);
-    else if (length < (1<<24))
-        return(4);
-    else
-        return(5);
-#endif
-}
-
-static void
-der_write_length(unsigned char **buf, int length)
-{
-    if (length < (1<<7)) {
-        *(*buf)++ = (unsigned char) length;
-    } else {
-        *(*buf)++ = (unsigned char) (der_length_size(length)+127);
-#if INT_MAX > 0x7fff
-        if (length >= (1<<24))
-            *(*buf)++ = (unsigned char) (length>>24);
-        if (length >= (1<<16))
-            *(*buf)++ = (unsigned char) ((length>>16)&0xff);
-#endif
-        if (length >= (1<<8))
-            *(*buf)++ = (unsigned char) ((length>>8)&0xff);
-        *(*buf)++ = (unsigned char) (length&0xff);
-    }
-}
-
-/* returns decoded length, or < 0 on failure.  Advances buf and
-   decrements bufsize */
-
-static int
-der_read_length(unsigned char **buf, int *bufsize)
-{
-    unsigned char sf;
-    int ret;
-
-    if (*bufsize < 1)
-        return(-1);
-    sf = *(*buf)++;
-    (*bufsize)--;
-    if (sf & 0x80) {
-        if ((sf &= 0x7f) > ((*bufsize)-1))
-            return(-1);
-        if (sf > sizeof(int))
-            return (-1);
-        ret = 0;
-        for (; sf; sf--) {
-            ret = (ret<<8) + (*(*buf)++);
-            (*bufsize)--;
-        }
-    } else {
-        ret = sf;
-    }
-
-    return(ret);
-}
-
-/* returns the length of a token, given the mech oid and the body size */
-
+/* Return the length of an RFC 4121 token with RFC 2743 token framing, given
+ * the mech oid and the body size (without the two-byte RFC 4121 token ID). */
 unsigned int
 g_token_size(const gss_OID_desc * mech, unsigned int body_size)
 {
-    /* set body_size to sequence contents size */
-    body_size += 4 + (unsigned int)mech->length;         /* NEED overflow check */
-    return(1 + der_length_size(body_size) + body_size);
+    size_t mech_der_len = k5_der_value_len(mech->length);
+
+    return k5_der_value_len(mech_der_len + 2 + body_size);
 }
 
-/* fills in a buffer with the token header.  The buffer is assumed to
-   be the right size.  buf is advanced past the token header */
-
+/*
+ * Add RFC 2743 generic token framing to buf with room left for body_size bytes
+ * in the sequence to be added by the caller.  If tok_type is not -1, add it as
+ * a two-byte RFC 4121 token identifier after the framing and include room for
+ * it in the sequence.
+ */
 void
-g_make_token_header(
-    const gss_OID_desc * mech,
-    unsigned int body_size,
-    unsigned char **buf,
-    int tok_type)
+g_make_token_header(struct k5buf *buf, const gss_OID_desc *mech,
+                    size_t body_size, int tok_type)
 {
-    *(*buf)++ = 0x60;
-    der_write_length(buf, ((tok_type == -1) ? 2 : 4) + mech->length + body_size);
-    *(*buf)++ = 0x06;
-    *(*buf)++ = (unsigned char) mech->length;
-    TWRITE_STR(*buf, mech->elements, mech->length);
-    if (tok_type != -1) {
-        *(*buf)++ = (unsigned char) ((tok_type>>8)&0xff);
-        *(*buf)++ = (unsigned char) (tok_type&0xff);
-    }
+    size_t tok_len = (tok_type == -1) ? 0 : 2;
+    size_t seq_len = k5_der_value_len(mech->length) + body_size + tok_len;
+
+    k5_der_add_taglen(buf, 0x60, seq_len);
+    k5_der_add_value(buf, 0x06, mech->elements, mech->length);
+    if (tok_type != -1)
+        k5_buf_add_uint16_be(buf, tok_type);
 }
 
 /*
@@ -176,54 +79,30 @@ g_verify_token_header(
     unsigned int toksize_in,
     int flags)
 {
-    unsigned char *buf = *buf_in;
-    int seqsize;
+    struct k5input in, mech_der;
     gss_OID_desc toid;
-    int toksize = toksize_in;
 
-    if ((toksize-=1) < 0)
-        return(G_BAD_TOK_HEADER);
-    if (*buf++ != 0x60) {
-        if (flags & G_VFY_TOKEN_HDR_WRAPPER_REQUIRED)
-            return(G_BAD_TOK_HEADER);
-        buf--;
-        toksize++;
-        goto skip_wrapper;
+    k5_input_init(&in, *buf_in, toksize_in);
+
+    if (k5_der_get_value(&in, 0x60, &in)) {
+        if (in.ptr + in.len != *buf_in + toksize_in)
+            return G_BAD_TOK_HEADER;
+        if (!k5_der_get_value(&in, 0x06, &mech_der))
+            return G_BAD_TOK_HEADER;
+        toid.elements = (uint8_t *)mech_der.ptr;
+        toid.length = mech_der.len;
+        if (!g_OID_equal(&toid, mech))
+            return G_WRONG_MECH;
+    } else if (flags & G_VFY_TOKEN_HDR_WRAPPER_REQUIRED) {
+        return G_BAD_TOK_HEADER;
     }
 
-    if ((seqsize = der_read_length(&buf, &toksize)) < 0)
-        return(G_BAD_TOK_HEADER);
-
-    if (seqsize != toksize)
-        return(G_BAD_TOK_HEADER);
-
-    if ((toksize-=1) < 0)
-        return(G_BAD_TOK_HEADER);
-    if (*buf++ != 0x06)
-        return(G_BAD_TOK_HEADER);
-
-    if ((toksize-=1) < 0)
-        return(G_BAD_TOK_HEADER);
-    toid.length = *buf++;
-
-    if ((toksize-=toid.length) < 0)
-        return(G_BAD_TOK_HEADER);
-    toid.elements = buf;
-    buf+=toid.length;
-
-    if (! g_OID_equal(&toid, mech))
-        return  G_WRONG_MECH;
-skip_wrapper:
     if (tok_type != -1) {
-        if ((toksize-=2) < 0)
-            return(G_BAD_TOK_HEADER);
-
-        if ((*buf++ != ((tok_type>>8)&0xff)) ||
-            (*buf++ != (tok_type&0xff)))
-            return(G_WRONG_TOKID);
+        if (k5_input_get_uint16_be(&in) != tok_type)
+            return in.status ? G_BAD_TOK_HEADER : G_WRONG_TOKID;
     }
-    *buf_in = buf;
-    *body_size = toksize;
 
+    *buf_in = (uint8_t *)in.ptr;
+    *body_size = in.len;
     return 0;
 }

--- a/src/lib/gssapi/krb5/accept_sec_context.c
+++ b/src/lib/gssapi/krb5/accept_sec_context.c
@@ -657,7 +657,6 @@ kg_accept_krb5(minor_status, context_handle,
 {
     krb5_context context;
     unsigned char *ptr;
-    char *sptr;
     krb5_gss_cred_id_t cred = 0;
     krb5_data ap_rep, ap_req;
     krb5_error_code code;
@@ -788,16 +787,13 @@ kg_accept_krb5(minor_status, context_handle,
     } else if (code == G_BAD_TOK_HEADER) {
         /* DCE style not encapsulated */
         ap_req.length = input_token->length;
-        ap_req.data = input_token->value;
         mech_used = gss_mech_krb5;
         no_encap = 1;
     } else {
         major_status = GSS_S_DEFECTIVE_TOKEN;
         goto fail;
     }
-
-    sptr = (char *) ptr;
-    TREAD_STR(sptr, ap_req.data, ap_req.length);
+    ap_req.data = (char *)ptr;
 
     /* construct the sender_addr */
 

--- a/src/lib/gssapi/krb5/k5seal.c
+++ b/src/lib/gssapi/krb5/k5seal.c
@@ -78,11 +78,11 @@ make_seal_token_v1 (krb5_context context,
      * tlen is the length of the token
      * including header. */
     unsigned int conflen=0, tmsglen, tlen, msglen;
-    unsigned char *t, *ptr;
+    unsigned char *t, *metadata, *checksum, *payload;
     unsigned char *plain;
     unsigned char pad;
     krb5_keyusage sign_usage = KG_USAGE_SIGN;
-
+    struct k5buf buf;
 
     assert((!do_encrypt) || (toktype == KG_TOK_SEAL_MSG));
     /* create the token buffer */
@@ -108,31 +108,37 @@ make_seal_token_v1 (krb5_context context,
         msglen = text->length;
         pad = 0;
     }
-    tlen = g_token_size((gss_OID) oid, 14+cksum_size+tmsglen);
 
-    if ((t = (unsigned char *) gssalloc_malloc(tlen)) == NULL)
+    tlen = g_token_size(oid, 14 + cksum_size + tmsglen);
+    t = gssalloc_malloc(tlen);
+    if (t == NULL)
         return(ENOMEM);
+    k5_buf_init_fixed(&buf, t, tlen);
 
     /*** fill in the token */
 
-    ptr = t;
-    g_make_token_header(oid, 14+cksum_size+tmsglen, &ptr, toktype);
+    g_make_token_header(&buf, oid, 14 + cksum_size + tmsglen, toktype);
+    metadata = k5_buf_get_space(&buf, 14);
+    checksum = k5_buf_get_space(&buf, cksum_size);
+    payload = k5_buf_get_space(&buf, tmsglen);
+    assert(metadata != NULL && checksum != NULL && payload != NULL);
+    assert(buf.len == tlen);
 
     /* 0..1 SIGN_ALG */
-    store_16_le(signalg, &ptr[0]);
+    store_16_le(signalg, &metadata[0]);
 
     /* 2..3 SEAL_ALG or Filler */
     if ((toktype == KG_TOK_SEAL_MSG) && do_encrypt) {
-        store_16_le(sealalg, &ptr[2]);
+        store_16_le(sealalg, &metadata[2]);
     } else {
         /* No seal */
-        ptr[2] = 0xff;
-        ptr[3] = 0xff;
+        metadata[2] = 0xFF;
+        metadata[3] = 0xFF;
     }
 
     /* 4..5 Filler */
-    ptr[4] = 0xff;
-    ptr[5] = 0xff;
+    metadata[4] = 0xFF;
+    metadata[5] = 0xFF;
 
     /* pad the plaintext, encrypt if needed, and stick it in the token */
 
@@ -183,8 +189,9 @@ make_seal_token_v1 (krb5_context context,
         gssalloc_free(t);
         return(ENOMEM);
     }
-    (void) memcpy(data_ptr, ptr-2, 8);
-    (void) memcpy(data_ptr+8, plain, msglen);
+    /* Checksum over the token ID, metadata bytes, and plaintext. */
+    memcpy(data_ptr, metadata - 2, 8);
+    memcpy(data_ptr + 8, plain, msglen);
     plaind.length = 8 + msglen;
     plaind.data = data_ptr;
     code = krb5_k_make_checksum(context, md5cksum.checksum_type, seq,
@@ -204,10 +211,10 @@ make_seal_token_v1 (krb5_context context,
          */
         if (md5cksum.length != cksum_size)
             abort ();
-        memcpy (ptr+14, md5cksum.contents, md5cksum.length);
+        memcpy(checksum, md5cksum.contents, md5cksum.length);
         break;
     case SGN_ALG_HMAC_MD5:
-        memcpy (ptr+14, md5cksum.contents, cksum_size);
+        memcpy(checksum, md5cksum.contents, cksum_size);
         break;
     }
 
@@ -215,8 +222,9 @@ make_seal_token_v1 (krb5_context context,
 
     /* create the seq_num */
 
-    if ((code = kg_make_seq_num(context, seq, direction?0:0xff,
-                                (krb5_ui_4)*seqnum, ptr+14, ptr+6))) {
+    code = kg_make_seq_num(context, seq, direction?0:0xff,
+                           (krb5_ui_4)*seqnum, checksum, metadata + 6);
+    if (code) {
         xfree (plain);
         gssalloc_free(t);
         return(code);
@@ -240,10 +248,8 @@ make_seal_token_v1 (krb5_context context,
             assert (enc_key->length == 16);
             for (i = 0; i <= 15; i++)
                 ((char *) enc_key->contents)[i] ^=0xf0;
-            code = kg_arcfour_docrypt (enc_key, 0,
-                                       bigend_seqnum, 4,
-                                       plain, tmsglen,
-                                       ptr+14+cksum_size);
+            code = kg_arcfour_docrypt(enc_key, 0, bigend_seqnum, 4, plain,
+                                      tmsglen, payload);
             krb5_free_keyblock (context, enc_key);
             if (code)
             {
@@ -254,10 +260,9 @@ make_seal_token_v1 (krb5_context context,
         }
         break;
         default:
-            if ((code = kg_encrypt(context, enc, KG_USAGE_SEAL, NULL,
-                                   (krb5_pointer) plain,
-                                   (krb5_pointer) (ptr+cksum_size+14),
-                                   tmsglen))) {
+            code = kg_encrypt(context, enc, KG_USAGE_SEAL, NULL,  plain,
+                              payload, tmsglen);
+            if (code) {
                 xfree(plain);
                 gssalloc_free(t);
                 return(code);
@@ -265,7 +270,7 @@ make_seal_token_v1 (krb5_context context,
         }
     }else {
         if (tmsglen)
-            memcpy(ptr+14+cksum_size, plain, tmsglen);
+            memcpy(payload, plain, tmsglen);
     }
     xfree(plain);
 

--- a/src/lib/gssapi/krb5/k5sealiov.c
+++ b/src/lib/gssapi/krb5/k5sealiov.c
@@ -44,9 +44,10 @@ make_seal_token_v1_iov(krb5_context context,
     krb5_checksum cksum;
     size_t k5_headerlen = 0, k5_trailerlen = 0;
     size_t data_length = 0, assoc_data_length = 0;
-    size_t tmsglen = 0, tlen;
-    unsigned char *ptr;
+    size_t tmsglen = 0, cnflen = 0, tlen;
+    uint8_t *metadata, *checksum, *confounder;
     krb5_keyusage sign_usage = KG_USAGE_SIGN;
+    struct k5buf buf;
 
     md5cksum.length = cksum.length = 0;
     md5cksum.contents = cksum.contents = NULL;
@@ -65,17 +66,15 @@ make_seal_token_v1_iov(krb5_context context,
         trailer->buffer.length = 0;
 
     /* Determine confounder length */
-    if (toktype == KG_TOK_WRAP_MSG || conf_req_flag)
-        k5_headerlen = kg_confounder_size(context, ctx->enc->keyblock.enctype);
-
-    /* Check padding length */
     if (toktype == KG_TOK_WRAP_MSG) {
         size_t k5_padlen = (ctx->sealalg == SEAL_ALG_MICROSOFT_RC4) ? 1 : 8;
         size_t gss_padlen;
         size_t conf_data_length;
 
+        cnflen = kg_confounder_size(context, ctx->enc->keyblock.enctype);
+
         kg_iov_msglen(iov, iov_count, &data_length, &assoc_data_length);
-        conf_data_length = k5_headerlen + data_length - assoc_data_length;
+        conf_data_length = cnflen + data_length - assoc_data_length;
 
         if (k5_padlen == 1)
             gss_padlen = 1; /* one byte to indicate one byte of padding */
@@ -103,7 +102,7 @@ make_seal_token_v1_iov(krb5_context context,
         }
 
         if (ctx->gss_flags & GSS_C_DCE_STYLE)
-            tmsglen = k5_headerlen; /* confounder length */
+            tmsglen = cnflen; /* confounder length */
         else
             tmsglen = conf_data_length + padding->buffer.length;
     }
@@ -111,7 +110,7 @@ make_seal_token_v1_iov(krb5_context context,
     /* Determine token size */
     tlen = g_token_size(ctx->mech_used, 14 + ctx->cksum_size + tmsglen);
 
-    k5_headerlen += tlen - tmsglen;
+    k5_headerlen = cnflen + tlen - tmsglen;
 
     if (header->type & GSS_IOV_BUFFER_FLAG_ALLOCATE)
         code = kg_allocate_iov(header, k5_headerlen);
@@ -122,24 +121,28 @@ make_seal_token_v1_iov(krb5_context context,
 
     header->buffer.length = k5_headerlen;
 
-    ptr = (unsigned char *)header->buffer.value;
-    g_make_token_header(ctx->mech_used, 14 + ctx->cksum_size + tmsglen, &ptr, toktype);
+    k5_buf_init_fixed(&buf, header->buffer.value, k5_headerlen);
+    g_make_token_header(&buf, ctx->mech_used, 14 + ctx->cksum_size + tmsglen,
+                        toktype);
+    metadata = k5_buf_get_space(&buf, 14);
+    checksum = k5_buf_get_space(&buf, ctx->cksum_size);
+    assert(metadata != NULL && checksum != NULL);
 
     /* 0..1 SIGN_ALG */
-    store_16_le(ctx->signalg, &ptr[0]);
+    store_16_le(ctx->signalg, &metadata[0]);
 
     /* 2..3 SEAL_ALG or Filler */
     if (toktype == KG_TOK_WRAP_MSG && conf_req_flag) {
-        store_16_le(ctx->sealalg, &ptr[2]);
+        store_16_le(ctx->sealalg, &metadata[2]);
     } else {
         /* No seal */
-        ptr[2] = 0xFF;
-        ptr[3] = 0xFF;
+        metadata[2] = 0xFF;
+        metadata[3] = 0xFF;
     }
 
     /* 4..5 Filler */
-    ptr[4] = 0xFF;
-    ptr[5] = 0xFF;
+    metadata[4] = 0xFF;
+    metadata[5] = 0xFF;
 
     /* pad the plaintext, encrypt if needed, and stick it in the token */
 
@@ -163,8 +166,10 @@ make_seal_token_v1_iov(krb5_context context,
     md5cksum.length = k5_trailerlen;
 
     if (k5_headerlen != 0 && toktype == KG_TOK_WRAP_MSG) {
+        confounder = k5_buf_get_space(&buf, cnflen);
+        assert(confounder != NULL);
         code = kg_make_confounder(context, ctx->enc->keyblock.enctype,
-                                  ptr + 14 + ctx->cksum_size);
+                                  confounder);
         if (code != 0)
             goto cleanup;
     }
@@ -180,16 +185,16 @@ make_seal_token_v1_iov(krb5_context context,
     switch (ctx->signalg) {
     case SGN_ALG_HMAC_SHA1_DES3_KD:
         assert(md5cksum.length == ctx->cksum_size);
-        memcpy(ptr + 14, md5cksum.contents, md5cksum.length);
+        memcpy(checksum, md5cksum.contents, md5cksum.length);
         break;
     case SGN_ALG_HMAC_MD5:
-        memcpy(ptr + 14, md5cksum.contents, ctx->cksum_size);
+        memcpy(checksum, md5cksum.contents, ctx->cksum_size);
         break;
     }
 
     /* create the seq_num */
     code = kg_make_seq_num(context, ctx->seq, ctx->initiate ? 0 : 0xFF,
-                           (OM_uint32)ctx->seq_send, ptr + 14, ptr + 6);
+                           (OM_uint32)ctx->seq_send, checksum, metadata + 6);
     if (code != 0)
         goto cleanup;
 

--- a/src/lib/gssapi/mechglue/g_encapsulate_token.c
+++ b/src/lib/gssapi/mechglue/g_encapsulate_token.c
@@ -38,7 +38,7 @@ gss_encapsulate_token(gss_const_buffer_t input_token,
                       gss_buffer_t output_token)
 {
     unsigned int tokenSize;
-    unsigned char *buf;
+    struct k5buf buf;
 
     if (input_token == GSS_C_NO_BUFFER || token_oid == GSS_C_NO_OID)
         return GSS_S_CALL_INACCESSIBLE_READ;
@@ -55,10 +55,10 @@ gss_encapsulate_token(gss_const_buffer_t input_token,
     if (output_token->value == NULL)
         return GSS_S_FAILURE;
 
-    buf = output_token->value;
-
-    g_make_token_header(token_oid, input_token->length, &buf, -1);
-    memcpy(buf, input_token->value, input_token->length);
+    k5_buf_init_fixed(&buf, output_token->value, tokenSize);
+    g_make_token_header(&buf, token_oid, input_token->length, -1);
+    k5_buf_add_len(&buf, input_token->value, input_token->length);
+    assert(buf.len == tokenSize);
     output_token->length = tokenSize;
 
     return GSS_S_COMPLETE;

--- a/src/lib/gssapi/mechglue/g_glue.c
+++ b/src/lib/gssapi/mechglue/g_glue.c
@@ -23,6 +23,7 @@
  */
 
 #include "mglueP.h"
+#include "k5-der.h"
 #include <stdio.h>
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
@@ -38,219 +39,24 @@ extern gss_mechanism *gssint_mechs_array;
  * This file contains the support routines for the glue layer.
  */
 
-/*
- * get_der_length: Givin a pointer to a buffer that contains a DER encoded
- * length, decode the length updating the buffer to point to the character
- * after the DER encoding. The parameter bytes will point to the number of
- * bytes that made up the DER encoding of the length originally pointed to
- * by the buffer. Note we return -1 on error.
- */
-int
-gssint_get_der_length(unsigned char **buf, unsigned int buf_len, unsigned int *bytes)
+/* Retrieve the mechanism OID from an RFC 2743 InitialContextToken.  Place
+ * the result into *oid_out, aliasing memory from token. */
+OM_uint32 gssint_get_mech_type_oid(gss_OID oid_out, gss_buffer_t token)
 {
-    /* p points to the beginning of the buffer */
-    unsigned char *p = *buf;
-    int length, new_length;
-    unsigned int octets;
+    struct k5input in;
 
-    if (buf_len < 1)
-	return (-1);
-
-    /* We should have at least one byte */
-    *bytes = 1;
-
-    /*
-     * If the High order bit is not set then the length is just the value
-     * of *p.
-     */
-    if (*p < 128) {
-	*buf = p+1;	/* Advance the buffer */
-	return (*p);		/* return the length */
-    }
-
-    /*
-     * if the High order bit is set, then the low order bits represent
-     * the number of bytes that contain the DER encoding of the length.
-     */
-
-    octets = *p++ & 0x7f;
-    *bytes += octets;
-
-    /* See if the supplied buffer contains enough bytes for the length. */
-    if (octets > buf_len - 1)
-	return (-1);
-
-    /*
-     * Calculate a multibyte length. The length is encoded as an
-     * unsigned integer base 256.
-     */
-    for (length = 0; octets; octets--) {
-	new_length = (length << 8) + *p++;
-	if (new_length < length)  /* overflow */
-	    return (-1);
-	length = new_length;
-    }
-
-    *buf = p; /* Advance the buffer */
-
-    return (length);
-}
-
-/*
- * der_length_size: Return the number of bytes to encode a given length.
- */
-unsigned int
-gssint_der_length_size(unsigned int len)
-{
-    int i;
-
-    if (len < 128)
-	return (1);
-
-    for (i = 0; len; i++) {
-	len >>= 8;
-    }
-
-    return (i+1);
-}
-
-/*
- * put_der_length: Encode the supplied length into the buffer pointed to
- * by buf. max_length represents the maximum length of the buffer pointed
- * to by buff. We will advance buf to point to the character after the newly
- * DER encoded length. We return 0 on success or -l it the length cannot
- * be encoded in max_len characters.
- */
-int
-gssint_put_der_length(unsigned int length, unsigned char **buf, unsigned int max_len)
-{
-    unsigned char *s, *p;
-    unsigned int buf_len = 0;
-    int i, first;
-
-    /* Oops */
-    if (buf == 0 || max_len < 1)
-	return (-1);
-
-    s = *buf;
-
-    /* Single byte is the length */
-    if (length < 128) {
-	*s++ = length;
-	*buf = s;
-	return (0);
-    }
-
-    /* First byte contains the number of octets */
-    p = s + 1;
-
-    /* Running total of the DER encoding length */
-    buf_len = 0;
-
-    /*
-     * Encode MSB first. We do the encoding by setting a shift
-     * factor to MSO_BIT (24 for 32 bit words) and then shifting the length
-     * by the factor. We then encode the resulting low order byte.
-     * We subtract 8 from the shift factor and repeat to ecnode the next
-     * byte. We stop when the shift factor is zero or we've run out of
-     * buffer to encode into.
-     */
-    first = 0;
-    for (i = MSO_BIT; i >= 0 && buf_len <= max_len; i -= 8) {
-	unsigned int v;
-	v = (length >> i) & 0xff;
-	if ((v) || first) {
-	    buf_len += 1;
-	    *p++ = v;
-	    first = 1;
-	}
-    }
-    if (i >= 0)			/* buffer overflow */
-	return (-1);
-
-    /*
-     * We go back now and set the first byte to be the length with
-     * the high order bit set.
-     */
-    *s = buf_len | 0x80;
-    *buf = p;
-
-    return (0);
-}
-
-
-/*
- *  glue routine for get_mech_type
- *
- */
-
-OM_uint32 gssint_get_mech_type_oid(OID, token)
-    gss_OID		OID;
-    gss_buffer_t	token;
-{
-    unsigned char * buffer_ptr;
-    size_t buflen, lenbytes, length, oidlen;
-
-    /*
-     * This routine reads the prefix of "token" in order to determine
-     * its mechanism type. It assumes the encoding suggested in
-     * Appendix B of RFC 1508. This format starts out as follows :
-     *
-     * tag for APPLICATION 0, Sequence[constructed, definite length]
-     * length of remainder of token
-     * tag of OBJECT IDENTIFIER
-     * length of mechanism OID
-     * encoding of mechanism OID
-     * <the rest of the token>
-     *
-     * Numerically, this looks like :
-     *
-     * 0x60
-     * <length> - could be multiple bytes
-     * 0x06
-     * <length> - assume only one byte, hence OID length < 127
-     * <mech OID bytes>
-     *
-     * The routine fills in the OID value and returns an error as necessary.
-     */
-
-	if (OID == NULL)
-		return (GSS_S_CALL_INACCESSIBLE_WRITE);
-
-	if ((token == NULL) || (token->value == NULL))
+    if (oid_out == NULL)
+	return (GSS_S_CALL_INACCESSIBLE_WRITE);
+    if (token == NULL || token->value == NULL)
 	return (GSS_S_DEFECTIVE_TOKEN);
 
-    /* Skip past the APP/Sequnce byte and the token length */
-
-    buffer_ptr = (unsigned char *) token->value;
-    buflen = token->length;
-
-    if (buflen < 2 || *buffer_ptr++ != 0x60)
+    k5_input_init(&in, token->value, token->length);
+    if (!k5_der_get_value(&in, 0x60, &in))
 	return (GSS_S_DEFECTIVE_TOKEN);
-    length = *buffer_ptr++;
-    buflen -= 2;
-
-	/* check if token length is null */
-	if (length == 0)
-	    return (GSS_S_DEFECTIVE_TOKEN);
-
-    if (length & 0x80) {
-	lenbytes = length & 0x7f;
-	if (lenbytes > 4 || lenbytes > buflen)
-	    return (GSS_S_DEFECTIVE_TOKEN);
-	buffer_ptr += lenbytes;
-	buflen -= lenbytes;
-    }
-
-    if (buflen < 2 || *buffer_ptr++ != 0x06)
+    if (!k5_der_get_value(&in, 0x06, &in))
 	return (GSS_S_DEFECTIVE_TOKEN);
-    oidlen = *buffer_ptr++;
-    buflen -= 2;
-    if (oidlen > 0x7f || oidlen > buflen)
-	return (GSS_S_DEFECTIVE_TOKEN);
-
-    OID->length = oidlen;
-    OID->elements = (void *) buffer_ptr;
+    oid_out->length = in.len;
+    oid_out->elements = (uint8_t *)in.ptr;
     return (GSS_S_COMPLETE);
 }
 
@@ -425,12 +231,8 @@ OM_uint32 gssint_export_internal_name(minor_status, mech_type,
     gss_mechanism mech;
     gss_buffer_desc dispName;
     gss_OID nameOid;
-    unsigned char *buf = NULL;
-    const unsigned char tokId[] = "\x04\x01";
-    const unsigned int tokIdLen = 2;
-    const int mechOidLenLen = 2, mechOidTagLen = 1, nameLenLen = 4;
-    int mechOidDERLen = 0;
-    int mechOidLen = 0;
+    int mech_der_len = 0;
+    struct k5buf buf;
 
     mech = gssint_get_mechanism(mech_type);
     if (!mech)
@@ -481,52 +283,24 @@ OM_uint32 gssint_export_internal_name(minor_status, mech_type,
 	return (status);
     }
 
-    /* determine the size of the buffer needed */
-    mechOidDERLen = gssint_der_length_size(mech_type->length);
-    name_buf->length = tokIdLen + mechOidLenLen +
-	mechOidTagLen + mechOidDERLen +
-	mech_type->length +
-	nameLenLen + dispName.length;
-    if ((name_buf->value = (void*)gssalloc_malloc(name_buf->length)) ==
-	(void*)NULL) {
+    /* Allocate space and prepare a buffer. */
+    mech_der_len = k5_der_value_len(mech_type->length);
+    name_buf->length = 2 + 2 + mech_der_len + 4 + dispName.length;
+    name_buf->value = gssalloc_malloc(name_buf->length);
+    if (name_buf->value == NULL) {
 	name_buf->length = 0;
 	(void) gss_release_buffer(&status, &dispName);
 	return (GSS_S_FAILURE);
     }
+    k5_buf_init_fixed(&buf, name_buf->value, name_buf->length);
 
-    /* now create the name ..... */
-    buf = (unsigned char *)name_buf->value;
-    (void) memset(name_buf->value, 0, name_buf->length);
-    (void) memcpy(buf, tokId, tokIdLen);
-    buf += tokIdLen;
-
-    /* spec allows only 2 bytes for the mech oid length */
-    mechOidLen = mechOidDERLen + mechOidTagLen + mech_type->length;
-    store_16_be(mechOidLen, buf);
-    buf += 2;
-
-    /*
-     * DER Encoding of mech OID contains OID Tag (0x06), length and
-     * mech OID value
-     */
-    *buf++ = 0x06;
-    if (gssint_put_der_length(mech_type->length, &buf,
-		       (name_buf->length - tokIdLen -2)) != 0) {
-	name_buf->length = 0;
-	free(name_buf->value);
-	(void) gss_release_buffer(&status, &dispName);
-	return (GSS_S_FAILURE);
-    }
-
-    (void) memcpy(buf, mech_type->elements, mech_type->length);
-    buf += mech_type->length;
-
-    /* spec designates the next 4 bytes for the name length */
-    store_32_be(dispName.length, buf);
-    buf += 4;
-
-    /* for the final ingredient - add the name from gss_display_name */
-    (void) memcpy(buf, dispName.value, dispName.length);
+    /* Assemble the name. */
+    k5_buf_add_len(&buf, "\x04\x01", 2);
+    k5_buf_add_uint16_be(&buf, mech_der_len);
+    k5_der_add_value(&buf, 0x06, mech_type->elements, mech_type->length);
+    k5_buf_add_uint32_be(&buf, dispName.length);
+    k5_buf_add_len(&buf, dispName.value, dispName.length);
+    assert(buf.len == name_buf->length);
 
     /* release the buffer obtained from gss_display_name */
     (void) gss_release_buffer(minor_status, &dispName);

--- a/src/lib/gssapi/mechglue/g_imp_name.c
+++ b/src/lib/gssapi/mechglue/g_imp_name.c
@@ -28,6 +28,7 @@
  */
 
 #include "mglueP.h"
+#include "k5-der.h"
 #include <stdio.h>
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
@@ -181,13 +182,6 @@ allocation_failure:
     return (major_status);
 }
 
-/*
- * GSS export name constants
- */
-static const unsigned int expNameTokIdLen = 2;
-static const unsigned int mechOidLenLen = 2;
-static const unsigned int nameTypeLenLen = 2;
-
 static OM_uint32
 importExportName(minor, unionName, inputNameType)
     OM_uint32 *minor;
@@ -196,59 +190,31 @@ importExportName(minor, unionName, inputNameType)
 {
     gss_OID_desc mechOid;
     gss_buffer_desc expName;
-    unsigned char *buf;
     gss_mechanism mech;
-    OM_uint32 major, mechOidLen, nameLen, curLength;
-    unsigned int bytes;
+    OM_uint32 major, mechOidLen, nameLen;
+    uint8_t b2;
+    const uint8_t *name;
+    struct k5input in, oid, old_format;
 
     expName.value = unionName->external_name->value;
     expName.length = unionName->external_name->length;
+    k5_input_init(&in, expName.value, expName.length);
 
-    curLength = expNameTokIdLen + mechOidLenLen;
-    if (expName.length < curLength)
+    if (k5_input_get_byte(&in) != 0x04)
+	return (GSS_S_DEFECTIVE_TOKEN);
+    b2 = k5_input_get_byte(&in);
+    if (b2 != 0x01 && b2 != 0x02) /* allow composite names */
 	return (GSS_S_DEFECTIVE_TOKEN);
 
-    buf = (unsigned char *)expName.value;
-    if (buf[0] != 0x04)
+    mechOidLen = k5_input_get_uint16_be(&in);
+
+    if (!k5_der_get_value(&in, 0x06, &oid))
 	return (GSS_S_DEFECTIVE_TOKEN);
-    if (buf[1] != 0x01 && buf[1] != 0x02) /* allow composite names */
+    /* Verify that mechOidLen is consistent with the DER OID length. */
+    if (mechOidLen != k5_der_value_len(oid.len))
 	return (GSS_S_DEFECTIVE_TOKEN);
-
-    buf += expNameTokIdLen;
-
-    /* extract the mechanism oid length */
-    mechOidLen = (*buf++ << 8);
-    mechOidLen |= (*buf++);
-    curLength += mechOidLen;
-    if (expName.length < curLength)
-	return (GSS_S_DEFECTIVE_TOKEN);
-    /*
-     * The mechOid itself is encoded in DER format, OID Tag (0x06)
-     * length and the value of mech_OID
-     */
-    if (*buf++ != 0x06)
-	return (GSS_S_DEFECTIVE_TOKEN);
-
-    /*
-     * mechoid Length is encoded twice; once in 2 bytes as
-     * explained in RFC2743 (under mechanism independent exported
-     * name object format) and once using DER encoding
-     *
-     * We verify both lengths.
-     */
-
-    mechOid.length = gssint_get_der_length(&buf,
-				    (expName.length - curLength), &bytes);
-    mechOid.elements = (void *)buf;
-
-    /*
-     * 'bytes' is the length of the DER length, '1' is for the DER
-     * tag for OID
-     */
-    if ((bytes + mechOid.length + 1) != mechOidLen)
-	return (GSS_S_DEFECTIVE_TOKEN);
-
-    buf += mechOid.length;
+    mechOid.length = oid.len;
+    mechOid.elements = (uint8_t *)oid.ptr;
     if ((mech = gssint_get_mechanism(&mechOid)) == NULL)
 	return (GSS_S_BAD_MECH);
 
@@ -297,21 +263,11 @@ importExportName(minor, unionName, inputNameType)
      * that included a null terminator which was counted in the
      * display name gss_buffer_desc.
      */
-    curLength += 4;		/* 4 bytes for name len */
-    if (expName.length < curLength)
-	return (GSS_S_DEFECTIVE_TOKEN);
 
     /* next 4 bytes in the name are the name length */
-    nameLen = load_32_be(buf);
-    buf += 4;
-
-    /*
-     * we use < here because bad code in rpcsec_gss rounds up exported
-     * name token lengths and pads with nulls, otherwise != would be
-     * appropriate
-     */
-    curLength += nameLen;   /* this is the total length */
-    if (expName.length < curLength)
+    nameLen = k5_input_get_uint32_be(&in);
+    name = k5_input_get_bytes(&in, nameLen);
+    if (name == NULL)
 	return (GSS_S_DEFECTIVE_TOKEN);
 
     /*
@@ -324,29 +280,19 @@ importExportName(minor, unionName, inputNameType)
      * and length) there's the name itself, though null-terminated;
      * this null terminator should also not be there, but it is.
      */
-    if (nameLen > 0 && *buf == '\0') {
+    if (nameLen > 0 && *name == '\0') {
 	OM_uint32 nameTypeLen;
-	/* next two bytes are the name oid */
-	if (nameLen < nameTypeLenLen)
+
+	/* Skip the name type. */
+	k5_input_init(&old_format, name, nameLen);
+	nameTypeLen = k5_input_get_uint16_be(&old_format);
+	if (k5_input_get_bytes(&old_format, nameTypeLen) == NULL)
 	    return (GSS_S_DEFECTIVE_TOKEN);
-
-	nameLen -= nameTypeLenLen;
-
-	nameTypeLen = (*buf++) << 8;
-	nameTypeLen |= (*buf++);
-
-	if (nameLen < nameTypeLen)
-	    return (GSS_S_DEFECTIVE_TOKEN);
-
-	buf += nameTypeLen;
-	nameLen -= nameTypeLen;
-
-	/*
-	 * adjust for expected null terminator that should
-	 * really not be there
-	 */
-	if (nameLen > 0 && *(buf + nameLen - 1) == '\0')
-	    nameLen--;
+	/* Remove a null terminator if one is present. */
+	if (old_format.len > 0 && old_format.ptr[old_format.len - 1] == 0)
+	    old_format.len--;
+	name = old_format.ptr;
+	nameLen = old_format.len;
     }
 
     /*
@@ -365,7 +311,7 @@ importExportName(minor, unionName, inputNameType)
      *	 IDN is thrown in with Kerberos V extensions).
      */
     expName.length = nameLen;
-    expName.value = nameLen ? (void *)buf : NULL;
+    expName.value = nameLen ? (uint8_t *)name : NULL;
     if (mech->gssspi_import_name_by_mech) {
 	major = mech->gssspi_import_name_by_mech(minor, &mechOid, &expName,
 						 GSS_C_NULL_OID,

--- a/src/lib/gssapi/mechglue/mglueP.h
+++ b/src/lib/gssapi/mechglue/mglueP.h
@@ -819,23 +819,6 @@ OM_uint32 gss_add_mech_name_type
  * Sun extensions to GSS-API v2
  */
 
-int
-gssint_get_der_length(
-	unsigned char **,	/* buf */
-	unsigned int,		/* buf_len */
-	unsigned int *		/* bytes */
-);
-
-unsigned int
-gssint_der_length_size(unsigned int /* len */);
-
-int
-gssint_put_der_length(
-	unsigned int,		/* length */
-	unsigned char **,	/* buf */
-	unsigned int		/* max_len */
-);
-
 OM_uint32
 gssint_wrap_aead (gss_mechanism,	/* mech */
 		  OM_uint32 *,		/* minor_status */

--- a/src/lib/gssapi/spnego/negoex_util.c
+++ b/src/lib/gssapi/spnego/negoex_util.c
@@ -157,7 +157,7 @@ guid_to_string(const uint8_t guid[GUID_LENGTH])
 
     k5_buf_init_dynamic(&buf);
     add_guid(&buf, guid);
-    return buf.data;
+    return k5_buf_cstring(&buf);
 }
 
 /* Check that the described vector lies within the message, and return a
@@ -188,7 +188,7 @@ trace_received_message(spnego_gss_ctx_id_t ctx,
             if (i + 1 < msg->u.n.nschemes)
                 k5_buf_add(&buf, " ");
         }
-        info = buf.data;
+        info = k5_buf_cstring(&buf);
     } else if (msg->type == INITIATOR_META_DATA ||
                msg->type == ACCEPTOR_META_DATA ||
                msg->type == CHALLENGE || msg->type == AP_REQUEST) {
@@ -613,7 +613,8 @@ negoex_add_nego_message(spnego_gss_ctx_id_t ctx, enum message_type type,
 
     if (buf.len > 0) {
         k5_buf_truncate(&buf, buf.len - 1);
-        TRACE_NEGOEX_OUTGOING(ctx->kctx, seqnum, typestr(type), buf.data);
+        TRACE_NEGOEX_OUTGOING(ctx->kctx, seqnum, typestr(type),
+                              k5_buf_cstring(&buf));
         k5_buf_free(&buf);
     }
 }

--- a/src/lib/kadm5/logger.c
+++ b/src/lib/kadm5/logger.c
@@ -182,7 +182,7 @@ static void
 klog_com_err_proc(const char *whoami, long int code, const char *format, va_list ap)
 {
     struct k5buf buf;
-    const char *emsg;
+    const char *emsg, *msg;
 
     if (format == NULL)
         return;
@@ -200,8 +200,9 @@ klog_com_err_proc(const char *whoami, long int code, const char *format, va_list
     /* Add the formatted message. */
     k5_buf_add_vfmt(&buf, format, ap);
 
-    if (k5_buf_status(&buf) == 0)
-        krb5_klog_syslog(code ? LOG_ERR : LOG_INFO, "%s", (char *)buf.data);
+    msg = k5_buf_cstring(&buf);
+    if (msg != NULL)
+        krb5_klog_syslog(code ? LOG_ERR : LOG_INFO, "%s", msg);
 
     k5_buf_free(&buf);
 }

--- a/src/lib/krb5/krb/chpw.c
+++ b/src/lib/krb5/krb/chpw.c
@@ -393,6 +393,7 @@ decode_ad_policy_info(const krb5_data *data, char **msg_out)
     uint64_t password_days;
     const char *p;
     struct k5buf buf;
+    char *msg;
 
     *msg_out = NULL;
     if (data->length != AD_POLICY_INFO_LENGTH)
@@ -462,13 +463,13 @@ decode_ad_policy_info(const krb5_data *data, char **msg_out)
                        (int)password_days);
     }
 
-    if (k5_buf_status(&buf) != 0)
+    msg = k5_buf_cstring(&buf);
+    if (msg == NULL)
         return ENOMEM;
-
-    if (buf.len > 0)
-        *msg_out = buf.data;
+    if (*msg != '\0')
+        *msg_out = msg;
     else
-        k5_buf_free(&buf);
+        free(msg);
     return 0;
 }
 

--- a/src/lib/krb5/krb/kerrs.c
+++ b/src/lib/krb5/krb/kerrs.c
@@ -165,7 +165,7 @@ err_fmt_fmt(const char *err_fmt, long code, const char *msg)
         s += 2;
     }
     k5_buf_add(&buf, s);        /* Remainder after last token */
-    return buf.data;
+    return k5_buf_cstring(&buf);
 }
 
 const char * KRB5_CALLCONV

--- a/src/lib/krb5/krb/preauth_otp.c
+++ b/src/lib/krb5/krb/preauth_otp.c
@@ -504,7 +504,7 @@ prompt_for_tokeninfo(krb5_context context, krb5_prompter_fct prompter,
                      void *prompter_data, krb5_otp_tokeninfo **tis,
                      krb5_otp_tokeninfo **out_ti)
 {
-    char response[1024];
+    char response[1024], *prompt;
     krb5_otp_tokeninfo *ti = NULL;
     krb5_error_code retval = 0;
     struct k5buf buf;
@@ -517,11 +517,12 @@ prompt_for_tokeninfo(krb5_context context, krb5_prompter_fct prompter,
         k5_buf_add_len(&buf, tis[i]->vendor.data, tis[i]->vendor.length);
         k5_buf_add(&buf, "\n");
     }
-    if (k5_buf_status(&buf) != 0)
+    prompt = k5_buf_cstring(&buf);
+    if (prompt == NULL)
         return ENOMEM;
 
     do {
-        retval = doprompt(context, prompter, prompter_data, buf.data,
+        retval = doprompt(context, prompter, prompter_data, prompt,
                           _("Enter #"), response, sizeof(response));
         if (retval != 0)
             goto cleanup;

--- a/src/lib/krb5/os/dnsglue.c
+++ b/src/lib/krb5/os/dnsglue.c
@@ -392,7 +392,7 @@ txt_lookup_name(const char *prefix, const char *name)
             k5_buf_add(&buf, ".");
     }
 
-    return buf.data;
+    return k5_buf_cstring(&buf);
 }
 
 /*

--- a/src/lib/krb5/os/dnssrv.c
+++ b/src/lib/krb5/os/dnssrv.c
@@ -72,7 +72,7 @@ make_lookup_name(const krb5_data *realm, const char *service,
     if (buf.len > 0 && ((char *)buf.data)[buf.len - 1] != '.')
         k5_buf_add(&buf, ".");
 
-    return buf.data;
+    return k5_buf_cstring(&buf);
 }
 
 /* Insert new into the list *head, ordering by priority.  Weight is not

--- a/src/lib/krb5/os/expand_path.c
+++ b/src/lib/krb5/os/expand_path.c
@@ -454,7 +454,7 @@ k5_expand_path_tokens_extra(krb5_context context, const char *path_in,
 {
     krb5_error_code ret;
     struct k5buf buf;
-    char *tok_begin, *tok_end, *tok_val, **extra_tokens = NULL;
+    char *tok_begin, *tok_end, *tok_val, **extra_tokens = NULL, *path;
     const char *path_left;
     size_t nargs = 0, i;
     va_list ap;
@@ -517,22 +517,25 @@ k5_expand_path_tokens_extra(krb5_context context, const char *path_in,
         path_left = tok_end + 1;
     }
 
-    ret = k5_buf_status(&buf);
-    if (ret)
+    path = k5_buf_cstring(&buf);
+    if (path == NULL) {
+        ret = ENOMEM;
         goto cleanup;
+    }
 
 #ifdef _WIN32
     /* Also deal with slashes. */
     {
         char *p;
-        for (p = buf.data; *p != '\0'; p++) {
+        for (p = path; *p != '\0'; p++) {
             if (*p == '/')
                 *p = '\\';
         }
     }
 #endif
-    *path_out = buf.data;
+    *path_out = path;
     memset(&buf, 0, sizeof(buf));
+    ret = 0;
 
 cleanup:
     k5_buf_free(&buf);

--- a/src/lib/krb5/os/localauth_rule.c
+++ b/src/lib/krb5/os/localauth_rule.c
@@ -130,10 +130,8 @@ do_replacement(const char *regstr, const char *repl, krb5_boolean doall,
     }
     regfree(&re);
     k5_buf_add(&buf, instr);
-    if (k5_buf_status(&buf) != 0)
-        return ENOMEM;
-    *outstr = buf.data;
-    return 0;
+    *outstr = k5_buf_cstring(&buf);
+    return (*outstr == NULL) ? ENOMEM : 0;
 }
 
 /*
@@ -265,11 +263,10 @@ aname_get_selstring(krb5_context context, krb5_const_principal aname,
         return KRB5_CONFIG_BADFORMAT;
     }
 
-    if (k5_buf_status(&selstring) != 0)
+    *selstring_out = k5_buf_cstring(&selstring);
+    if (*selstring_out == NULL)
         return ENOMEM;
-
     *contextp = current + 1;
-    *selstring_out = selstring.data;
     return 0;
 }
 

--- a/src/lib/krb5/os/trace.c
+++ b/src/lib/krb5/os/trace.c
@@ -366,7 +366,7 @@ trace_format(krb5_context context, const char *fmt, va_list ap)
                    creds->client, creds->server);
         }
     }
-    return buf.data;
+    return k5_buf_cstring(&buf);
 }
 
 /* Allows trace_format formatters to be represented in terms of other

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.c
@@ -1370,7 +1370,7 @@ get_ldap_auth_ind(krb5_context context, LDAP *ld, LDAPMessage *ldap_ent,
 {
     krb5_error_code ret;
     int i;
-    char **auth_inds = NULL;
+    char **auth_inds = NULL, *indstr;
     struct k5buf buf = EMPTY_K5BUF;
 
     auth_inds = ldap_get_values(ld, ldap_ent, "krbPrincipalAuthInd");
@@ -1386,12 +1386,14 @@ get_ldap_auth_ind(krb5_context context, LDAP *ld, LDAPMessage *ldap_ent,
             k5_buf_add(&buf, " ");
     }
 
-    ret = k5_buf_status(&buf);
-    if (ret)
+    indstr = k5_buf_cstring(&buf);
+    if (indstr == NULL) {
+        ret = ENOMEM;
         goto cleanup;
+    }
 
     ret = krb5_dbe_set_string(context, entry, KRB5_KDB_SK_REQUIRE_AUTH,
-                              buf.data);
+                              indstr);
     if (!ret)
         *mask |= KDB_AUTH_IND_ATTR;
 

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.c
@@ -614,8 +614,6 @@ krb5_ldap_parse_principal_name(char *i_princ_name, char **o_princ_name)
     at_rlm_name = strrchr(i_princ_name, '@');
     if (!at_rlm_name) {
         *o_princ_name = strdup(i_princ_name);
-        if (!*o_princ_name)
-            return ENOMEM;
     } else {
         k5_buf_init_dynamic(&buf);
         for (p = i_princ_name; p < at_rlm_name; p++) {
@@ -624,9 +622,7 @@ krb5_ldap_parse_principal_name(char *i_princ_name, char **o_princ_name)
             k5_buf_add_len(&buf, p, 1);
         }
         k5_buf_add(&buf, at_rlm_name);
-        if (k5_buf_status(&buf) != 0)
-            return ENOMEM;
-        *o_princ_name = buf.data;
+        *o_princ_name = k5_buf_cstring(&buf);
     }
-    return 0;
+    return (*o_princ_name == NULL) ? ENOMEM : 0;
 }

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_realm.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_realm.c
@@ -87,7 +87,7 @@ ldap_filter_correct (char *in)
             break;
         k5_buf_add_fmt(&buf, "\\%2x", (unsigned char)*in++);
     }
-    return buf.data;
+    return k5_buf_cstring(&buf);
 }
 
 static int

--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -4406,7 +4406,6 @@ reassemble_pkcs11_name(pkinit_identity_opts *idopts)
 {
     struct k5buf buf;
     int n = 0;
-    char *ret;
 
     k5_buf_init_dynamic(&buf);
     k5_buf_add(&buf, "PKCS11:");
@@ -4431,12 +4430,7 @@ reassemble_pkcs11_name(pkinit_identity_opts *idopts)
         k5_buf_add_fmt(&buf, "%sslotid=%ld", n++ ? ":" : "",
                        (long)idopts->slotid);
     }
-    if (k5_buf_status(&buf) == 0)
-        ret = strdup(buf.data);
-    else
-        ret = NULL;
-    k5_buf_free(&buf);
-    return ret;
+    return k5_buf_cstring(&buf);
 }
 
 static krb5_error_code

--- a/src/util/support/json.c
+++ b/src/util/support/json.c
@@ -696,10 +696,8 @@ k5_json_encode(k5_json_value val, char **json_out)
         k5_buf_free(&buf);
         return ret;
     }
-    if (k5_buf_status(&buf) != 0)
-        return ENOMEM;
-    *json_out = buf.data;
-    return 0;
+    *json_out = k5_buf_cstring(&buf);
+    return (*json_out == NULL) ? ENOMEM : 0;
 }
 
 /*** JSON decoding ***/

--- a/src/util/support/libkrb5support-fixed.exports
+++ b/src/util/support/libkrb5support-fixed.exports
@@ -8,6 +8,7 @@ k5_buf_add
 k5_buf_add_len
 k5_buf_add_fmt
 k5_buf_add_vfmt
+k5_buf_cstring
 k5_buf_get_space
 k5_buf_truncate
 k5_buf_status

--- a/src/util/support/utf8_conv.c
+++ b/src/util/support/utf8_conv.c
@@ -191,8 +191,8 @@ k5_utf16le_to_utf8(const uint8_t *utf16bytes, size_t nbytes, char **utf8_out)
     if (in.status)
         goto invalid;
 
-    *utf8_out = buf.data;
-    return 0;
+    *utf8_out = k5_buf_cstring(&buf);
+    return (*utf8_out == NULL) ? ENOMEM : 0;
 
 invalid:
     k5_buf_free(&buf);


### PR DESCRIPTION
OSS-Fuzz sound several low-impact read overruns in SPNEGO token processing.  They were fixed in commit 47c2a12830dbd7fb8e13c239ddc0ac74129a91f6.  This PR rewrites the SPNEGO token processing code to use k5input for improved safety.
