### PR TITLE
Update CI for newer Ubuntu and fix associated warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,17 +14,17 @@ jobs:
                 name: [linux-clang, linux-clang-openssl, linux-gcc]
                 include:
                     - name: linux-clang
-                      os: ubuntu-18.04
+                      os: ubuntu-latest
                       compiler: clang
                       makevars: CPPFLAGS=-Werror
                       configureopts: --enable-asan
                     - name: linux-clang-openssl
-                      os: ubuntu-18.04
+                      os: ubuntu-latest
                       compiler: clang
                       makevars: CPPFLAGS=-Werror
                       configureopts: --with-crypto-impl=openssl
                     - name: linux-gcc
-                      os: ubuntu-18.04
+                      os: ubuntu-latest
                       compiler: gcc
         steps:
             - name: Checkout repository
@@ -33,7 +33,7 @@ jobs:
               if: startsWith(matrix.os, 'ubuntu')
               run: |
                 sudo apt-get update -qq
-                sudo apt-get install -y bison gettext keyutils ldap-utils libcmocka-dev libldap2-dev libkeyutils-dev libresolv-wrapper libsasl2-dev libssl-dev python3-kdcproxy python3-pip slapd tcsh
+                sudo apt-get install -y bison gettext keyutils ldap-utils libcmocka-dev libldap2-dev libkeyutils-dev libsasl2-dev libssl-dev python3-kdcproxy python3-pip slapd tcsh
                 pip3 install pyrad
             - name: Build
               env:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -6,21 +6,21 @@ on:
 
 jobs:
     doc-older-sphinx:
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-22.04
         steps:
             - name: Checkout repository
               uses: actions/checkout@v1
             - name: Linux setup
               run: |
                 sudo apt-get update -qq
-                sudo apt-get install -y doxygen python3-lxml python3-pip python-sphinx
+                sudo apt-get install -y doxygen python3-lxml python3-pip python3-sphinx
                 pip3 install Cheetah3
             - name: Build documentation
               run: |
                 cd src/doc
                 make -f Makefile.in SPHINX_ARGS=-W htmlsrc
     doc-newest-sphinx:
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout repository
               uses: actions/checkout@v1

--- a/src/config/ac-archive/README
+++ b/src/config/ac-archive/README
@@ -5,5 +5,5 @@ https://www.gnu.org/software/autoconf-archive/ .  They are licensed
 under a modified version of the GNU General Public License as noted in
 the comments near the top of each file.
 
-ax_pthread.m4 serial 24 2017-02-06
+ax_pthread.m4 serial 31 2023-02-20
 ax_recursive_eval.m4 serial 1 2017-01-05

--- a/src/config/ac-archive/ax_pthread.m4
+++ b/src/config/ac-archive/ax_pthread.m4
@@ -14,20 +14,24 @@
 #   flags that are needed. (The user can also force certain compiler
 #   flags/libs to be tested by setting these environment variables.)
 #
-#   Also sets PTHREAD_CC to any special C compiler that is needed for
-#   multi-threaded programs (defaults to the value of CC otherwise). (This
-#   is necessary on AIX to use the special cc_r compiler alias.)
+#   Also sets PTHREAD_CC and PTHREAD_CXX to any special C compiler that is
+#   needed for multi-threaded programs (defaults to the value of CC
+#   respectively CXX otherwise). (This is necessary on e.g. AIX to use the
+#   special cc_r/CC_r compiler alias.)
 #
 #   NOTE: You are assumed to not only compile your program with these flags,
 #   but also to link with them as well. For example, you might link with
 #   $PTHREAD_CC $CFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
+#   $PTHREAD_CXX $CXXFLAGS $PTHREAD_CFLAGS $LDFLAGS ... $PTHREAD_LIBS $LIBS
 #
 #   If you are only building threaded programs, you may wish to use these
 #   variables in your default LIBS, CFLAGS, and CC:
 #
 #     LIBS="$PTHREAD_LIBS $LIBS"
 #     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+#     CXXFLAGS="$CXXFLAGS $PTHREAD_CFLAGS"
 #     CC="$PTHREAD_CC"
+#     CXX="$PTHREAD_CXX"
 #
 #   In addition, if the PTHREAD_CREATE_JOINABLE thread-attribute constant
 #   has a nonstandard name, this macro defines PTHREAD_CREATE_JOINABLE to
