### PR TITLE
PKINIT ECDH support

### DIFF
--- a/doc/admin/conf_files/kdc_conf.rst
+++ b/doc/admin/conf_files/kdc_conf.rst
@@ -768,8 +768,11 @@ For information about the syntax of some of these options, see
     be specified multiple times.
 
 **pkinit_dh_min_bits**
-    Specifies the minimum number of bits the KDC is willing to accept
-    for a client's Diffie-Hellman key.  The default is 2048.
+    Specifies the minimum strength of Diffie-Hellman group the KDC is
+    willing to accept for key exchange.  Valid values in order of
+    increasing strength are 1024, 2048, P-256, 4096, P-384, and P-521.
+    The default is 2048.  (P-256, P-384, and P-521 are new in release
+    1.22.)
 
 **pkinit_allow_upn**
     Specifies that the KDC is willing to accept client certificates

--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -1128,9 +1128,10 @@ PKINIT krb5.conf options
         option is not recommended.
 
 **pkinit_dh_min_bits**
-    Specifies the size of the Diffie-Hellman key the client will
-    attempt to use.  The acceptable values are 1024, 2048, and 4096.
-    The default is 2048.
+    Specifies the group of the Diffie-Hellman key the client will
+    attempt to use.  The acceptable values are 1024, 2048, P-256,
+    4096, P-384, and P-521.  The default is 2048.  (P-256, P-384, and
+    P-521 are new in release 1.22.)
 
 **pkinit_identities**
     Specifies the location(s) to be used to find the user's X.509

--- a/src/plugins/preauth/pkinit/pkinit.h
+++ b/src/plugins/preauth/pkinit/pkinit.h
@@ -59,6 +59,10 @@
 
 #define PKINIT_DEFAULT_DH_MIN_BITS  2048
 #define PKINIT_DH_MIN_CONFIG_BITS   1024
+/* Rough finite-field bit strength equivalents for the elliptic curve groups */
+#define PKINIT_DH_P256_BITS         3072
+#define PKINIT_DH_P384_BITS         7680
+#define PKINIT_DH_P521_BITS         15360
 
 #define KRB5_CONF_KDCDEFAULTS                   "kdcdefaults"
 #define KRB5_CONF_LIBDEFAULTS                   "libdefaults"
@@ -100,8 +104,6 @@ static inline void pkiDebug (const char *fmt, ...) { }
     (k5d)->length = (pad)->length; (k5d)->data = (char *)(pad)->contents;
 #define OCTETDATA_TO_KRB5DATA(octd, k5d) \
     (k5d)->length = (octd)->length; (k5d)->data = (char *)(octd)->data;
