### PR TITLE
Enable PKINIT plugin if at least 1 of the 3 well-known groups is available

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_clnt.c
+++ b/src/plugins/preauth/pkinit/pkinit_clnt.c
@@ -1378,7 +1378,7 @@ pkinit_client_plugin_init(krb5_context context,
     if (retval)
         goto errout;
 
-    retval = pkinit_init_plg_crypto(&ctx->cryptoctx);
+    retval = pkinit_init_plg_crypto(context, &ctx->cryptoctx);
     if (retval)
         goto errout;
 

--- a/src/plugins/preauth/pkinit/pkinit_crypto.h
+++ b/src/plugins/preauth/pkinit/pkinit_crypto.h
@@ -103,7 +103,8 @@ typedef struct _pkinit_cert_matching_data {
 /*
  * Functions to initialize and cleanup crypto contexts
  */
-krb5_error_code pkinit_init_plg_crypto(pkinit_plg_crypto_context *);
+krb5_error_code pkinit_init_plg_crypto(krb5_context,
+				       pkinit_plg_crypto_context *);
 void pkinit_fini_plg_crypto(pkinit_plg_crypto_context);
 
 krb5_error_code pkinit_init_req_crypto(pkinit_req_crypto_context *);

--- a/src/plugins/preauth/pkinit/pkinit_srv.c
+++ b/src/plugins/preauth/pkinit/pkinit_srv.c
@@ -1222,7 +1222,7 @@ pkinit_server_plugin_init_realm(krb5_context context, const char *realmname,
         goto errout;
     plgctx->realmname_len = strlen(plgctx->realmname);
 
-    retval = pkinit_init_plg_crypto(&plgctx->cryptoctx);
+    retval = pkinit_init_plg_crypto(context, &plgctx->cryptoctx);
     if (retval)
         goto errout;
 

--- a/src/plugins/preauth/pkinit/pkinit_trace.h
+++ b/src/plugins/preauth/pkinit/pkinit_trace.h
@@ -90,6 +90,9 @@
 #define TRACE_PKINIT_CLIENT_TRYAGAIN(c)                                 \
     TRACE(c, "PKINIT client trying again with KDC-provided parameters")
 
+#define TRACE_PKINIT_DH_GROUP_UNAVAILABLE(c, name)                      \
+    TRACE(c, "PKINIT key exchange group {str} unsupported", name)
+
 #define TRACE_PKINIT_OPENSSL_ERROR(c, msg)              \
     TRACE(c, "PKINIT OpenSSL error: {str}", msg)
 


### PR DESCRIPTION
OpenSSL may no longer allow to decode non-well-known Diffie-Hellman groups as EVP_PKEY objects in FIPS mode. However, OpenSSL does not know about the MODP well-known group 2 (1024-bit), which is [considered as a custom group](https://github.com/openssl/openssl/issues/18981). As a consequence, the PKINIT plugin failed to load systematically in FIPS mode because the 3 groups are required.

This pull request allows initialization of the PKINIT plugin if at least one of the MODP well-known groups succeed to load. So the PKINIT plugin will continue to work with groups 14 (2048-bit) and 16 (4096) in FIPS mode.