@@ -55,6 +59,7 @@
 #
 #   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
 #   Copyright (c) 2011 Daniel Richard G. <skunk@iSKUNK.ORG>
+#   Copyright (c) 2019 Marc Stevens <marc.stevens@cwi.nl>
 #
 #   This program is free software: you can redistribute it and/or modify it
 #   under the terms of the GNU General Public License as published by the
@@ -82,7 +87,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 24
+#serial 31
 
 AU_ALIAS([ACX_PTHREAD], [AX_PTHREAD])
 AC_DEFUN([AX_PTHREAD], [
@@ -104,6 +109,7 @@ if test "x$PTHREAD_CFLAGS$PTHREAD_LIBS" != "x"; then
         ax_pthread_save_CFLAGS="$CFLAGS"
         ax_pthread_save_LIBS="$LIBS"
         AS_IF([test "x$PTHREAD_CC" != "x"], [CC="$PTHREAD_CC"])
+        AS_IF([test "x$PTHREAD_CXX" != "x"], [CXX="$PTHREAD_CXX"])
         CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
         LIBS="$PTHREAD_LIBS $LIBS"
         AC_MSG_CHECKING([for pthread_join using $CC $PTHREAD_CFLAGS $PTHREAD_LIBS])
@@ -123,10 +129,12 @@ fi
 # (e.g. DEC) have both -lpthread and -lpthreads, where one of the
 # libraries is broken (non-POSIX).
 
-# Create a list of thread flags to try.  Items starting with a "-" are
-# C compiler flags, and other items are library names, except for "none"
-# which indicates that we try without any flags at all, and "pthread-config"
-# which is a program returning the flags for the Pth emulation library.
+# Create a list of thread flags to try. Items with a "," contain both
+# C compiler flags (before ",") and linker flags (after ","). Other items
+# starting with a "-" are C compiler flags, and remaining items are
+# library names, except for "none" which indicates that we try without
+# any flags at all, and "pthread-config" which is a program returning
+# the flags for the Pth emulation library.
 
 ax_pthread_flags="pthreads none -Kthread -pthread -pthreads -mthreads pthread --thread-safe -mt pthread-config"
 
@@ -194,14 +202,47 @@ case $host_os in
         # that too in a future libc.)  So we'll check first for the
         # standard Solaris way of linking pthreads (-mt -lpthread).
 
-        ax_pthread_flags="-mt,pthread pthread $ax_pthread_flags"
+        ax_pthread_flags="-mt,-lpthread pthread $ax_pthread_flags"
         ;;
 esac
 
+# Are we compiling with Clang?
+
+AC_CACHE_CHECK([whether $CC is Clang],
+    [ax_cv_PTHREAD_CLANG],
+    [ax_cv_PTHREAD_CLANG=no
+     # Note that Autoconf sets GCC=yes for Clang as well as GCC
+     if test "x$GCC" = "xyes"; then
+        AC_EGREP_CPP([AX_PTHREAD_CC_IS_CLANG],
+            [/* Note: Clang 2.7 lacks __clang_[a-z]+__ */
+#            if defined(__clang__) && defined(__llvm__)
+             AX_PTHREAD_CC_IS_CLANG
+#            endif
+            ],
+            [ax_cv_PTHREAD_CLANG=yes])
+     fi
+    ])
+ax_pthread_clang="$ax_cv_PTHREAD_CLANG"
+
+
 # GCC generally uses -pthread, or -pthreads on some platforms (e.g. SPARC)
 
+# Note that for GCC and Clang -pthread generally implies -lpthread,
+# except when -nostdlib is passed.
+# This is problematic using libtool to build C++ shared libraries with pthread:
+# [1] https://gcc.gnu.org/bugzilla/show_bug.cgi?id=25460
+# [2] https://bugzilla.redhat.com/show_bug.cgi?id=661333
+# [3] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=468555
+# To solve this, first try -pthread together with -lpthread for GCC
+
 AS_IF([test "x$GCC" = "xyes"],
-      [ax_pthread_flags="-pthread -pthreads $ax_pthread_flags"])
+      [ax_pthread_flags="-pthread,-lpthread -pthread -pthreads $ax_pthread_flags"])
+
+# Clang takes -pthread (never supported any other flag), but we'll try with -lpthread first
+
+AS_IF([test "x$ax_pthread_clang" = "xyes"],
+      [ax_pthread_flags="-pthread,-lpthread -pthread"])
+
 
 # The presence of a feature test macro requesting re-entrant function
 # definitions is, on some systems, a strong hint that pthreads support is
@@ -224,101 +265,6 @@ AS_IF([test "x$ax_pthread_check_macro" = "x--"],
       [ax_pthread_check_cond=0],
       [ax_pthread_check_cond="!defined($ax_pthread_check_macro)"])
 
-# Are we compiling with Clang?
-
-AC_CACHE_CHECK([whether $CC is Clang],
-    [ax_cv_PTHREAD_CLANG],
-    [ax_cv_PTHREAD_CLANG=no
-     # Note that Autoconf sets GCC=yes for Clang as well as GCC
-     if test "x$GCC" = "xyes"; then
-        AC_EGREP_CPP([AX_PTHREAD_CC_IS_CLANG],
-            [/* Note: Clang 2.7 lacks __clang_[a-z]+__ */
-#            if defined(__clang__) && defined(__llvm__)
-             AX_PTHREAD_CC_IS_CLANG
-#            endif
-            ],
-            [ax_cv_PTHREAD_CLANG=yes])
-     fi
-    ])
-ax_pthread_clang="$ax_cv_PTHREAD_CLANG"
-
-ax_pthread_clang_warning=no
-
-# Clang needs special handling, because older versions handle the -pthread
-# option in a rather... idiosyncratic way
-
-if test "x$ax_pthread_clang" = "xyes"; then
-
-        # Clang takes -pthread; it has never supported any other flag
-
-        # (Note 1: This will need to be revisited if a system that Clang
-        # supports has POSIX threads in a separate library.  This tends not
-        # to be the way of modern systems, but it's conceivable.)
-
-        # (Note 2: On some systems, notably Darwin, -pthread is not needed
-        # to get POSIX threads support; the API is always present and
-        # active.  We could reasonably leave PTHREAD_CFLAGS empty.  But
-        # -pthread does define _REENTRANT, and while the Darwin headers
-        # ignore this macro, third-party headers might not.)
-
-        PTHREAD_CFLAGS="-pthread"
-        PTHREAD_LIBS=
-
-        ax_pthread_ok=yes
-
-        # However, older versions of Clang make a point of warning the user
-        # that, in an invocation where only linking and no compilation is
-        # taking place, the -pthread option has no effect ("argument unused
-        # during compilation").  They expect -pthread to be passed in only
-        # when source code is being compiled.
-        #
-        # Problem is, this is at odds with the way Automake and most other
-        # C build frameworks function, which is that the same flags used in
-        # compilation (CFLAGS) are also used in linking.  Many systems
-        # supported by AX_PTHREAD require exactly this for POSIX threads
-        # support, and in fact it is often not straightforward to specify a
-        # flag that is used only in the compilation phase and not in
-        # linking.  Such a scenario is extremely rare in practice.
-        #
-        # Even though use of the -pthread flag in linking would only print
-        # a warning, this can be a nuisance for well-run software projects
-        # that build with -Werror.  So if the active version of Clang has
-        # this misfeature, we search for an option to squash it.
-
-        AC_CACHE_CHECK([whether Clang needs flag to prevent "argument unused" warning when linking with -pthread],
-            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG],
-            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG=unknown
-             # Create an alternate version of $ac_link that compiles and
-             # links in two steps (.c -> .o, .o -> exe) instead of one
-             # (.c -> exe), because the warning occurs only in the second
-             # step
-             ax_pthread_save_ac_link="$ac_link"
-             ax_pthread_sed='s/conftest\.\$ac_ext/conftest.$ac_objext/g'
-             ax_pthread_link_step=`$as_echo "$ac_link" | sed "$ax_pthread_sed"`
-             ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
-             ax_pthread_save_CFLAGS="$CFLAGS"
-             for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do
-                AS_IF([test "x$ax_pthread_try" = "xunknown"], [break])
-                CFLAGS="-Werror -Wunknown-warning-option $ax_pthread_try -pthread $ax_pthread_save_CFLAGS"
-                ac_link="$ax_pthread_save_ac_link"
-                AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
-                    [ac_link="$ax_pthread_2step_ac_link"
-                     AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
-                         [break])
-                    ])
-             done
-             ac_link="$ax_pthread_save_ac_link"
-             CFLAGS="$ax_pthread_save_CFLAGS"
-             AS_IF([test "x$ax_pthread_try" = "x"], [ax_pthread_try=no])
-             ax_cv_PTHREAD_CLANG_NO_WARN_FLAG="$ax_pthread_try"
-            ])
-
-        case "$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG" in
-                no | unknown) ;;
-                *) PTHREAD_CFLAGS="$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG $PTHREAD_CFLAGS" ;;
-        esac
-
-fi # $ax_pthread_clang = yes
 
 if test "x$ax_pthread_ok" = "xno"; then
 for ax_pthread_try_flag in $ax_pthread_flags; do