-
-extern const krb5_data dh_oid;
 
 /*
  * notes about crypto contexts:

--- a/src/plugins/preauth/pkinit/pkinit_clnt.c
+++ b/src/plugins/preauth/pkinit/pkinit_clnt.c
@@ -774,7 +774,7 @@ pkinit_client_profile(krb5_context context,
                       const krb5_data *realm)
 {
     const char *configured_identity;
-    char *eku_string = NULL;
+    char *eku_string = NULL, *minbits = NULL;
 
     pkiDebug("pkinit_client_profile %p %p %p %p\n",
              context, plgctx, reqctx, realm);
@@ -783,17 +783,10 @@ pkinit_client_profile(krb5_context context,
                               KRB5_CONF_PKINIT_REQUIRE_CRL_CHECKING,
                               reqctx->opts->require_crl_checking,
                               &reqctx->opts->require_crl_checking);
-    pkinit_libdefault_integer(context, realm,
-                              KRB5_CONF_PKINIT_DH_MIN_BITS,
-                              reqctx->opts->dh_size,
-                              &reqctx->opts->dh_size);
-    if (reqctx->opts->dh_size != 1024 && reqctx->opts->dh_size != 2048
-        && reqctx->opts->dh_size != 4096) {
-        pkiDebug("%s: invalid value (%d) for pkinit_dh_min_bits, "
-                 "using default value (%d) instead\n", __FUNCTION__,
-                 reqctx->opts->dh_size, PKINIT_DEFAULT_DH_MIN_BITS);
-        reqctx->opts->dh_size = PKINIT_DEFAULT_DH_MIN_BITS;
-    }
+    pkinit_libdefault_string(context, realm, KRB5_CONF_PKINIT_DH_MIN_BITS,
+                             &minbits);
+    reqctx->opts->dh_size = parse_dh_min_bits(context, minbits);
+    free(minbits);
     pkinit_libdefault_string(context, realm,
                              KRB5_CONF_PKINIT_EKU_CHECKING,
                              &eku_string);

--- a/src/plugins/preauth/pkinit/pkinit_constants.c
+++ b/src/plugins/preauth/pkinit/pkinit_constants.c
@@ -320,6 +320,33 @@ static const uint8_t o4096[] = {
     0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
 };
 
+/* Named curve prime256v1 (1.2.840.10045.3.1.7) as parameters for RFC 3279
+ * section 2.3.5 id-ecPublicKey */
+static const uint8_t p256[] = {
+    0x06, 0x08, 0x2A, 0x86, 0x48, 0xCE, 0x3D, 0x03, 0x01, 0x07
+};
+
+/* Named curve secp384r1 (1.3.132.0.34, from RFC 5480 section 2.1.1.1) as
+ * parameters for RFC 3279 section 2.3.5 id-ecPublicKey */
+static const uint8_t p384[] = {
+    0x06, 0x05, 0x2B, 0x81, 0x04, 0x00, 0x22
+};
+
+/* Named curve secp521r1 (1.3.132.0.35, from RFC 5480 section 2.1.1.1) as
+ * parameters for RFC 3279 section 2.3.5 id-ecPublicKey */
+static const uint8_t p521[] = {
+    0x06, 0x05, 0x2B, 0x81, 0x04, 0x00, 0x23
+};
+
 const krb5_data oakley_1024 = { KV5M_DATA, sizeof(o1024), (char *)o1024 };
 const krb5_data oakley_2048 = { KV5M_DATA, sizeof(o2048), (char *)o2048 };
 const krb5_data oakley_4096 = { KV5M_DATA, sizeof(o4096), (char *)o4096 };
+const krb5_data ec_p256 = { KV5M_DATA, sizeof(p256), (char *)p256 };
+const krb5_data ec_p384 = { KV5M_DATA, sizeof(p384), (char *)p384 };
+const krb5_data ec_p521 = { KV5M_DATA, sizeof(p521), (char *)p521 };
+
+/* RFC 3279 section 2.3.3 dhpublicnumber (1.2.840.10046.2.1) */
+const krb5_data dh_oid = { 0, 7, "\x2A\x86\x48\xce\x3e\x02\x01" };
+
+/* RFC 3279 section 2.3.5 id-ecPublicKey (1.2.840.10045.2.1) */
+const krb5_data ec_oid = { 0, 7, "\x2A\x86\x48\xCE\x3D\x02\x01" };

--- a/src/plugins/preauth/pkinit/pkinit_crypto.h
+++ b/src/plugins/preauth/pkinit/pkinit_crypto.h
@@ -607,6 +607,11 @@ extern const krb5_data sha512_id;
 extern const krb5_data oakley_1024;
 extern const krb5_data oakley_2048;
 extern const krb5_data oakley_4096;
+extern const krb5_data ec_p256;
+extern const krb5_data ec_p384;
+extern const krb5_data ec_p521;
+extern const krb5_data dh_oid;
+extern const krb5_data ec_oid;
 
 /**
  * An ordered set of OIDs, stored as krb5_data, of KDF algorithms
@@ -628,5 +633,7 @@ crypto_req_cert_matching_data(krb5_context context,
 			      pkinit_plg_crypto_context plgctx,
 			      pkinit_req_crypto_context reqctx,
 			      pkinit_cert_matching_data **md_out);
+
+int parse_dh_min_bits(krb5_context context, const char *str);
 
 #endif	/* _PKINIT_CRYPTO_H */

