### PR TITLE
Defer primary KDC lookups

### DIFF
--- a/src/include/k5-trace.h
+++ b/src/include/k5-trace.h
@@ -203,8 +203,6 @@ void krb5int_trace(krb5_context context, const char *fmt, ...);
     TRACE(c, "Attempting password change; {int} tries remaining", tries)
 #define TRACE_GIC_PWD_EXPIRED(c)                                \
     TRACE(c, "Principal expired; getting changepw ticket")
-#define TRACE_GIC_PWD_PRIMARY(c)                        \
-    TRACE(c, "Retrying AS request with primary KDC")
 
 #define TRACE_GSS_CLIENT_KEYTAB_FAIL(c, ret)                            \
     TRACE(c, "Unable to resolve default client keytab: {kerr}", ret)
@@ -249,6 +247,8 @@ void krb5int_trace(krb5_context context, const char *fmt, ...);
 #define TRACE_INIT_CREDS_PREAUTH_TRYAGAIN(c, patype, code)              \
     TRACE(c, "Recovering from KDC error {int} using preauth mech {patype}", \
           patype, (int)code)
+#define TRACE_INIT_CREDS_PRIMARY(c)                     \
+    TRACE(c, "Retrying AS request with primary KDC")
 #define TRACE_INIT_CREDS_RESTART_FAST(c)        \
     TRACE(c, "Restarting to upgrade to FAST")
 #define TRACE_INIT_CREDS_RESTART_PREAUTH_FAILED(c)                      \
@@ -387,8 +387,6 @@ void krb5int_trace(krb5_context context, const char *fmt, ...);
           rlm, (primary) ? " (primary)" : "", (tcp) ? " (tcp only)" : "")
 #define TRACE_SENDTO_KDC_K5TLS_LOAD_ERROR(c, ret)       \
     TRACE(c, "Error loading k5tls module: {kerr}", ret)
-#define TRACE_SENDTO_KDC_PRIMARY(c, primary)                            \
-    TRACE(c, "Response was{str} from primary KDC", (primary) ? "" : " not")
 #define TRACE_SENDTO_KDC_RESOLVING(c, hostname)         \
     TRACE(c, "Resolving hostname {str}", hostname)
 #define TRACE_SENDTO_KDC_RESPONSE(c, len, raddr)                        \

--- a/src/lib/krb5/krb/get_creds.c
+++ b/src/lib/krb5/krb/get_creds.c
@@ -1214,23 +1214,22 @@ krb5_tkt_creds_get(krb5_context context, krb5_tkt_creds_context ctx)
     krb5_data request = empty_data(), reply = empty_data();
     krb5_data realm = empty_data();
     unsigned int flags = 0;