@@ -328,10 +274,10 @@ for ax_pthread_try_flag in $ax_pthread_flags; do
                 AC_MSG_CHECKING([whether pthreads work without any flags])
                 ;;
 
-                -mt,pthread)
-                AC_MSG_CHECKING([whether pthreads work with -mt -lpthread])
-                PTHREAD_CFLAGS="-mt"
-                PTHREAD_LIBS="-lpthread"
+                *,*)
+                PTHREAD_CFLAGS=`echo $ax_pthread_try_flag | sed "s/^\(.*\),\(.*\)$/\1/"`
+                PTHREAD_LIBS=`echo $ax_pthread_try_flag | sed "s/^\(.*\),\(.*\)$/\2/"`
+                AC_MSG_CHECKING([whether pthreads work with "$PTHREAD_CFLAGS" and "$PTHREAD_LIBS"])
                 ;;
 
                 -*)
@@ -371,7 +317,13 @@ for ax_pthread_try_flag in $ax_pthread_flags; do
 #                       if $ax_pthread_check_cond
 #                        error "$ax_pthread_check_macro must be defined"
 #                       endif
-                        static void routine(void *a) { a = 0; }
+                        static void *some_global = NULL;
+                        static void routine(void *a)
+                          {
+                             /* To avoid any unused-parameter or
+                                unused-but-set-parameter warning.  */
+                             some_global = a;
+                          }
                         static void *start_routine(void *a) { return a; }],
                        [pthread_t th; pthread_attr_t attr;
                         pthread_create(&th, 0, start_routine, 0);
@@ -392,6 +344,80 @@ for ax_pthread_try_flag in $ax_pthread_flags; do
         PTHREAD_CFLAGS=""
 done
 fi
+
+
+# Clang needs special handling, because older versions handle the -pthread
+# option in a rather... idiosyncratic way
+
+if test "x$ax_pthread_clang" = "xyes"; then
+
+        # Clang takes -pthread; it has never supported any other flag
+
+        # (Note 1: This will need to be revisited if a system that Clang
+        # supports has POSIX threads in a separate library.  This tends not
+        # to be the way of modern systems, but it's conceivable.)
+
+        # (Note 2: On some systems, notably Darwin, -pthread is not needed
+        # to get POSIX threads support; the API is always present and
+        # active.  We could reasonably leave PTHREAD_CFLAGS empty.  But
+        # -pthread does define _REENTRANT, and while the Darwin headers
+        # ignore this macro, third-party headers might not.)
+
+        # However, older versions of Clang make a point of warning the user
+        # that, in an invocation where only linking and no compilation is
+        # taking place, the -pthread option has no effect ("argument unused
+        # during compilation").  They expect -pthread to be passed in only
+        # when source code is being compiled.
+        #
+        # Problem is, this is at odds with the way Automake and most other
+        # C build frameworks function, which is that the same flags used in
+        # compilation (CFLAGS) are also used in linking.  Many systems
+        # supported by AX_PTHREAD require exactly this for POSIX threads
+        # support, and in fact it is often not straightforward to specify a
+        # flag that is used only in the compilation phase and not in
+        # linking.  Such a scenario is extremely rare in practice.
+        #
+        # Even though use of the -pthread flag in linking would only print
+        # a warning, this can be a nuisance for well-run software projects
+        # that build with -Werror.  So if the active version of Clang has
+        # this misfeature, we search for an option to squash it.
+
+        AC_CACHE_CHECK([whether Clang needs flag to prevent "argument unused" warning when linking with -pthread],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG],
+            [ax_cv_PTHREAD_CLANG_NO_WARN_FLAG=unknown
+             # Create an alternate version of $ac_link that compiles and
+             # links in two steps (.c -> .o, .o -> exe) instead of one
+             # (.c -> exe), because the warning occurs only in the second
+             # step
+             ax_pthread_save_ac_link="$ac_link"
+             ax_pthread_sed='s/conftest\.\$ac_ext/conftest.$ac_objext/g'
+             ax_pthread_link_step=`AS_ECHO(["$ac_link"]) | sed "$ax_pthread_sed"`
+             ax_pthread_2step_ac_link="($ac_compile) && (echo ==== >&5) && ($ax_pthread_link_step)"
+             ax_pthread_save_CFLAGS="$CFLAGS"
+             for ax_pthread_try in '' -Qunused-arguments -Wno-unused-command-line-argument unknown; do
+                AS_IF([test "x$ax_pthread_try" = "xunknown"], [break])
+                CFLAGS="-Werror -Wunknown-warning-option $ax_pthread_try -pthread $ax_pthread_save_CFLAGS"
+                ac_link="$ax_pthread_save_ac_link"
+                AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                    [ac_link="$ax_pthread_2step_ac_link"
+                     AC_LINK_IFELSE([AC_LANG_SOURCE([[int main(void){return 0;}]])],
+                         [break])
+                    ])
+             done
+             ac_link="$ax_pthread_save_ac_link"
+             CFLAGS="$ax_pthread_save_CFLAGS"
+             AS_IF([test "x$ax_pthread_try" = "x"], [ax_pthread_try=no])
+             ax_cv_PTHREAD_CLANG_NO_WARN_FLAG="$ax_pthread_try"
+            ])
+
+        case "$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG" in
+                no | unknown) ;;
+                *) PTHREAD_CFLAGS="$ax_cv_PTHREAD_CLANG_NO_WARN_FLAG $PTHREAD_CFLAGS" ;;
+        esac
+
+fi # $ax_pthread_clang = yes
+
+
 
 # Various other checks:
 if test "x$ax_pthread_ok" = "xyes"; then