--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.h
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.h
@@ -99,6 +99,9 @@ struct _pkinit_plg_crypto_context {
     EVP_PKEY *dh_1024;
     EVP_PKEY *dh_2048;
     EVP_PKEY *dh_4096;
+    EVP_PKEY *ec_p256;
+    EVP_PKEY *ec_p384;
+    EVP_PKEY *ec_p521;
     ASN1_OBJECT *id_pkinit_authData;
     ASN1_OBJECT *id_pkinit_DHKeyData;
     ASN1_OBJECT *id_pkinit_rkeyData;
@@ -113,7 +116,6 @@ struct _pkinit_plg_crypto_context {
 struct _pkinit_req_crypto_context {
     X509 *received_cert;
     EVP_PKEY *client_pkey;
-    EVP_PKEY *received_params;
 };
 
 #endif	/* _PKINIT_CRYPTO_OPENSSL_H */

--- a/src/plugins/preauth/pkinit/pkinit_lib.c
+++ b/src/plugins/preauth/pkinit/pkinit_lib.c
@@ -33,9 +33,6 @@
 
 #define FAKECERT
 
-const krb5_data dh_oid = { 0, 7, "\x2A\x86\x48\xce\x3e\x02\x01" };
-
-
 krb5_error_code
 pkinit_init_req_opts(pkinit_req_opts **reqopts)
 {

--- a/src/plugins/preauth/pkinit/pkinit_srv.c
+++ b/src/plugins/preauth/pkinit/pkinit_srv.c
@@ -1070,7 +1070,7 @@ static krb5_error_code
 pkinit_init_kdc_profile(krb5_context context, pkinit_kdc_context plgctx)
 {
     krb5_error_code retval;
-    char *eku_string = NULL, *ocsp_check = NULL;
+    char *eku_string = NULL, *ocsp_check = NULL, *minbits = NULL;
 
     pkiDebug("%s: entered for realm %s\n", __FUNCTION__, plgctx->realmname);
     retval = pkinit_kdcdefault_string(context, plgctx->realmname,
@@ -1115,17 +1115,10 @@ pkinit_init_kdc_profile(krb5_context context, pkinit_kdc_context plgctx)
         goto errout;
     }
 
-    pkinit_kdcdefault_integer(context, plgctx->realmname,
-                              KRB5_CONF_PKINIT_DH_MIN_BITS,
-                              PKINIT_DEFAULT_DH_MIN_BITS,
-                              &plgctx->opts->dh_min_bits);
-    if (plgctx->opts->dh_min_bits < PKINIT_DH_MIN_CONFIG_BITS) {
-        pkiDebug("%s: invalid value (%d < %d) for pkinit_dh_min_bits, "
-                 "using default value (%d) instead\n", __FUNCTION__,
-                 plgctx->opts->dh_min_bits, PKINIT_DH_MIN_CONFIG_BITS,
-                 PKINIT_DEFAULT_DH_MIN_BITS);
-        plgctx->opts->dh_min_bits = PKINIT_DEFAULT_DH_MIN_BITS;
-    }
+    pkinit_kdcdefault_string(context, plgctx->realmname,
+                             KRB5_CONF_PKINIT_DH_MIN_BITS, &minbits);
+    plgctx->opts->dh_min_bits = parse_dh_min_bits(context, minbits);
+    free(minbits);
 
     pkinit_kdcdefault_boolean(context, plgctx->realmname,
                               KRB5_CONF_PKINIT_ALLOW_UPN,

--- a/src/plugins/preauth/pkinit/pkinit_trace.h
+++ b/src/plugins/preauth/pkinit/pkinit_trace.h
@@ -92,6 +92,17 @@
 
 #define TRACE_PKINIT_DH_GROUP_UNAVAILABLE(c, name)                      \
     TRACE(c, "PKINIT key exchange group {str} unsupported", name)
+#define TRACE_PKINIT_DH_INVALID_MIN_BITS(c, str)                        \
+    TRACE(c, "Invalid pkinit_dh_min_bits value {str}, using default", str)
+#define TRACE_PKINIT_DH_NEGOTIATED_GROUP(c, desc)                       \
+    TRACE(c, "PKINIT accepting KDC key exchange group preference {str}", desc)
+#define TRACE_PKINIT_DH_PROPOSING_GROUP(c, desc)                \
+    TRACE(c, "PKINIT using {str} key exchange group", desc)
+#define TRACE_PKINIT_DH_RECEIVED_GROUP(c, desc)                         \
+    TRACE(c, "PKINIT received {str} key from client for key exchange", desc)
+#define TRACE_PKINIT_DH_REJECTING_GROUP(c, desc, mindesc)               \
+    TRACE(c, "PKINIT client key has group {str}, need at least {str}",  \
+          desc, mindesc)
 
 #define TRACE_PKINIT_OPENSSL_ERROR(c, msg)              \
     TRACE(c, "PKINIT OpenSSL error: {str}", msg)


### PR DESCRIPTION
I've been wanting to implement ECC PKINIT support (RFC 5349) for a long time, and some concerns about OpenSSL's finite-field DH support gave me the impetus to put some work into an alternative.  Currently I have a proof of concept, but need to work out some details of the user experience before it will be ready for merging.

The biggest problem is how we decide when to use ECDH on the client, how ECDH support interacts with the pkinit_dh_min_bits variable, and how ECDH support interacts with TD-DH-PARAMETERS negotiation.  Some notes on that:

* Heimdal uses ECDH if the client cert has an EC public key.  This is nice in that it puts the decision under control of the client CA, but it doesn't address anonymous PKINIT, and support for EC certs doesn't actually imply KDC support for ECDH (the current MIT PKINIT code works fine with EC certs, empirically, but does not support ECDH).  Heimdal does not implement TD-DH-PARAMETERS.

* The current TD-DH-PARAMETERS negotiation code in the client does not allow downgrades in bit strength.  (It does allow DH parameters that aren't the normally-used Oakley groups, as long as they check out with EVP_PKEY_param_check()/DH_check().)

* RFC 5349 gives a rough bit-strength correspondence table between ECC curve sizes and RSA key sizes.  I'm not sure how accurate that table is and whether it also applies to finite-field DH key sizes, but one option would be to do some additional research and assign FFDH bit equivalents to P-256, P-384, and P-521.  P-256 would probably land in between the 2048-bit and 4096-bit Oakley groups.

* Bit strength is not a great configuration knob.  My intuition is that P-256 is the most secure group out of any available option (except X25519, which has no PKINIT standard) because it has had the most effort focused on its OpenSSL implementation and its bit strength is more than sufficient.

There are also some OpenSSL bug concerns, specifically for the client operation where we combine the KDC public DH key with the client's key parameters to produce an EVP_PKEY object (compose_dh_pkey()).  OpenSSL 1.1 had a bug prior to 1.1.1b where d2i_PublicKey() didn't work for EC keys, but there is a wordier equivalent using EC_KEY functions.  OpenSSL 3.0.0 reintroduced that bug, and in 3.0 there is (I think) no working equivalent that doesn't involve deprecated functions.  Fortunately, this bug was fixed just a few months later in 3.0.1, and we might be able to get away with being optimistic that few people would link against 3.0.0 specifically (as Heimdal appears to).  The PR currently uses the alternative EC_KEY sequence for 1.0/1.1 and d2i_PublicKey() for 3.0.