-    int tcp_only = 0, use_primary;
+    int no_udp = 0;
 
     for (;;) {
         /* Get the next request and realm.  Turn on TCP if necessary. */
         code = krb5_tkt_creds_step(context, ctx, &reply, &request, &realm,
                                    &flags);
-        if (code == KRB5KRB_ERR_RESPONSE_TOO_BIG && !tcp_only) {
+        if (code == KRB5KRB_ERR_RESPONSE_TOO_BIG && !no_udp) {
             TRACE_TKT_CREDS_RETRY_TCP(context);
-            tcp_only = 1;
+            no_udp = 1;
         } else if (code != 0 || !(flags & KRB5_TKT_CREDS_STEP_FLAG_CONTINUE))
             break;
         krb5_free_data_contents(context, &reply);
 
         /* Send it to a KDC for the appropriate realm. */
-        use_primary = 0;
-        code = krb5_sendto_kdc(context, &request, &realm,
-                               &reply, &use_primary, tcp_only);
+        code = k5_sendto_kdc(context, &request, &realm, FALSE, no_udp,
+                             &reply, NULL);
         if (code != 0)
             break;
 

--- a/src/lib/krb5/krb/get_in_tkt.c
+++ b/src/lib/krb5/krb/get_in_tkt.c
@@ -544,14 +544,14 @@ krb5_init_creds_free(krb5_context context,
 
 krb5_error_code
 k5_init_creds_get(krb5_context context, krb5_init_creds_context ctx,
-                  int *use_primary)
+                  krb5_boolean use_primary, struct kdclist *kdcs)
 {
     krb5_error_code code;
     krb5_data request;
     krb5_data reply;
     krb5_data realm;
     unsigned int flags = 0;
-    int tcp_only = 0, primary = *use_primary;
+    int no_udp = 0;
 
     request.length = 0;
     request.data = NULL;
@@ -567,17 +567,16 @@ k5_init_creds_get(krb5_context context, krb5_init_creds_context ctx,
                                     &request,
                                     &realm,
                                     &flags);
-        if (code == KRB5KRB_ERR_RESPONSE_TOO_BIG && !tcp_only) {
+        if (code == KRB5KRB_ERR_RESPONSE_TOO_BIG && !no_udp) {
             TRACE_INIT_CREDS_RETRY_TCP(context);
-            tcp_only = 1;
+            no_udp = 1;
         } else if (code != 0 || !(flags & KRB5_INIT_CREDS_STEP_FLAG_CONTINUE))
             break;
 
         krb5_free_data_contents(context, &reply);
 
-        primary = *use_primary;
-        code = krb5_sendto_kdc(context, &request, &realm,
-                               &reply, &primary, tcp_only);
+        code = k5_sendto_kdc(context, &request, &realm, use_primary, no_udp,
+                             &reply, kdcs);
         if (code != 0)
             break;
 
@@ -589,7 +588,6 @@ k5_init_creds_get(krb5_context context, krb5_init_creds_context ctx,
     krb5_free_data_contents(context, &reply);
     krb5_free_data_contents(context, &realm);
 
-    *use_primary = primary;
     return code;
 }
 
@@ -598,9 +596,7 @@ krb5_error_code KRB5_CALLCONV
 krb5_init_creds_get(krb5_context context,
                     krb5_init_creds_context ctx)
 {
-    int use_primary = 0;
-
-    return k5_init_creds_get(context, ctx, &use_primary);
+    return k5_init_creds_get(context, ctx, FALSE, NULL);
 }
 
 krb5_error_code KRB5_CALLCONV
@@ -1954,13 +1950,13 @@ cleanup:
     return code;
 }
 
-krb5_error_code KRB5_CALLCONV
-k5_get_init_creds(krb5_context context, krb5_creds *creds,
-                  krb5_principal client, krb5_prompter_fct prompter,
-                  void *prompter_data, krb5_deltat start_time,
-                  const char *in_tkt_service, krb5_get_init_creds_opt *options,
-                  get_as_key_fn gak_fct, void *gak_data, int *use_primary,
-                  krb5_kdc_rep **as_reply)
+static krb5_error_code
+try_init_creds(krb5_context context, krb5_creds *creds, krb5_principal client,
+               krb5_prompter_fct prompter, void *prompter_data,
+               krb5_deltat start_time, const char *in_tkt_service,
+               krb5_get_init_creds_opt *options, get_as_key_fn gak_fct,
+               void *gak_data, krb5_boolean use_primary, struct kdclist *kdcs,
+               krb5_kdc_rep **as_reply)
 {
     krb5_error_code code;
     krb5_init_creds_context ctx = NULL;
@@ -1984,7 +1980,7 @@ k5_get_init_creds(krb5_context context, krb5_creds *creds,
             goto cleanup;
     }
 
-    code = k5_init_creds_get(context, ctx, use_primary);
+    code = k5_init_creds_get(context, ctx, use_primary, kdcs);
     if (code != 0)
         goto cleanup;
 
@@ -2004,13 +2000,62 @@ cleanup:
 }
 
 krb5_error_code
+k5_get_init_creds(krb5_context context, krb5_creds *creds,
+                  krb5_principal client, krb5_prompter_fct prompter,
+                  void *prompter_data, krb5_deltat start_time,
+                  const char *in_tkt_service, krb5_get_init_creds_opt *options,
+                  get_as_key_fn gak_fct, void *gak_data,
+                  krb5_kdc_rep **as_reply)
+{
+    krb5_error_code ret;
+    struct kdclist *kdcs = NULL;
+    struct errinfo errsave = EMPTY_ERRINFO;
+
+    ret = k5_kdclist_create(&kdcs);
+    if (ret)
+        goto cleanup;
+
+    /* Try getting the requested ticket from any KDC. */
+    ret = try_init_creds(context, creds, client, prompter, prompter_data,
+                         start_time, in_tkt_service, options, gak_fct,
+                         gak_data, FALSE, kdcs, as_reply);
+    if (!ret)
+        goto cleanup;
+
+    /* If all of the KDCs are unavailable, or if the error was due to a user
+     * interrupt, fail. */
+    if (ret == KRB5_KDC_UNREACH || ret == KRB5_REALM_CANT_RESOLVE ||
+        ret == KRB5_LIBOS_PWDINTR || ret == KRB5_LIBOS_CANTREADPWD)
+        goto cleanup;
+
+    /* If any reply came from a replica, try again with only primary KDCs. */
+    if (k5_kdclist_any_replicas(context, kdcs)) {
+        k5_save_ctx_error(context, ret, &errsave);
+        TRACE_INIT_CREDS_PRIMARY(context);
+        ret = try_init_creds(context, creds, client, prompter, prompter_data,
+                             start_time, in_tkt_service, options, gak_fct,
+                             gak_data, TRUE, NULL, as_reply);
+        if (ret == KRB5_KDC_UNREACH || ret == KRB5_REALM_CANT_RESOLVE ||
+            ret == KRB5_REALM_UNKNOWN) {
+            /* We couldn't contact a primary KDC; return the error from the
+             * replica we were able to contact. */
+            ret = k5_restore_ctx_error(context, &errsave);
+        }
+    }
+
+cleanup:
+    k5_kdclist_free(kdcs);
+    k5_clear_error(&errsave);
+    return ret;
+}
+
+krb5_error_code
 k5_identify_realm(krb5_context context, krb5_principal client,
                   const krb5_data *subject_cert, krb5_principal *client_out)
 {
     krb5_error_code ret;
     krb5_get_init_creds_opt *opts = NULL;
     krb5_init_creds_context ctx = NULL;
-    int use_primary = 0;
 
     *client_out = NULL;
 
@@ -2030,7 +2075,7 @@ k5_identify_realm(krb5_context context, krb5_principal client,
     ctx->identify_realm = TRUE;
     ctx->subject_cert = subject_cert;
 
-    ret = k5_init_creds_get(context, ctx, &use_primary);
+    ret = k5_init_creds_get(context, ctx, FALSE, NULL);
     if (ret)
         goto cleanup;
 

--- a/src/lib/krb5/krb/in_tkt_sky.c
+++ b/src/lib/krb5/krb/in_tkt_sky.c
@@ -75,7 +75,6 @@ krb5_get_in_tkt_with_skey(krb5_context context, krb5_flags options,
     krb5_error_code retval;
     char *server;
     krb5_principal server_princ, client_princ;
-    int use_primary = 0;
     krb5_get_init_creds_opt *opts = NULL;
 
     retval = k5_populate_gic_opt(context, &opts, options, addrs, ktypes,
@@ -105,8 +104,7 @@ krb5_get_in_tkt_with_skey(krb5_context context, krb5_flags options,
     client_princ = creds->client;
     retval = k5_get_init_creds(context, creds, creds->client,
                                krb5_prompter_posix, NULL, 0, server, opts,
-                               get_as_key_skey, (void *)key, &use_primary,
-                               ret_as_reply);
+                               get_as_key_skey, (void *)key, ret_as_reply);
     krb5_free_unparsed_name(context, server);
     if (retval)
         goto cleanup;

--- a/src/lib/krb5/krb/int-proto.h
+++ b/src/lib/krb5/krb/int-proto.h
@@ -28,6 +28,7 @@
 #define KRB5_INT_FUNC_PROTO__
 
 struct krb5int_fast_request_state;
+struct kdclist;
 
 typedef struct k5_response_items_st k5_response_items;
 
@@ -201,7 +202,7 @@ k5_ccselect_free_context(krb5_context context);
 
 krb5_error_code
 k5_init_creds_get(krb5_context context, krb5_init_creds_context ctx,
-                  int *use_primary);
+                  krb5_boolean use_primary, struct kdclist *kdcs);
 
 krb5_error_code
 k5_init_creds_current_time(krb5_context context, krb5_init_creds_context ctx,
@@ -286,13 +287,12 @@ k5_encrypt_keyhelper(krb5_context context, krb5_key key,
                      krb5_keyusage keyusage, const krb5_data *plain,
                      krb5_enc_data *cipher);
 
-krb5_error_code KRB5_CALLCONV
+krb5_error_code
 k5_get_init_creds(krb5_context context, krb5_creds *creds,
                   krb5_principal client, krb5_prompter_fct prompter,
                   void *prompter_data, krb5_deltat start_time,
                   const char *in_tkt_service, krb5_get_init_creds_opt *options,
-                  get_as_key_fn gak, void *gak_data, int *primary,
-                  krb5_kdc_rep **as_reply);
+                  get_as_key_fn gak, void *gak_data, krb5_kdc_rep **as_reply);
 
 /*
  * Make AS requests with the canonicalize flag set, stopping when we get a

--- a/src/tests/Makefile.in
+++ b/src/tests/Makefile.in
@@ -191,6 +191,7 @@ check-pytests: responder s2p s4u2proxy unlockiter s4u2self
 	$(RUNPYTEST) $(srcdir)/t_u2u.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_kdcoptions.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_replay.py $(PYTESTFLAGS)
+	$(RUNPYTEST) $(srcdir)/t_sendto_kdc.py $(PYTESTFLAGS)
 
 clean:
 	$(RM) adata conccache etinfo forward gcred hist hooks hrealm

--- a/src/tests/t_sendto_kdc.py
+++ b/src/tests/t_sendto_kdc.py
@@ -1,0 +1,28 @@
+from k5test import *
+
+realm = K5Realm(create_host=False)
+
+mark('Fallback to primary KDC')
+
+# Create a replica database and start a KDC.
+conf_rep = {'dbmodules': {'db': {'database_name': '$testdir/db.replica2'}},
+            'realms': {'$realm': {'kdc_listen': '$port9',
+                                  'kdc_tcp_listen': '$port9'}}}
+replica = realm.special_env('replica', True, kdc_conf=conf_rep)
+dumpfile = os.path.join(realm.testdir, 'dump')
+realm.run([kdb5_util, 'dump', dumpfile])
+realm.run([kdb5_util, 'load', dumpfile], env=replica)
+replica_kdc = realm.start_server([krb5kdc, '-n'], 'starting...', env=replica)
+
+# Change the password on the primary.
+realm.run([kadminl, 'cpw', '-pw', 'new', realm.user_princ])
+
+conf_fallback = {'realms': {'$realm': {'kdc': '$hostname:$port9',
+                                       'primary_kdc': '$hostname:$port0'}}}
+fallback = realm.special_env('fallback', False, krb5_conf=conf_fallback)
+msgs = ('Retrying AS request with primary KDC',)
+realm.kinit(realm.user_princ, 'new', env=fallback, expected_trace=msgs)
+
+stop_daemon(replica_kdc)
+
+success('sendto_kdc')


### PR DESCRIPTION
Add an internal variant of krb5_sendto_kdc() which records the answering KDC in a history object.  Callers can check the history object for replica KDC use after the success or failure of the KDC exchange is determined, using only DNS query per realm and transport when DNS queries are needed.

Preserve the current signature of krb5_sendto_kdc() (it is used within the tree outside of libkrb5, and might be used by other software despite being non-public), but remove the behavior of setting *use_primary.

See https://krbdev.mit.edu/rt/Ticket/Display.html?id=7721 for more information.  This solution is a little higher on complexity than I would like, and I need to think about whether I can add any tests for it.  The best alternative design I could think of (the second candidate) would bleed some complexity into the future locate interface by adding the concept of an "only if it's cheap" primary KDC lookup, and is more approximate.