@@ -438,7 +464,8 @@ if test "x$ax_pthread_ok" = "xyes"; then
         AC_CACHE_CHECK([for PTHREAD_PRIO_INHERIT],
             [ax_cv_PTHREAD_PRIO_INHERIT],
             [AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <pthread.h>]],
-                                             [[int i = PTHREAD_PRIO_INHERIT;]])],
+                                             [[int i = PTHREAD_PRIO_INHERIT;
+                                               return i;]])],
                             [ax_cv_PTHREAD_PRIO_INHERIT=yes],
                             [ax_cv_PTHREAD_PRIO_INHERIT=no])
             ])
@@ -460,18 +487,28 @@ if test "x$ax_pthread_ok" = "xyes"; then
                     [#handle absolute path differently from PATH based program lookup
                      AS_CASE(["x$CC"],
                          [x/*],
-                         [AS_IF([AS_EXECUTABLE_P([${CC}_r])],[PTHREAD_CC="${CC}_r"])],
-                         [AC_CHECK_PROGS([PTHREAD_CC],[${CC}_r],[$CC])])])
+                         [
+			   AS_IF([AS_EXECUTABLE_P([${CC}_r])],[PTHREAD_CC="${CC}_r"])
+			   AS_IF([test "x${CXX}" != "x"], [AS_IF([AS_EXECUTABLE_P([${CXX}_r])],[PTHREAD_CXX="${CXX}_r"])])
+			 ],
+                         [
+			   AC_CHECK_PROGS([PTHREAD_CC],[${CC}_r],[$CC])
+			   AS_IF([test "x${CXX}" != "x"], [AC_CHECK_PROGS([PTHREAD_CXX],[${CXX}_r],[$CXX])])
+			 ]
+                     )
+                    ])
                 ;;
             esac
         fi
 fi
 
 test -n "$PTHREAD_CC" || PTHREAD_CC="$CC"
+test -n "$PTHREAD_CXX" || PTHREAD_CXX="$CXX"
 
 AC_SUBST([PTHREAD_LIBS])
 AC_SUBST([PTHREAD_CFLAGS])
 AC_SUBST([PTHREAD_CC])
+AC_SUBST([PTHREAD_CXX])
 
 # Finally, execute ACTION-IF-FOUND/ACTION-IF-NOT-FOUND:
 if test "x$ax_pthread_ok" = "xyes"; then

--- a/src/lib/krb5/krb/deltat.c
+++ b/src/lib/krb5/krb/deltat.c
@@ -15,7 +15,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -1664,8 +1664,8 @@ mylex(int *intp, struct param *tmv)
 	/* XXX assumes ASCII */
 	num = c - '0';
 	while (isdigit ((int) *P)) {
-	  if (num > MAX_TIME / 10)
-	    return tok_OVERFLOW;
+	    if (num > MAX_TIME / 10)
+	      return tok_OVERFLOW;
 	    num *= 10;
 	    if (num > MAX_TIME - (*P - '0'))
 	      return tok_OVERFLOW;

--- a/src/lib/krb5/krb/x-deltat.y
+++ b/src/lib/krb5/krb/x-deltat.y
@@ -207,8 +207,8 @@ mylex(int *intp, struct param *tmv)
 	/* XXX assumes ASCII */
 	num = c - '0';
 	while (isdigit ((int) *P)) {
-	  if (num > MAX_TIME / 10)
-	    return tok_OVERFLOW;
+	    if (num > MAX_TIME / 10)
+	      return tok_OVERFLOW;
 	    num *= 10;
 	    if (num > MAX_TIME - (*P - '0'))
 	      return tok_OVERFLOW;

--- a/src/plugins/kdb/ldap/ldap_util/kdb5_ldap_realm.c
+++ b/src/plugins/kdb/ldap/ldap_util/kdb5_ldap_realm.c
@@ -135,20 +135,17 @@ get_ticket_policy(krb5_ldap_realm_params *rparams, int *i, char *argv[],
     time_t now;
     int mask = 0;
     krb5_error_code retval = 0;
-    krb5_boolean no_msg = FALSE;
-
-    krb5_boolean print_usage = FALSE;
     char *me = progname;
 
     time(&now);
     if (!strcmp(argv[*i], "-maxtktlife")) {
         if (++(*i) > argc-1)
-            goto err_usage;
+            return 0;
         date = get_date(argv[*i]);
         if (date == (time_t)(-1)) {
             retval = EINVAL;
             com_err(me, retval, _("while providing time specification"));
-            goto err_nomsg;
+            return 0;
         }
         rparams->max_life = date-now;
         mask |= LDAP_REALM_MAXTICKETLIFE;
@@ -157,13 +154,13 @@ get_ticket_policy(krb5_ldap_realm_params *rparams, int *i, char *argv[],
 
     else if (!strcmp(argv[*i], "-maxrenewlife")) {
         if (++(*i) > argc-1)
-            goto err_usage;
+            return 0;
 
         date = get_date(argv[*i]);
         if (date == (time_t)(-1)) {
             retval = EINVAL;
             com_err(me, retval, _("while providing time specification"));
-            goto err_nomsg;
+            return 0;
         }
         rparams->max_renewable_life = date-now;
         mask |= LDAP_REALM_MAXRENEWLIFE;
@@ -173,7 +170,7 @@ get_ticket_policy(krb5_ldap_realm_params *rparams, int *i, char *argv[],
         else if (*(argv[*i]) == '-')
             rparams->tktflags |= KRB5_KDB_DISALLOW_POSTDATED;
         else
-            goto err_usage;
+            return 0;
 
         mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "allow_forwardable")) {
@@ -183,7 +180,7 @@ get_ticket_policy(krb5_ldap_realm_params *rparams, int *i, char *argv[],
         else if (*(argv[*i]) == '-')
             rparams->tktflags |= KRB5_KDB_DISALLOW_FORWARDABLE;
         else
-            goto err_usage;
+            return 0;
 
         mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "allow_renewable")) {
@@ -192,7 +189,7 @@ get_ticket_policy(krb5_ldap_realm_params *rparams, int *i, char *argv[],
         else if (*(argv[*i]) == '-')
             rparams->tktflags |= KRB5_KDB_DISALLOW_RENEWABLE;
         else
-            goto err_usage;
+            return 0;
 
         mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "allow_proxiable")) {
@@ -201,7 +198,7 @@ get_ticket_policy(krb5_ldap_realm_params *rparams, int *i, char *argv[],
         else if (*(argv[*i]) == '-')
             rparams->tktflags |= KRB5_KDB_DISALLOW_PROXIABLE;
         else
-            goto err_usage;
+            return 0;
 
         mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "allow_dup_skey")) {
@@ -210,7 +207,7 @@ get_ticket_policy(krb5_ldap_realm_params *rparams, int *i, char *argv[],
         else if (*(argv[*i]) == '-')
             rparams->tktflags |= KRB5_KDB_DISALLOW_DUP_SKEY;
         else
-            goto err_usage;
+            return 0;
 
         mask |= LDAP_REALM_KRBTICKETFLAGS;
     }
@@ -221,7 +218,7 @@ get_ticket_policy(krb5_ldap_realm_params *rparams, int *i, char *argv[],
         else if (*(argv[*i]) == '-')
             rparams->tktflags &= (int)(~KRB5_KDB_REQUIRES_PRE_AUTH);
         else
-            goto err_usage;
+            return 0;
 
         mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "requires_hwauth")) {
@@ -230,7 +227,7 @@ get_ticket_policy(krb5_ldap_realm_params *rparams, int *i, char *argv[],
         else if (*(argv[*i]) == '-')
             rparams->tktflags &= (int)(~KRB5_KDB_REQUIRES_HW_AUTH);
         else
-            goto err_usage;
+            return 0;
 
         mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "allow_svr")) {
@@ -239,7 +236,7 @@ get_ticket_policy(krb5_ldap_realm_params *rparams, int *i, char *argv[],
         else if (*(argv[*i]) == '-')
             rparams->tktflags |= KRB5_KDB_DISALLOW_SVR;
         else
-            goto err_usage;
+            return 0;
 
         mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "allow_tgs_req")) {
@@ -248,7 +245,7 @@ get_ticket_policy(krb5_ldap_realm_params *rparams, int *i, char *argv[],
         else if (*(argv[*i]) == '-')
             rparams->tktflags |= KRB5_KDB_DISALLOW_TGT_BASED;
         else
-            goto err_usage;
+            return 0;
 
         mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "allow_tix")) {
@@ -257,7 +254,7 @@ get_ticket_policy(krb5_ldap_realm_params *rparams, int *i, char *argv[],
         else if (*(argv[*i]) == '-')
             rparams->tktflags |= KRB5_KDB_DISALLOW_ALL_TIX;
         else
-            goto err_usage;
+            return 0;
 
         mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "needchange")) {
@@ -266,7 +263,7 @@ get_ticket_policy(krb5_ldap_realm_params *rparams, int *i, char *argv[],
         else if (*(argv[*i]) == '-')
             rparams->tktflags &= (int)(~KRB5_KDB_REQUIRES_PWCHANGE);
         else
-            goto err_usage;
+            return 0;
 
         mask |= LDAP_REALM_KRBTICKETFLAGS;
     } else if (!strcmp((argv[*i] + 1), "password_changing_service")) {
@@ -275,15 +272,10 @@ get_ticket_policy(krb5_ldap_realm_params *rparams, int *i, char *argv[],
         else if (*(argv[*i]) == '-')
             rparams->tktflags &= (int)(~KRB5_KDB_PWCHANGE_SERVICE);
         else
-            goto err_usage;
+            return 0;
 
         mask |=LDAP_REALM_KRBTICKETFLAGS;
     }
-err_usage:
-    print_usage = TRUE;
-
-err_nomsg:
-    no_msg = TRUE;
 
     return mask;
 }

--- a/src/util/export-check.pl
+++ b/src/util/export-check.pl
@@ -49,6 +49,7 @@ map chop, @export;
 while (<NM>) {
     chop;
     s/^[0-9a-fA-F]+ +//;
+    s/@@.*$//;
     next if /^A /;
     if (!/^[TDRBGS] /) {
 	unlink $libfile;


### PR DESCRIPTION
I'm still unsure of whether resolv-wrapper is expected to work on Ubuntu 22.04 (see https://bugzilla.samba.org/show_bug.cgi?id=14830 ).  I may need to find an alternative way to test URI discovery.
