### PR TITLE
Revise certauth interface

### DIFF
--- a/src/include/krb5/certauth_plugin.h
+++ b/src/include/krb5/certauth_plugin.h
@@ -35,7 +35,7 @@
  *
  * The certauth pluggable interface currently has only one supported major
  * version, which is 1.  Major version 1 has a current minor version number of
- * 1.
+ * 2.
  *
  * certauth plugin modules should define a function named
  * certauth_<modulename>_initvt, matching the signature:
@@ -77,6 +77,13 @@ struct _krb5_db_entry_new;
 typedef krb5_error_code
 (*krb5_certauth_init_fn)(krb5_context context,
                          krb5_certauth_moddata *moddata_out);
+
+/*
+ * Optional: Initialize module data.  Supersedes init if present.
+ */
+typedef krb5_error_code
+(*krb5_certauth_init_ex_fn)(krb5_context context, const char *const *realmlist,
+                            krb5_certauth_moddata *moddata_out);
 
 /*
  * Optional: Clean up the module data.
@@ -132,6 +139,10 @@ typedef struct krb5_certauth_vtable_st {
     krb5_certauth_fini_fn fini;
     krb5_certauth_authorize_fn authorize;
     krb5_certauth_free_indicator_fn free_ind;
+    /* Minor version 1 ends here. */
+
+    krb5_certauth_init_ex_fn init_ex;
+    /* Minor version 2 ends here. */
 } *krb5_certauth_vtable;
 
 #endif /* KRB5_CERTAUTH_PLUGIN_H */


### PR DESCRIPTION
Increment the certauth interface major version to 2, without backward compatibility.  Add the realm names list to the init method.  Add an hwauth_out parameter to the authorize method to make that output independent of the error code.

@kenh: Please let me know if this meets your requirements, and if the major version bump would be a burden.  My sene is that there aren't other users of the certauth interface or that they are in similar situations (site administrators rather than downstream software).  (@jrisc you aren't aware of any Red Hat package uses of this interface, right?)

If the major version bump is a burden, we could instead add a second init function to provide the realm list, similar to the kdcpreauth interface's loop() method, and defer the authorize() cleanup.

In the mail thread about this Nico suggested that PKINIT could provide the whole cert chain to the authorize method.  I don't know how to do that without using OpenSSL types in the interface, so it isn't included in this revision.
