### PR TITLE
Allow to set PAC ticket signature as optional

### DIFF
--- a/doc/admin/admin_commands/kadmin_local.rst
+++ b/doc/admin/admin_commands/kadmin_local.rst
@@ -649,6 +649,13 @@ KDC:
     is in the same format as those used by the **pkinit_cert_match**
     option in :ref:`krb5.conf(5)`.  (New in release 1.16.)
 
+**optional_pac_tkt_chksum**
+    Boolean value defining the behavior of the KDC in case an expected
+    ticket checksum signed with one of this principal keys is not
+    present in the PAC. This is typically the case for TGT or
+    cross-realm TGT principals when processing S4U2Proxy requests.
+    (New in release ...)
+
 This command requires the **modify** privilege.
 
 Alias: **setstr**

--- a/doc/appdev/refs/api/index.rst
+++ b/doc/appdev/refs/api/index.rst
@@ -225,6 +225,7 @@ Rarely used public interfaces
    krb5_is_referral_realm.rst
    krb5_kdc_sign_ticket.rst
    krb5_kdc_verify_ticket.rst
+   krb5_kdc_verify_ticket_ext.rst
    krb5_kt_add_entry.rst
    krb5_kt_end_seq_get.rst
    krb5_kt_get_entry.rst

--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -135,6 +135,7 @@
 /* String attribute names recognized by krb5 */
 #define KRB5_KDB_SK_SESSION_ENCTYPES            "session_enctypes"
 #define KRB5_KDB_SK_REQUIRE_AUTH                "require_auth"
+#define KRB5_KDB_SK_OPTIONAL_PAC_TKT_CHKSUM     "optional_pac_tkt_chksum"
 
 #if !defined(_WIN32)
 

--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -8349,6 +8349,48 @@ krb5_kdc_verify_ticket(krb5_context context, const krb5_enc_tkt_part *enc_tkt,
                        const krb5_keyblock *server,
                        const krb5_keyblock *privsvr, krb5_pac *pac_out);
 
+/**
+ * Verify a PAC, possibly including ticket signature
+ *
+ * @param [in] context              Library context
+ * @param [in] enc_tkt              Ticket enc-part, possibly containing a PAC
+ * @param [in] server_princ         Canonicalized name of ticket server
+ * @param [in] server               Key to validate server checksum (or NULL)
+ * @param [in] privsvr              Key to validate KDC checksum (or NULL)
+ * @paran [in] optional_tkt_chksum  Whether to require a ticket checksum
+ * @param [out] pac_out             Verified PAC (NULL if no PAC included)
+ *
+ * This function is an extension of krb5_kdc_verify_ticket(), adding the @a
+ * optional_tkt_chksum parameter allowing to tolerate the absence of the PAC
+ * ticket signature.
+ *
+ * If a PAC is present in @a enc_tkt, verify its signatures.  If @a privsvr is
+ * not NULL and @a server_princ is not a krbtgt or kadmin/changepw service and
+ * @a optional_tkt_chksum is FALSE, require a ticket signature over @a enc_tkt
+ * in addition to the KDC signature. Place the verified PAC in @a pac_out.  If
+ * an invalid PAC signature is found, return an error matching the Windows KDC
+ * protocol code for that condition as closely as possible.
+ *
+ * If no PAC is present in @a enc_tkt, set @a pac_out to NULL and return
+ * successfully.
+ *
+ * @note This function does not validate the PAC_CLIENT_INFO buffer.  If a
+ * specific value is expected, the caller can make a separate call to
+ * krb5_pac_verify_ext() with a principal but no keys.
+ *
+ * @retval 0 Success; otherwise - Kerberos error codes
+ *
+ * @version New in (TODO: set version)
+ */
+krb5_error_code KRB5_CALLCONV
+krb5_kdc_verify_ticket_ext(krb5_context context,
+                           const krb5_enc_tkt_part *enc_tkt,
+                           krb5_const_principal server_princ,
+                           const krb5_keyblock *server,
+                           const krb5_keyblock *privsvr,
+                           krb5_boolean optional_tkt_chksum,
+                           krb5_pac *pac_out);
+
 /** @deprecated Use krb5_kdc_sign_ticket() instead. */
 krb5_error_code KRB5_CALLCONV
 krb5_pac_sign(krb5_context context, krb5_pac pac, krb5_timestamp authtime,

--- a/src/lib/krb5/libkrb5.exports
+++ b/src/lib/krb5/libkrb5.exports
@@ -463,6 +463,7 @@ krb5_is_thread_safe
 krb5_kdc_rep_decrypt_proc
 krb5_kdc_sign_ticket
 krb5_kdc_verify_ticket
+krb5_kdc_verify_ticket_ext
 krb5_kt_add_entry
 krb5_kt_client_default
 krb5_kt_close

--- a/src/lib/krb5_32.def
+++ b/src/lib/krb5_32.def
@@ -510,3 +510,4 @@ EXPORTS
 	k5_sname_compare				@474 ; PRIVATE GSSAPI
 	krb5_kdc_sign_ticket                            @475 ;
 	krb5_kdc_verify_ticket                          @476 ;
+	krb5_kdc_verify_ticket_ext                      @477 ;

--- a/src/man/kadmin.man
+++ b/src/man/kadmin.man
@@ -715,6 +715,12 @@ attributes required for the client certificate used by the
 principal during PKINIT authentication.  The matching expression
 is in the same format as those used by the \fBpkinit_cert_match\fP
 option in krb5.conf(5)\&.  (New in release 1.16.)
+.TP
+\fBoptional_pac_tkt_chksum\fP
+Boolean value defining the behavior of the KDC in case an expected ticket
+checksum signed with one of this principal keys is not present in the PAC. This
+is typically the case for TGT or cross-realm TGT principals when processing
+S4U2Proxy requests.  (New in release ...)
 .UNINDENT
 .sp
 This command requires the \fBmodify\fP privilege.


### PR DESCRIPTION
[MS-PAC states that](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-pac/76c10ef5-de76-44bf-b208-0d8750fc2edd) *"The ticket signature SHOULD be included in tickets that are not encrypted to the krbtgt account"*. However, the implementation of `krb5_kdc_verify_ticket()` will [require the ticket signature to be present](https://github.com/krb5/krb5/blob/krb5-1.20.1-final/src/lib/krb5/krb/pac.c#L672-L694) in case the target of the request is a service principal.

In gradual upgrade environments, it results in S4U2Proxy requests against a 1.20 KDC using a service ticket generated by an older version KDC to fail (more details [here](https://bugzilla.redhat.com/show_bug.cgi?id=2178298#c0)).

This commit adds a `krb5_kdc_verify_ticket_ext()` function with an extra switch parameter to tolerate the absence of ticket signature in this scenario. If the ticket signature is present, it has to be valid, regardless of this parameter.

This parameter is set based on the `optional_pac_tkt_chksum` string attribute of the TGT KDB entry.