### PR TITLE
Switch to modern (ANSI) function prototypes

### DIFF
--- a/src/aclocal.m4
+++ b/src/aclocal.m4
@@ -545,7 +545,7 @@ if test "$GCC" = yes ; then
     TRY_WARN_CC_FLAG(-Wno-format-zero-length)
     # Other flags here may not be supported on some versions of
     # gcc that people want to use.
-    for flag in overflow strict-overflow missing-format-attribute missing-prototypes return-type missing-braces parentheses switch unused-function unused-label unused-variable unused-value unknown-pragmas sign-compare newline-eof error=uninitialized no-maybe-uninitialized error=pointer-arith error=int-conversion error=incompatible-pointer-types error=discarded-qualifiers error=implicit-int ; do
+    for flag in overflow strict-overflow missing-format-attribute missing-prototypes return-type missing-braces parentheses switch unused-function unused-label unused-variable unused-value unknown-pragmas sign-compare newline-eof error=uninitialized no-maybe-uninitialized error=pointer-arith error=int-conversion error=incompatible-pointer-types error=discarded-qualifiers error=implicit-int error=strict-prototypes; do
       TRY_WARN_CC_FLAG(-W$flag)
     done
     #  old-style-definition? generates many, many warnings

--- a/src/appl/gss-sample/gss-client.c
+++ b/src/appl/gss-sample/gss-client.c
@@ -75,7 +75,7 @@ static gss_OID_desc gss_spnego_mechanism_oid_desc =
 {6, (void *)"\x2b\x06\x01\x05\x05\x02"};
 
 static void
-usage()
+usage(void)
 {
     fprintf(stderr, "Usage: gss-client [-port port] [-mech mechanism] "
             "[-spnego] [-d]\n");
@@ -359,9 +359,7 @@ client_establish_context(int s, char *service_name, OM_uint32 gss_flags,
 }
 
 static void
-read_file(file_name, in_buf)
-    char   *file_name;
-    gss_buffer_t in_buf;
+read_file(char *file_name, gss_buffer_t in_buf)
 {
     int     fd, count;
     struct stat stat_buf;
@@ -431,21 +429,10 @@ read_file(file_name, in_buf)
  * verifies it with gss_verify.  -1 is returned if any step fails,
  * otherwise 0 is returned.  */
 static int
-call_server(host, port, oid, service_name, gss_flags, auth_flag,
-            wrap_flag, encrypt_flag, mic_flag, v1_format, msg, use_file,
-            mcount, username, password)
-    char   *host;
-    u_short port;
-    gss_OID oid;
-    char   *service_name;
-    OM_uint32 gss_flags;
-    int     auth_flag, wrap_flag, encrypt_flag, mic_flag;
-    int     v1_format;
-    char   *msg;
-    int     use_file;
-    int     mcount;
-    char    *username;
-    char    *password;
+call_server(char *host, u_short port, gss_OID oid, char *service_name,
+            OM_uint32 gss_flags, int auth_flag, int wrap_flag,
+            int encrypt_flag, int mic_flag, int v1_format, char *msg,
+            int use_file, int mcount, char *username, char *password)
 {
     gss_ctx_id_t context = GSS_C_NO_CONTEXT;
     gss_buffer_desc in_buf, out_buf;
@@ -774,9 +761,7 @@ worker_bee(void *unused)
 }
 
 int
-main(argc, argv)
-    int     argc;
-    char  **argv;
+main(int argc, char **argv)
 {
     int     i;
 

--- a/src/appl/gss-sample/gss-misc.c
+++ b/src/appl/gss-sample/gss-misc.c
@@ -157,10 +157,7 @@ read_all(int fildes, void *data, unsigned int nbyte)
  * if an error occurs or if it could not write all the data.
  */
 int
-send_token(s, flags, tok)
-    int     s;
-    int     flags;
-    gss_buffer_t tok;
+send_token(int s, int flags, gss_buffer_t tok)
 {
     int     ret;
     unsigned char char_flags = (unsigned char) flags;
@@ -230,10 +227,7 @@ send_token(s, flags, tok)
  * and -1 if an error occurs or if it could not read all the data.
  */
 int
-recv_token(s, flags, tok)
-    int     s;
-    int    *flags;
-    gss_buffer_t tok;
+recv_token(int s, int *flags, gss_buffer_t tok)
 {
     int     ret;
     unsigned char char_flags;
@@ -303,10 +297,7 @@ recv_token(s, flags, tok)
 }
 
 static void
-display_status_1(m, code, type)
-    char   *m;
-    OM_uint32 code;
-    int     type;
+display_status_1(char *m, OM_uint32 code, int type)
 {
     OM_uint32 min_stat;
     gss_buffer_desc msg;
@@ -344,10 +335,7 @@ display_status_1(m, code, type)
  * followed by a newline.
  */
 void
-display_status(msg, maj_stat, min_stat)
-    char   *msg;
-    OM_uint32 maj_stat;
-    OM_uint32 min_stat;
+display_status(char *msg, OM_uint32 maj_stat, OM_uint32 min_stat)
 {
     display_status_1(msg, maj_stat, GSS_C_GSS_CODE);
     display_status_1(msg, min_stat, GSS_C_MECH_CODE);
@@ -370,8 +358,7 @@ display_status(msg, maj_stat, min_stat)
  */
 
 void
-display_ctx_flags(flags)
-    OM_uint32 flags;
+display_ctx_flags(OM_uint32 flags)
 {
     if (flags & GSS_C_DELEG_FLAG)
         fprintf(display_file, "context flag: GSS_C_DELEG_FLAG\n");
@@ -388,8 +375,7 @@ display_ctx_flags(flags)
 }
 
 void
-print_token(tok)
-    gss_buffer_t tok;
+print_token(gss_buffer_t tok)
 {
     unsigned int   i;
     unsigned char *p = tok->value;

--- a/src/appl/gss-sample/gss-server.c
+++ b/src/appl/gss-sample/gss-server.c
@@ -73,7 +73,7 @@ static OM_uint32
 showLocalIdentity(OM_uint32 *minor, gss_name_t name);
 
 static void
-usage()
+usage(void)
 {
     fprintf(stderr, "Usage: gss-server [-port port] [-verbose] [-once]");
 #ifdef _WIN32

--- a/src/appl/user_user/server.c
+++ b/src/appl/user_user/server.c
@@ -39,9 +39,8 @@
 
 /* fd 0 is a tcp socket used to talk to the client */
 
-int main(argc, argv)
-    int argc;
-    char *argv[];
+int
+main(int argc, char *argv[])
 {
     krb5_data pname_data, tkt_data;
     int sock = 0;

--- a/src/clients/kdestroy/kdestroy.c
+++ b/src/clients/kdestroy/kdestroy.c
@@ -47,7 +47,7 @@ char *progname;
 
 
 static void
-usage()
+usage(void)
 {
     fprintf(stderr, _("Usage: %s [-A] [-q] [-c cache_name] [-p princ_name]\n"),
             progname);

--- a/src/clients/kinit/kinit.c
+++ b/src/clients/kinit/kinit.c
@@ -45,7 +45,7 @@
 #ifdef HAVE_PWD_H
 #include <pwd.h>
 static char *
-get_name_from_os()
+get_name_from_os(void)
 {
     struct passwd *pw;
 
@@ -137,7 +137,7 @@ const char *shopts = "r:fpFPn54aAVl:s:c:kit:T:RS:vX:CEI:";
 #define USAGE_BREAK "\n\t"
 
 static void
-usage()
+usage(void)
 {
     fprintf(stderr,
             _("Usage: %s [-V] [-l lifetime] [-s start_time] "

--- a/src/clients/klist/klist.c
+++ b/src/clients/klist/klist.c
@@ -80,7 +80,7 @@ static void fillit(FILE *, unsigned int, int);
 #define KEYTAB 2
 
 static void
-usage()
+usage(void)
 {
     fprintf(stderr, _("Usage: %s [-e] [-V] [[-c] [-l] [-A] [-d] [-f] [-s] "
                       "[-a [-n]]] [-k [-i] [-t] [-K]] [-C] [name]\n"),

--- a/src/clients/ksu/authorization.c
+++ b/src/clients/ksu/authorization.c
@@ -30,9 +30,8 @@
 
 static void auth_cleanup (FILE *, FILE *, char *);
 
-krb5_boolean fowner(fp, uid)
-    FILE *fp;
-    uid_t uid;
+krb5_boolean
+fowner(FILE *fp, uid_t uid)
 {
     struct stat sbuf;
 
@@ -59,16 +58,10 @@ krb5_boolean fowner(fp, uid)
  *
  */
 
-krb5_error_code krb5_authorization(context, principal, luser,
-                                   cmd, ok, out_fcmd)
-/* IN */
-    krb5_context context;
-    krb5_principal principal;
-    const char *luser;
-    char *cmd;
-    /* OUT */
-    krb5_boolean *ok;
-    char **out_fcmd;
+krb5_error_code
+krb5_authorization(krb5_context context, krb5_principal principal,
+                   const char *luser, char *cmd, krb5_boolean *ok,
+                   char **out_fcmd)
 {
     struct passwd *pwd;
     char *princname;
@@ -178,10 +171,8 @@ any tokens after the principal name  FALSE is returned.
 
 ***********************************************************/
 
-krb5_error_code k5login_lookup (fp, princname, found)
-    FILE *fp;
-    char *princname;
-    krb5_boolean *found;
+krb5_error_code
+k5login_lookup(FILE *fp, char *princname, krb5_boolean *found)
 {
 
     krb5_error_code retval;
@@ -240,12 +231,9 @@ if princname is found{
 
 
 ***********************************************************/
-krb5_error_code k5users_lookup (fp, princname, cmd, found, out_fcmd)
-    FILE *fp;
-    char *princname;
-    char *cmd;
-    krb5_boolean *found;
-    char **out_fcmd;
+krb5_error_code
+k5users_lookup(FILE *fp, char *princname, char *cmd,
+               krb5_boolean *found, char **out_fcmd)
 {
     krb5_error_code retval;
     char * line;
@@ -328,10 +316,8 @@ resolves it into a full path name.
 
 ************************************************/
 
-krb5_boolean fcmd_resolve(fcmd, out_fcmd, out_err)
-    char *fcmd;
-    char ***out_fcmd;
-    char **out_err;
+krb5_boolean
+fcmd_resolve(char *fcmd, char ***out_fcmd, char **out_err)
 {
     char * err;
     char ** tmp_fcmd;
@@ -407,8 +393,8 @@ cmd_single - checks if cmd consists of a path
 
 ********************************************/
 
-krb5_boolean cmd_single(cmd)
-    char * cmd;
+krb5_boolean
+cmd_single(char *cmd)
 {
 
     if ( ( strrchr( cmd, '/')) ==  NULL){
@@ -423,9 +409,8 @@ cmd_arr_cmp_postfix - compares a command with the postfix
          of fcmd
 ********************************************/
 
-int cmd_arr_cmp_postfix(fcmd_arr, cmd)
-    char **fcmd_arr;
-    char *cmd;
+int
+cmd_arr_cmp_postfix(char **fcmd_arr, char *cmd)
 {
     char  * temp_fcmd;
     char *ptr;
@@ -457,9 +442,8 @@ cmd_arr_cmp - checks if cmd matches any
 
 **********************************************/
 
-int cmd_arr_cmp (fcmd_arr, cmd)
-    char **fcmd_arr;
-    char *cmd;
+int
+cmd_arr_cmp(char **fcmd_arr, char *cmd)
 {
     int result =1;
     int i = 0;
@@ -475,10 +459,8 @@ int cmd_arr_cmp (fcmd_arr, cmd)
 }
 
 
-krb5_boolean find_first_cmd_that_exists(fcmd_arr, cmd_out, err_out)
-    char **fcmd_arr;
-    char **cmd_out;
-    char **err_out;
+krb5_boolean
+find_first_cmd_that_exists(char **fcmd_arr, char **cmd_out, char **err_out)
 {
     struct stat st_temp;
     int i = 0;
@@ -517,12 +499,9 @@ returns 1 if there is an error, 0 if no error.
 
 ***************************************************************/
 
-int match_commands (fcmd, cmd, match, cmd_out, err_out)
-    char *fcmd;
-    char *cmd;
-    krb5_boolean *match;
-    char **cmd_out;
-    char **err_out;
+int
+match_commands(char *fcmd, char *cmd, krb5_boolean *match,
+               char **cmd_out, char **err_out)
 {
     char ** fcmd_arr;
     char * err;
@@ -566,11 +545,8 @@ int match_commands (fcmd, cmd, match, cmd_out, err_out)
               is set to null if eof.
 *********************************************************/
 
-krb5_error_code get_line (fp, out_line)
-/* IN */
-    FILE *fp;
-    /* OUT */
-    char **out_line;
+krb5_error_code
+get_line(FILE *fp, char **out_line)
 {
     char * line, *r, *newline , *line_ptr;
     int chunk_count = 1;
@@ -615,9 +591,8 @@ will be returned as part of the first token.
 Note: this routine reuses the space pointed to by line
 ******************************************************/
 
-char *  get_first_token (line, lnext)
-    char *line;
-    char **lnext;
+char *
+get_first_token(char *line, char **lnext)
 {
 
     char * lptr, * out_ptr;
@@ -651,8 +626,8 @@ Note: that this function modifies the stream
       lnext to the next tocken.
 **********************************************************/
 
-char *  get_next_token (lnext)
-    char **lnext;
+char *
+get_next_token (char **lnext)
 {
     char * lptr, * out_ptr;
 
@@ -677,10 +652,8 @@ char *  get_next_token (lnext)
     return out_ptr;
 }
 
-static void auth_cleanup(users_fp, login_fp, princname)
-    FILE *users_fp;
-    FILE *login_fp;
-    char *princname;
+static void
+auth_cleanup(FILE *users_fp, FILE *login_fp, char *princname)
 {
 
     free (princname);
@@ -690,8 +663,8 @@ static void auth_cleanup(users_fp, login_fp, princname)
         fclose(login_fp);
 }
 
-void init_auth_names(pw_dir)
-    char *pw_dir;
+void
+init_auth_names(char *pw_dir)
 {
     const char *sep;
     int r1, r2;

--- a/src/clients/ksu/ccache.c
+++ b/src/clients/ksu/ccache.c
@@ -40,24 +40,18 @@ copies the default cache into the secondary cache,
 
 ************************************************************************/
 
-void show_credential();
+void show_credential(krb5_context, krb5_creds *, krb5_ccache);
 
 /* modifies only the cc_other, the algorithm may look a bit funny,
    but I had to do it this way, since remove function did not come
    with k5 beta 3 release.
 */
 
-krb5_error_code krb5_ccache_copy(context, cc_def, target_principal, cc_target,
-                                 restrict_creds, primary_principal, stored)
-/* IN */
-    krb5_context context;
-    krb5_ccache cc_def;
-    krb5_principal target_principal;
-    krb5_ccache cc_target;
-    krb5_boolean restrict_creds;
-    krb5_principal primary_principal;
-    /* OUT */
-    krb5_boolean *stored;
+krb5_error_code
+krb5_ccache_copy(krb5_context context, krb5_ccache cc_def,
+                 krb5_principal target_principal, krb5_ccache cc_target,
+                 krb5_boolean restrict_creds, krb5_principal primary_principal,
+                 krb5_boolean *stored)
 {
     int i=0;
     krb5_error_code retval=0;
@@ -105,11 +99,9 @@ krb5_error_code krb5_ccache_copy(context, cc_def, target_principal, cc_target,
 }
 
 
-krb5_error_code krb5_store_all_creds(context, cc, creds_def, creds_other)
-    krb5_context context;
-    krb5_ccache cc;
-    krb5_creds **creds_def;
-    krb5_creds **creds_other;
+krb5_error_code
+krb5_store_all_creds(krb5_context context, krb5_ccache cc,
+                     krb5_creds **creds_def, krb5_creds **creds_other)
 {
 
     int i = 0;
@@ -173,10 +165,8 @@ krb5_error_code krb5_store_all_creds(context, cc, creds_def, creds_other)
     return 0;
 }
 
-krb5_boolean compare_creds(context, cred1, cred2)
-    krb5_context context;
-    krb5_creds *cred1;
-    krb5_creds *cred2;
+krb5_boolean
+compare_creds(krb5_context context, krb5_creds *cred1, krb5_creds *cred2)
 {
     krb5_boolean retval;
 
@@ -188,13 +178,9 @@ krb5_boolean compare_creds(context, cred1, cred2)
     return retval;
 }
 
-
-
-
-krb5_error_code krb5_get_nonexp_tkts(context, cc, creds_array)
-    krb5_context context;
-    krb5_ccache cc;
-    krb5_creds ***creds_array;
+krb5_error_code
+krb5_get_nonexp_tkts(krb5_context context, krb5_ccache cc,
+                     krb5_creds ***creds_array)
 {
 
     krb5_creds creds, temp_tktq, temp_tkt;
@@ -262,10 +248,8 @@ krb5_error_code krb5_get_nonexp_tkts(context, cc, creds_array)
 
 }
 
-
-krb5_error_code krb5_check_exp(context, tkt_time)
-    krb5_context context;
-    krb5_ticket_times tkt_time;
+krb5_error_code
+krb5_check_exp(krb5_context context, krb5_ticket_times tkt_time)
 {
     krb5_error_code retval =0;
     krb5_timestamp currenttime;
@@ -290,9 +274,8 @@ krb5_error_code krb5_check_exp(context, tkt_time)
     return 0;
 }
 
-
-char *flags_string(cred)
-    krb5_creds *cred;
+char *
+flags_string(krb5_creds *cred)
 {
     static char buf[32];
     int i = 0;
@@ -323,7 +306,8 @@ char *flags_string(cred)
     return(buf);
 }
 
-void printtime(krb5_timestamp ts)
+void
+printtime(krb5_timestamp ts)
 {
     char fmtbuf[18], fill = ' ';
 
@@ -333,9 +317,7 @@ void printtime(krb5_timestamp ts)
 
 
 krb5_error_code
-krb5_get_login_princ(luser, princ_list)
-    const char *luser;
-    char ***princ_list;
+krb5_get_login_princ(const char *luser, char ***princ_list)
 {
     struct stat sbuf;
     struct passwd *pwd;
@@ -420,13 +402,8 @@ krb5_get_login_princ(luser, princ_list)
     return 0;
 }
 
-
-
 void
-show_credential(context, cred, cc)
-    krb5_context context;
-    krb5_creds *cred;
-    krb5_ccache cc;
+show_credential(krb5_context context, krb5_creds *cred, krb5_ccache cc)
 {
     krb5_error_code retval;
     char *name, *sname, *flags;
@@ -519,11 +496,9 @@ gen_sym(krb5_context context, char **sym_out)
     return 0;
 }
 
-krb5_error_code krb5_ccache_overwrite(context, ccs, cct, primary_principal)
-    krb5_context context;
-    krb5_ccache ccs;
-    krb5_ccache cct;
-    krb5_principal primary_principal;
+krb5_error_code
+krb5_ccache_overwrite(krb5_context context, krb5_ccache ccs, krb5_ccache cct,
+                      krb5_principal primary_principal)
 {
     krb5_error_code retval=0;
     krb5_principal temp_principal;
@@ -560,14 +535,10 @@ krb5_error_code krb5_ccache_overwrite(context, ccs, cct, primary_principal)
     return retval;
 }
 
-krb5_error_code krb5_store_some_creds(context, cc, creds_def, creds_other, prst,
-                                      stored)
-    krb5_context context;
-    krb5_ccache cc;
-    krb5_creds **creds_def;
-    krb5_creds **creds_other;
-    krb5_principal prst;
-    krb5_boolean *stored;
+krb5_error_code
+krb5_store_some_creds(krb5_context context, krb5_ccache cc,
+                      krb5_creds **creds_def, krb5_creds **creds_other,
+                      krb5_principal prst, krb5_boolean *stored)
 {
 
     int i = 0;
@@ -610,10 +581,8 @@ krb5_error_code krb5_store_some_creds(context, cc, creds_def, creds_other, prst,
     return 0;
 }
 
-krb5_error_code krb5_ccache_filter (context, cc, prst)
-    krb5_context context;
-    krb5_ccache cc;
-    krb5_principal prst;
+krb5_error_code
+krb5_ccache_filter(krb5_context context, krb5_ccache cc, krb5_principal prst)
 {
 
     int i=0;
@@ -657,10 +626,9 @@ krb5_error_code krb5_ccache_filter (context, cc, prst)
     return 0;
 }
 
-krb5_boolean  krb5_find_princ_in_cred_list (context, creds_list, princ)
-    krb5_context context;
-    krb5_creds **creds_list;
-    krb5_principal princ;
+krb5_boolean
+krb5_find_princ_in_cred_list(krb5_context context, krb5_creds **creds_list,
+                             krb5_principal princ)
 {
 
     int i = 0;
@@ -682,11 +650,9 @@ krb5_boolean  krb5_find_princ_in_cred_list (context, creds_list, princ)
     return temp_stored;
 }
 
-krb5_error_code  krb5_find_princ_in_cache (context, cc, princ, found)
-    krb5_context context;
-    krb5_ccache cc;
-    krb5_principal princ;
-    krb5_boolean *found;
+krb5_error_code
+krb5_find_princ_in_cache(krb5_context context, krb5_ccache cc,
+                         krb5_principal princ, krb5_boolean *found)
 {
     krb5_error_code retval;
     krb5_creds ** creds_list = NULL;

--- a/src/clients/ksu/heuristic.c
+++ b/src/clients/ksu/heuristic.c
@@ -41,9 +41,8 @@ get_all_princ_from_file - retrieves all principal names
 static void close_time (int, FILE *, int, FILE *);
 static krb5_boolean find_str_in_list (char **, char *);
 
-krb5_error_code get_all_princ_from_file (fp, plist)
-    FILE *fp;
-    char ***plist;
+krb5_error_code
+get_all_princ_from_file(FILE *fp, char ***plist)
 {
 
     krb5_error_code retval;
@@ -92,10 +91,8 @@ list_union - combines list1 and list2 into combined_list.
              or used by combined_list.
 **************************************************************/
 
-krb5_error_code list_union(list1, list2, combined_list)
-    char **list1;
-    char **list2;
-    char ***combined_list;
+krb5_error_code
+list_union(char **list1, char **list2, char ***combined_list)
 {
 
     unsigned int c1 =0, c2 = 0, i=0, j=0;
@@ -141,11 +138,7 @@ krb5_error_code list_union(list1, list2, combined_list)
 }
 
 krb5_error_code
-filter(fp, cmd, k5users_list, k5users_filt_list)
-    FILE *fp;
-    char *cmd;
-    char **k5users_list;
-    char ***k5users_filt_list;
+filter(FILE *fp, char *cmd, char **k5users_list, char ***k5users_filt_list)
 {
 
     krb5_error_code retval =0;
@@ -195,10 +188,7 @@ filter(fp, cmd, k5users_list, k5users_filt_list)
 }
 
 krb5_error_code
-get_authorized_princ_names(luser, cmd, princ_list)
-    const char *luser;
-    char *cmd;
-    char ***princ_list;
+get_authorized_princ_names(const char *luser, char *cmd, char ***princ_list)
 {
 
     struct passwd *pwd;
@@ -272,11 +262,8 @@ get_authorized_princ_names(luser, cmd, princ_list)
     return 0;
 }
 
-static void close_time(k5users_flag, users_fp, k5login_flag, login_fp)
-    int k5users_flag;
-    FILE *users_fp;
-    int k5login_flag;
-    FILE *login_fp;
+static void
+close_time(int k5users_flag, FILE *users_fp, int k5login_flag, FILE *login_fp)
 {
 
     if (!k5users_flag) fclose(users_fp);
@@ -284,9 +271,8 @@ static void close_time(k5users_flag, users_fp, k5login_flag, login_fp)
 
 }
 
-static krb5_boolean find_str_in_list(list , elm)
-    char **list;
-    char *elm;
+static krb5_boolean
+find_str_in_list(char **list, char *elm)
 {
 
     int i=0;
@@ -313,12 +299,9 @@ A principal is picked that has the best chance of getting in.
 
 **********************************************************************/
 
-
-krb5_error_code get_closest_principal(context, plist, client, found)
-    krb5_context context;
-    char **plist;
-    krb5_principal *client;
-    krb5_boolean *found;
+krb5_error_code
+get_closest_principal(krb5_context context, char **plist,
+                      krb5_principal *client, krb5_boolean *found)
 {
     krb5_error_code retval =0;
     krb5_principal temp_client, best_client = NULL;
@@ -385,12 +368,9 @@ find_either_ticket checks to see whether there is a ticket for the
    end server or tgt, if neither is there the return FALSE,
 *****************************************************************/
 
-krb5_error_code find_either_ticket (context, cc, client, end_server, found)
-    krb5_context context;
-    krb5_ccache cc;
-    krb5_principal client;
-    krb5_principal end_server;
-    krb5_boolean *found;
+krb5_error_code
+find_either_ticket(krb5_context context, krb5_ccache cc, krb5_principal client,
+                   krb5_principal end_server, krb5_boolean *found)
 {
 
     krb5_principal kdc_server;
@@ -424,13 +404,9 @@ krb5_error_code find_either_ticket (context, cc, client, end_server, found)
     return 0;
 }
 
-
-krb5_error_code find_ticket (context, cc, client, server, found)
-    krb5_context context;
-    krb5_ccache cc;
-    krb5_principal client;
-    krb5_principal server;
-    krb5_boolean *found;
+krb5_error_code
+find_ticket(krb5_context context, krb5_ccache cc, krb5_principal client,
+            krb5_principal server, krb5_boolean *found)
 {
 
     krb5_creds tgt, tgtq;
@@ -470,13 +446,9 @@ krb5_error_code find_ticket (context, cc, client, server, found)
     return 0;
 }
 
-
-
-krb5_error_code find_princ_in_list (context, princ, plist, found)
-    krb5_context context;
-    krb5_principal princ;
-    char **plist;
-    krb5_boolean *found;
+krb5_error_code
+find_princ_in_list(krb5_context context, krb5_principal princ, char **plist,
+                   krb5_boolean *found)
 {
 
     int i=0;
@@ -516,21 +488,13 @@ path_out gets set to ...
 
 ***********************************************************************/
 
-krb5_error_code get_best_princ_for_target(context, source_uid, target_uid,
-                                          source_user, target_user,
-                                          cc_source, options, cmd,
-                                          hostname, client, path_out)
-    krb5_context context;
-    uid_t source_uid;
-    uid_t target_uid;
-    char *source_user;
-    char *target_user;
-    krb5_ccache cc_source;
-    krb5_get_init_creds_opt *options;
-    char *cmd;
-    char *hostname;
-    krb5_principal *client;
-    int *path_out;
+krb5_error_code
+get_best_princ_for_target(krb5_context context, uid_t source_uid,
+                          uid_t target_uid, char *source_user,
+                          char *target_user, krb5_ccache cc_source,
+                          krb5_get_init_creds_opt *options, char *cmd,
+                          char *hostname, krb5_principal *client,
+                          int *path_out)
 {
 
     princ_info princ_trials[10];

--- a/src/clients/ksu/krb_auth_su.c
+++ b/src/clients/ksu/krb_auth_su.c
@@ -29,18 +29,13 @@
 #include "ksu.h"
 
 
-void plain_dump_principal ();
+void plain_dump_principal(krb5_context, krb5_principal);
 
-krb5_boolean krb5_auth_check(context, client_pname, hostname, options,
-                             target_user, cc, path_passwd, target_uid)
-    krb5_context context;
-    krb5_principal client_pname;
-    char *hostname;
-    krb5_get_init_creds_opt *options;
-    char *target_user;
-    uid_t target_uid;
-    krb5_ccache cc;
-    int *path_passwd;
+krb5_boolean
+krb5_auth_check(krb5_context context, krb5_principal client_pname,
+                char *hostname, krb5_get_init_creds_opt *options,
+                char *target_user, krb5_ccache cc, int *path_passwd,
+                uid_t target_uid)
 {
     krb5_principal client;
     krb5_verify_init_creds_opt vfy_opts;
@@ -137,13 +132,10 @@ krb5_boolean krb5_auth_check(context, client_pname, hostname, options,
     return (TRUE);
 }
 
-krb5_boolean ksu_get_tgt_via_passwd(context, client, options, zero_password,
-                                    creds_out)
-    krb5_context context;
-    krb5_principal client;
-    krb5_get_init_creds_opt *options;
-    krb5_boolean *zero_password;
-    krb5_creds *creds_out;
+krb5_boolean
+ksu_get_tgt_via_passwd(krb5_context context, krb5_principal client,
+                       krb5_get_init_creds_opt *options,
+                       krb5_boolean *zero_password, krb5_creds *creds_out)
 {
     krb5_error_code code;
     krb5_creds creds;
@@ -212,11 +204,8 @@ krb5_boolean ksu_get_tgt_via_passwd(context, client, options, zero_password,
     return (TRUE);
 }
 
-
-void dump_principal (context, str, p)
-    krb5_context context;
-    char *str;
-    krb5_principal p;
+void
+dump_principal(krb5_context context, char *str, krb5_principal p)
 {
     char * stname;
     krb5_error_code retval;
@@ -228,9 +217,8 @@ void dump_principal (context, str, p)
     fprintf(stderr, " %s: %s\n", str, stname);
 }
 
-void plain_dump_principal (context, p)
-    krb5_context context;
-    krb5_principal p;
+void
+plain_dump_principal (krb5_context context, krb5_principal p)
 {
     char * stname;
     krb5_error_code retval;
@@ -251,11 +239,8 @@ A principal is picked that has the best chance of getting in.
 
 **********************************************************************/
 
-
-krb5_error_code get_best_principal(context, plist, client)
-    krb5_context context;
-    char **plist;
-    krb5_principal *client;
+krb5_error_code
+get_best_principal(krb5_context context, char **plist, krb5_principal *client)
 {
     krb5_error_code retval =0;
     krb5_principal temp_client, best_client = NULL;

--- a/src/clients/ksu/main.c
+++ b/src/clients/ksu/main.c
@@ -64,7 +64,9 @@ static krb5_error_code resolve_target_cache(krb5_context ksu_context,
 /* insure the proper specification of target user as well as catching
    ill specified arguments to commands */
 
-void usage (){
+void
+usage(void)
+{
     fprintf(stderr,
             _("Usage: %s [target user] [-n principal] [-c source cachename] "
               "[-k] [-r time] [-p|-P] [-f|-F] [-l lifetime] [-zZ] [-q] "
@@ -80,9 +82,7 @@ void usage (){
 static uid_t source_uid, target_uid;
 
 int
-main (argc, argv)
-    int argc;
-    char ** argv;
+main(int argc, char ** argv)
 {
     int hp =0;
     int some_rest_copy = 0;
@@ -114,7 +114,6 @@ main (argc, argv)
     char ** params;
     int keep_target_cache = 0;
     int child_pid, child_pgrp, ret_pid;
-    extern char * getpass(), *crypt();
     int pargc;
     char ** pargv;
     krb5_boolean stored = FALSE, cc_reused = FALSE, given_princ = FALSE;
@@ -965,11 +964,10 @@ cleanup:
 
 #ifdef HAVE_GETUSERSHELL
 
-int standard_shell(sh)
-    char *sh;
+int
+standard_shell(char *sh)
 {
     char *cp;
-    char *getusershell();
 
     while ((cp = getusershell()) != NULL)
         if (!strcmp(cp, sh))
@@ -979,7 +977,8 @@ int standard_shell(sh)
 
 #endif /* HAVE_GETUSERSHELL */
 
-static char * ontty()
+static char *
+ontty(void)
 {
     char *p;
     static char buf[MAXPATHLEN + 5];
@@ -996,10 +995,8 @@ static char * ontty()
     return (buf);
 }
 
-
-static int set_env_var(name, value)
-    char *name;
-    char *value;
+static int
+set_env_var(char *name, char *value)
 {
     char * env_var_buf;
 
@@ -1008,9 +1005,8 @@ static int set_env_var(name, value)
 
 }
 
-static void sweep_up(context, cc)
-    krb5_context context;
-    krb5_ccache cc;
+static void
+sweep_up(krb5_context context, krb5_ccache cc)
 {
     krb5_error_code retval;
 
@@ -1038,11 +1034,7 @@ get_params is to be called for the -a option or -e option to
 *****************************************************************/
 
 krb5_error_code
-get_params(optindex, pargc, pargv, params)
-    int *optindex;
-    int pargc;
-    char **pargv;
-    char ***params;
+get_params(int *optindex, int pargc, char **pargv, char ***params)
 {
 
     int i,j;
@@ -1075,10 +1067,8 @@ void print_status(const char *fmt, ...)
 }
 
 krb5_error_code
-ksu_tgtname(context, server, client, tgtprinc)
-    krb5_context context;
-    const krb5_data *server, *client;
-    krb5_principal *tgtprinc;
+ksu_tgtname(krb5_context context, const krb5_data *server,
+            const krb5_data *client, krb5_principal *tgtprinc)
 {
     return krb5_build_principal_ext(context, tgtprinc, client->length, client->data,
                                     KRB5_TGS_NAME_SIZE, KRB5_TGS_NAME,

--- a/src/clients/kvno/kvno.c
+++ b/src/clients/kvno/kvno.c
@@ -39,7 +39,7 @@ static char *prog;
 static int quiet = 0;
 
 static void
-xusage()
+xusage(void)
 {
     fprintf(stderr, _("usage: %s [-c ccache] [-e etype] [-k keytab] [-q] "
                       "[-u | -S sname]\n"

--- a/src/include/gssrpc/auth_gssapi.h
+++ b/src/include/gssrpc/auth_gssapi.h
@@ -82,14 +82,12 @@ bool_t xdr_authgssapi_init_res(XDR *, auth_gssapi_init_res *);
 
 bool_t auth_gssapi_wrap_data
 (OM_uint32 *major, OM_uint32 *minor,
-	   gss_ctx_id_t context, uint32_t seq_num, XDR
-	   *out_xdrs, bool_t (*xdr_func)(), caddr_t
-	   xdr_ptr);
+	   gss_ctx_id_t context, uint32_t seq_num,
+	   XDR *out_xdrs, xdrproc_t xdr_func, caddr_t xdr_ptr);
 bool_t auth_gssapi_unwrap_data
 (OM_uint32 *major, OM_uint32 *minor,
-	   gss_ctx_id_t context, uint32_t seq_num, XDR
-	   *in_xdrs, bool_t (*xdr_func)(), caddr_t
-	   xdr_ptr);
+	   gss_ctx_id_t context, uint32_t seq_num,
+	   XDR *in_xdrs, xdrproc_t xdr_func, caddr_t xdr_ptr);
 
 AUTH *auth_gssapi_create
 (CLIENT *clnt,

--- a/src/include/gssrpc/xdr.h
+++ b/src/include/gssrpc/xdr.h
@@ -102,7 +102,6 @@ enum xdr_op {
  *
  * XXX can't actually prototype it, because some take three args!!!
  */
-typedef	bool_t (*xdrproc_t)();
 
 /*
  * The XDR handle.
@@ -142,6 +141,8 @@ typedef struct XDR {
 	caddr_t 	x_base;		/* private used for position info */
 	int		x_handy;	/* extra private word */
 } XDR;
+
+typedef	bool_t (*xdrproc_t)(XDR *, void *);
 
 /*
  * Operations defined on a XDR handle

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -2239,7 +2239,7 @@ make_data(void *data, unsigned int len)
 }
 
 static inline krb5_data
-empty_data()
+empty_data(void)
 {
     return make_data(NULL, 0);
 }

--- a/src/include/k5-plugin.h
+++ b/src/include/k5-plugin.h
@@ -97,7 +97,7 @@ krb5int_get_plugin_data (struct plugin_file_handle *, const char *, void **,
 
 long KRB5_CALLCONV
 krb5int_get_plugin_func (struct plugin_file_handle *, const char *,
-                         void (**)(), struct errinfo *);
+                         void (**)(void), struct errinfo *);
 
 
 long KRB5_CALLCONV

--- a/src/include/net-server.h
+++ b/src/include/net-server.h
@@ -30,6 +30,7 @@
 #define NET_SERVER_H
 
 #include <verto.h>
+#include <gssrpc/rpc.h>
 
 /* The delimiter characters supported by the addresses string. */
 #define ADDRESSES_DELIM ",; "
@@ -64,13 +65,14 @@ krb5_error_code loop_add_udp_address(int default_port, const char *addresses);
 krb5_error_code loop_add_tcp_address(int default_port, const char *addresses);
 krb5_error_code loop_add_rpc_service(int default_port, const char *addresses,
                                      u_long prognum, u_long versnum,
-                                     void (*dispatchfn)());
+                                     void (*dispatchfn)(struct svc_req *,
+                                                        SVCXPRT *));
 
 krb5_error_code loop_setup_network(verto_ctx *ctx, void *handle,
                                    const char *progname,
                                    int tcp_listen_backlog);
 krb5_error_code loop_setup_signals(verto_ctx *ctx, void *handle,
-                                   void (*reset)());
+                                   void (*reset)(void *));
 void loop_free(verto_ctx *ctx);
 
 /* to be supplied by the server application */

--- a/src/kadmin/cli/getdate.y
+++ b/src/kadmin/cli/getdate.y
@@ -100,9 +100,6 @@ struct my_timeb {
 #define bcopy(from, to, len) memcpy ((to), (from), (len))
 #endif
 
-extern struct tm	*gmtime();
-extern struct tm	*localtime();
-
 #define yyparse getdate_yyparse
 #define yylex getdate_yylex
 #define yyerror getdate_yyerror

--- a/src/kadmin/cli/kadmin.c
+++ b/src/kadmin/cli/kadmin.c
@@ -98,7 +98,7 @@ error(const char *fmt, ...)
 }
 
 static void
-usage()
+usage(void)
 {
     error(_("Usage: %s [-r realm] [-p principal] [-q query] "
             "[clnt|local args]\n"
@@ -1130,7 +1130,7 @@ kadmin_parse_princ_args(int argc, char *argv[], kadm5_principal_ent_t oprinc,
 }
 
 static void
-kadmin_addprinc_usage()
+kadmin_addprinc_usage(void)
 {
     error(_("usage: add_principal [options] principal\n"));
     error(_("\toptions are:\n"));
@@ -1154,7 +1154,7 @@ kadmin_addprinc_usage()
 }
 
 static void
-kadmin_modprinc_usage()
+kadmin_modprinc_usage(void)
 {
     error(_("usage: modify_principal [options] principal\n"));
     error(_("\toptions are:\n"));

--- a/src/kadmin/cli/keytab.c
+++ b/src/kadmin/cli/keytab.c
@@ -50,14 +50,14 @@ static int quiet;
 static int norandkey;
 
 static void
-add_usage()
+add_usage(void)
 {
     fprintf(stderr, _("Usage: ktadd [-k[eytab] keytab] [-q] [-e keysaltlist] "
                       "[-norandkey] [principal | -glob princ-exp] [...]\n"));
 }
 
 static void
-rem_usage()
+rem_usage(void)
 {
     fprintf(stderr, _("Usage: ktremove [-k[eytab] keytab] [-q] principal "
                       "[kvno|\"all\"|\"old\"]\n"));

--- a/src/kadmin/dbutil/kdb5_create.c
+++ b/src/kadmin/dbutil/kdb5_create.c
@@ -139,9 +139,8 @@ extern int exit_status;
 extern kadm5_config_params global_params;
 extern krb5_context util_context;
 
-void kdb5_create(argc, argv)
-    int argc;
-    char *argv[];
+void
+kdb5_create(int argc, char *argv[])
 {
     int optchar;
 
@@ -337,9 +336,7 @@ void kdb5_create(argc, argv)
 }
 
 static krb5_error_code
-tgt_keysalt_iterate(ksent, ptr)
-    krb5_key_salt_tuple *ksent;
-    krb5_pointer        ptr;
+tgt_keysalt_iterate(krb5_key_salt_tuple *ksent, krb5_pointer ptr)
 {
     krb5_context        context;
     krb5_error_code     kret;
@@ -378,11 +375,8 @@ tgt_keysalt_iterate(ksent, ptr)
 }
 
 static krb5_error_code
-add_principal(context, princ, op, pblock)
-    krb5_context context;
-    krb5_principal princ;
-    enum ap_op op;
-    struct realm_info *pblock;
+add_principal(krb5_context context, krb5_principal princ, enum ap_op op,
+              struct realm_info *pblock)
 {
     krb5_error_code       retval;
     krb5_db_entry         *entry = NULL;

--- a/src/kadmin/dbutil/kdb5_destroy.c
+++ b/src/kadmin/dbutil/kdb5_destroy.c
@@ -39,9 +39,7 @@ char *yes = "yes\n";                    /* \n to compare against result of
                                            fgets */
 
 void
-kdb5_destroy(argc, argv)
-    int argc;
-    char *argv[];
+kdb5_destroy(int argc, char *argv[])
 {
     extern int optind;
     int optchar;

--- a/src/kadmin/dbutil/kdb5_stash.c
+++ b/src/kadmin/dbutil/kdb5_stash.c
@@ -63,9 +63,7 @@ extern int exit_status;
 extern int close_policy_db;
 
 void
-kdb5_stash(argc, argv)
-    int argc;
-    char *argv[];
+kdb5_stash(int argc, char *argv[])
 {
     extern char *optarg;
     extern int optind;

--- a/src/kadmin/dbutil/kdb5_util.c
+++ b/src/kadmin/dbutil/kdb5_util.c
@@ -143,8 +143,8 @@ struct _cmd_table {
     {NULL, NULL, 0},
 };
 
-static struct _cmd_table *cmd_lookup(name)
-    char *name;
+static struct _cmd_table *
+cmd_lookup(char *name)
 {
     struct _cmd_table *cmd = cmd_table;
     while (cmd->name) {
@@ -162,8 +162,9 @@ static struct _cmd_table *cmd_lookup(name)
 char **db5util_db_args = NULL;
 int    db5util_db_args_size = 0;
 
-static void extended_com_err_fn (const char *myprog, errcode_t code,
-                                 const char *fmt, va_list args)
+static void
+extended_com_err_fn(const char *myprog, errcode_t code, const char *fmt,
+                    va_list args)
 {
     const char *emsg;
     if (code) {
@@ -177,7 +178,8 @@ static void extended_com_err_fn (const char *myprog, errcode_t code,
     fprintf (stderr, "\n");
 }
 
-int add_db_arg(char *arg)
+int
+add_db_arg(char *arg)
 {
     char **temp;
     db5util_db_args_size++;
@@ -191,9 +193,8 @@ int add_db_arg(char *arg)
     return 1;
 }
 
-int main(argc, argv)
-    int argc;
-    char *argv[];
+int
+main(int argc, char *argv[])
 {
     struct _cmd_table *cmd = NULL;
     char *koptarg, **cmd_argv;
@@ -365,7 +366,8 @@ int main(argc, argv)
  * cannot be fetched (the master key stash file may not exist when the
  * program is run).
  */
-static int open_db_and_mkey()
+static int
+open_db_and_mkey()
 {
     krb5_error_code retval;
     krb5_data scratch, pwd, seed;
@@ -508,9 +510,7 @@ quit()
 }
 
 static void
-add_random_key(argc, argv)
-    int argc;
-    char **argv;
+add_random_key(int argc, char **argv)
 {
     krb5_error_code ret;
     krb5_principal princ;

--- a/src/kadmin/dbutil/ovload.c
+++ b/src/kadmin/dbutil/ovload.c
@@ -11,9 +11,8 @@
 
 #define LINESIZE        32768 /* XXX */
 
-static int parse_pw_hist_ent(current, hist)
-    char *current;
-    osa_pw_hist_ent *hist;
+static int
+parse_pw_hist_ent(char *current, osa_pw_hist_ent *hist)
 {
     int tmp, i, j, ret;
     char *cp;
@@ -90,12 +89,9 @@ done:
  *      [modifies]
  *
  */
-int process_ov_principal(kcontext, fname, filep, verbose, linenop)
-    krb5_context        kcontext;
-    const char          *fname;
-    FILE                *filep;
-    krb5_boolean        verbose;
-    int                 *linenop;
+int
+process_ov_principal(krb5_context kcontext, const char *fname, FILE *filep,
+                     krb5_boolean verbose, int *linenop)
 {
     XDR                     xdrs;
     osa_princ_ent_t         rec;

--- a/src/kadmin/dbutil/strtok.c
+++ b/src/kadmin/dbutil/strtok.c
@@ -50,9 +50,7 @@
  */
 
 char *
-nstrtok(s, delim)
-    char *s;
-    const char *delim;
+nstrtok(char *s, const char *delim)
 {
     const char *spanp;
     int c, sc;

--- a/src/kadmin/ktutil/ktutil.c
+++ b/src/kadmin/ktutil/ktutil.c
@@ -39,9 +39,8 @@ extern ss_request_table ktutil_cmds;
 krb5_context kcontext;
 krb5_kt_list ktlist = NULL;
 
-int main(argc, argv)
-    int argc;
-    char *argv[];
+int
+main(int argc, char *argv[])
 {
     krb5_error_code retval;
     int sci_idx;
@@ -63,9 +62,8 @@ int main(argc, argv)
     exit(0);
 }
 
-void ktutil_clear_list(argc, argv)
-    int argc;
-    char *argv[];
+void
+ktutil_clear_list(int argc, char *argv[])
 {
     krb5_error_code retval;
 
@@ -79,9 +77,8 @@ void ktutil_clear_list(argc, argv)
     ktlist = NULL;
 }
 
-void ktutil_read_v5(argc, argv)
-    int argc;
-    char *argv[];
+void
+ktutil_read_v5(int argc, char *argv[])
 {
     krb5_error_code retval;
 
@@ -94,17 +91,15 @@ void ktutil_read_v5(argc, argv)
         com_err(argv[0], retval, _("while reading keytab \"%s\""), argv[1]);
 }
 
-void ktutil_read_v4(argc, argv)
-    int argc;
-    char *argv[];
+void
+ktutil_read_v4(int argc, char *argv[])
 {
     fprintf(stderr, _("%s: reading srvtabs is no longer supported\n"),
             argv[0]);
 }
 
-void ktutil_write_v5(argc, argv)
-    int argc;
-    char *argv[];
+void
+ktutil_write_v5(int argc, char *argv[])
 {
     krb5_error_code retval;
 
@@ -117,17 +112,15 @@ void ktutil_write_v5(argc, argv)
         com_err(argv[0], retval, _("while writing keytab \"%s\""), argv[1]);
 }
 
-void ktutil_write_v4(argc, argv)
-    int argc;
-    char *argv[];
+void
+ktutil_write_v4(int argc, char *argv[])
 {
     fprintf(stderr, _("%s: writing srvtabs is no longer supported\n"),
             argv[0]);
 }
 
-void ktutil_add_entry(argc, argv)
-    int argc;
-    char *argv[];
+void
+ktutil_add_entry(int argc, char *argv[])
 {
     krb5_error_code retval;
     char *princ = NULL;
@@ -183,9 +176,8 @@ void ktutil_add_entry(argc, argv)
         com_err(argv[0], retval, _("while adding new entry"));
 }
 
-void ktutil_delete_entry(argc, argv)
-    int argc;
-    char *argv[];
+void
+ktutil_delete_entry(int argc, char *argv[])
 {
     krb5_error_code retval;
 
@@ -198,9 +190,8 @@ void ktutil_delete_entry(argc, argv)
         com_err(argv[0], retval, _("while deleting entry %d"), atoi(argv[1]));
 }
 
-void ktutil_list(argc, argv)
-    int argc;
-    char *argv[];
+void
+ktutil_list(int argc, char *argv[])
 {
     krb5_error_code retval;
     krb5_kt_list lp;

--- a/src/kadmin/ktutil/ktutil_funcs.c
+++ b/src/kadmin/ktutil/ktutil_funcs.c
@@ -37,9 +37,8 @@
 /*
  * Free a kt_list
  */
-krb5_error_code ktutil_free_kt_list(context, list)
-    krb5_context context;
-    krb5_kt_list list;
+krb5_error_code
+ktutil_free_kt_list(krb5_context context, krb5_kt_list list)
 {
     krb5_kt_list lp, prev;
     krb5_error_code retval = 0;
@@ -60,10 +59,8 @@ krb5_error_code ktutil_free_kt_list(context, list)
  * Delete a numbered entry in a kt_list.  Takes a pointer to a kt_list
  * in case head gets deleted.
  */
-krb5_error_code ktutil_delete(context, list, idx)
-    krb5_context context;
-    krb5_kt_list *list;
-    int idx;
+krb5_error_code
+ktutil_delete(krb5_context context, krb5_kt_list *list, int idx)
 {
     krb5_kt_list lp, prev;
     int i;
@@ -138,16 +135,10 @@ get_etype_info(krb5_context context, krb5_principal princ, int fetch,
  * password or key.  If the keytab list is NULL, allocate a new
  * one first.
  */
-krb5_error_code ktutil_add(context, list, princ_str, fetch, kvno,
-                           enctype_str, use_pass, salt_str)
-    krb5_context context;
-    krb5_kt_list *list;
-    char *princ_str;
-    int fetch;
-    krb5_kvno kvno;
-    char *enctype_str;
-    int use_pass;
-    char *salt_str;
+krb5_error_code
+ktutil_add(krb5_context context, krb5_kt_list *list, char *princ_str,
+           int fetch, krb5_kvno kvno, char *enctype_str, int use_pass,
+           char *salt_str)
 {
     krb5_keytab_entry *entry = NULL;
     krb5_kt_list lp, *last;
@@ -269,10 +260,8 @@ cleanup:
  * Read in a keytab and append it to list.  If list starts as NULL,
  * allocate a new one if necessary.
  */
-krb5_error_code ktutil_read_keytab(context, name, list)
-    krb5_context context;
-    char *name;
-    krb5_kt_list *list;
+krb5_error_code
+ktutil_read_keytab(krb5_context context, char *name, krb5_kt_list *list)
 {
     krb5_kt_list lp = NULL, tail = NULL, back = NULL;
     krb5_keytab kt;
@@ -344,10 +333,8 @@ close_kt:
 /*
  * Takes a kt_list and writes it to the named keytab.
  */
-krb5_error_code ktutil_write_keytab(context, list, name)
-    krb5_context context;
-    krb5_kt_list list;
-    char *name;
+krb5_error_code
+ktutil_write_keytab(krb5_context context, krb5_kt_list list, char *name)
 {
     krb5_kt_list lp;
     krb5_keytab kt;

--- a/src/kadmin/server/ipropd_svc.c
+++ b/src/kadmin/server/ipropd_svc.c
@@ -535,8 +535,8 @@ krb5_iprop_prog_1(struct svc_req *rqstp,
 	kdb_last_t iprop_get_updates_1_arg;
     } argument;
     void *result;
-    bool_t (*_xdr_argument)(), (*_xdr_result)();
-    void *(*local)(/* union XXX *, struct svc_req * */);
+    xdrproc_t _xdr_argument, _xdr_result;
+    void *(*local)(char *, struct svc_req *);
     char *whoami = "krb5_iprop_prog_1";
 
     if (!check_iprop_rpcsec_auth(rqstp)) {
@@ -555,21 +555,21 @@ krb5_iprop_prog_1(struct svc_req *rqstp,
 	return;
 
     case IPROP_GET_UPDATES:
-	_xdr_argument = xdr_kdb_last_t;
-	_xdr_result = xdr_kdb_incr_result_t;
-	local = (void *(*)()) iprop_get_updates_1_svc;
+	_xdr_argument = (xdrproc_t)xdr_kdb_last_t;
+	_xdr_result = (xdrproc_t)xdr_kdb_incr_result_t;
+	local = (void *(*)(char *, struct svc_req *))iprop_get_updates_1_svc;
 	break;
 
     case IPROP_FULL_RESYNC:
-	_xdr_argument = xdr_void;
-	_xdr_result = xdr_kdb_fullresync_result_t;
-	local = (void *(*)()) iprop_full_resync_1_svc;
+	_xdr_argument = (xdrproc_t)xdr_void;
+	_xdr_result = (xdrproc_t)xdr_kdb_fullresync_result_t;
+	local = (void *(*)(char *, struct svc_req *))iprop_full_resync_1_svc;
 	break;
 
     case IPROP_FULL_RESYNC_EXT:
-	_xdr_argument = xdr_u_int32;
-	_xdr_result = xdr_kdb_fullresync_result_t;
-	local = (void *(*)()) iprop_full_resync_ext_1_svc;
+	_xdr_argument = (xdrproc_t)xdr_u_int32;
+	_xdr_result = (xdrproc_t)xdr_kdb_fullresync_result_t;
+	local = (void *(*)(char *, struct svc_req *))iprop_full_resync_ext_1_svc;
 	break;
 
     default:
@@ -587,7 +587,7 @@ krb5_iprop_prog_1(struct svc_req *rqstp,
 	svcerr_decode(transp);
 	return;
     }
-    result = (*local)(&argument, rqstp);
+    result = (*local)((char *)&argument, rqstp);
 
     if (_xdr_result && result != NULL &&
 	!svc_sendreply(transp, _xdr_result, result)) {

--- a/src/kadmin/server/kadm_rpc_svc.c
+++ b/src/kadmin/server/kadm_rpc_svc.c
@@ -9,6 +9,7 @@
 #include <gssapi/gssapi_krb5.h> /* for gss_nt_krb5_name */
 #include <syslog.h>
 #include <kadm5/kadm_rpc.h>
+#include <kadm5/admin_xdr.h>
 #include <krb5.h>
 #include <kadm5/admin.h>
 #include <adm_proto.h>
@@ -36,9 +37,8 @@ static int check_rpcsec_auth(struct svc_req *);
  * Modifies:
  */
 
-void kadm_1(rqstp, transp)
-   struct svc_req *rqstp;
-   SVCXPRT *transp;
+void
+kadm_1(struct svc_req *rqstp, SVCXPRT *transp)
 {
      union {
 	  cprinc_arg create_principal_2_arg;
@@ -73,8 +73,8 @@ void kadm_1(rqstp, transp)
 	  getpkeys_ret get_principal_keys_ret;
      } result;
      bool_t retval;
-     bool_t (*xdr_argument)(), (*xdr_result)();
-     bool_t (*local)();
+     xdrproc_t xdr_argument, xdr_result;
+     bool_t (*local)(char *, void *, struct svc_req *);
 
      if (rqstp->rq_cred.oa_flavor != AUTH_GSSAPI &&
 	 !check_rpcsec_auth(rqstp)) {
@@ -92,153 +92,153 @@ void kadm_1(rqstp, transp)
 	  return;
 
      case CREATE_PRINCIPAL:
-	  xdr_argument = xdr_cprinc_arg;
-	  xdr_result = xdr_generic_ret;
-	  local = (bool_t (*)()) create_principal_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_cprinc_arg;
+	  xdr_result = (xdrproc_t)xdr_generic_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))create_principal_2_svc;
 	  break;
 
      case DELETE_PRINCIPAL:
-	  xdr_argument = xdr_dprinc_arg;
-	  xdr_result = xdr_generic_ret;
-	  local = (bool_t (*)()) delete_principal_2_svc;
+          xdr_argument = (xdrproc_t)xdr_dprinc_arg;
+	  xdr_result = (xdrproc_t)xdr_generic_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))delete_principal_2_svc;
 	  break;
 
      case MODIFY_PRINCIPAL:
-	  xdr_argument = xdr_mprinc_arg;
-	  xdr_result = xdr_generic_ret;
-	  local = (bool_t (*)()) modify_principal_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_mprinc_arg;
+	  xdr_result = (xdrproc_t)xdr_generic_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))modify_principal_2_svc;
 	  break;
 
      case RENAME_PRINCIPAL:
-	  xdr_argument = xdr_rprinc_arg;
-	  xdr_result = xdr_generic_ret;
-	  local = (bool_t (*)()) rename_principal_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_rprinc_arg;
+	  xdr_result = (xdrproc_t)xdr_generic_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))rename_principal_2_svc;
 	  break;
 
      case GET_PRINCIPAL:
-	  xdr_argument = xdr_gprinc_arg;
-	  xdr_result = xdr_gprinc_ret;
-	  local = (bool_t (*)()) get_principal_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_gprinc_arg;
+	  xdr_result = (xdrproc_t)xdr_gprinc_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))get_principal_2_svc;
 	  break;
 
      case GET_PRINCS:
-	  xdr_argument = xdr_gprincs_arg;
-	  xdr_result = xdr_gprincs_ret;
-	  local = (bool_t (*)()) get_princs_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_gprincs_arg;
+	  xdr_result = (xdrproc_t)xdr_gprincs_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))get_princs_2_svc;
 	  break;
 
      case CHPASS_PRINCIPAL:
-	  xdr_argument = xdr_chpass_arg;
-	  xdr_result = xdr_generic_ret;
-	  local = (bool_t (*)()) chpass_principal_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_chpass_arg;
+	  xdr_result = (xdrproc_t)xdr_generic_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))chpass_principal_2_svc;
 	  break;
 
      case SETKEY_PRINCIPAL:
-	  xdr_argument = xdr_setkey_arg;
-	  xdr_result = xdr_generic_ret;
-	  local = (bool_t (*)()) setkey_principal_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_setkey_arg;
+	  xdr_result = (xdrproc_t)xdr_generic_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))setkey_principal_2_svc;
 	  break;
 
      case CHRAND_PRINCIPAL:
-	  xdr_argument = xdr_chrand_arg;
-	  xdr_result = xdr_chrand_ret;
-	  local = (bool_t (*)()) chrand_principal_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_chrand_arg;
+	  xdr_result = (xdrproc_t)xdr_chrand_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))chrand_principal_2_svc;
 	  break;
 
      case CREATE_POLICY:
-	  xdr_argument = xdr_cpol_arg;
-	  xdr_result = xdr_generic_ret;
-	  local = (bool_t (*)()) create_policy_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_cpol_arg;
+	  xdr_result = (xdrproc_t)xdr_generic_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))create_policy_2_svc;
 	  break;
 
      case DELETE_POLICY:
-	  xdr_argument = xdr_dpol_arg;
-	  xdr_result = xdr_generic_ret;
-	  local = (bool_t (*)()) delete_policy_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_dpol_arg;
+	  xdr_result = (xdrproc_t)xdr_generic_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))delete_policy_2_svc;
 	  break;
 
      case MODIFY_POLICY:
-	  xdr_argument = xdr_mpol_arg;
-	  xdr_result = xdr_generic_ret;
-	  local = (bool_t (*)()) modify_policy_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_mpol_arg;
+	  xdr_result = (xdrproc_t)xdr_generic_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))modify_policy_2_svc;
 	  break;
 
      case GET_POLICY:
-	  xdr_argument = xdr_gpol_arg;
-	  xdr_result = xdr_gpol_ret;
-	  local = (bool_t (*)()) get_policy_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_gpol_arg;
+	  xdr_result = (xdrproc_t)xdr_gpol_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))get_policy_2_svc;
 	  break;
 
      case GET_POLS:
-	  xdr_argument = xdr_gpols_arg;
-	  xdr_result = xdr_gpols_ret;
-	  local = (bool_t (*)()) get_pols_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_gpols_arg;
+	  xdr_result = (xdrproc_t)xdr_gpols_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))get_pols_2_svc;
 	  break;
 
      case GET_PRIVS:
-	  xdr_argument = xdr_u_int32;
-	  xdr_result = xdr_getprivs_ret;
-	  local = (bool_t (*)()) get_privs_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_u_int32;
+	  xdr_result = (xdrproc_t)xdr_getprivs_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))get_privs_2_svc;
 	  break;
 
      case INIT:
-	  xdr_argument = xdr_u_int32;
-	  xdr_result = xdr_generic_ret;
-	  local = (bool_t (*)()) init_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_u_int32;
+	  xdr_result = (xdrproc_t)xdr_generic_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))init_2_svc;
 	  break;
 
      case CREATE_PRINCIPAL3:
-	  xdr_argument = xdr_cprinc3_arg;
-	  xdr_result = xdr_generic_ret;
-	  local = (bool_t (*)()) create_principal3_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_cprinc3_arg;
+	  xdr_result = (xdrproc_t)xdr_generic_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))create_principal3_2_svc;
 	  break;
 
      case CHPASS_PRINCIPAL3:
-	  xdr_argument = xdr_chpass3_arg;
-	  xdr_result = xdr_generic_ret;
-	  local = (bool_t (*)()) chpass_principal3_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_chpass3_arg;
+	  xdr_result = (xdrproc_t)xdr_generic_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))chpass_principal3_2_svc;
 	  break;
 
      case CHRAND_PRINCIPAL3:
-	  xdr_argument = xdr_chrand3_arg;
-	  xdr_result = xdr_chrand_ret;
-	  local = (bool_t (*)()) chrand_principal3_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_chrand3_arg;
+	  xdr_result = (xdrproc_t)xdr_chrand_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))chrand_principal3_2_svc;
 	  break;
 
      case SETKEY_PRINCIPAL3:
-	  xdr_argument = xdr_setkey3_arg;
-	  xdr_result = xdr_generic_ret;
-	  local = (bool_t (*)()) setkey_principal3_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_setkey3_arg;
+	  xdr_result = (xdrproc_t)xdr_generic_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))setkey_principal3_2_svc;
 	  break;
 
      case PURGEKEYS:
-	  xdr_argument = xdr_purgekeys_arg;
-	  xdr_result = xdr_generic_ret;
-	  local = (bool_t (*)()) purgekeys_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_purgekeys_arg;
+	  xdr_result = (xdrproc_t)xdr_generic_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))purgekeys_2_svc;
 	  break;
 
      case GET_STRINGS:
-	  xdr_argument = xdr_gstrings_arg;
-	  xdr_result = xdr_gstrings_ret;
-	  local = (bool_t (*)()) get_strings_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_gstrings_arg;
+	  xdr_result = (xdrproc_t)xdr_gstrings_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))get_strings_2_svc;
 	  break;
 
      case SET_STRING:
-	  xdr_argument = xdr_sstring_arg;
-	  xdr_result = xdr_generic_ret;
-	  local = (bool_t (*)()) set_string_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_sstring_arg;
+	  xdr_result = (xdrproc_t)xdr_generic_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))set_string_2_svc;
 	  break;
 
      case SETKEY_PRINCIPAL4:
-	  xdr_argument = xdr_setkey4_arg;
-	  xdr_result = xdr_generic_ret;
-	  local = (bool_t (*)()) setkey_principal4_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_setkey4_arg;
+	  xdr_result = (xdrproc_t)xdr_generic_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))setkey_principal4_2_svc;
 	  break;
 
      case EXTRACT_KEYS:
-	  xdr_argument = xdr_getpkeys_arg;
-	  xdr_result = xdr_getpkeys_ret;
-	  local = (bool_t (*)()) get_principal_keys_2_svc;
+	  xdr_argument = (xdrproc_t)xdr_getpkeys_arg;
+	  xdr_result = (xdrproc_t)xdr_getpkeys_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))get_principal_keys_2_svc;
 	  break;
 
      default:
@@ -253,7 +253,7 @@ void kadm_1(rqstp, transp)
 	  return;
      }
      memset(&result, 0, sizeof(result));
-     retval = (*local)(&argument, &result, rqstp);
+     retval = (*local)((char *)&argument, &result, rqstp);
      if (retval && !svc_sendreply(transp, xdr_result, (void *)&result)) {
 	  krb5_klog_syslog(LOG_ERR, "WARNING! Unable to send function results, "
 		 "continuing.");

--- a/src/kadmin/server/ovsec_kadmd.c
+++ b/src/kadmin/server/ovsec_kadmd.c
@@ -77,7 +77,7 @@ static krb5_context context;
 static char *progname;
 
 static void
-usage()
+usage(void)
 {
     fprintf(stderr, _("Usage: kadmind [-x db_args]* [-r realm] [-m] [-nofork] "
                       "[-port port-number]\n"
@@ -173,7 +173,7 @@ setup_loop(kadm5_config_params *params, int proponly, verto_ctx **ctx_out)
 
 /* Point GSSAPI at the KDB keytab so we don't need an actual file keytab. */
 static krb5_error_code
-setup_kdb_keytab()
+setup_kdb_keytab(void)
 {
     krb5_error_code ret;
 

--- a/src/kdc/t_ndr.c
+++ b/src/kdc/t_ndr.c
@@ -173,7 +173,7 @@ test_dec_enc(uint8_t *blob, size_t len, char *name, int fail)
 #define RUN_TEST_FAIL(blob) test_dec_enc(blob, sizeof(blob), #blob, 1)
 
 int
-main()
+main(void)
 {
     printf("Running NDR tests...\n");
 

--- a/src/kdc/t_replay.c
+++ b/src/kdc/t_replay.c
@@ -570,7 +570,8 @@ test_kdc_insert_lookaside_cache_expire(void **state)
     assert_int_equal(total_size, e2_size);
 }
 
-int main()
+int
+main(void)
 {
     int ret;
 
@@ -611,7 +612,8 @@ int main()
 
 #else /* NOCACHE */
 
-int main()
+int
+main(void)
 {
     return 0;
 }

--- a/src/kprop/kpropd.c
+++ b/src/kprop/kpropd.c
@@ -165,7 +165,7 @@ static kadm5_ret_t kadm5_get_kiprop_host_srv_name(krb5_context context,
                                                   char **host_service_name);
 
 static void
-usage()
+usage(void)
 {
     fprintf(stderr,
             _("\nUsage: %s [-r realm] [-s keytab] [-d] [-D] [-S]\n"

--- a/src/kprop/kproplog.c
+++ b/src/kprop/kproplog.c
@@ -24,7 +24,7 @@
 static char *progname;
 
 static void
-usage()
+usage(void)
 {
     fprintf(stderr, _("\nUsage: %s [-h] [-v] [-v] [-e num]\n\t%s -R\n\n"),
             progname, progname);
@@ -393,7 +393,7 @@ print_update(kdb_hlog_t *ulog, uint32_t entry, uint32_t ulogentries,
                 print_attr(&upd.kdb_update.kdbe_t_val[j], verbose > 1 ? 1 : 0);
         }
 
-        xdr_free(xdr_kdb_incr_update_t, (char *)&upd);
+        xdr_free((xdrproc_t)xdr_kdb_incr_update_t, (char *)&upd);
         free(dbprinc);
     }
 }

--- a/src/lib/apputils/net-server.c
+++ b/src/lib/apputils/net-server.c
@@ -203,7 +203,7 @@ struct connection {
 struct rpc_svc_data {
     u_long prognum;
     u_long versnum;
-    void (*dispatch)();
+    void (*dispatch)(struct svc_req *, SVCXPRT *);
 };
 
 struct bind_address {
@@ -255,7 +255,7 @@ free_sighup_context(verto_ctx *ctx, verto_ev *ev)
 }
 
 krb5_error_code
-loop_setup_signals(verto_ctx *ctx, void *handle, void (*reset)())
+loop_setup_signals(verto_ctx *ctx, void *handle, void (*reset)(void *))
 {
     struct sighup_context *sc;
     verto_ev *ev;
@@ -434,7 +434,8 @@ loop_add_tcp_address(int default_port, const char *addresses)
 
 krb5_error_code
 loop_add_rpc_service(int default_port, const char *addresses, u_long prognum,
-                     u_long versnum, void (*dispatchfn)())
+                     u_long versnum,
+                     void (*dispatchfn)(struct svc_req *, SVCXPRT *))
 {
     struct rpc_svc_data svc;
 

--- a/src/lib/crypto/builtin/aes/aes-gen.c
+++ b/src/lib/crypto/builtin/aes/aes-gen.c
@@ -54,7 +54,8 @@ uint8_t test_case[NTESTS][4 * B] = {
 aes_encrypt_ctx ctx;
 aes_decrypt_ctx dctx;
 
-static void init ()
+static void
+init (void)
 {
     AES_RETURN r;
 
@@ -71,7 +72,8 @@ static void hexdump(const unsigned char *ptr, size_t len)
 	printf ("%s%02X", (i % 16 == 0) ? "\n    " : " ", ptr[i]);
 }
 
-static void fips_test ()
+static void
+fips_test (void)
 {
     static const unsigned char fipskey[16] = {
 	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
@@ -254,7 +256,8 @@ cts_dec (unsigned char *out, unsigned char *in, unsigned char *iv,
     memcpy(out+B, pn, len-B);
 }
 
-static void ecb_test ()
+static void
+ecb_test (void)
 {
     unsigned int testno;
     uint8_t output[4 * B], tmp[4 * B];
@@ -285,7 +288,8 @@ static void ecb_test ()
 
 unsigned char ivec[16] = { 0 };
 
-static void cbc_test ()
+static void
+cbc_test (void)
 {
     unsigned int testno;
     uint8_t output[4 * B], tmp[4 * B];
@@ -314,7 +318,8 @@ static void cbc_test ()
     printf ("\n");
 }
 
-static void cts_test ()
+static void
+cts_test (void)
 {
     unsigned int testno;
     uint8_t output[4 * B], tmp[4 * B];
@@ -339,7 +344,8 @@ static void cts_test ()
     printf ("\n");
 }
 
-int main ()
+int
+main (void)
 {
     init ();
     fips_test ();

--- a/src/lib/crypto/builtin/camellia/camellia-gen.c
+++ b/src/lib/crypto/builtin/camellia/camellia-gen.c
@@ -19,7 +19,8 @@ struct {
 } test_case[NTESTS];
 camellia_ctx ctx, dctx;
 
-static void init ()
+static void
+init (void)
 {
     size_t i, j;
     cam_rval r;
@@ -46,7 +47,8 @@ static void hexdump(const unsigned char *ptr, size_t len)
 	printf ("%s%02X", (i % 16 == 0) ? "\n    " : " ", ptr[i]);
 }
 
-static void fips_test ()
+static void
+fips_test (void)
 {
     static const unsigned char fipskey[16] = {
 	0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
@@ -234,7 +236,8 @@ cts_dec (unsigned char *out, unsigned char *in, unsigned char *iv,
     memcpy(out+B, pn, len-B);
 }
 
-static void ecb_test ()
+static void
+ecb_test (void)
 {
     size_t testno;
     unsigned char tmp[4*B];
@@ -265,7 +268,8 @@ static void ecb_test ()
 
 unsigned char ivec[16] = { 0 };
 
-static void cbc_test ()
+static void
+cbc_test (void)
 {
     size_t testno;
     unsigned char tmp[4*B];
@@ -294,7 +298,8 @@ static void cbc_test ()
     printf ("\n");
 }
 
-static void cts_test ()
+static void
+cts_test (void)
 {
     size_t testno;
     unsigned char tmp[4*B];
@@ -319,7 +324,8 @@ static void cts_test ()
     printf ("\n");
 }
 
-int main ()
+int
+main (void)
 {
     init ();
     fips_test ();

--- a/src/lib/crypto/builtin/des/des_int.h
+++ b/src/lib/crypto/builtin/des/des_int.h
@@ -203,9 +203,6 @@ krb5_error_code mit_des_combine_subkeys(const krb5_keyblock *,
                                         const krb5_keyblock *,
                                         krb5_keyblock **);
 
-/* f_pcbc.c */
-int mit_des_pcbc_encrypt();
-
 /* f_sched.c */
 int mit_des_make_key_sched(mit_des_cblock, mit_des_key_schedule);
 

--- a/src/lib/crypto/builtin/des/destest.c
+++ b/src/lib/crypto/builtin/des/destest.c
@@ -62,9 +62,7 @@ void des_cblock_print_file (mit_des_cblock, FILE *);
 krb5_octet zeroblock[8] = {0,0,0,0,0,0,0,0};
 
 int
-main(argc, argv)
-    int argc;
-    char *argv[];
+main(int argc, char *argv[])
 {
     char block1[17], block2[17], block3[17];
     /* Force tests of unaligned accesses.  */
@@ -151,9 +149,7 @@ int value[128] = {
 };
 
 void
-convert(text, cblock)
-    char *text;
-    unsigned char cblock[];
+convert(char *text, unsigned char cblock[])
 {
     int i;
     for (i = 0; i < 8; i++) {
@@ -173,16 +169,13 @@ convert(text, cblock)
  */
 
 int
-mit_des_is_weak_key(key)
-    mit_des_cblock key;
+mit_des_is_weak_key(mit_des_cblock key)
 {
     return 0;                           /* fake it out for testing */
 }
 
 void
-des_cblock_print_file(x, fp)
-    mit_des_cblock x;
-    FILE *fp;
+des_cblock_print_file(mit_des_cblock x, FILE *fp)
 {
     unsigned char *y = (unsigned char *) x;
     int i = 0;
@@ -207,8 +200,7 @@ des_cblock_print_file(x, fp)
  *                       correct des parity.
  */
 int
-mit_des_check_key_parity(key)
-    mit_des_cblock key;
+mit_des_check_key_parity(mit_des_cblock key)
 {
     unsigned int i;
 
@@ -226,8 +218,7 @@ mit_des_check_key_parity(key)
 }
 
 void
-mit_des_fixup_key_parity(key)
-    mit_des_cblock key;
+mit_des_fixup_key_parity(mit_des_cblock key)
 {
     unsigned int i;
     for (i=0; i<sizeof(mit_des_cblock); i++)

--- a/src/lib/crypto/builtin/des/t_verify.c
+++ b/src/lib/crypto/builtin/des/t_verify.c
@@ -128,9 +128,7 @@ unsigned char mresult[8] = {
 mit_des_key_schedule sched;
 
 int
-main(argc,argv)
-    int argc;
-    char *argv[];
+main(int argc, char *argv[])
 {
     /* Local Declarations */
     size_t  in_length;
@@ -335,9 +333,7 @@ main(argc,argv)
 }
 
 static void
-do_encrypt(in,out)
-    unsigned char *in;
-    unsigned char *out;
+do_encrypt(unsigned char *in, unsigned char *out)
 {
     int i, j;
     for (i =1; i<=nflag; i++) {
@@ -359,9 +355,7 @@ do_encrypt(in,out)
 }
 
 static void
-do_decrypt(in,out)
-    unsigned char *out;
-    unsigned char *in;
+do_decrypt(unsigned char *in, unsigned char *out)
     /* try to invert it */
 {
     int i, j;
@@ -388,8 +382,7 @@ do_decrypt(in,out)
  */
 
 int
-mit_des_is_weak_key(key)
-    mit_des_cblock key;
+mit_des_is_weak_key(mit_des_cblock key)
 {
     return 0;                           /* fake it out for testing */
 }

--- a/src/lib/crypto/builtin/sha1/t_shs.c
+++ b/src/lib/crypto/builtin/sha1/t_shs.c
@@ -29,9 +29,8 @@ static SHS_LONG shsTestResults[][ 5 ] = {
 };
 #endif /* NEW_SHS */
 
-static int compareSHSresults(shsInfo, shsTestLevel)
-    SHS_INFO *shsInfo;
-    int shsTestLevel;
+static int
+compareSHSresults(SHS_INFO *shsInfo, int shsTestLevel)
 {
     int i, fail = 0;
 
@@ -55,7 +54,7 @@ static int compareSHSresults(shsInfo, shsTestLevel)
 }
 
 int
-main()
+main(int argc, char *argv[])
 {
     SHS_INFO shsInfo;
     unsigned int i;

--- a/src/lib/crypto/builtin/sha1/t_shs3.c
+++ b/src/lib/crypto/builtin/sha1/t_shs3.c
@@ -55,9 +55,7 @@ int mode;
 int Dflag;
 
 int
-main(argc,argv)
-    int argc;
-    char **argv;
+main(int argc, char **argv)
 {
     char *argp;
 
@@ -131,8 +129,7 @@ static void process(void)
 
 #ifndef shsDigest
 static unsigned char *
-shsDigest(si)
-    SHS_INFO *si;
+shsDigest(SHS_INFO *si)
 {
     longReverse(si->digest, SHS_DIGESTSIZE);
     return (unsigned char*) si->digest;

--- a/src/lib/crypto/crypto_tests/aes-test.c
+++ b/src/lib/crypto/crypto_tests/aes-test.c
@@ -37,14 +37,14 @@ static char plain[16], cipher[16], zero[16];
 
 static krb5_keyblock enc_key;
 static krb5_data ivec;
-static void init()
+static void init(void)
 {
     enc_key.contents = (krb5_octet *)key;
     enc_key.length = 16;
     ivec.data = zero;
     ivec.length = 16;
 }
-static void enc()
+static void enc(void)
 {
     krb5_key k;
     krb5_crypto_iov iov;
@@ -93,7 +93,7 @@ static void vk_test_1(int len, krb5_enctype etype)
     }
     printf("\n==========\n");
 }
-static void vk_test()
+static void vk_test(void)
 {
     vk_test_1(16, ENCTYPE_AES128_CTS_HMAC_SHA1_96);
     vk_test_1(32, ENCTYPE_AES256_CTS_HMAC_SHA1_96);
@@ -119,7 +119,7 @@ static void vt_test_1(int len, krb5_enctype etype)
     }
     printf("\n==========\n");
 }
-static void vt_test()
+static void vt_test(void)
 {
     vt_test_1(16, ENCTYPE_AES128_CTS_HMAC_SHA1_96);
     vt_test_1(32, ENCTYPE_AES256_CTS_HMAC_SHA1_96);

--- a/src/lib/crypto/crypto_tests/camellia-test.c
+++ b/src/lib/crypto/crypto_tests/camellia-test.c
@@ -35,14 +35,14 @@ static char plain[16], cipher[16], zero[16];
 
 static krb5_keyblock enc_key;
 static krb5_data ivec;
-static void init()
+static void init(void)
 {
     enc_key.contents = (unsigned char *)key;
     enc_key.length = 16;
     ivec.data = zero;
     ivec.length = 16;
 }
-static void enc()
+static void enc(void)
 {
     krb5_key k;
     krb5_crypto_iov iov;
@@ -91,7 +91,7 @@ static void vk_test_1(int len)
     }
     printf("\n==========\n");
 }
-static void vk_test()
+static void vk_test(void)
 {
     vk_test_1(16);
     vk_test_1(32);
@@ -117,7 +117,7 @@ static void vt_test_1(int len, krb5_enctype etype)
     }
     printf("\n==========\n");
 }
-static void vt_test()
+static void vt_test(void)
 {
     vt_test_1(16, ENCTYPE_CAMELLIA128_CTS_CMAC);
     vt_test_1(32, ENCTYPE_CAMELLIA256_CTS_CMAC);

--- a/src/lib/crypto/crypto_tests/t_cf2.c
+++ b/src/lib/crypto/crypto_tests/t_cf2.c
@@ -46,7 +46,9 @@
 #include <stdio.h>
 #include <string.h>
 
-int main () {
+int
+main(void)
+{
     krb5_error_code ret;
     char pepper1[1025], pepper2[1025];
     krb5_keyblock *k1 = NULL, *k2 = NULL, *out = NULL;

--- a/src/lib/crypto/crypto_tests/t_cts.c
+++ b/src/lib/crypto/crypto_tests/t_cts.c
@@ -77,7 +77,7 @@ static void printk(const char *descr, krb5_keyblock *k) {
     printd(descr, &d);
 }
 
-static void test_cts()
+static void test_cts(void)
 {
     static const char input[4*16] =
         "I would like the General Gau's Chicken, please, and wonton soup.";

--- a/src/lib/crypto/crypto_tests/t_encrypt.c
+++ b/src/lib/crypto/crypto_tests/t_encrypt.c
@@ -88,7 +88,7 @@ display(const char *msg, const krb5_data *d)
 }
 
 int
-main ()
+main(void)
 {
     krb5_context context = 0;
     krb5_data  in, in2, out, out2, check, check2, state, signdata;

--- a/src/lib/crypto/crypto_tests/t_fork.c
+++ b/src/lib/crypto/crypto_tests/t_fork.c
@@ -55,7 +55,7 @@ prepare_enc_data(krb5_key key, size_t in_len, krb5_enc_data *enc_data)
 }
 
 int
-main()
+main(void)
 {
     krb5_keyblock kb_aes, kb_rc4;
     krb5_key key_aes, key_rc4;

--- a/src/lib/crypto/crypto_tests/t_hmac.c
+++ b/src/lib/crypto/crypto_tests/t_hmac.c
@@ -122,7 +122,8 @@ static krb5_error_code hmac1(const struct krb5_hash_provider *h,
     return err;
 }
 
-static void test_hmac()
+static void
+test_hmac(void)
 {
     krb5_keyblock key;
     krb5_data in, out;

--- a/src/lib/crypto/crypto_tests/t_mddriver.c
+++ b/src/lib/crypto/crypto_tests/t_mddriver.c
@@ -111,9 +111,8 @@ struct md_test_entry md_test_suite[] = {
    -t       - runs time trial
    -x       - runs test script
 */
-int main (argc, argv)
-    int argc;
-    char *argv[];
+int
+main(int argc, char *argv[])
 {
     int i;
 
@@ -128,10 +127,8 @@ int main (argc, argv)
     return (0);
 }
 
-static void MDHash (bytes, len, count, out)
-    char *bytes;
-    size_t len, count;
-    unsigned char *out;
+static void
+MDHash(char *bytes, size_t len, size_t count, unsigned char *out)
 {
     krb5_crypto_iov *iov;
     krb5_data outdata = make_data (out, MDProvider.hashsize);
@@ -150,8 +147,8 @@ static void MDHash (bytes, len, count, out)
 
 /* Digests a string and prints the result.
  */
-static void MDString (string)
-    char *string;
+static void
+MDString(char *string)
 {
     unsigned char digest[16];
 
@@ -164,7 +161,8 @@ static void MDString (string)
 /* Measures the time to digest TEST_BLOCK_COUNT TEST_BLOCK_LEN-byte
    blocks.
 */
-static void MDTimeTrial ()
+static void
+MDTimeTrial(void)
 {
     time_t endTime, startTime;
     unsigned char block[TEST_BLOCK_LEN], digest[16];
@@ -197,7 +195,8 @@ static void MDTimeTrial ()
 
 /* Digests a reference suite of strings and prints the results.
  */
-static void MDTestSuite ()
+static void
+MDTestSuite(void)
 {
 #ifdef HAVE_TEST_SUITE
     struct md_test_entry *entry;
@@ -246,8 +245,8 @@ static void MDTestSuite ()
 
 /* Prints a message digest in hexadecimal.
  */
-static void MDPrint (digest)
-    unsigned char digest[16];
+static void
+MDPrint(unsigned char digest[16])
 {
     unsigned int i;
 

--- a/src/lib/crypto/crypto_tests/t_nfold.c
+++ b/src/lib/crypto/crypto_tests/t_nfold.c
@@ -33,17 +33,20 @@
 
 #define ASIZE(ARRAY) (sizeof(ARRAY)/sizeof(ARRAY[0]))
 
-static void printhex (size_t len, const unsigned char *p)
+static void
+printhex(size_t len, const unsigned char *p)
 {
     while (len--)
         printf ("%02x", 0xff & *p++);
 }
 
-static void printstringhex (const unsigned char *p) {
+static void
+printstringhex(const unsigned char *p) {
     printhex (strlen ((const char *) p), p);
 }
 
-static void rfc_tests ()
+static void
+rfc_tests(void)
 {
     unsigned i;
     struct {
@@ -92,7 +95,8 @@ static void rfc_tests ()
     }
 }
 
-static void fold_kerberos(unsigned int nbytes)
+static void
+fold_kerberos(unsigned int nbytes)
 {
     unsigned char cipher_text[300];
     unsigned int j;
@@ -125,9 +129,7 @@ unsigned char nfold_192[4][24] = {
 };
 
 int
-main(argc, argv)
-    int argc;
-    char *argv[];
+main(int argc, char *argv[])
 {
     unsigned char cipher_text[64];
     unsigned int i, j;

--- a/src/lib/crypto/crypto_tests/t_prf.c
+++ b/src/lib/crypto/crypto_tests/t_prf.c
@@ -116,7 +116,7 @@ struct test {
 };
 
 int
-main()
+main(void)
 {
     krb5_error_code ret;
     krb5_data output;

--- a/src/lib/crypto/crypto_tests/t_sha2.c
+++ b/src/lib/crypto/crypto_tests/t_sha2.c
@@ -137,7 +137,7 @@ hash_test(const struct krb5_hash_provider *hash, struct test *tests)
 }
 
 int
-main()
+main(void)
 {
     hash_test(&krb5int_hash_sha256, sha256_tests);
     hash_test(&krb5int_hash_sha384, sha384_tests);

--- a/src/lib/gssapi/generic/t_seqstate.c
+++ b/src/lib/gssapi/generic/t_seqstate.c
@@ -164,7 +164,7 @@ struct test {
 };
 
 int
-main()
+main(void)
 {
     size_t i, j;
     enum width w;

--- a/src/lib/gssapi/krb5/accept_sec_context.c
+++ b/src/lib/gssapi/krb5/accept_sec_context.c
@@ -160,11 +160,8 @@ create_constrained_deleg_creds(OM_uint32 *minor_status,
 
 /* Decode, decrypt and store the forwarded creds in the local ccache. */
 static krb5_error_code
-rd_and_store_for_creds(context, auth_context, inbuf, out_cred)
-    krb5_context context;
-    krb5_auth_context auth_context;
-    krb5_data *inbuf;
-    krb5_gss_cred_id_t *out_cred;
+rd_and_store_for_creds(krb5_context context, krb5_auth_context auth_context,
+                       krb5_data *inbuf, krb5_gss_cred_id_t *out_cred)
 {
     krb5_creds ** creds = NULL;
     krb5_error_code retval;
@@ -286,20 +283,12 @@ cleanup:
  * Performs third leg of DCE authentication
  */
 static OM_uint32
-kg_accept_dce(minor_status, context_handle, verifier_cred_handle,
-              input_token, input_chan_bindings, src_name, mech_type,
-              output_token, ret_flags, time_rec, delegated_cred_handle)
-    OM_uint32 *minor_status;
-    gss_ctx_id_t *context_handle;
-    gss_cred_id_t verifier_cred_handle;
-    gss_buffer_t input_token;
-    gss_channel_bindings_t input_chan_bindings;
-    gss_name_t *src_name;
-    gss_OID *mech_type;
-    gss_buffer_t output_token;
-    OM_uint32 *ret_flags;
-    OM_uint32 *time_rec;
-    gss_cred_id_t *delegated_cred_handle;
+kg_accept_dce(OM_uint32 *minor_status, gss_ctx_id_t *context_handle,
+              gss_cred_id_t verifier_cred_handle, gss_buffer_t input_token,
+              gss_channel_bindings_t input_chan_bindings, gss_name_t *src_name,
+              gss_OID *mech_type, gss_buffer_t output_token,
+              OM_uint32 *ret_flags, OM_uint32 *time_rec,
+              gss_cred_id_t *delegated_cred_handle)
 {
     krb5_error_code code;
     krb5_gss_ctx_id_rec *ctx = 0;
@@ -637,23 +626,13 @@ fail:
 }
 
 static OM_uint32
-kg_accept_krb5(minor_status, context_handle,
-               verifier_cred_handle, input_token,
-               input_chan_bindings, src_name, mech_type,
-               output_token, ret_flags, time_rec,
-               delegated_cred_handle, exts)
-    OM_uint32 *minor_status;
-    gss_ctx_id_t *context_handle;
-    gss_cred_id_t verifier_cred_handle;
-    gss_buffer_t input_token;
-    gss_channel_bindings_t input_chan_bindings;
-    gss_name_t *src_name;
-    gss_OID *mech_type;
-    gss_buffer_t output_token;
-    OM_uint32 *ret_flags;
-    OM_uint32 *time_rec;
-    gss_cred_id_t *delegated_cred_handle;
-    krb5_gss_ctx_ext_t exts;
+kg_accept_krb5(OM_uint32 *minor_status, gss_ctx_id_t *context_handle,
+               gss_cred_id_t verifier_cred_handle, gss_buffer_t input_token,
+               gss_channel_bindings_t input_chan_bindings,
+               gss_name_t *src_name, gss_OID *mech_type,
+               gss_buffer_t output_token, OM_uint32 *ret_flags,
+               OM_uint32 *time_rec, gss_cred_id_t *delegated_cred_handle,
+               krb5_gss_ctx_ext_t exts)
 {
     krb5_context context;
     unsigned char *ptr;
@@ -1310,22 +1289,15 @@ krb5_gss_accept_sec_context_ext(
 }
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_accept_sec_context(minor_status, context_handle,
-                            verifier_cred_handle, input_token,
-                            input_chan_bindings, src_name, mech_type,
-                            output_token, ret_flags, time_rec,
-                            delegated_cred_handle)
-    OM_uint32 *minor_status;
-    gss_ctx_id_t *context_handle;
-    gss_cred_id_t verifier_cred_handle;
-    gss_buffer_t input_token;
-    gss_channel_bindings_t input_chan_bindings;
-    gss_name_t *src_name;
-    gss_OID *mech_type;
-    gss_buffer_t output_token;
-    OM_uint32 *ret_flags;
-    OM_uint32 *time_rec;
-    gss_cred_id_t *delegated_cred_handle;
+krb5_gss_accept_sec_context(OM_uint32 *minor_status,
+                            gss_ctx_id_t *context_handle,
+                            gss_cred_id_t verifier_cred_handle,
+                            gss_buffer_t input_token,
+                            gss_channel_bindings_t input_chan_bindings,
+                            gss_name_t *src_name, gss_OID *mech_type,
+                            gss_buffer_t output_token, OM_uint32 *ret_flags,
+                            OM_uint32 *time_rec,
+                            gss_cred_id_t *delegated_cred_handle)
 {
     krb5_gss_ctx_ext_rec exts;
 

--- a/src/lib/gssapi/krb5/compare_name.c
+++ b/src/lib/gssapi/krb5/compare_name.c
@@ -28,11 +28,8 @@
 #include "gssapiP_krb5.h"
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_compare_name(minor_status, name1, name2, name_equal)
-    OM_uint32 *minor_status;
-    gss_name_t name1;
-    gss_name_t name2;
-    int *name_equal;
+krb5_gss_compare_name(OM_uint32 *minor_status, gss_name_t name1,
+                      gss_name_t name2, int *name_equal)
 {
     krb5_context context;
     krb5_error_code code;

--- a/src/lib/gssapi/krb5/context_time.c
+++ b/src/lib/gssapi/krb5/context_time.c
@@ -28,10 +28,8 @@
  */
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_context_time(minor_status, context_handle, time_rec)
-    OM_uint32 *minor_status;
-    gss_ctx_id_t context_handle;
-    OM_uint32 *time_rec;
+krb5_gss_context_time(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
+                      OM_uint32 *time_rec)
 {
     krb5_error_code code;
     krb5_gss_ctx_id_rec *ctx;

--- a/src/lib/gssapi/krb5/delete_sec_context.c
+++ b/src/lib/gssapi/krb5/delete_sec_context.c
@@ -28,10 +28,9 @@
  */
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_delete_sec_context(minor_status, context_handle, output_token)
-    OM_uint32 *minor_status;
-    gss_ctx_id_t *context_handle;
-    gss_buffer_t output_token;
+krb5_gss_delete_sec_context(OM_uint32 *minor_status,
+                            gss_ctx_id_t *context_handle,
+                            gss_buffer_t output_token)
 {
     krb5_context context;
     krb5_gss_ctx_id_rec *ctx;

--- a/src/lib/gssapi/krb5/disp_name.c
+++ b/src/lib/gssapi/krb5/disp_name.c
@@ -24,12 +24,9 @@
 #include "gssapiP_krb5.h"
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_display_name(minor_status, input_name, output_name_buffer,
-                      output_name_type)
-    OM_uint32 *minor_status;
-    gss_name_t input_name;
-    gss_buffer_t output_name_buffer;
-    gss_OID *output_name_type;
+krb5_gss_display_name(OM_uint32 *minor_status, gss_name_t input_name,
+                      gss_buffer_t output_name_buffer,
+                      gss_OID *output_name_type)
 {
     krb5_context context;
     krb5_error_code code;

--- a/src/lib/gssapi/krb5/disp_status.c
+++ b/src/lib/gssapi/krb5/disp_status.c
@@ -154,14 +154,9 @@ void krb5_gss_delete_error_info(void *p)
 /**/
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_display_status(minor_status, status_value, status_type,
-                        mech_type, message_context, status_string)
-    OM_uint32 *minor_status;
-    OM_uint32 status_value;
-    int status_type;
-    gss_OID mech_type;
-    OM_uint32 *message_context;
-    gss_buffer_t status_string;
+krb5_gss_display_status(OM_uint32 *minor_status, OM_uint32 status_value,
+                        int status_type, gss_OID mech_type,
+                        OM_uint32 *message_context, gss_buffer_t status_string)
 {
     status_string->length = 0;
     status_string->value = NULL;

--- a/src/lib/gssapi/krb5/export_sec_context.c
+++ b/src/lib/gssapi/krb5/export_sec_context.c
@@ -27,10 +27,9 @@
 #include "gssapiP_krb5.h"
 #ifndef LEAN_CLIENT
 OM_uint32 KRB5_CALLCONV
-krb5_gss_export_sec_context(minor_status, context_handle, interprocess_token)
-    OM_uint32           *minor_status;
-    gss_ctx_id_t        *context_handle;
-    gss_buffer_t        interprocess_token;
+krb5_gss_export_sec_context(OM_uint32 *minor_status,
+                            gss_ctx_id_t *context_handle,
+                            gss_buffer_t interprocess_token)
 {
     krb5_context        context = NULL;
     krb5_error_code     kret;

--- a/src/lib/gssapi/krb5/gssapi_krb5.c
+++ b/src/lib/gssapi/krb5/gssapi_krb5.c
@@ -197,9 +197,7 @@ g_set kg_vdb = G_SET_INIT;
  * so handling the expiration/invalidation condition here isn't needed.
  */
 OM_uint32
-kg_get_defcred(minor_status, cred)
-    OM_uint32 *minor_status;
-    gss_cred_id_t *cred;
+kg_get_defcred(OM_uint32 *minor_status, gss_cred_id_t *cred)
 {
     OM_uint32 major;
 

--- a/src/lib/gssapi/krb5/import_name.c
+++ b/src/lib/gssapi/krb5/import_name.c
@@ -120,12 +120,8 @@ parse_hostbased(const char *str, size_t len,
 }
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_import_name(minor_status, input_name_buffer,
-                     input_name_type, output_name)
-    OM_uint32 *minor_status;
-    gss_buffer_t input_name_buffer;
-    gss_OID input_name_type;
-    gss_name_t *output_name;
+krb5_gss_import_name(OM_uint32 *minor_status, gss_buffer_t input_name_buffer,
+                     gss_OID input_name_type, gss_name_t *output_name)
 {
     krb5_context context;
     krb5_principal princ = NULL;

--- a/src/lib/gssapi/krb5/import_sec_context.c
+++ b/src/lib/gssapi/krb5/import_sec_context.c
@@ -32,8 +32,7 @@
  * Fix up the OID of the mechanism so that uses the static version of
  * the OID if possible.
  */
-gss_OID krb5_gss_convert_static_mech_oid(oid)
-    gss_OID    oid;
+gss_OID krb5_gss_convert_static_mech_oid(gss_OID oid)
 {
     const gss_OID_desc      *p;
     OM_uint32               minor_status;
@@ -49,10 +48,9 @@ gss_OID krb5_gss_convert_static_mech_oid(oid)
 }
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_import_sec_context(minor_status, interprocess_token, context_handle)
-    OM_uint32           *minor_status;
-    gss_buffer_t        interprocess_token;
-    gss_ctx_id_t        *context_handle;
+krb5_gss_import_sec_context(OM_uint32 *minor_status,
+                            gss_buffer_t interprocess_token,
+                            gss_ctx_id_t *context_handle)
 {
     krb5_context        context;
     krb5_error_code     kret = 0;

--- a/src/lib/gssapi/krb5/indicate_mechs.c
+++ b/src/lib/gssapi/krb5/indicate_mechs.c
@@ -29,9 +29,7 @@
 #include "mglueP.h"
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_indicate_mechs(minor_status, mech_set)
-    OM_uint32 *minor_status;
-    gss_OID_set *mech_set;
+krb5_gss_indicate_mechs(OM_uint32 *minor_status, gss_OID_set *mech_set)
 {
     return generic_gss_copy_oid_set(minor_status, kg_all_mechs, mech_set);
 }

--- a/src/lib/gssapi/krb5/init_sec_context.c
+++ b/src/lib/gssapi/krb5/init_sec_context.c
@@ -117,14 +117,10 @@ int krb5_gss_dbg_client_expcreds = 0;
  * Common code which fetches the correct krb5 credentials from the
  * ccache.
  */
-static krb5_error_code get_credentials(context, cred, server, now,
-                                       endtime, out_creds)
-    krb5_context context;
-    krb5_gss_cred_id_t cred;
-    krb5_gss_name_t server;
-    krb5_timestamp now;
-    krb5_timestamp endtime;
-    krb5_creds **out_creds;
+static krb5_error_code
+get_credentials(krb5_context context, krb5_gss_cred_id_t cred,
+                krb5_gss_name_t server, krb5_timestamp now,
+                krb5_timestamp endtime, krb5_creds **out_creds)
 {
     krb5_error_code     code;
     krb5_creds          in_creds, evidence_creds, mcreds, *result_creds = NULL;
@@ -365,17 +361,11 @@ cleanup:
 }
 
 static krb5_error_code
-make_ap_req_v1(context, ctx, cred, k_cred, ad_context,
-               chan_bindings, mech_type, token, exts)
-    krb5_context context;
-    krb5_gss_ctx_id_rec *ctx;
-    krb5_gss_cred_id_t cred;
-    krb5_creds *k_cred;
-    krb5_authdata_context ad_context;
-    gss_channel_bindings_t chan_bindings;
-    gss_OID mech_type;
-    gss_buffer_t token;
-    krb5_gss_ctx_ext_t exts;
+make_ap_req_v1(krb5_context context, krb5_gss_ctx_id_rec *ctx,
+               krb5_gss_cred_id_t cred, krb5_creds *k_cred,
+               krb5_authdata_context ad_context,
+               gss_channel_bindings_t chan_bindings, gss_OID mech_type,
+               gss_buffer_t token, krb5_gss_ctx_ext_t exts)
 {
     krb5_flags mk_req_flags = 0;
     krb5_error_code code;
@@ -1048,24 +1038,15 @@ krb5int_gss_use_kdc_context(OM_uint32 *minor_status,
 #endif
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_init_sec_context(minor_status, claimant_cred_handle,
-                          context_handle, target_name, mech_type,
-                          req_flags, time_req, input_chan_bindings,
-                          input_token, actual_mech_type, output_token,
-                          ret_flags, time_rec)
-    OM_uint32 *minor_status;
-    gss_cred_id_t claimant_cred_handle;
-    gss_ctx_id_t *context_handle;
-    gss_name_t target_name;
-    gss_OID mech_type;
-    OM_uint32 req_flags;
-    OM_uint32 time_req;
-    gss_channel_bindings_t input_chan_bindings;
-    gss_buffer_t input_token;
-    gss_OID *actual_mech_type;
-    gss_buffer_t output_token;
-    OM_uint32 *ret_flags;
-    OM_uint32 *time_rec;
+krb5_gss_init_sec_context(OM_uint32 *minor_status,
+                          gss_cred_id_t claimant_cred_handle,
+                          gss_ctx_id_t *context_handle,
+                          gss_name_t target_name, gss_OID mech_type,
+                          OM_uint32 req_flags, OM_uint32 time_req,
+                          gss_channel_bindings_t input_chan_bindings,
+                          gss_buffer_t input_token, gss_OID *actual_mech_type,
+                          gss_buffer_t output_token, OM_uint32 *ret_flags,
+                          OM_uint32 *time_rec)
 {
     krb5_gss_ctx_ext_rec exts;
 

--- a/src/lib/gssapi/krb5/inq_context.c
+++ b/src/lib/gssapi/krb5/inq_context.c
@@ -78,18 +78,11 @@
 #include "gssapiP_krb5.h"
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_inquire_context(minor_status, context_handle, initiator_name,
-                         acceptor_name, lifetime_rec, mech_type, ret_flags,
-                         locally_initiated, opened)
-    OM_uint32 *minor_status;
-    gss_ctx_id_t context_handle;
-    gss_name_t *initiator_name;
-    gss_name_t *acceptor_name;
-    OM_uint32 *lifetime_rec;
-    gss_OID *mech_type;
-    OM_uint32 *ret_flags;
-    int *locally_initiated;
-    int *opened;
+krb5_gss_inquire_context(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
+                         gss_name_t *initiator_name, gss_name_t *acceptor_name,
+                         OM_uint32 *lifetime_rec, gss_OID *mech_type,
+                         OM_uint32 *ret_flags, int *locally_initiated,
+                         int *opened)
 {
     krb5_context context;
     krb5_error_code code;

--- a/src/lib/gssapi/krb5/inq_cred.c
+++ b/src/lib/gssapi/krb5/inq_cred.c
@@ -73,14 +73,9 @@
 #include "gssapiP_krb5.h"
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_inquire_cred(minor_status, cred_handle, name, lifetime_ret,
-                      cred_usage, mechanisms)
-    OM_uint32 *minor_status;
-    gss_cred_id_t cred_handle;
-    gss_name_t *name;
-    OM_uint32 *lifetime_ret;
-    gss_cred_usage_t *cred_usage;
-    gss_OID_set *mechanisms;
+krb5_gss_inquire_cred(OM_uint32 *minor_status, gss_cred_id_t cred_handle,
+                      gss_name_t *name, OM_uint32 *lifetime_ret,
+                      gss_cred_usage_t *cred_usage, gss_OID_set *mechanisms)
 {
     krb5_context context;
     gss_cred_id_t defcred = GSS_C_NO_CREDENTIAL;
@@ -209,16 +204,11 @@ cleanup:
 
 /* V2 interface */
 OM_uint32 KRB5_CALLCONV
-krb5_gss_inquire_cred_by_mech(minor_status, cred_handle,
-                              mech_type, name, initiator_lifetime,
-                              acceptor_lifetime, cred_usage)
-    OM_uint32           *minor_status;
-    gss_cred_id_t       cred_handle;
-    gss_OID             mech_type;
-    gss_name_t          *name;
-    OM_uint32           *initiator_lifetime;
-    OM_uint32           *acceptor_lifetime;
-    gss_cred_usage_t *cred_usage;
+krb5_gss_inquire_cred_by_mech(OM_uint32 *minor_status,
+                              gss_cred_id_t cred_handle, gss_OID mech_type,
+                              gss_name_t *name, OM_uint32 *initiator_lifetime,
+                              OM_uint32 *acceptor_lifetime,
+                              gss_cred_usage_t *cred_usage)
 {
     krb5_gss_cred_id_t  cred;
     OM_uint32           lifetime;

--- a/src/lib/gssapi/krb5/inq_names.c
+++ b/src/lib/gssapi/krb5/inq_names.c
@@ -27,10 +27,8 @@
 #include "gssapiP_krb5.h"
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_inquire_names_for_mech(minor_status, mechanism, name_types)
-    OM_uint32   *minor_status;
-    gss_OID     mechanism;
-    gss_OID_set *name_types;
+krb5_gss_inquire_names_for_mech(OM_uint32 *minor_status, gss_OID mechanism,
+                                gss_OID_set *name_types)
 {
     OM_uint32   major, minor;
 

--- a/src/lib/gssapi/krb5/k5seal.c
+++ b/src/lib/gssapi/krb5/k5seal.c
@@ -290,16 +290,10 @@ make_seal_token_v1 (krb5_context context,
    and do not encode the ENC_TYPE, MSG_LENGTH, or MSG_TEXT fields */
 
 OM_uint32
-kg_seal(minor_status, context_handle, conf_req_flag, qop_req,
-        input_message_buffer, conf_state, output_message_buffer, toktype)
-    OM_uint32 *minor_status;
-    gss_ctx_id_t context_handle;
-    int conf_req_flag;
-    gss_qop_t qop_req;
-    gss_buffer_t input_message_buffer;
-    int *conf_state;
-    gss_buffer_t output_message_buffer;
-    int toktype;
+kg_seal(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
+        int conf_req_flag, gss_qop_t qop_req,
+        gss_buffer_t input_message_buffer, int *conf_state,
+        gss_buffer_t output_message_buffer, int toktype)
 {
     krb5_gss_ctx_id_rec *ctx;
     krb5_error_code code;
@@ -361,16 +355,10 @@ kg_seal(minor_status, context_handle, conf_req_flag, qop_req,
 }
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_wrap(minor_status, context_handle, conf_req_flag,
-              qop_req, input_message_buffer, conf_state,
-              output_message_buffer)
-    OM_uint32           *minor_status;
-    gss_ctx_id_t        context_handle;
-    int                 conf_req_flag;
-    gss_qop_t           qop_req;
-    gss_buffer_t        input_message_buffer;
-    int                 *conf_state;
-    gss_buffer_t        output_message_buffer;
+krb5_gss_wrap(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
+              int conf_req_flag, gss_qop_t qop_req,
+              gss_buffer_t input_message_buffer, int *conf_state,
+              gss_buffer_t output_message_buffer)
 {
     return(kg_seal(minor_status, context_handle, conf_req_flag,
                    qop_req, input_message_buffer, conf_state,
@@ -378,13 +366,9 @@ krb5_gss_wrap(minor_status, context_handle, conf_req_flag,
 }
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_get_mic(minor_status, context_handle, qop_req,
-                 message_buffer, message_token)
-    OM_uint32           *minor_status;
-    gss_ctx_id_t        context_handle;
-    gss_qop_t           qop_req;
-    gss_buffer_t        message_buffer;
-    gss_buffer_t        message_token;
+krb5_gss_get_mic(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
+                 gss_qop_t qop_req, gss_buffer_t message_buffer,
+                 gss_buffer_t message_token)
 {
     return(kg_seal(minor_status, context_handle, 0,
                    qop_req, message_buffer, NULL,

--- a/src/lib/gssapi/krb5/k5unseal.c
+++ b/src/lib/gssapi/krb5/k5unseal.c
@@ -58,17 +58,10 @@
    conf_state is only valid if SEAL. */
 
 static OM_uint32
-kg_unseal_v1(context, minor_status, ctx, ptr, bodysize, message_buffer,
-             conf_state, qop_state, toktype)
-    krb5_context context;
-    OM_uint32 *minor_status;
-    krb5_gss_ctx_id_rec *ctx;
-    unsigned char *ptr;
-    int bodysize;
-    gss_buffer_t message_buffer;
-    int *conf_state;
-    gss_qop_t *qop_state;
-    int toktype;
+kg_unseal_v1(krb5_context context, OM_uint32 *minor_status,
+             krb5_gss_ctx_id_rec *ctx, unsigned char *ptr, int bodysize,
+             gss_buffer_t message_buffer, int *conf_state,
+             gss_qop_t *qop_state, int toktype)
 {
     krb5_error_code code;
     int conflen = 0;
@@ -360,15 +353,9 @@ kg_unseal_v1(context, minor_status, ctx, ptr, bodysize, message_buffer,
    conf_state is only valid if SEAL. */
 
 OM_uint32
-kg_unseal(minor_status, context_handle, input_token_buffer,
-          message_buffer, conf_state, qop_state, toktype)
-    OM_uint32 *minor_status;
-    gss_ctx_id_t context_handle;
-    gss_buffer_t input_token_buffer;
-    gss_buffer_t message_buffer;
-    int *conf_state;
-    gss_qop_t *qop_state;
-    int toktype;
+kg_unseal(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
+          gss_buffer_t input_token_buffer, gss_buffer_t message_buffer,
+          int *conf_state, gss_qop_t *qop_state, int toktype)
 {
     krb5_gss_ctx_id_rec *ctx;
     unsigned char *ptr;
@@ -439,15 +426,10 @@ kg_unseal(minor_status, context_handle, input_token_buffer,
 }
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_unwrap(minor_status, context_handle,
-                input_message_buffer, output_message_buffer,
-                conf_state, qop_state)
-    OM_uint32           *minor_status;
-    gss_ctx_id_t        context_handle;
-    gss_buffer_t        input_message_buffer;
-    gss_buffer_t        output_message_buffer;
-    int                 *conf_state;
-    gss_qop_t           *qop_state;
+krb5_gss_unwrap(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
+                gss_buffer_t input_message_buffer,
+                gss_buffer_t output_message_buffer, int *conf_state,
+                gss_qop_t *qop_state)
 {
     OM_uint32           rstat;
 
@@ -458,14 +440,9 @@ krb5_gss_unwrap(minor_status, context_handle,
 }
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_verify_mic(minor_status, context_handle,
-                    message_buffer, token_buffer,
-                    qop_state)
-    OM_uint32           *minor_status;
-    gss_ctx_id_t        context_handle;
-    gss_buffer_t        message_buffer;
-    gss_buffer_t        token_buffer;
-    gss_qop_t           *qop_state;
+krb5_gss_verify_mic(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
+                    gss_buffer_t message_buffer, gss_buffer_t token_buffer,
+                    gss_qop_t *qop_state)
 {
     OM_uint32           rstat;
 

--- a/src/lib/gssapi/krb5/process_context_token.c
+++ b/src/lib/gssapi/krb5/process_context_token.c
@@ -28,11 +28,9 @@
  */
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_process_context_token(minor_status, context_handle,
-                               token_buffer)
-    OM_uint32 *minor_status;
-    gss_ctx_id_t context_handle;
-    gss_buffer_t token_buffer;
+krb5_gss_process_context_token(OM_uint32 *minor_status,
+                               gss_ctx_id_t context_handle,
+                               gss_buffer_t token_buffer)
 {
     krb5_gss_ctx_id_rec *ctx;
     OM_uint32 majerr;

--- a/src/lib/gssapi/krb5/rel_cred.c
+++ b/src/lib/gssapi/krb5/rel_cred.c
@@ -24,9 +24,7 @@
 #include "gssapiP_krb5.h"
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_release_cred(minor_status, cred_handle)
-    OM_uint32 *minor_status;
-    gss_cred_id_t *cred_handle;
+krb5_gss_release_cred(OM_uint32 *minor_status, gss_cred_id_t *cred_handle)
 {
     krb5_context context;
     krb5_gss_cred_id_t cred;

--- a/src/lib/gssapi/krb5/rel_name.c
+++ b/src/lib/gssapi/krb5/rel_name.c
@@ -24,9 +24,7 @@
 #include "gssapiP_krb5.h"
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_release_name(minor_status, input_name)
-    OM_uint32 *minor_status;
-    gss_name_t *input_name;
+krb5_gss_release_name(OM_uint32 *minor_status, gss_name_t *input_name)
 {
     krb5_context context;
     krb5_error_code code;

--- a/src/lib/gssapi/krb5/rel_oid.c
+++ b/src/lib/gssapi/krb5/rel_oid.c
@@ -27,9 +27,7 @@
 #include "gssapiP_krb5.h"
 
 OM_uint32
-krb5_gss_release_oid(minor_status, oid)
-    OM_uint32   *minor_status;
-    gss_OID     *oid;
+krb5_gss_release_oid(OM_uint32 *minor_status, gss_OID *oid)
 {
     /*
      * The V2 API says the following!
@@ -52,9 +50,7 @@ krb5_gss_release_oid(minor_status, oid)
 }
 
 OM_uint32 KRB5_CALLCONV
-krb5_gss_internal_release_oid(minor_status, oid)
-    OM_uint32   *minor_status;
-    gss_OID     *oid;
+krb5_gss_internal_release_oid(OM_uint32 *minor_status, gss_OID *oid)
 {
     /*
      * This function only knows how to release internal OIDs. It will

--- a/src/lib/gssapi/krb5/ser_sctx.c
+++ b/src/lib/gssapi/krb5/ser_sctx.c
@@ -137,10 +137,8 @@ kg_oid_size(gss_OID oid, size_t *sizep)
 }
 
 static krb5_error_code
-kg_seqstate_externalize(arg, buffer, lenremain)
-    g_seqnum_state      arg;
-    krb5_octet          **buffer;
-    size_t              *lenremain;
+kg_seqstate_externalize(g_seqnum_state arg, krb5_octet **buffer,
+                        size_t *lenremain)
 {
     krb5_error_code err;
     err = krb5_ser_pack_int32(KV5M_GSS_QUEUE, buffer, lenremain);
@@ -152,10 +150,8 @@ kg_seqstate_externalize(arg, buffer, lenremain)
 }
 
 static krb5_error_code
-kg_seqstate_internalize(argp, buffer, lenremain)
-    g_seqnum_state      *argp;
-    krb5_octet          **buffer;
-    size_t              *lenremain;
+kg_seqstate_internalize(g_seqnum_state *argp, krb5_octet **buffer,
+                        size_t *lenremain)
 {
     krb5_int32 ibuf;
     krb5_octet         *bp;
@@ -193,9 +189,7 @@ kg_seqstate_internalize(argp, buffer, lenremain)
 }
 
 static krb5_error_code
-kg_seqstate_size(arg, sizep)
-    g_seqnum_state      arg;
-    size_t              *sizep;
+kg_seqstate_size(g_seqnum_state arg, size_t *sizep)
 {
     krb5_error_code kret;
     size_t required;

--- a/src/lib/gssapi/krb5/util_cksum.c
+++ b/src/lib/gssapi/krb5/util_cksum.c
@@ -28,10 +28,8 @@
 
 /* Checksumming the channel bindings always uses plain MD5.  */
 krb5_error_code
-kg_checksum_channel_bindings(context, cb, cksum)
-    krb5_context context;
-    gss_channel_bindings_t cb;
-    krb5_checksum *cksum;
+kg_checksum_channel_bindings(krb5_context context, gss_channel_bindings_t cb,
+                             krb5_checksum *cksum)
 {
     struct k5buf buf;
     size_t sumlen;

--- a/src/lib/gssapi/krb5/util_seed.c
+++ b/src/lib/gssapi/krb5/util_seed.c
@@ -29,10 +29,7 @@
 static const unsigned char zeros[16] = {0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0};
 
 krb5_error_code
-kg_make_seed(context, key, seed)
-    krb5_context context;
-    krb5_key key;
-    unsigned char *seed;
+kg_make_seed(krb5_context context, krb5_key key, unsigned char *seed)
 {
     krb5_error_code code;
     krb5_key rkey = NULL;

--- a/src/lib/gssapi/krb5/util_seqnum.c
+++ b/src/lib/gssapi/krb5/util_seqnum.c
@@ -30,13 +30,8 @@
  */
 
 krb5_error_code
-kg_make_seq_num(context, key, direction, seqnum, cksum, buf)
-    krb5_context context;
-    krb5_key key;
-    int direction;
-    krb5_ui_4 seqnum;
-    unsigned char *cksum;
-    unsigned char *buf;
+kg_make_seq_num(krb5_context context, krb5_key key, int direction,
+                krb5_ui_4 seqnum, unsigned char *cksum, unsigned char *buf)
 {
     unsigned char plain[8];
 
@@ -59,13 +54,9 @@ kg_make_seq_num(context, key, direction, seqnum, cksum, buf)
     return(kg_encrypt(context, key, KG_USAGE_SEQ, cksum, plain, buf, 8));
 }
 
-krb5_error_code kg_get_seq_num(context, key, cksum, buf, direction, seqnum)
-    krb5_context context;
-    krb5_key key;
-    unsigned char *cksum;
-    unsigned char *buf;
-    int *direction;
-    krb5_ui_4 *seqnum;
+krb5_error_code
+kg_get_seq_num(krb5_context context, krb5_key key, unsigned char *cksum,
+               unsigned char *buf, int *direction, krb5_ui_4 *seqnum)
 {
     krb5_error_code code;
     unsigned char plain[8];

--- a/src/lib/gssapi/krb5/val_cred.c
+++ b/src/lib/gssapi/krb5/val_cred.c
@@ -57,9 +57,7 @@ krb5_gss_validate_cred_1(OM_uint32 *minor_status, gss_cred_id_t cred_handle,
 }
 
 OM_uint32
-krb5_gss_validate_cred(minor_status, cred_handle)
-    OM_uint32 *minor_status;
-    gss_cred_id_t cred_handle;
+krb5_gss_validate_cred(OM_uint32 *minor_status, gss_cred_id_t cred_handle)
 {
     krb5_context context;
     krb5_error_code code;

--- a/src/lib/gssapi/krb5/wrap_size_limit.c
+++ b/src/lib/gssapi/krb5/wrap_size_limit.c
@@ -74,14 +74,9 @@
 
 /* V2 interface */
 OM_uint32 KRB5_CALLCONV
-krb5_gss_wrap_size_limit(minor_status, context_handle, conf_req_flag,
-                         qop_req, req_output_size, max_input_size)
-    OM_uint32           *minor_status;
-    gss_ctx_id_t        context_handle;
-    int                 conf_req_flag;
-    gss_qop_t           qop_req;
-    OM_uint32           req_output_size;
-    OM_uint32           *max_input_size;
+krb5_gss_wrap_size_limit(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
+                         int conf_req_flag, gss_qop_t qop_req,
+                         OM_uint32 req_output_size, OM_uint32 *max_input_size)
 {
     krb5_gss_ctx_id_rec *ctx;
     OM_uint32           data_size, conflen;

--- a/src/lib/gssapi/mechglue/g_accept_sec_context.c
+++ b/src/lib/gssapi/mechglue/g_accept_sec_context.c
@@ -128,30 +128,13 @@ allow_mech_by_default(gss_OID mech)
 }
 
 OM_uint32 KRB5_CALLCONV
-gss_accept_sec_context (minor_status,
-                        context_handle,
-                        verifier_cred_handle,
-                        input_token_buffer,
-                        input_chan_bindings,
-                        src_name,
-                        mech_type,
-                        output_token,
-                        ret_flags,
-                        time_rec,
-                        d_cred)
-
-OM_uint32 *		minor_status;
-gss_ctx_id_t *		context_handle;
-gss_cred_id_t		verifier_cred_handle;
-gss_buffer_t		input_token_buffer;
-gss_channel_bindings_t	input_chan_bindings;
-gss_name_t *		src_name;
-gss_OID *		mech_type;
-gss_buffer_t		output_token;
-OM_uint32 *		ret_flags;
-OM_uint32 *		time_rec;
-gss_cred_id_t *		d_cred;
-
+gss_accept_sec_context(OM_uint32 *minor_status, gss_ctx_id_t *context_handle,
+		       gss_cred_id_t verifier_cred_handle,
+		       gss_buffer_t input_token_buffer,
+		       gss_channel_bindings_t input_chan_bindings,
+		       gss_name_t *src_name, gss_OID *mech_type,
+		       gss_buffer_t output_token, OM_uint32 *ret_flags,
+		       OM_uint32 *time_rec, gss_cred_id_t *d_cred)
 {
     OM_uint32		status, temp_status, temp_minor_status;
     OM_uint32		temp_ret_flags = 0;

--- a/src/lib/gssapi/mechglue/g_acquire_cred.c
+++ b/src/lib/gssapi/mechglue/g_acquire_cred.c
@@ -85,24 +85,10 @@ val_acq_cred_args(
 
 
 OM_uint32 KRB5_CALLCONV
-gss_acquire_cred(minor_status,
-                 desired_name,
-                 time_req,
-                 desired_mechs,
-		 cred_usage,
-                 output_cred_handle,
-                 actual_mechs,
-                 time_rec)
-
-OM_uint32 *		minor_status;
-gss_name_t		desired_name;
-OM_uint32		time_req;
-gss_OID_set		desired_mechs;
-int			cred_usage;
-gss_cred_id_t *		output_cred_handle;
-gss_OID_set *		actual_mechs;
-OM_uint32 *		time_rec;
-
+gss_acquire_cred(OM_uint32 *minor_status, gss_name_t desired_name,
+		 OM_uint32 time_req, gss_OID_set desired_mechs,
+		 int cred_usage, gss_cred_id_t *output_cred_handle,
+		 gss_OID_set *actual_mechs, OM_uint32 *time_rec)
 {
     return gss_acquire_cred_from(minor_status, desired_name, time_req,
 				 desired_mechs, cred_usage, NULL,
@@ -110,26 +96,11 @@ OM_uint32 *		time_rec;
 }
 
 OM_uint32 KRB5_CALLCONV
-gss_acquire_cred_from(minor_status,
-		      desired_name,
-		      time_req,
-		      desired_mechs,
-		      cred_usage,
-		      cred_store,
-		      output_cred_handle,
-		      actual_mechs,
-		      time_rec)
-
-OM_uint32 *			minor_status;
-gss_name_t			desired_name;
-OM_uint32			time_req;
-gss_OID_set			desired_mechs;
-int				cred_usage;
-gss_const_key_value_set_t	cred_store;
-gss_cred_id_t *			output_cred_handle;
-gss_OID_set *			actual_mechs;
-OM_uint32 *			time_rec;
-
+gss_acquire_cred_from(OM_uint32 * minor_status, gss_name_t desired_name,
+		      OM_uint32 time_req, gss_OID_set desired_mechs,
+		      int cred_usage, gss_const_key_value_set_t cred_store,
+		      gss_cred_id_t *output_cred_handle,
+		      gss_OID_set *actual_mechs, OM_uint32 *time_rec)
 {
     OM_uint32 major = GSS_S_FAILURE, tmpMinor;
     OM_uint32 first_major = GSS_S_COMPLETE, first_minor = 0;
@@ -397,22 +368,12 @@ error:
 
 /* V2 KRB5_CALLCONV */
 OM_uint32 KRB5_CALLCONV
-gss_add_cred(minor_status, input_cred_handle,
-		  desired_name, desired_mech, cred_usage,
-		  initiator_time_req, acceptor_time_req,
-		  output_cred_handle, actual_mechs,
-		  initiator_time_rec, acceptor_time_rec)
-    OM_uint32		*minor_status;
-    gss_cred_id_t	input_cred_handle;
-    gss_name_t		desired_name;
-    gss_OID		desired_mech;
-    gss_cred_usage_t	cred_usage;
-    OM_uint32		initiator_time_req;
-    OM_uint32		acceptor_time_req;
-    gss_cred_id_t	*output_cred_handle;
-    gss_OID_set		*actual_mechs;
-    OM_uint32		*initiator_time_rec;
-    OM_uint32		*acceptor_time_rec;
+gss_add_cred(OM_uint32 *minor_status, gss_cred_id_t input_cred_handle,
+	     gss_name_t desired_name, gss_OID desired_mech,
+	     gss_cred_usage_t cred_usage, OM_uint32 initiator_time_req,
+	     OM_uint32 acceptor_time_req, gss_cred_id_t *output_cred_handle,
+	     gss_OID_set *actual_mechs, OM_uint32 *initiator_time_rec,
+	     OM_uint32 *acceptor_time_rec)
 {
     return gss_add_cred_from(minor_status, input_cred_handle, desired_name,
 			     desired_mech, cred_usage, initiator_time_req,
@@ -422,25 +383,13 @@ gss_add_cred(minor_status, input_cred_handle,
 }
 
 OM_uint32 KRB5_CALLCONV
-gss_add_cred_from(minor_status, input_cred_handle,
-		  desired_name, desired_mech,
-		  cred_usage,
-		  initiator_time_req, acceptor_time_req,
-		  cred_store,
-		  output_cred_handle, actual_mechs,
-		  initiator_time_rec, acceptor_time_rec)
-    OM_uint32		*minor_status;
-    gss_cred_id_t	input_cred_handle;
-    gss_name_t		desired_name;
-    gss_OID		desired_mech;
-    gss_cred_usage_t	cred_usage;
-    OM_uint32		initiator_time_req;
-    OM_uint32		acceptor_time_req;
-    gss_const_key_value_set_t  cred_store;
-    gss_cred_id_t	*output_cred_handle;
-    gss_OID_set		*actual_mechs;
-    OM_uint32		*initiator_time_rec;
-    OM_uint32		*acceptor_time_rec;
+gss_add_cred_from(OM_uint32 *minor_status, gss_cred_id_t input_cred_handle,
+		  gss_name_t desired_name, gss_OID desired_mech,
+		  gss_cred_usage_t cred_usage, OM_uint32 initiator_time_req,
+		  OM_uint32 acceptor_time_req,
+		  gss_const_key_value_set_t cred_store,
+		  gss_cred_id_t *output_cred_handle, gss_OID_set *actual_mechs,
+		  OM_uint32 *initiator_time_rec, OM_uint32 *acceptor_time_rec)
 {
     OM_uint32		status, temp_minor_status;
     OM_uint32		time_req, time_rec = 0, *time_recp = NULL;

--- a/src/lib/gssapi/mechglue/g_acquire_cred_with_pw.c
+++ b/src/lib/gssapi/mechglue/g_acquire_cred_with_pw.c
@@ -98,26 +98,12 @@ val_acq_cred_pw_args(
 
 
 OM_uint32 KRB5_CALLCONV
-gss_acquire_cred_with_password(
-    minor_status,
-    desired_name,
-    password,
-    time_req,
-    desired_mechs,
-    cred_usage,
-    output_cred_handle,
-    actual_mechs,
-    time_rec)
-
-OM_uint32 *		minor_status;
-const gss_name_t	desired_name;
-const gss_buffer_t	password;
-OM_uint32		time_req;
-const gss_OID_set	desired_mechs;
-int			cred_usage;
-gss_cred_id_t *		output_cred_handle;
-gss_OID_set *		actual_mechs;
-OM_uint32 *		time_rec;
+gss_acquire_cred_with_password(OM_uint32 *minor_status,
+			       const gss_name_t desired_name,
+			       const gss_buffer_t password, OM_uint32 time_req,
+			       const gss_OID_set desired_mechs, int cred_usage,
+			       gss_cred_id_t *output_cred_handle,
+			       gss_OID_set *actual_mechs, OM_uint32 *time_rec)
 {
     OM_uint32 major = GSS_S_FAILURE;
     OM_uint32 initTimeOut, acceptTimeOut, outTime = GSS_C_INDEFINITE;
@@ -306,23 +292,19 @@ val_add_cred_pw_args(
 
 /* V2 KRB5_CALLCONV */
 OM_uint32 KRB5_CALLCONV
-gss_add_cred_with_password(minor_status, input_cred_handle,
-		  desired_name, desired_mech, password, cred_usage,
-		  initiator_time_req, acceptor_time_req,
-		  output_cred_handle, actual_mechs,
-		  initiator_time_rec, acceptor_time_rec)
-    OM_uint32		*minor_status;
-    const gss_cred_id_t	input_cred_handle;
-    const gss_name_t	desired_name;
-    const gss_OID	desired_mech;
-    const gss_buffer_t	password;
-    gss_cred_usage_t	cred_usage;
-    OM_uint32		initiator_time_req;
-    OM_uint32		acceptor_time_req;
-    gss_cred_id_t	*output_cred_handle;
-    gss_OID_set		*actual_mechs;
-    OM_uint32		*initiator_time_rec;
-    OM_uint32		*acceptor_time_rec;
+gss_add_cred_with_password(
+    OM_uint32 *minor_status,
+    const gss_cred_id_t input_cred_handle,
+    const gss_name_t desired_name,
+    const gss_OID desired_mech,
+    const gss_buffer_t password,
+    gss_cred_usage_t cred_usage,
+    OM_uint32 initiator_time_req,
+    OM_uint32 acceptor_time_req,
+    gss_cred_id_t *output_cred_handle,
+    gss_OID_set *actual_mechs,
+    OM_uint32 *initiator_time_rec,
+    OM_uint32 *acceptor_time_rec)
 {
     OM_uint32		status, temp_minor_status;
     OM_uint32		time_req, time_rec;

--- a/src/lib/gssapi/mechglue/g_canon_name.c
+++ b/src/lib/gssapi/mechglue/g_canon_name.c
@@ -54,14 +54,8 @@ val_canon_name_args(
 
 
 OM_uint32 KRB5_CALLCONV
-gss_canonicalize_name(minor_status,
-				input_name,
-				mech_type,
-				output_name)
-OM_uint32 *minor_status;
-const gss_name_t input_name;
-const gss_OID mech_type;
-gss_name_t *output_name;
+gss_canonicalize_name(OM_uint32 *minor_status, const gss_name_t input_name,
+		      const gss_OID mech_type, gss_name_t *output_name)
 {
 	gss_union_name_t in_union, out_union = NULL, dest_union = NULL;
 	OM_uint32 major_status = GSS_S_FAILURE, tmpmin;

--- a/src/lib/gssapi/mechglue/g_compare_name.c
+++ b/src/lib/gssapi/mechglue/g_compare_name.c
@@ -59,16 +59,8 @@ val_comp_name_args(
 
 
 OM_uint32 KRB5_CALLCONV
-gss_compare_name (minor_status,
-                  name1,
-                  name2,
-                  name_equal)
-
-OM_uint32 *		minor_status;
-gss_name_t		name1;
-gss_name_t		name2;
-int *			name_equal;
-
+gss_compare_name(OM_uint32 * minor_status, gss_name_t name1, gss_name_t name2,
+		 int * name_equal)
 {
     OM_uint32		major_status, temp_minor;
     gss_union_name_t	union_name1, union_name2;

--- a/src/lib/gssapi/mechglue/g_context_time.c
+++ b/src/lib/gssapi/mechglue/g_context_time.c
@@ -29,14 +29,8 @@
 #include "mglueP.h"
 
 OM_uint32 KRB5_CALLCONV
-gss_context_time (minor_status,
-                  context_handle,
-                  time_rec)
-
-OM_uint32 *		minor_status;
-gss_ctx_id_t		context_handle;
-OM_uint32 *		time_rec;
-
+gss_context_time(OM_uint32 * minor_status, gss_ctx_id_t context_handle,
+		 OM_uint32 * time_rec)
 {
     OM_uint32		status;
     gss_union_ctx_id_t	ctx;

--- a/src/lib/gssapi/mechglue/g_delete_sec_context.c
+++ b/src/lib/gssapi/mechglue/g_delete_sec_context.c
@@ -62,14 +62,8 @@ val_del_sec_ctx_args(
 
 
 OM_uint32 KRB5_CALLCONV
-gss_delete_sec_context (minor_status,
-                        context_handle,
-                        output_token)
-
-OM_uint32 *		minor_status;
-gss_ctx_id_t *		context_handle;
-gss_buffer_t		output_token;
-
+gss_delete_sec_context(OM_uint32 *minor_status, gss_ctx_id_t *context_handle,
+		       gss_buffer_t output_token)
 {
     OM_uint32		status;
     gss_union_ctx_id_t	ctx;

--- a/src/lib/gssapi/mechglue/g_dsp_name.c
+++ b/src/lib/gssapi/mechglue/g_dsp_name.c
@@ -70,16 +70,8 @@ val_dsp_name_args(
 
 
 OM_uint32 KRB5_CALLCONV
-gss_display_name (minor_status,
-                  input_name,
-                  output_name_buffer,
-                  output_name_type)
-
-OM_uint32 *		minor_status;
-gss_name_t		input_name;
-gss_buffer_t		output_name_buffer;
-gss_OID *		output_name_type;
-
+gss_display_name(OM_uint32 *minor_status, gss_name_t input_name,
+		 gss_buffer_t output_name_buffer, gss_OID *output_name_type)
 {
     OM_uint32		major_status;
     gss_union_name_t	union_name;

--- a/src/lib/gssapi/mechglue/g_dsp_status.c
+++ b/src/lib/gssapi/mechglue/g_dsp_status.c
@@ -36,20 +36,9 @@
 static OM_uint32 displayMajor(OM_uint32, OM_uint32 *, gss_buffer_t);
 
 OM_uint32 KRB5_CALLCONV
-gss_display_status (minor_status,
-                    status_value,
-                    status_type,
-                    req_mech_type,
-                    message_context,
-                    status_string)
-
-OM_uint32 *		minor_status;
-OM_uint32		status_value;
-int			status_type;
-gss_OID			req_mech_type;
-OM_uint32 *		message_context;
-gss_buffer_t		status_string;
-
+gss_display_status(OM_uint32 *minor_status, OM_uint32 status_value,
+		   int status_type, gss_OID req_mech_type,
+		   OM_uint32 *message_context, gss_buffer_t status_string)
 {
     gss_OID		mech_type = (gss_OID) req_mech_type;
     gss_mechanism	mech;
@@ -147,10 +136,7 @@ gss_buffer_t		status_string;
  *	>= 2 - the supplementary error code bit shifted by 1
  */
 static OM_uint32
-displayMajor(status, msgCtxt, outStr)
-OM_uint32 status;
-OM_uint32 *msgCtxt;
-gss_buffer_t outStr;
+displayMajor(OM_uint32 status, OM_uint32 *msgCtxt, gss_buffer_t outStr)
 {
 	OM_uint32 oneVal, mask = 0x1, currErr;
 	char *errStr = NULL;

--- a/src/lib/gssapi/mechglue/g_dup_name.c
+++ b/src/lib/gssapi/mechglue/g_dup_name.c
@@ -51,12 +51,8 @@ val_dup_name_args(
 
 
 OM_uint32 KRB5_CALLCONV
-gss_duplicate_name(minor_status,
-		src_name,
-		dest_name)
-OM_uint32 *minor_status;
-const gss_name_t src_name;
-gss_name_t *dest_name;
+gss_duplicate_name(OM_uint32 *minor_status, const gss_name_t src_name,
+		   gss_name_t *dest_name)
 {
 		gss_union_name_t src_union, dest_union;
 		OM_uint32 major_status = GSS_S_FAILURE;

--- a/src/lib/gssapi/mechglue/g_exp_sec_context.c
+++ b/src/lib/gssapi/mechglue/g_exp_sec_context.c
@@ -68,14 +68,8 @@ val_exp_sec_ctx_args(
 
 
 OM_uint32 KRB5_CALLCONV
-gss_export_sec_context(minor_status,
-                       context_handle,
-                       interprocess_token)
-
-OM_uint32 *		minor_status;
-gss_ctx_id_t *		context_handle;
-gss_buffer_t		interprocess_token;
-
+gss_export_sec_context(OM_uint32 *minor_status, gss_ctx_id_t *context_handle,
+		       gss_buffer_t interprocess_token)
 {
     OM_uint32		status;
     OM_uint32 		length;

--- a/src/lib/gssapi/mechglue/g_export_name.c
+++ b/src/lib/gssapi/mechglue/g_export_name.c
@@ -20,12 +20,8 @@
 #include <errno.h>
 
 OM_uint32 KRB5_CALLCONV
-gss_export_name(minor_status,
-			input_name,
-			exported_name)
-OM_uint32 *		minor_status;
-const gss_name_t	input_name;
-gss_buffer_t		exported_name;
+gss_export_name(OM_uint32 *minor_status, const gss_name_t input_name,
+		gss_buffer_t exported_name)
 {
 	gss_union_name_t		union_name;
 

--- a/src/lib/gssapi/mechglue/g_glue.c
+++ b/src/lib/gssapi/mechglue/g_glue.c
@@ -75,9 +75,8 @@ static gss_OID_desc gss_krb5_mechanism_oid_desc =
 
 #define NTLMSSP_SIGNATURE "NTLMSSP"
 
-OM_uint32 gssint_get_mech_type(OID, token)
-    gss_OID		OID;
-    gss_buffer_t	token;
+OM_uint32
+gssint_get_mech_type(gss_OID OID, gss_buffer_t token)
 {
     /* Check for interoperability exceptions */
     if (token->length >= sizeof(NTLMSSP_SIGNATURE) &&
@@ -163,12 +162,10 @@ import_internal_attributes(OM_uint32 *minor,
  *  Internal routines to get and release an internal mechanism name
  */
 
-OM_uint32 gssint_import_internal_name (minor_status, mech_type, union_name,
-				internal_name)
-OM_uint32	*minor_status;
-gss_OID		mech_type;
-gss_union_name_t	union_name;
-gss_name_t	*internal_name;
+OM_uint32
+gssint_import_internal_name(OM_uint32 *minor_status, gss_OID mech_type,
+			    gss_union_name_t union_name,
+			    gss_name_t *internal_name)
 {
     OM_uint32		status, tmpMinor;
     gss_mechanism	mech;
@@ -220,12 +217,10 @@ gss_name_t	*internal_name;
     return (status);
 }
 
-OM_uint32 gssint_export_internal_name(minor_status, mech_type,
-				     internal_name, name_buf)
-    OM_uint32		*minor_status;
-    const gss_OID		mech_type;
-    const gss_name_t	internal_name;
-    gss_buffer_t		name_buf;
+OM_uint32
+gssint_export_internal_name(OM_uint32 *minor_status, const gss_OID mech_type,
+			    const gss_name_t internal_name,
+			    gss_buffer_t name_buf)
 {
     OM_uint32 status;
     gss_mechanism mech;
@@ -307,13 +302,10 @@ OM_uint32 gssint_export_internal_name(minor_status, mech_type,
     return (GSS_S_COMPLETE);
 } /*  gssint_export_internal_name */
 
-OM_uint32 gssint_display_internal_name (minor_status, mech_type, internal_name,
-				 external_name, name_type)
-OM_uint32	*minor_status;
-gss_OID		mech_type;
-gss_name_t	internal_name;
-gss_buffer_t	external_name;
-gss_OID		*name_type;
+OM_uint32
+gssint_display_internal_name(OM_uint32 *minor_status, gss_OID mech_type,
+			     gss_name_t internal_name,
+			     gss_buffer_t external_name, gss_OID *name_type)
 {
     OM_uint32		status;
     gss_mechanism	mech;
@@ -337,10 +329,9 @@ gss_OID		*name_type;
     return (GSS_S_BAD_MECH);
 }
 
-OM_uint32 gssint_release_internal_name (minor_status, mech_type, internal_name)
-OM_uint32	*minor_status;
-gss_OID		mech_type;
-gss_name_t	*internal_name;
+OM_uint32
+gssint_release_internal_name(OM_uint32 *minor_status, gss_OID mech_type,
+			     gss_name_t *internal_name)
 {
     OM_uint32		status;
     gss_mechanism	mech;
@@ -362,14 +353,10 @@ gss_name_t	*internal_name;
     return (GSS_S_BAD_MECH);
 }
 
-OM_uint32 gssint_delete_internal_sec_context (minor_status,
-					      mech_type,
-					      internal_ctx,
-					      output_token)
-OM_uint32	*minor_status;
-gss_OID		mech_type;
-gss_ctx_id_t	*internal_ctx;
-gss_buffer_t	output_token;
+OM_uint32
+gssint_delete_internal_sec_context(OM_uint32 *minor_status, gss_OID mech_type,
+				   gss_ctx_id_t *internal_ctx,
+				   gss_buffer_t output_token)
 {
     OM_uint32		status;
     gss_mechanism	mech;
@@ -394,12 +381,10 @@ gss_buffer_t	output_token;
  * name.  Note that internal_name should be considered "consumed" by
  * this call, whether or not we return an error.
  */
-OM_uint32 gssint_convert_name_to_union_name(minor_status, mech,
-					   internal_name, external_name)
-    OM_uint32 *minor_status;
-    gss_mechanism	mech;
-    gss_name_t	internal_name;
-    gss_name_t	*external_name;
+OM_uint32
+gssint_convert_name_to_union_name(OM_uint32 *minor_status, gss_mechanism mech,
+				  gss_name_t internal_name,
+				  gss_name_t *external_name)
 {
     OM_uint32 major_status,tmp;
     gss_union_name_t union_name;
@@ -473,9 +458,7 @@ allocation_failure:
  * external union credential.
  */
 gss_cred_id_t
-gssint_get_mechanism_cred(union_cred, mech_type)
-    gss_union_cred_t	union_cred;
-    gss_OID		mech_type;
+gssint_get_mechanism_cred(gss_union_cred_t union_cred, gss_OID mech_type)
 {
     int		i;
 
@@ -494,10 +477,8 @@ gssint_get_mechanism_cred(union_cred, mech_type)
  * Both space for the structure and the data is allocated.
  */
 OM_uint32
-gssint_create_copy_buffer(srcBuf, destBuf, addNullChar)
-    const gss_buffer_t	srcBuf;
-    gss_buffer_t 		*destBuf;
-    int			addNullChar;
+gssint_create_copy_buffer(const gss_buffer_t srcBuf, gss_buffer_t *destBuf,
+			  int addNullChar)
 {
     gss_buffer_t aBuf;
     unsigned int len;

--- a/src/lib/gssapi/mechglue/g_imp_name.c
+++ b/src/lib/gssapi/mechglue/g_imp_name.c
@@ -81,16 +81,8 @@ val_imp_name_args(
 static gss_buffer_desc emptyNameBuffer;
 
 OM_uint32 KRB5_CALLCONV
-gss_import_name(minor_status,
-                input_name_buffer,
-                input_name_type,
-                output_name)
-
-OM_uint32 *		minor_status;
-gss_buffer_t		input_name_buffer;
-gss_OID			input_name_type;
-gss_name_t *		output_name;
-
+gss_import_name(OM_uint32 * minor_status, gss_buffer_t input_name_buffer,
+		gss_OID input_name_type, gss_name_t * output_name)
 {
     gss_union_name_t	union_name;
     OM_uint32		tmp, major_status = GSS_S_FAILURE;
@@ -183,10 +175,8 @@ allocation_failure:
 }
 
 static OM_uint32
-importExportName(minor, unionName, inputNameType)
-    OM_uint32 *minor;
-    gss_union_name_t unionName;
-    gss_OID inputNameType;
+importExportName(OM_uint32 *minor, gss_union_name_t unionName,
+		 gss_OID inputNameType)
 {
     gss_OID_desc mechOid;
     gss_buffer_desc expName;

--- a/src/lib/gssapi/mechglue/g_imp_sec_context.c
+++ b/src/lib/gssapi/mechglue/g_imp_sec_context.c
@@ -69,14 +69,9 @@ val_imp_sec_ctx_args(
 
 
 OM_uint32 KRB5_CALLCONV
-gss_import_sec_context(minor_status,
-                       interprocess_token,
-                       context_handle)
-
-OM_uint32 *		minor_status;
-gss_buffer_t		interprocess_token;
-gss_ctx_id_t *		context_handle;
-
+gss_import_sec_context(OM_uint32 *minor_status,
+		       gss_buffer_t interprocess_token,
+		       gss_ctx_id_t *context_handle)
 {
     OM_uint32		length = 0;
     OM_uint32		status;

--- a/src/lib/gssapi/mechglue/g_init_sec_context.c
+++ b/src/lib/gssapi/mechglue/g_init_sec_context.c
@@ -88,34 +88,15 @@ val_init_sec_ctx_args(
 
 
 OM_uint32 KRB5_CALLCONV
-gss_init_sec_context (minor_status,
-                      claimant_cred_handle,
-                      context_handle,
-                      target_name,
-                      req_mech_type,
-                      req_flags,
-                      time_req,
-                      input_chan_bindings,
-                      input_token,
-                      actual_mech_type,
-                      output_token,
-                      ret_flags,
-                      time_rec)
-
-OM_uint32 *		minor_status;
-gss_cred_id_t		claimant_cred_handle;
-gss_ctx_id_t *		context_handle;
-gss_name_t		target_name;
-gss_OID			req_mech_type;
-OM_uint32		req_flags;
-OM_uint32		time_req;
-gss_channel_bindings_t	input_chan_bindings;
-gss_buffer_t		input_token;
-gss_OID *		actual_mech_type;
-gss_buffer_t		output_token;
-OM_uint32 *		ret_flags;
-OM_uint32 *		time_rec;
-
+gss_init_sec_context(OM_uint32 *minor_status,
+		     gss_cred_id_t claimant_cred_handle,
+		     gss_ctx_id_t *context_handle, gss_name_t target_name,
+		     gss_OID req_mech_type, OM_uint32 req_flags,
+		     OM_uint32 time_req,
+		     gss_channel_bindings_t input_chan_bindings,
+		     gss_buffer_t input_token, gss_OID *actual_mech_type,
+		     gss_buffer_t output_token, OM_uint32 *ret_flags,
+		     OM_uint32 *time_rec)
 {
     OM_uint32		status, temp_minor_status;
     gss_union_name_t	union_name;

--- a/src/lib/gssapi/mechglue/g_initialize.c
+++ b/src/lib/gssapi/mechglue/g_initialize.c
@@ -169,9 +169,7 @@ gssint_mechglue_initialize_library(void)
  * This routine requires direct access to the mechList.
  */
 OM_uint32 KRB5_CALLCONV
-gss_release_oid(minor_status, oid)
-OM_uint32 *minor_status;
-gss_OID *oid;
+gss_release_oid(OM_uint32 *minor_status, gss_OID *oid)
 {
 	OM_uint32 major;
 	gss_mech_info aMech;
@@ -267,9 +265,7 @@ prune_deprecated(gss_OID_set mech_set)
  * a mech oid set, and only update it once the file has changed.
  */
 OM_uint32 KRB5_CALLCONV
-gss_indicate_mechs(minorStatus, mechSet_out)
-OM_uint32 *minorStatus;
-gss_OID_set *mechSet_out;
+gss_indicate_mechs(OM_uint32 *minorStatus, gss_OID_set *mechSet_out)
 {
 	OM_uint32 status;
 
@@ -417,8 +413,7 @@ build_mechSet(void)
  * caller is responsible for freeing the memory
  */
 char *
-gssint_get_modOptions(oid)
-const gss_OID oid;
+gssint_get_modOptions(const gss_OID oid)
 {
 	gss_mech_info aMech;
 	char *modOptions = NULL;
@@ -479,7 +474,7 @@ load_if_changed(const char *pathname, time_t last, time_t *highest)
 /* Try to load any config files which have changed since the last call.  Config
  * files are MECH_CONF and any files matching MECH_CONF_PATTERN. */
 static void
-loadConfigFiles()
+loadConfigFiles(void)
 {
 	glob_t globbuf;
 	time_t highest = (time_t)-1, now;
@@ -679,7 +674,8 @@ gssint_register_mechinfo(gss_mech_info template)
 		memset(&errinfo, 0, sizeof(errinfo)); \
 		if (krb5int_get_plugin_func(_dl, \
 					    #_symbol, \
-					    (void (**)())&(_mech)->_symbol, \
+					    (void (**)(void)) \
+					    &(_mech)->_symbol, \
 					    &errinfo) || errinfo.code) {  \
 			(_mech)->_symbol = NULL; \
 			k5_clear_error(&errinfo); \
@@ -801,7 +797,7 @@ build_dynamicMech(void *dl, const gss_OID mech_type)
 		memset(&errinfo, 0, sizeof(errinfo));			\
 		if (krb5int_get_plugin_func(_dl,			\
 					    "gssi" #_nsym,		\
-					    (void (**)())&(_mech)->_psym \
+					    (void (**)(void))&(_mech)->_psym \
 					    ## _nsym,			\
 					    &errinfo) || errinfo.code) { \
 			(_mech)->_psym ## _nsym = NULL;			\
@@ -948,7 +944,7 @@ loadInterMech(gss_mech_info minfo)
 	}
 
 	if (krb5int_get_plugin_func(dl, MECH_INTERPOSER_SYM,
-				    (void (**)())&isym, &errinfo) != 0)
+				    (void (**)(void))&isym, &errinfo) != 0)
 		goto cleanup;
 
 	/* Get a list of mechs to interpose. */
@@ -1184,7 +1180,7 @@ gssint_get_mechanism(gss_const_OID oid)
 		return ((gss_mechanism)NULL);
 	}
 
-	if (krb5int_get_plugin_func(dl, MECH_SYM, (void (**)())&sym,
+	if (krb5int_get_plugin_func(dl, MECH_SYM, (void (**)(void))&sym,
 				    &errinfo) == 0) {
 		/* Call the symbol to get the mechanism table */
 		aMech->mech = (*sym)(aMech->mech_type);

--- a/src/lib/gssapi/mechglue/g_inq_cred.c
+++ b/src/lib/gssapi/mechglue/g_inq_cred.c
@@ -35,20 +35,9 @@
 #include <time.h>
 
 OM_uint32 KRB5_CALLCONV
-gss_inquire_cred(minor_status,
-                 cred_handle,
-                 name,
-                 lifetime,
-		 cred_usage,
-                 mechanisms)
-
-OM_uint32 *		minor_status;
-gss_cred_id_t 		cred_handle;
-gss_name_t *		name;
-OM_uint32 *		lifetime;
-int *			cred_usage;
-gss_OID_set *		mechanisms;
-
+gss_inquire_cred(OM_uint32 *minor_status, gss_cred_id_t cred_handle,
+		 gss_name_t *name, OM_uint32 *lifetime, int *cred_usage,
+		 gss_OID_set *mechanisms)
 {
     OM_uint32		status, temp_minor_status;
     gss_union_cred_t	union_cred;
@@ -159,15 +148,11 @@ error:
 }
 
 OM_uint32 KRB5_CALLCONV
-gss_inquire_cred_by_mech(minor_status, cred_handle, mech_type, name,
-			 initiator_lifetime, acceptor_lifetime, cred_usage)
-    OM_uint32		*minor_status;
-    gss_cred_id_t	cred_handle;
-    gss_OID		mech_type;
-    gss_name_t		*name;
-    OM_uint32		*initiator_lifetime;
-    OM_uint32		*acceptor_lifetime;
-    gss_cred_usage_t *cred_usage;
+gss_inquire_cred_by_mech(OM_uint32 *minor_status, gss_cred_id_t cred_handle,
+			 gss_OID mech_type, gss_name_t *name,
+			 OM_uint32 *initiator_lifetime,
+			 OM_uint32 *acceptor_lifetime,
+			 gss_cred_usage_t *cred_usage)
 {
     gss_union_cred_t	union_cred;
     gss_cred_id_t	mech_cred;

--- a/src/lib/gssapi/mechglue/g_inq_names.c
+++ b/src/lib/gssapi/mechglue/g_inq_names.c
@@ -32,12 +32,8 @@
 
 /* Last argument new for V2 */
 OM_uint32 KRB5_CALLCONV
-gss_inquire_names_for_mech(minor_status, mechanism, name_types)
-
-OM_uint32 *	minor_status;
-gss_OID 	mechanism;
-gss_OID_set *	name_types;
-
+gss_inquire_names_for_mech(OM_uint32 *minor_status, gss_OID mechanism,
+			   gss_OID_set *name_types)
 {
     OM_uint32		status;
     gss_OID		selected_mech = GSS_C_NO_OID, public_mech;

--- a/src/lib/gssapi/mechglue/g_mechname.c
+++ b/src/lib/gssapi/mechglue/g_mechname.c
@@ -20,8 +20,8 @@ static gss_mech_spec_name name_list = NULL;
 /*
  * generic searching helper function.
  */
-static gss_mech_spec_name search_mech_spec(name_type)
-    gss_OID name_type;
+static gss_mech_spec_name
+search_mech_spec(gss_OID name_type)
 {
     gss_mech_spec_name p;
 
@@ -36,8 +36,8 @@ static gss_mech_spec_name search_mech_spec(name_type)
  * Given a name_type, if it is specific to a mechanism, return the
  * mechanism OID.  Otherwise, return NULL.
  */
-gss_OID gss_find_mechanism_from_name_type(name_type)
-    gss_OID name_type;
+gss_OID
+gss_find_mechanism_from_name_type(gss_OID name_type)
 {
     gss_mech_spec_name p;
 
@@ -54,10 +54,8 @@ gss_OID gss_find_mechanism_from_name_type(name_type)
  * Otherwise, enter the pair into the registry.
  */
 OM_uint32
-gss_add_mech_name_type(minor_status, name_type, mech)
-    OM_uint32	*minor_status;
-    gss_OID	name_type;
-    gss_OID	mech;
+gss_add_mech_name_type(OM_uint32 *minor_status, gss_OID name_type,
+		       gss_OID mech)
 {
     OM_uint32	major_status, tmp;
     gss_mech_spec_name p;

--- a/src/lib/gssapi/mechglue/g_oid_ops.c
+++ b/src/lib/gssapi/mechglue/g_oid_ops.c
@@ -33,9 +33,7 @@
  */
 
 OM_uint32 KRB5_CALLCONV
-gss_create_empty_oid_set(minor_status, oid_set)
-    OM_uint32	*minor_status;
-    gss_OID_set	*oid_set;
+gss_create_empty_oid_set(OM_uint32 *minor_status, gss_OID_set *oid_set)
 {
     OM_uint32 status;
     status = generic_gss_create_empty_oid_set(minor_status, oid_set);
@@ -45,10 +43,8 @@ gss_create_empty_oid_set(minor_status, oid_set)
 }
 
 OM_uint32 KRB5_CALLCONV
-gss_add_oid_set_member(minor_status, member_oid, oid_set)
-    OM_uint32	*minor_status;
-    gss_OID	member_oid;
-    gss_OID_set	*oid_set;
+gss_add_oid_set_member(OM_uint32 *minor_status, gss_OID member_oid,
+		       gss_OID_set *oid_set)
 {
     OM_uint32 status;
     status = generic_gss_add_oid_set_member(minor_status, member_oid, oid_set);
@@ -58,20 +54,14 @@ gss_add_oid_set_member(minor_status, member_oid, oid_set)
 }
 
 OM_uint32 KRB5_CALLCONV
-gss_test_oid_set_member(minor_status, member, set, present)
-    OM_uint32	*minor_status;
-    gss_OID	member;
-    gss_OID_set	set;
-    int		*present;
+gss_test_oid_set_member(OM_uint32 *minor_status, gss_OID member,
+			gss_OID_set set, int *present)
 {
     return generic_gss_test_oid_set_member(minor_status, member, set, present);
 }
 
 OM_uint32 KRB5_CALLCONV
-gss_oid_to_str(minor_status, oid, oid_str)
-    OM_uint32		*minor_status;
-    gss_OID		oid;
-    gss_buffer_t	oid_str;
+gss_oid_to_str(OM_uint32 *minor_status, gss_OID oid, gss_buffer_t oid_str)
 {
     OM_uint32 status = generic_gss_oid_to_str(minor_status, oid, oid_str);
     if (status != GSS_S_COMPLETE)
@@ -80,10 +70,7 @@ gss_oid_to_str(minor_status, oid, oid_str)
 }
 
 OM_uint32 KRB5_CALLCONV
-gss_str_to_oid(minor_status, oid_str, oid)
-    OM_uint32		*minor_status;
-    gss_buffer_t	oid_str;
-    gss_OID		*oid;
+gss_str_to_oid(OM_uint32 *minor_status, gss_buffer_t oid_str, gss_OID *oid)
 {
     OM_uint32 status = generic_gss_str_to_oid(minor_status, oid_str, oid);
     if (status != GSS_S_COMPLETE)

--- a/src/lib/gssapi/mechglue/g_process_context.c
+++ b/src/lib/gssapi/mechglue/g_process_context.c
@@ -29,14 +29,8 @@
 #include "mglueP.h"
 
 OM_uint32 KRB5_CALLCONV
-gss_process_context_token (minor_status,
-                           context_handle,
-                           token_buffer)
-
-OM_uint32 *		minor_status;
-gss_ctx_id_t		context_handle;
-gss_buffer_t		token_buffer;
-
+gss_process_context_token(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
+			  gss_buffer_t token_buffer)
 {
     OM_uint32		status;
     gss_union_ctx_id_t	ctx;

--- a/src/lib/gssapi/mechglue/g_rel_buffer.c
+++ b/src/lib/gssapi/mechglue/g_rel_buffer.c
@@ -33,11 +33,7 @@
 #endif
 
 OM_uint32 KRB5_CALLCONV
-gss_release_buffer (minor_status,
-		    buffer)
-
-OM_uint32 *		minor_status;
-gss_buffer_t		buffer;
+gss_release_buffer(OM_uint32 *minor_status, gss_buffer_t buffer)
 {
     if (minor_status)
 	*minor_status = 0;

--- a/src/lib/gssapi/mechglue/g_rel_cred.c
+++ b/src/lib/gssapi/mechglue/g_rel_cred.c
@@ -31,12 +31,7 @@
 #endif
 
 OM_uint32 KRB5_CALLCONV
-gss_release_cred(minor_status,
-                 cred_handle)
-
-OM_uint32 *		minor_status;
-gss_cred_id_t *		cred_handle;
-
+gss_release_cred(OM_uint32 *minor_status, gss_cred_id_t *cred_handle)
 {
     OM_uint32		status, temp_status;
     int			j;

--- a/src/lib/gssapi/mechglue/g_rel_name.c
+++ b/src/lib/gssapi/mechglue/g_rel_name.c
@@ -34,12 +34,7 @@
 #include <string.h>
 
 OM_uint32 KRB5_CALLCONV
-gss_release_name (minor_status,
-		  input_name)
-
-OM_uint32 *		minor_status;
-gss_name_t *		input_name;
-
+gss_release_name(OM_uint32 *minor_status, gss_name_t *input_name)
 {
     gss_union_name_t	union_name;
 

--- a/src/lib/gssapi/mechglue/g_rel_oid_set.c
+++ b/src/lib/gssapi/mechglue/g_rel_oid_set.c
@@ -33,11 +33,7 @@
 #endif
 
 OM_uint32 KRB5_CALLCONV
-gss_release_oid_set (minor_status,
-		     set)
-
-OM_uint32 *		minor_status;
-gss_OID_set *		set;
+gss_release_oid_set(OM_uint32 *minor_status, gss_OID_set *set)
 {
     return generic_gss_release_oid_set(minor_status, set);
 }

--- a/src/lib/gssapi/mechglue/g_sign.c
+++ b/src/lib/gssapi/mechglue/g_sign.c
@@ -66,18 +66,9 @@ val_get_mic_args(
 
 
 OM_uint32 KRB5_CALLCONV
-gss_get_mic (minor_status,
-	     context_handle,
-	     qop_req,
-	     message_buffer,
-	     msg_token)
-
-OM_uint32 *		minor_status;
-gss_ctx_id_t		context_handle;
-gss_qop_t		qop_req;
-gss_buffer_t		message_buffer;
-gss_buffer_t		msg_token;
-
+gss_get_mic(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
+	    gss_qop_t qop_req, gss_buffer_t message_buffer,
+	    gss_buffer_t msg_token)
 {
     OM_uint32		status;
     gss_union_ctx_id_t	ctx;
@@ -118,18 +109,8 @@ gss_buffer_t		msg_token;
 }
 
 OM_uint32 KRB5_CALLCONV
-gss_sign (minor_status,
-          context_handle,
-          qop_req,
-          message_buffer,
-          msg_token)
-
-OM_uint32 *		minor_status;
-gss_ctx_id_t		context_handle;
-int			qop_req;
-gss_buffer_t		message_buffer;
-gss_buffer_t		msg_token;
-
+gss_sign(OM_uint32 *minor_status, gss_ctx_id_t context_handle, int qop_req,
+	 gss_buffer_t message_buffer, gss_buffer_t msg_token)
 {
 	return (gss_get_mic(minor_status, context_handle, (gss_qop_t) qop_req,
 			    message_buffer, msg_token));

--- a/src/lib/gssapi/mechglue/g_store_cred.c
+++ b/src/lib/gssapi/mechglue/g_store_cred.c
@@ -93,24 +93,10 @@ val_store_cred_args(
 
 
 OM_uint32 KRB5_CALLCONV
-gss_store_cred(minor_status,
-	       input_cred_handle,
-	       cred_usage,
-	       desired_mech,
-	       overwrite_cred,
-	       default_cred,
-	       elements_stored,
-	       cred_usage_stored)
-
-OM_uint32		*minor_status;
-gss_cred_id_t	         input_cred_handle;
-gss_cred_usage_t	 cred_usage;
-const gss_OID		 desired_mech;
-OM_uint32		 overwrite_cred;
-OM_uint32		 default_cred;
-gss_OID_set		*elements_stored;
-gss_cred_usage_t	*cred_usage_stored;
-
+gss_store_cred(OM_uint32 *minor_status, gss_cred_id_t input_cred_handle,
+	       gss_cred_usage_t cred_usage, const gss_OID desired_mech,
+	       OM_uint32 overwrite_cred, OM_uint32 default_cred,
+	       gss_OID_set *elements_stored, gss_cred_usage_t *cred_usage_stored)
 {
 	return gss_store_cred_into(minor_status, input_cred_handle, cred_usage,
 				   desired_mech, overwrite_cred, default_cred,
@@ -119,26 +105,12 @@ gss_cred_usage_t	*cred_usage_stored;
 }
 
 OM_uint32 KRB5_CALLCONV
-gss_store_cred_into(minor_status,
-		    input_cred_handle,
-		    cred_usage,
-		    desired_mech,
-		    overwrite_cred,
-		    default_cred,
-		    cred_store,
-		    elements_stored,
-		    cred_usage_stored)
-
-OM_uint32			 *minor_status;
-gss_cred_id_t			 input_cred_handle;
-gss_cred_usage_t		 cred_usage;
-gss_OID				 desired_mech;
-OM_uint32			 overwrite_cred;
-OM_uint32			 default_cred;
-gss_const_key_value_set_t	 cred_store;
-gss_OID_set			 *elements_stored;
-gss_cred_usage_t		 *cred_usage_stored;
-
+gss_store_cred_into(OM_uint32 *minor_status, gss_cred_id_t input_cred_handle,
+		    gss_cred_usage_t cred_usage, gss_OID desired_mech,
+		    OM_uint32 overwrite_cred, OM_uint32 default_cred,
+		    gss_const_key_value_set_t cred_store,
+		    gss_OID_set *elements_stored,
+		    gss_cred_usage_t *cred_usage_stored)
 {
 	OM_uint32		major_status = GSS_S_FAILURE;
 	gss_union_cred_t	union_cred;

--- a/src/lib/gssapi/mechglue/g_unseal.c
+++ b/src/lib/gssapi/mechglue/g_unseal.c
@@ -29,20 +29,10 @@
 #include "mglueP.h"
 
 OM_uint32 KRB5_CALLCONV
-gss_unwrap (minor_status,
-            context_handle,
-            input_message_buffer,
-            output_message_buffer,
-            conf_state,
-            qop_state)
-
-OM_uint32 *		minor_status;
-gss_ctx_id_t		context_handle;
-gss_buffer_t		input_message_buffer;
-gss_buffer_t		output_message_buffer;
-int *			conf_state;
-gss_qop_t *		qop_state;
-
+gss_unwrap(OM_uint32 * minor_status, gss_ctx_id_t context_handle,
+	   gss_buffer_t input_message_buffer,
+	   gss_buffer_t output_message_buffer,
+	   int *conf_state, gss_qop_t *qop_state)
 {
 /* EXPORT DELETE START */
     OM_uint32		status;
@@ -111,20 +101,9 @@ gss_qop_t *		qop_state;
 }
 
 OM_uint32 KRB5_CALLCONV
-gss_unseal (minor_status,
-            context_handle,
-            input_message_buffer,
-            output_message_buffer,
-            conf_state,
-            qop_state)
-
-OM_uint32 *		minor_status;
-gss_ctx_id_t		context_handle;
-gss_buffer_t		input_message_buffer;
-gss_buffer_t		output_message_buffer;
-int *			conf_state;
-int *			qop_state;
-
+gss_unseal(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
+	   gss_buffer_t input_message_buffer,
+	   gss_buffer_t output_message_buffer, int *conf_state, int *qop_state)
 {
     return (gss_unwrap(minor_status, context_handle,
 		       input_message_buffer,

--- a/src/lib/gssapi/mechglue/g_unwrap_aead.c
+++ b/src/lib/gssapi/mechglue/g_unwrap_aead.c
@@ -154,20 +154,11 @@ gssint_unwrap_aead (gss_mechanism mech,
 }
 
 OM_uint32 KRB5_CALLCONV
-gss_unwrap_aead (minor_status,
-                 context_handle,
-		 input_message_buffer,
-		 input_assoc_buffer,
-		 output_payload_buffer,
-                 conf_state,
-                 qop_state)
-OM_uint32 *		minor_status;
-gss_ctx_id_t		context_handle;
-gss_buffer_t		input_message_buffer;
-gss_buffer_t		input_assoc_buffer;
-gss_buffer_t		output_payload_buffer;
-int 			*conf_state;
-gss_qop_t		*qop_state;
+gss_unwrap_aead(OM_uint32 * minor_status, gss_ctx_id_t context_handle,
+		gss_buffer_t input_message_buffer,
+		gss_buffer_t input_assoc_buffer,
+		gss_buffer_t output_payload_buffer,
+		int *conf_state, gss_qop_t *qop_state)
 {
 
     OM_uint32		status;

--- a/src/lib/gssapi/mechglue/g_unwrap_iov.c
+++ b/src/lib/gssapi/mechglue/g_unwrap_iov.c
@@ -59,18 +59,9 @@ val_unwrap_iov_args(
 
 
 OM_uint32 KRB5_CALLCONV
-gss_unwrap_iov (minor_status,
-                context_handle,
-                conf_state,
-                qop_state,
-                iov,
-                iov_count)
-OM_uint32 *		minor_status;
-gss_ctx_id_t		context_handle;
-int *			conf_state;
-gss_qop_t		*qop_state;
-gss_iov_buffer_desc  *	iov;
-int			iov_count;
+gss_unwrap_iov(OM_uint32 * minor_status, gss_ctx_id_t context_handle,
+	       int *conf_state, gss_qop_t *qop_state,
+	       gss_iov_buffer_desc *iov, int iov_count)
 {
  /* EXPORT DELETE START */
 

--- a/src/lib/gssapi/mechglue/g_verify.c
+++ b/src/lib/gssapi/mechglue/g_verify.c
@@ -29,18 +29,9 @@
 #include "mglueP.h"
 
 OM_uint32 KRB5_CALLCONV
-gss_verify_mic (minor_status,
-		context_handle,
-		message_buffer,
-		token_buffer,
-		qop_state)
-
-OM_uint32 *		minor_status;
-gss_ctx_id_t		context_handle;
-gss_buffer_t		message_buffer;
-gss_buffer_t		token_buffer;
-gss_qop_t *		qop_state;
-
+gss_verify_mic(OM_uint32 * minor_status, gss_ctx_id_t context_handle,
+	       gss_buffer_t message_buffer, gss_buffer_t token_buffer,
+	       gss_qop_t *qop_state)
 {
     OM_uint32		status;
     gss_union_ctx_id_t	ctx;
@@ -89,18 +80,9 @@ gss_qop_t *		qop_state;
 }
 
 OM_uint32 KRB5_CALLCONV
-gss_verify (minor_status,
-            context_handle,
-            message_buffer,
-            token_buffer,
-            qop_state)
-
-OM_uint32 *		minor_status;
-gss_ctx_id_t		context_handle;
-gss_buffer_t		message_buffer;
-gss_buffer_t		token_buffer;
-int *			qop_state;
-
+gss_verify(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
+	   gss_buffer_t message_buffer, gss_buffer_t token_buffer,
+	   int *qop_state)
 {
 	return (gss_verify_mic(minor_status, context_handle,
 			       message_buffer, token_buffer,

--- a/src/lib/gssapi/mechglue/g_wrap_aead.c
+++ b/src/lib/gssapi/mechglue/g_wrap_aead.c
@@ -177,15 +177,11 @@ gssint_wrap_aead_iov_shim(gss_mechanism mech,
 }
 
 OM_uint32
-gssint_wrap_aead (gss_mechanism mech,
-		  OM_uint32 *minor_status,
-		  gss_union_ctx_id_t ctx,
-		  int conf_req_flag,
-		  gss_qop_t qop_req,
-		  gss_buffer_t input_assoc_buffer,
-		  gss_buffer_t input_payload_buffer,
-		  int *conf_state,
-		  gss_buffer_t output_message_buffer)
+gssint_wrap_aead(gss_mechanism mech, OM_uint32 *minor_status,
+		 gss_union_ctx_id_t ctx, int conf_req_flag, gss_qop_t qop_req,
+		 gss_buffer_t input_assoc_buffer,
+		 gss_buffer_t input_payload_buffer,
+		 int *conf_state, gss_buffer_t output_message_buffer)
 {
  /* EXPORT DELETE START */
     OM_uint32		status;
@@ -223,22 +219,15 @@ gssint_wrap_aead (gss_mechanism mech,
 }
 
 OM_uint32 KRB5_CALLCONV
-gss_wrap_aead (minor_status,
-               context_handle,
-               conf_req_flag,
-               qop_req,
-	       input_assoc_buffer,
-	       input_payload_buffer,
-               conf_state,
-               output_message_buffer)
-OM_uint32 *		minor_status;
-gss_ctx_id_t		context_handle;
-int			conf_req_flag;
-gss_qop_t		qop_req;
-gss_buffer_t		input_assoc_buffer;
-gss_buffer_t		input_payload_buffer;
-int *			conf_state;
-gss_buffer_t		output_message_buffer;
+gss_wrap_aead (
+    OM_uint32 * minor_status,
+    gss_ctx_id_t context_handle,
+    int conf_req_flag,
+    gss_qop_t qop_req,
+    gss_buffer_t input_assoc_buffer,
+    gss_buffer_t input_payload_buffer,
+    int * conf_state,
+    gss_buffer_t output_message_buffer)
 {
     OM_uint32		status;
     gss_mechanism	mech;

--- a/src/lib/gssapi/mechglue/g_wrap_iov.c
+++ b/src/lib/gssapi/mechglue/g_wrap_iov.c
@@ -60,20 +60,9 @@ val_wrap_iov_args(
 
 
 OM_uint32 KRB5_CALLCONV
-gss_wrap_iov (minor_status,
-              context_handle,
-              conf_req_flag,
-              qop_req,
-              conf_state,
-              iov,
-              iov_count)
-OM_uint32 *		minor_status;
-gss_ctx_id_t		context_handle;
-int			conf_req_flag;
-gss_qop_t		qop_req;
-int *			conf_state;
-gss_iov_buffer_desc  *	iov;
-int			iov_count;
+gss_wrap_iov(OM_uint32 * minor_status, gss_ctx_id_t context_handle,
+	     int conf_req_flag, gss_qop_t qop_req, int *conf_state,
+	     gss_iov_buffer_desc *iov, int iov_count)
 {
  /* EXPORT DELETE START */
 
@@ -120,20 +109,10 @@ int			iov_count;
 }
 
 OM_uint32 KRB5_CALLCONV
-gss_wrap_iov_length (minor_status,
-                     context_handle,
-                     conf_req_flag,
-                     qop_req,
-                     conf_state,
-                     iov,
-                     iov_count)
-OM_uint32 *		minor_status;
-gss_ctx_id_t		context_handle;
-int			conf_req_flag;
-gss_qop_t		qop_req;
-int *			conf_state;
-gss_iov_buffer_desc  *	iov;
-int			iov_count;
+gss_wrap_iov_length(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
+		    int conf_req_flag, gss_qop_t qop_req,
+		    int *conf_state, gss_iov_buffer_desc *iov,
+		    int iov_count)
 {
  /* EXPORT DELETE START */
 
@@ -239,12 +218,8 @@ gss_get_mic_iov_length(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
 }
 
 OM_uint32 KRB5_CALLCONV
-gss_release_iov_buffer (minor_status,
-			iov,
-			iov_count)
-OM_uint32 *		minor_status;
-gss_iov_buffer_desc *	iov;
-int			iov_count;
+gss_release_iov_buffer(OM_uint32 * minor_status, gss_iov_buffer_desc *iov,
+		       int iov_count)
 {
     OM_uint32		status = GSS_S_COMPLETE;
     int			i;

--- a/src/lib/kadm5/clnt/client_rpc.c
+++ b/src/lib/kadm5/clnt/client_rpc.c
@@ -1,6 +1,7 @@
 /* -*- mode: c; c-file-style: "bsd"; indent-tabs-mode: t -*- */
 #include <gssrpc/rpc.h>
 #include <kadm5/kadm_rpc.h>
+#include <kadm5/admin_xdr.h>
 #include <krb5.h>
 #include <kadm5/admin.h>
 #include <string.h>  /* for memset prototype */

--- a/src/lib/kadm5/kadm_rpc.h
+++ b/src/lib/kadm5/kadm_rpc.h
@@ -360,49 +360,4 @@ extern enum clnt_stat get_principal_keys_2(getpkeys_arg *, getpkeys_ret *,
 					   CLIENT *);
 extern  bool_t get_principal_keys_2_svc(getpkeys_arg *, getpkeys_ret *,
 					struct svc_req *);
-
-extern bool_t xdr_cprinc_arg ();
-extern bool_t xdr_cprinc3_arg ();
-extern bool_t xdr_generic_ret ();
-extern bool_t xdr_dprinc_arg ();
-extern bool_t xdr_mprinc_arg ();
-extern bool_t xdr_rprinc_arg ();
-extern bool_t xdr_gprincs_arg ();
-extern bool_t xdr_gprincs_ret ();
-extern bool_t xdr_chpass_arg ();
-extern bool_t xdr_chpass3_arg ();
-extern bool_t xdr_setkey_arg ();
-extern bool_t xdr_setkey3_arg ();
-extern bool_t xdr_setkey4_arg ();
-extern bool_t xdr_chrand_arg ();
-extern bool_t xdr_chrand3_arg ();
-extern bool_t xdr_chrand_ret ();
-extern bool_t xdr_gprinc_arg ();
-extern bool_t xdr_gprinc_ret ();
-extern bool_t xdr_kadm5_ret_t ();
-extern bool_t xdr_kadm5_principal_ent_rec ();
-extern bool_t xdr_kadm5_policy_ent_rec ();
-extern bool_t	xdr_krb5_keyblock ();
-extern bool_t	xdr_krb5_principal ();
-extern bool_t	xdr_krb5_enctype ();
-extern bool_t	xdr_krb5_octet ();
-extern bool_t	xdr_krb5_int32 ();
-extern bool_t	xdr_u_int32 ();
-extern bool_t xdr_cpol_arg ();
-extern bool_t xdr_dpol_arg ();
-extern bool_t xdr_mpol_arg ();
-extern bool_t xdr_gpol_arg ();
-extern bool_t xdr_gpol_ret ();
-extern bool_t xdr_gpols_arg ();
-extern bool_t xdr_gpols_ret ();
-extern bool_t xdr_getprivs_ret ();
-extern bool_t xdr_purgekeys_arg ();
-extern bool_t xdr_gstrings_arg ();
-extern bool_t xdr_gstrings_ret ();
-extern bool_t xdr_sstring_arg ();
-extern bool_t xdr_krb5_string_attr ();
-extern bool_t xdr_kadm5_key_data ();
-extern bool_t xdr_getpkeys_arg ();
-extern bool_t xdr_getpkeys_ret ();
-
 #endif /* __KADM_RPC_H__ */

--- a/src/lib/kadm5/kadm_rpc_xdr.c
+++ b/src/lib/kadm5/kadm_rpc_xdr.c
@@ -408,7 +408,7 @@ _xdr_kadm5_principal_ent_rec(XDR *xdrs, kadm5_principal_ent_rec *objp,
 		return (FALSE);
 	}
 	if (!xdr_nulltype(xdrs, (void **) &objp->mod_name,
-			  xdr_krb5_principal)) {
+			  (xdrproc_t)xdr_krb5_principal)) {
 		return (FALSE);
 	}
 	if (!xdr_krb5_timestamp(xdrs, &objp->mod_date)) {
@@ -451,12 +451,13 @@ _xdr_kadm5_principal_ent_rec(XDR *xdrs, kadm5_principal_ent_rec *objp,
 		return (FALSE);
 	}
 	if (!xdr_nulltype(xdrs, (void **) &objp->tl_data,
-			  xdr_krb5_tl_data)) {
+			  (xdrproc_t)xdr_krb5_tl_data)) {
 		return FALSE;
 	}
 	n = objp->n_key_data;
 	r = xdr_array(xdrs, (caddr_t *) &objp->key_data, &n, objp->n_key_data,
-		      sizeof(krb5_key_data), xdr_krb5_key_data_nocontents);
+		      sizeof(krb5_key_data),
+		      (xdrproc_t)xdr_krb5_key_data_nocontents);
 	objp->n_key_data = n;
 	if (!r) {
 		return (FALSE);
@@ -528,7 +529,7 @@ _xdr_kadm5_policy_ent_rec(XDR *xdrs, kadm5_policy_ent_rec *objp, int vers)
 			return (FALSE);
 		}
 		if (!xdr_nulltype(xdrs, (void **) &objp->tl_data,
-				  xdr_krb5_tl_data)) {
+				  (xdrproc_t)xdr_krb5_tl_data)) {
 			return FALSE;
 		}
 	}
@@ -576,7 +577,7 @@ xdr_cprinc3_arg(XDR *xdrs, cprinc3_arg *objp)
 	if (!xdr_array(xdrs, (caddr_t *)&objp->ks_tuple,
 		       (unsigned int *)&objp->n_ks_tuple, ~0,
 		       sizeof(krb5_key_salt_tuple),
-		       xdr_krb5_key_salt_tuple)) {
+		       (xdrproc_t)xdr_krb5_key_salt_tuple)) {
 		return (FALSE);
 	}
 	if (!xdr_nullstring(xdrs, &objp->passwd)) {
@@ -668,7 +669,7 @@ xdr_gprincs_ret(XDR *xdrs, gprincs_ret *objp)
 	  }
 	  if (!xdr_array(xdrs, (caddr_t *) &objp->princs,
 			 (unsigned int *) &objp->count, ~0,
-			 sizeof(char *), xdr_nullstring)) {
+			 sizeof(char *), (xdrproc_t)xdr_nullstring)) {
 	       return (FALSE);
 	  }
      }
@@ -706,7 +707,7 @@ xdr_chpass3_arg(XDR *xdrs, chpass3_arg *objp)
 	if (!xdr_array(xdrs, (caddr_t *)&objp->ks_tuple,
 		       (unsigned int*)&objp->n_ks_tuple, ~0,
 		       sizeof(krb5_key_salt_tuple),
-		       xdr_krb5_key_salt_tuple)) {
+		       (xdrproc_t)xdr_krb5_key_salt_tuple)) {
 		return (FALSE);
 	}
 	if (!xdr_nullstring(xdrs, &objp->pass)) {
@@ -726,7 +727,7 @@ xdr_setkey_arg(XDR *xdrs, setkey_arg *objp)
 	}
 	if (!xdr_array(xdrs, (caddr_t *) &objp->keyblocks,
 		       (unsigned int *) &objp->n_keys, ~0,
-		       sizeof(krb5_keyblock), xdr_krb5_keyblock)) {
+		       sizeof(krb5_keyblock), (xdrproc_t)xdr_krb5_keyblock)) {
 		return (FALSE);
 	}
 	return (TRUE);
@@ -746,12 +747,13 @@ xdr_setkey3_arg(XDR *xdrs, setkey3_arg *objp)
 	}
 	if (!xdr_array(xdrs, (caddr_t *) &objp->ks_tuple,
 		       (unsigned int *) &objp->n_ks_tuple, ~0,
-		       sizeof(krb5_key_salt_tuple), xdr_krb5_key_salt_tuple)) {
+		       sizeof(krb5_key_salt_tuple),
+		       (xdrproc_t)xdr_krb5_key_salt_tuple)) {
 		return (FALSE);
 	}
 	if (!xdr_array(xdrs, (caddr_t *) &objp->keyblocks,
 		       (unsigned int *) &objp->n_keys, ~0,
-		       sizeof(krb5_keyblock), xdr_krb5_keyblock)) {
+		       sizeof(krb5_keyblock), (xdrproc_t)xdr_krb5_keyblock)) {
 		return (FALSE);
 	}
 	return (TRUE);
@@ -771,7 +773,8 @@ xdr_setkey4_arg(XDR *xdrs, setkey4_arg *objp)
 	}
 	if (!xdr_array(xdrs, (caddr_t *) &objp->key_data,
 		       (unsigned int *) &objp->n_key_data, ~0,
-		       sizeof(kadm5_key_data), xdr_kadm5_key_data)) {
+		       sizeof(kadm5_key_data),
+		       (xdrproc_t)xdr_kadm5_key_data)) {
 		return FALSE;
 	}
 	return TRUE;
@@ -804,7 +807,7 @@ xdr_chrand3_arg(XDR *xdrs, chrand3_arg *objp)
 	if (!xdr_array(xdrs, (caddr_t *)&objp->ks_tuple,
 		       (unsigned int*)&objp->n_ks_tuple, ~0,
 		       sizeof(krb5_key_salt_tuple),
-		       xdr_krb5_key_salt_tuple)) {
+		       (xdrproc_t)xdr_krb5_key_salt_tuple)) {
 		return (FALSE);
 	}
 	return (TRUE);
@@ -822,7 +825,8 @@ xdr_chrand_ret(XDR *xdrs, chrand_ret *objp)
 	if (objp->code == KADM5_OK) {
 		if (!xdr_array(xdrs, (char **)&objp->keys,
 			       (unsigned int *)&objp->n_keys, ~0,
-			       sizeof(krb5_keyblock), xdr_krb5_keyblock))
+			       sizeof(krb5_keyblock),
+			       (xdrproc_t)xdr_krb5_keyblock))
 			return FALSE;
 	}
 
@@ -965,7 +969,7 @@ xdr_gpols_ret(XDR *xdrs, gpols_ret *objp)
 	  }
 	  if (!xdr_array(xdrs, (caddr_t *) &objp->pols,
 			 (unsigned int *) &objp->count, ~0,
-			 sizeof(char *), xdr_nullstring)) {
+			 sizeof(char *), (xdrproc_t)xdr_nullstring)) {
 	       return (FALSE);
 	  }
      }
@@ -1030,7 +1034,7 @@ xdr_gstrings_ret(XDR *xdrs, gstrings_ret *objp)
 		if (!xdr_array(xdrs, (caddr_t *) &objp->strings,
 			       (unsigned int *) &objp->count, ~0,
 			       sizeof(krb5_string_attr),
-			       xdr_krb5_string_attr)) {
+			       (xdrproc_t)xdr_krb5_string_attr)) {
 			return (FALSE);
 		}
 	}
@@ -1198,7 +1202,8 @@ xdr_getpkeys_ret(XDR *xdrs, getpkeys_ret *objp)
 	if (objp->code == KADM5_OK) {
 		if (!xdr_array(xdrs, (caddr_t *) &objp->key_data,
 			       (unsigned int *) &objp->n_key_data, ~0,
-			       sizeof(kadm5_key_data), xdr_kadm5_key_data)) {
+			       sizeof(kadm5_key_data),
+			       (xdrproc_t)xdr_kadm5_key_data)) {
 		    return FALSE;
 		}
 	}

--- a/src/lib/kadm5/misc_free.c
+++ b/src/lib/kadm5/misc_free.c
@@ -41,9 +41,8 @@ kadm5_free_name_list(void *server_handle, char **names, int count)
 }
 
 /* XXX this ought to be in libkrb5.a, but isn't */
-kadm5_ret_t krb5_free_key_data_contents(context, key)
-    krb5_context context;
-    krb5_key_data *key;
+kadm5_ret_t
+krb5_free_key_data_contents(krb5_context context, krb5_key_data *key)
 {
     int i, idx;
 

--- a/src/lib/kadm5/srv/adb_xdr.c
+++ b/src/lib/kadm5/srv/adb_xdr.c
@@ -53,8 +53,7 @@ xdr_osa_pw_hist_ent(XDR *xdrs, osa_pw_hist_ent *objp)
 {
     if (!xdr_array(xdrs, (caddr_t *) &objp->key_data,
 		   (u_int *) &objp->n_key_data, ~0,
-		   sizeof(krb5_key_data),
-		   xdr_krb5_key_data))
+		   sizeof(krb5_key_data), (xdrproc_t)xdr_krb5_key_data))
 	return (FALSE);
     return (TRUE);
 }
@@ -88,8 +87,7 @@ xdr_osa_princ_ent_rec(XDR *xdrs, osa_princ_ent_t objp)
 	return (FALSE);
     if (!xdr_array(xdrs, (caddr_t *) &objp->old_keys,
 		   (unsigned int *) &objp->old_key_len, ~0,
-		   sizeof(osa_pw_hist_ent),
-		   xdr_osa_pw_hist_ent))
+		   sizeof(osa_pw_hist_ent), (xdrproc_t)xdr_osa_pw_hist_ent))
 	return (FALSE);
     return (TRUE);
 }

--- a/src/lib/kadm5/srv/svr_principal.c
+++ b/src/lib/kadm5/srv/svr_principal.c
@@ -30,9 +30,9 @@ static int decrypt_key_data(krb5_context context,
 /*
  * XXX Functions that ought to be in libkrb5.a, but aren't.
  */
-kadm5_ret_t krb5_copy_key_data_contents(context, from, to)
-    krb5_context context;
-    krb5_key_data *from, *to;
+kadm5_ret_t
+krb5_copy_key_data_contents(krb5_context context, krb5_key_data *from,
+                            krb5_key_data *to)
 {
     int i, idx;
 
@@ -75,10 +75,8 @@ static krb5_tl_data *dup_tl_data(krb5_tl_data *tl)
 }
 
 /* This is in lib/kdb/kdb_cpw.c, but is static */
-static void cleanup_key_data(context, count, data)
-    krb5_context   context;
-    int                    count;
-    krb5_key_data        * data;
+static void
+cleanup_key_data(krb5_context context, int count, krb5_key_data *data)
 {
     int i;
 

--- a/src/lib/kadm5/str_conv.c
+++ b/src/lib/kadm5/str_conv.c
@@ -267,11 +267,8 @@ cleanup:
  *      Salttype may be negative to indicate a search for only a enctype.
  */
 krb5_boolean
-krb5_keysalt_is_present(ksaltlist, nksalts, enctype, salttype)
-    krb5_key_salt_tuple *ksaltlist;
-    krb5_int32          nksalts;
-    krb5_enctype        enctype;
-    krb5_int32          salttype;
+krb5_keysalt_is_present(krb5_key_salt_tuple *ksaltlist, krb5_int32 nksalts,
+                        krb5_enctype enctype, krb5_int32 salttype)
 {
     krb5_boolean        foundit;
     int                 i;
@@ -375,12 +372,11 @@ cleanup:
  * If ignoresalt set, then salttype is ignored.
  */
 krb5_error_code
-krb5_keysalt_iterate(ksaltlist, nksalt, ignoresalt, iterator, arg)
-    krb5_key_salt_tuple *ksaltlist;
-    krb5_int32          nksalt;
-    krb5_boolean        ignoresalt;
-    krb5_error_code     (*iterator) (krb5_key_salt_tuple *, krb5_pointer);
-    krb5_pointer        arg;
+krb5_keysalt_iterate(krb5_key_salt_tuple *ksaltlist, krb5_int32 nksalt,
+                     krb5_boolean ignoresalt,
+                     krb5_error_code (*iterator)(krb5_key_salt_tuple *,
+                                                 void *),
+                     void *arg)
 {
     int                 i;
     krb5_error_code     kret;

--- a/src/lib/kadm5/t_kadm5.c
+++ b/src/lib/kadm5/t_kadm5.c
@@ -276,7 +276,7 @@ cpw_test_succeed(char *user, krb5_principal princ, char *pass)
 }
 
 static void
-test_chpass()
+test_chpass(void)
 {
     krb5_principal princ = parse_princ("chpass-test");
     krb5_principal hist_princ = parse_princ("kadmin/history");
@@ -334,7 +334,7 @@ cpol_test_compare(char *user, kadm5_policy_ent_t ent, uint32_t mask)
 }
 
 static void
-test_create_policy()
+test_create_policy(void)
 {
     void *handle;
     kadm5_policy_ent_rec ent;
@@ -440,7 +440,7 @@ cprinc_test_compare(char *user, kadm5_principal_ent_t ent, uint32_t mask,
 }
 
 static void
-test_create_principal()
+test_create_principal(void)
 {
     void *handle;
     kadm5_principal_ent_rec ent;
@@ -535,7 +535,7 @@ dpol_test_succeed(char *user, char *name)
 }
 
 static void
-test_delete_policy()
+test_delete_policy(void)
 {
     krb5_principal princ = parse_princ("delete-policy-test-princ");
 
@@ -587,7 +587,7 @@ dprinc_test_succeed(char *user, krb5_principal princ)
 }
 
 static void
-test_delete_principal()
+test_delete_principal(void)
 {
     krb5_principal princ = parse_princ("delete-principal-test");
 
@@ -638,7 +638,7 @@ gpol_test_fail(char *user, char *name, krb5_error_code code)
 }
 
 static void
-test_get_policy()
+test_get_policy(void)
 {
     /* Fails with unknown policy. */
     dpol_test_fail("admin", "unknown-policy", KADM5_UNK_POLICY);
@@ -684,7 +684,7 @@ gprinc_test_fail(char *user, krb5_principal princ, krb5_error_code code)
 }
 
 static void
-test_get_principal()
+test_get_principal(void)
 {
     void *handle;
     kadm5_principal_ent_rec ent;
@@ -743,7 +743,7 @@ test_get_principal()
 }
 
 static void
-test_init_destroy()
+test_init_destroy(void)
 {
     krb5_context ctx;
     kadm5_ret_t ret;
@@ -1019,7 +1019,7 @@ mpol_test_compare(void *handle, kadm5_policy_ent_t ent, uint32_t mask)
 }
 
 static void
-test_modify_policy()
+test_modify_policy(void)
 {
     kadm5_policy_ent_rec ent;
 
@@ -1109,7 +1109,7 @@ mprinc_test_compare(char *user, kadm5_principal_ent_t ent, uint32_t mask)
 }
 
 static void
-test_modify_principal()
+test_modify_principal(void)
 {
     void *handle;
     krb5_principal princ = parse_princ("modify-principal-test");
@@ -1233,7 +1233,7 @@ rnd_test_succeed(char *user, krb5_principal princ)
 }
 
 static void
-test_randkey()
+test_randkey(void)
 {
     void *handle;
     krb5_principal princ = parse_princ("randkey-principal-test");

--- a/src/lib/kdb/kdb5.c
+++ b/src/lib/kdb/kdb5.c
@@ -75,13 +75,13 @@ free_mkey_list(krb5_context context, krb5_keylist_node *mkey_list)
 }
 
 int
-kdb_init_lock_list()
+kdb_init_lock_list(void)
 {
     return k5_mutex_finish_init(&db_lock);
 }
 
 static int
-kdb_lock_list()
+kdb_lock_list(void)
 {
     int err;
     err = CALL_INIT_FUNCTION (kdb_init_lock_list);
@@ -92,14 +92,14 @@ kdb_lock_list()
 }
 
 void
-kdb_fini_lock_list()
+kdb_fini_lock_list(void)
 {
     if (INITIALIZER_RAN(kdb_init_lock_list))
         k5_mutex_destroy(&db_lock);
 }
 
 static void
-kdb_unlock_list()
+kdb_unlock_list(void)
 {
     k5_mutex_unlock(&db_lock);
 }

--- a/src/lib/kdb/kdb_cpw.c
+++ b/src/lib/kdb/kdb_cpw.c
@@ -57,10 +57,7 @@
 enum save { DISCARD_ALL, KEEP_LAST_KVNO, KEEP_ALL };
 
 int
-krb5_db_get_key_data_kvno(context, count, data)
-    krb5_context          context;
-    int                   count;
-    krb5_key_data       * data;
+krb5_db_get_key_data_kvno(krb5_context context, int count, krb5_key_data *data)
 {
     int i, kvno;
     /* Find last key version number */
@@ -73,10 +70,7 @@ krb5_db_get_key_data_kvno(context, count, data)
 }
 
 static void
-cleanup_key_data(context, count, data)
-    krb5_context          context;
-    int                   count;
-    krb5_key_data       * data;
+cleanup_key_data(krb5_context context, int count, krb5_key_data *data)
 {
     int i;
 
@@ -149,13 +143,9 @@ preserve_old_keys(krb5_context context, krb5_keyblock *mkey,
 }
 
 static krb5_error_code
-add_key_rnd(context, master_key, ks_tuple, ks_tuple_count, db_entry, kvno)
-    krb5_context          context;
-    krb5_keyblock       * master_key;
-    krb5_key_salt_tuple * ks_tuple;
-    int                   ks_tuple_count;
-    krb5_db_entry       * db_entry;
-    int                   kvno;
+add_key_rnd(krb5_context context, krb5_keyblock *master_key,
+            krb5_key_salt_tuple *ks_tuple, int ks_tuple_count,
+            krb5_db_entry *db_entry, int kvno)
 {
     krb5_keyblock         key;
     int                   i, j;
@@ -246,15 +236,9 @@ make_random_salt(krb5_context context, krb5_keysalt *salt_out)
  * If passwd is NULL the assumes that the caller wants a random password.
  */
 static krb5_error_code
-add_key_pwd(context, master_key, ks_tuple, ks_tuple_count, passwd,
-            db_entry, kvno)
-    krb5_context          context;
-    krb5_keyblock       * master_key;
-    krb5_key_salt_tuple * ks_tuple;
-    int                   ks_tuple_count;
-    const char          * passwd;
-    krb5_db_entry       * db_entry;
-    int                   kvno;
+add_key_pwd(krb5_context context, krb5_keyblock *master_key,
+            krb5_key_salt_tuple *ks_tuple, int ks_tuple_count,
+            const char *passwd, krb5_db_entry *db_entry, int kvno)
 {
     krb5_error_code       retval;
     krb5_keysalt          key_salt;

--- a/src/lib/kdb/keytab.c
+++ b/src/lib/kdb/keytab.c
@@ -71,10 +71,7 @@ krb5_db_register_keytab(krb5_context context)
 }
 
 krb5_error_code
-krb5_ktkdb_resolve(context, name, id)
-    krb5_context          context;
-    const char          * name;
-    krb5_keytab         * id;
+krb5_ktkdb_resolve(krb5_context context, const char *name, krb5_keytab *id)
 {
     if ((*id = (krb5_keytab) malloc(sizeof(**id))) == NULL)
         return(ENOMEM);
@@ -84,9 +81,7 @@ krb5_ktkdb_resolve(context, name, id)
 }
 
 krb5_error_code
-krb5_ktkdb_close(context, kt)
-    krb5_context context;
-    krb5_keytab kt;
+krb5_ktkdb_close(krb5_context context, krb5_keytab kt)
 {
     /*
      * This routine is responsible for freeing all memory allocated
@@ -119,13 +114,9 @@ krb5_ktkdb_set_context(krb5_context ctx)
 }
 
 krb5_error_code
-krb5_ktkdb_get_entry(in_context, id, principal, kvno, enctype, entry)
-    krb5_context          in_context;
-    krb5_keytab           id;
-    krb5_const_principal  principal;
-    krb5_kvno             kvno;
-    krb5_enctype          enctype;
-    krb5_keytab_entry   * entry;
+krb5_ktkdb_get_entry(krb5_context in_context, krb5_keytab id,
+                     krb5_const_principal principal, krb5_kvno kvno,
+                     krb5_enctype enctype, krb5_keytab_entry *entry)
 {
     krb5_context          context;
     krb5_error_code       kerror = 0;

--- a/src/lib/kdb/t_stringattr.c
+++ b/src/lib/kdb/t_stringattr.c
@@ -38,7 +38,7 @@
  */
 
 int
-main()
+main(void)
 {
     krb5_db_entry *ent;
     krb5_context context;

--- a/src/lib/krad/packet.c
+++ b/src/lib/krad/packet.c
@@ -200,7 +200,7 @@ auth_generate_response(krb5_context ctx, const char *secret,
 
 /* Create a new packet. */
 static krad_packet *
-packet_new()
+packet_new(void)
 {
     krad_packet *pkt;
 

--- a/src/lib/krad/t_attr.c
+++ b/src/lib/krad/t_attr.c
@@ -40,7 +40,7 @@ const static unsigned char auth[] = {
 };
 
 int
-main()
+main(void)
 {
     unsigned char outbuf[MAX_ATTRSETSIZE];
     const char *decoded = "accept";

--- a/src/lib/krad/t_attrset.c
+++ b/src/lib/krad/t_attrset.c
@@ -40,7 +40,7 @@ const static unsigned char encpass[] = {
 };
 
 int
-main()
+main(void)
 {
     unsigned char buffer[KRAD_PACKET_SIZE_MAX], encoded[MAX_ATTRSETSIZE];
     const char *username = "testUser", *password = "accept";

--- a/src/lib/krad/t_code.c
+++ b/src/lib/krad/t_code.c
@@ -30,7 +30,7 @@
 #include "t_test.h"
 
 int
-main()
+main(void)
 {
     const char *tmp;
 

--- a/src/lib/krb5/ccache/cc_keyring.c
+++ b/src/lib/krb5/ccache/cc_keyring.c
@@ -314,7 +314,7 @@ get_persistent_real(uid_t uid)
  * for the session anchor.
  */
 static key_serial_t
-session_write_anchor()
+session_write_anchor(void)
 {
     key_serial_t s, u;
 

--- a/src/lib/krb5/krb/plugin.c
+++ b/src/lib/krb5/krb/plugin.c
@@ -355,7 +355,7 @@ load_if_needed(krb5_context context, struct plugin_mapping *map,
     krb5_error_code ret;
     char *symname = NULL;
     struct plugin_file_handle *handle = NULL;
-    void (*initvt_fn)();
+    void (*initvt_fn)(void);
 
     if (map->module != NULL || map->dyn_path == NULL)
         return;

--- a/src/lib/krb5/krb/t_authdata.c
+++ b/src/lib/krb5/krb/t_authdata.c
@@ -74,7 +74,7 @@ static void compare_authdata(const krb5_authdata *adc1, krb5_authdata *adc2) {
 }
 
 int
-main()
+main(void)
 {
     krb5_context context;
     krb5_authdata **results;

--- a/src/lib/krb5/krb/t_response_items.c
+++ b/src/lib/krb5/krb/t_response_items.c
@@ -61,7 +61,7 @@ nstrcmp(const char *a, const char *b)
 }
 
 int
-main()
+main(void)
 {
     k5_response_items *ri;
 

--- a/src/lib/krb5/krb/t_ser.c
+++ b/src/lib/krb5/krb/t_ser.c
@@ -195,7 +195,7 @@ ser_checksum(krb5_checksum *cksum)
 }
 
 static void
-ser_context_test()
+ser_context_test(void)
 {
     krb5_context context;
     profile_t sprofile;
@@ -216,7 +216,7 @@ ser_context_test()
 }
 
 static void
-ser_acontext_test()
+ser_acontext_test(void)
 {
     krb5_auth_context   actx;
     krb5_address        local_address;
@@ -306,7 +306,7 @@ ser_acontext_test()
 }
 
 static void
-ser_princ_test()
+ser_princ_test(void)
 {
     krb5_principal      princ;
     char                pname[1024];
@@ -320,7 +320,7 @@ ser_princ_test()
 }
 
 static void
-ser_cksum_test()
+ser_cksum_test(void)
 {
     krb5_checksum       checksum;
     krb5_octet          ckdata[24];

--- a/src/lib/krb5/krb/t_sname_match.c
+++ b/src/lib/krb5/krb/t_sname_match.c
@@ -80,7 +80,7 @@ struct test {
 };
 
 int
-main()
+main(void)
 {
     size_t i;
     struct test *t;

--- a/src/lib/krb5/krb/t_valid_times.c
+++ b/src/lib/krb5/krb/t_valid_times.c
@@ -36,7 +36,7 @@
 #define BOUNDARY (uint32_t)INT32_MIN
 
 int
-main()
+main(void)
 {
     krb5_error_code ret;
     krb5_context context;

--- a/src/lib/krb5/rcache/t_memrcache.c
+++ b/src/lib/krb5/rcache/t_memrcache.c
@@ -33,7 +33,7 @@
 #include "memrcache.c"
 
 int
-main()
+main(void)
 {
     krb5_error_code ret;
     krb5_context context;

--- a/src/lib/rpc/auth_gss.c
+++ b/src/lib/rpc/auth_gss.c
@@ -445,9 +445,9 @@ authgss_refresh(AUTH *auth, struct rpc_msg *msg)
 			memset(&gr, 0, sizeof(gr));
 
 			call_stat = clnt_call(gd->clnt, NULLPROC,
-					      xdr_rpc_gss_init_args,
+					      (xdrproc_t)xdr_rpc_gss_init_args,
 					      &send_token,
-					      xdr_rpc_gss_init_res,
+					      (xdrproc_t)xdr_rpc_gss_init_res,
 					      (caddr_t)&gr, AUTH_TIMEOUT);
 
 			gss_release_buffer(&min_stat, &send_token);

--- a/src/lib/rpc/auth_gssapi.c
+++ b/src/lib/rpc/auth_gssapi.c
@@ -283,11 +283,11 @@ next_token:
 
 	  PRINTF(("gssapi_create: calling GSSAPI_INIT (%d)\n", init_func));
 
-	  xdr_free(xdr_authgssapi_init_res, &call_res);
+	  xdr_free((xdrproc_t)xdr_authgssapi_init_res, &call_res);
 	  memset(&call_res, 0, sizeof(call_res));
 	  callstat = clnt_call(clnt, init_func,
-			       xdr_authgssapi_init_arg, &call_arg,
-			       xdr_authgssapi_init_res, &call_res,
+			       (xdrproc_t)xdr_authgssapi_init_arg, &call_arg,
+			       (xdrproc_t)xdr_authgssapi_init_res, &call_res,
 			       timeout);
 	  gss_release_buffer(minor_stat, &call_arg.token);
 
@@ -436,7 +436,7 @@ next_token:
      /* don't assume the caller will want to change clnt->cl_auth */
      clnt->cl_auth = save_auth;
 
-     xdr_free(xdr_authgssapi_init_res, &call_res);
+     xdr_free((xdrproc_t)xdr_authgssapi_init_res, &call_res);
      return auth;
 
      /******************************************************************/
@@ -458,7 +458,7 @@ cleanup:
      if (rpc_createerr.cf_stat == 0)
 	  rpc_createerr.cf_stat = RPC_AUTHERROR;
 
-     xdr_free(xdr_authgssapi_init_res, &call_res);
+     xdr_free((xdrproc_t)xdr_authgssapi_init_res, &call_res);
      return auth;
 }
 
@@ -760,7 +760,7 @@ skip_call:
 static bool_t auth_gssapi_wrap(
      AUTH *auth,
      XDR *out_xdrs,
-     bool_t (*xdr_func)(),
+     xdrproc_t xdr_func,
      caddr_t xdr_ptr)
 {
      OM_uint32 gssstat, minor_stat;
@@ -791,7 +791,7 @@ static bool_t auth_gssapi_wrap(
 static bool_t auth_gssapi_unwrap(
      AUTH *auth,
      XDR *in_xdrs,
-     bool_t (*xdr_func)(),
+     xdrproc_t xdr_func,
      caddr_t xdr_ptr)
 {
      OM_uint32 gssstat, minor_stat;

--- a/src/lib/rpc/auth_gssapi_misc.c
+++ b/src/lib/rpc/auth_gssapi_misc.c
@@ -199,7 +199,7 @@ bool_t auth_gssapi_wrap_data(
      gss_ctx_id_t context,
      uint32_t seq_num,
      XDR *out_xdrs,
-     bool_t (*xdr_func)(),
+     xdrproc_t xdr_func,
      caddr_t xdr_ptr)
 {
      gss_buffer_desc in_buf, out_buf;
@@ -267,7 +267,7 @@ bool_t auth_gssapi_unwrap_data(
      gss_ctx_id_t context,
      uint32_t seq_num,
      XDR *in_xdrs,
-     bool_t (*xdr_func)(),
+     xdrproc_t xdr_func,
      caddr_t xdr_ptr)
 {
      gss_buffer_desc in_buf, out_buf;

--- a/src/lib/rpc/authunix_prot.c
+++ b/src/lib/rpc/authunix_prot.c
@@ -58,7 +58,8 @@ xdr_authunix_parms(XDR *xdrs, struct authunix_parms *p)
 	    && xdr_int(xdrs, &(p->aup_uid))
 	    && xdr_int(xdrs, &(p->aup_gid))
 	    && xdr_array(xdrs, (caddr_t *)&(p->aup_gids),
-		    &(p->aup_len), NGRPS, sizeof(int), xdr_int) ) {
+			 &(p->aup_len), NGRPS, sizeof(int),
+			 (xdrproc_t)xdr_int)) {
 		return (TRUE);
 	}
 	return (FALSE);

--- a/src/lib/rpc/clnt_perror.c
+++ b/src/lib/rpc/clnt_perror.c
@@ -76,7 +76,6 @@ char *
 clnt_sperror(CLIENT *rpch, char *s)
 {
 	struct rpc_err e;
-	void clnt_perrno();
 	char *err;
 	char *bufstart = get_buf();
 	char *str = bufstart;

--- a/src/lib/rpc/clnt_raw.c
+++ b/src/lib/rpc/clnt_raw.c
@@ -80,7 +80,7 @@ static struct clnt_ops client_ops = {
 	clntraw_control
 };
 
-void	svc_getreq();
+void	svc_getreq(int);
 
 /*
  * Create a client handle for memory based rpc.

--- a/src/lib/rpc/dyn.c
+++ b/src/lib/rpc/dyn.c
@@ -30,10 +30,8 @@
 /*
  * Made obsolete by DynInsert, now just a convenience function.
  */
-int DynAppend(obj, els, num)
-   DynObjectP obj;
-   DynPtr els;
-   int num;
+int
+DynAppend(DynObjectP obj, DynPtr els, int num)
 {
      return DynInsert(obj, DynSize(obj), els, num);
 }
@@ -52,8 +50,8 @@ int DynAppend(obj, els, num)
 
 static int default_increment = DEFAULT_INC;
 
-DynObjectP DynCreate(el_size, inc)
-   int	el_size, inc;
+DynObjectP
+DynCreate(int el_size, int inc)
 {
      DynObjectP obj;
 
@@ -77,8 +75,8 @@ DynObjectP DynCreate(el_size, inc)
      return obj;
 }
 
-DynObjectP DynCopy(obj)
-   DynObjectP obj;
+DynObjectP
+DynCopy(DynObjectP obj)
 {
      DynObjectP obj1;
 
@@ -104,8 +102,8 @@ DynObjectP DynCopy(obj)
      return obj1;
 }
 
-int DynDestroy(obj)
-     /*@only@*/DynObjectP obj;
+int
+DynDestroy(/*@only@*/DynObjectP obj)
 {
      if (obj->paranoid) {
 	  if (obj->debug)
@@ -118,8 +116,8 @@ int DynDestroy(obj)
      return DYN_OK;
 }
 
-int DynRelease(obj)
-   DynObjectP obj;
+int
+DynRelease(DynObjectP obj)
 {
      if (obj->debug)
 	  fprintf(stderr, "dyn: release: freeing object structure.\n");
@@ -134,9 +132,8 @@ int DynRelease(obj)
  * contains the source code for the function DynDebug().
  */
 
-int DynDebug(obj, state)
-   DynObjectP obj;
-   int state;
+int
+DynDebug(DynObjectP obj, int state)
 {
      obj->debug = state;
 
@@ -155,9 +152,8 @@ int DynDebug(obj, state)
  * Checkers!  Get away from that "hard disk erase" button!
  *    (Stupid dog.  He almost did it to me again ...)
  */
-int DynDelete(obj, idx)
-   DynObjectP obj;
-   int idx;
+int
+DynDelete(DynObjectP obj, int idx)
 {
      if (idx < 0) {
 	  if (obj->debug)
@@ -219,9 +215,8 @@ int DynDelete(obj, idx)
  * contains the source code for the function DynInitZero().
  */
 
-int DynInitzero(obj, state)
-   DynObjectP obj;
-   int state;
+int
+DynInitzero(DynObjectP obj, int state)
 {
      obj->initzero = state;
 
@@ -237,10 +232,8 @@ int DynInitzero(obj, state)
  * contains the source code for the function DynInsert().
  */
 
-int DynInsert(obj, idx, els_in, num)
-   DynObjectP obj;
-   void *els_in;
-   int idx, num;
+int
+DynInsert(DynObjectP obj, int idx, void *els_in, int num)
 {
      DynPtr els = (DynPtr) els_in;
      int ret;
@@ -290,9 +283,8 @@ int DynInsert(obj, idx, els_in, num)
  * contains the source code for the function DynDebug().
  */
 
-int DynParanoid(obj, state)
-   DynObjectP obj;
-   int state;
+int
+DynParanoid(DynObjectP obj, int state)
 {
      obj->paranoid = state;
 
@@ -308,8 +300,8 @@ int DynParanoid(obj, state)
  * contains the source code for the functions DynGet() and DynAdd().
  */
 
-DynPtr DynArray(obj)
-   DynObjectP obj;
+DynPtr
+DynArray(DynObjectP obj)
 {
      if (obj->debug)
 	  fprintf(stderr, "dyn: array: returning array pointer %p.\n",
@@ -318,9 +310,8 @@ DynPtr DynArray(obj)
      return obj->array;
 }
 
-DynPtr DynGet(obj, num)
-   DynObjectP obj;
-   int num;
+DynPtr
+DynGet(DynObjectP obj, int num)
 {
      if (num < 0) {
 	  if (obj->debug)
@@ -342,9 +333,7 @@ DynPtr DynGet(obj, num)
      return (DynPtr) obj->array + obj->el_size*num;
 }
 
-int DynAdd(obj, el)
-   DynObjectP obj;
-   void *el;
+int DynAdd(DynObjectP obj, void *el)
 {
      int	ret;
 
@@ -364,10 +353,8 @@ int DynAdd(obj, el)
  * obj->num_el) will not be updated properly and many other functions
  * in the library will lose.  Have a nice day.
  */
-int DynPut(obj, el_in, idx)
-   DynObjectP obj;
-   void *el_in;
-   int idx;
+int
+DynPut(DynObjectP obj, void *el_in, int idx)
 {
      DynPtr el = (DynPtr) el_in;
      int ret;
@@ -397,9 +384,8 @@ int DynPut(obj, el_in, idx)
 /*
  * Resize the array so that element req exists.
  */
-int _DynResize(obj, req)
-   DynObjectP obj;
-   int req;
+int
+_DynResize(DynObjectP obj, int req)
 {
      int size;
 
@@ -430,9 +416,8 @@ int _DynResize(obj, req)
  * Ideally, this function should not be called from outside the
  * library.  However, nothing will break if it is.
  */
-int _DynRealloc(obj, num_incs)
-   DynObjectP obj;
-   int num_incs;
+int
+_DynRealloc(DynObjectP obj, int num_incs)
 {
      DynPtr temp;
      int new_size_in_bytes;
@@ -475,8 +460,8 @@ int _DynRealloc(obj, num_incs)
  * contains the source code for the function DynSize().
  */
 
-int DynSize(obj)
-   DynObjectP obj;
+int
+DynSize(DynObjectP obj)
 {
      if (obj->debug)
 	  fprintf(stderr, "dyn: size: returning size %d.\n", obj->num_el);
@@ -484,8 +469,8 @@ int DynSize(obj)
      return obj->num_el;
 }
 
-int DynCapacity(obj)
-   DynObjectP obj;
+int
+DynCapacity(DynObjectP obj)
 {
      if (obj->debug)
 	  fprintf(stderr, "dyn: capacity: returning cap of %d.\n", obj->size);

--- a/src/lib/rpc/pmap_clnt.c
+++ b/src/lib/rpc/pmap_clnt.c
@@ -54,8 +54,6 @@ static char sccsid[] = "@(#)pmap_clnt.c 1.37 87/08/11 Copyr 1984 Sun Micro";
 static struct timeval timeout = { 5, 0 };
 static struct timeval tottimeout = { 60, 0 };
 
-void clnt_perror();
-
 /*
  * Set a mapping between program,version and port.
  * Calls the pmap service remotely to do the mapping.
@@ -128,7 +126,8 @@ pmap_set(
 	    }
 	}
 #endif
-	if (CLNT_CALL(client, PMAPPROC_SET, xdr_pmap, &parms, xdr_bool, &rslt,
+	if (CLNT_CALL(client, PMAPPROC_SET, (xdrproc_t)xdr_pmap, &parms,
+		      (xdrproc_t)xdr_bool, &rslt,
 	    tottimeout) != RPC_SUCCESS) {
 		clnt_perror(client, "Cannot register service");
 		return (FALSE);
@@ -161,8 +160,8 @@ pmap_unset(
 	parms.pm_prog = program;
 	parms.pm_vers = version;
 	parms.pm_port = parms.pm_prot = 0;
-	CLNT_CALL(client, PMAPPROC_UNSET, xdr_pmap, &parms, xdr_bool, &rslt,
-	    tottimeout);
+	CLNT_CALL(client, PMAPPROC_UNSET, (xdrproc_t)xdr_pmap, &parms,
+		  (xdrproc_t)xdr_bool, &rslt, tottimeout);
 	CLNT_DESTROY(client);
 	(void)close(sock);
 	return (rslt);

--- a/src/lib/rpc/pmap_getmaps.c
+++ b/src/lib/rpc/pmap_getmaps.c
@@ -77,8 +77,9 @@ pmap_getmaps(struct sockaddr_in *address)
 	client = clnttcp_create(address, PMAPPROG,
 	    PMAPVERS, &sock, 50, 500);
 	if (client != (CLIENT *)NULL) {
-		if (CLNT_CALL(client, PMAPPROC_DUMP, xdr_void, NULL, xdr_pmaplist,
-		    &head, minutetimeout) != RPC_SUCCESS) {
+		if (CLNT_CALL(client, PMAPPROC_DUMP, xdr_void, NULL,
+			      (xdrproc_t)xdr_pmaplist, &head,
+			      minutetimeout) != RPC_SUCCESS) {
 			clnt_perror(client, "pmap_getmaps rpc problem");
 		}
 		CLNT_DESTROY(client);

--- a/src/lib/rpc/pmap_getport.c
+++ b/src/lib/rpc/pmap_getport.c
@@ -79,8 +79,10 @@ pmap_getport(
 		parms.pm_vers = version;
 		parms.pm_prot = protocol;
 		parms.pm_port = 0;  /* not needed or used */
-		if (CLNT_CALL(client, PMAPPROC_GETPORT, xdr_pmap, &parms,
-		    xdr_u_short, &port, tottimeout) != RPC_SUCCESS){
+		if (CLNT_CALL(client, PMAPPROC_GETPORT,
+			      (xdrproc_t)xdr_pmap, &parms,
+			      (xdrproc_t)xdr_u_short, &port,
+			      tottimeout) != RPC_SUCCESS){
 			rpc_createerr.cf_stat = RPC_PMAPFAILURE;
 			clnt_geterr(client, &rpc_createerr.cf_error);
 		} else if (port == 0) {

--- a/src/lib/rpc/pmap_prot2.c
+++ b/src/lib/rpc/pmap_prot2.c
@@ -109,7 +109,8 @@ xdr_pmaplist(XDR *xdrs, struct pmaplist **rp)
 		if (freeing)
 			next = &((*rp)->pml_next);
 		if (! xdr_reference(xdrs, (caddr_t *)rp,
-		    (u_int)sizeof(struct pmaplist), xdr_pmap))
+				    (u_int)sizeof(struct pmaplist),
+				    (xdrproc_t)xdr_pmap))
 			return (FALSE);
 		rp = (freeing) ? next : &((*rp)->pml_next);
 	}

--- a/src/lib/rpc/pmap_rmt.c
+++ b/src/lib/rpc/pmap_rmt.c
@@ -105,8 +105,9 @@ pmap_rmtcall(
 		r.port_ptr = port_ptr;
 		r.results_ptr = resp;
 		r.xdr_results = xdrres;
-		stat = CLNT_CALL(client, PMAPPROC_CALLIT, xdr_rmtcall_args, &a,
-		    xdr_rmtcallres, &r, tout);
+		stat = CLNT_CALL(client, PMAPPROC_CALLIT,
+				 (xdrproc_t)xdr_rmtcall_args, &a,
+				 (xdrproc_t)xdr_rmtcallres, &r, tout);
 		CLNT_DESTROY(client);
 	} else {
 		stat = RPC_FAILED;
@@ -161,7 +162,8 @@ xdr_rmtcallres(
 
 	port_ptr = (caddr_t)(void *)crp->port_ptr;
 	if (xdr_reference(xdrs, &port_ptr, sizeof (uint32_t),
-	    xdr_u_int32) && xdr_u_int32(xdrs, &crp->resultslen)) {
+			  (xdrproc_t)xdr_u_int32) &&
+	    xdr_u_int32(xdrs, &crp->resultslen)) {
 		crp->port_ptr = (uint32_t *)(void *)port_ptr;
 		return ((*(crp->xdr_results))(xdrs, crp->results_ptr));
 	}
@@ -343,7 +345,7 @@ clnt_broadcast(
 	recv_again:
 		msg.acpted_rply.ar_verf = gssrpc__null_auth;
 		msg.acpted_rply.ar_results.where = (caddr_t)&r;
-                msg.acpted_rply.ar_results.proc = xdr_rmtcallres;
+		msg.acpted_rply.ar_results.proc = (xdrproc_t)xdr_rmtcallres;
 		readfds = mask;
 		t2 = t;
 		switch (select(gssrpc__rpc_dtablesize(), &readfds, (fd_set *)NULL,

--- a/src/lib/rpc/rpc_prot.c
+++ b/src/lib/rpc/rpc_prot.c
@@ -132,8 +132,8 @@ xdr_rejected_reply(XDR *xdrs, struct rejected_reply *rr)
 }
 
 static struct xdr_discrim reply_dscrm[3] = {
-	{ (int)MSG_ACCEPTED, xdr_accepted_reply },
-	{ (int)MSG_DENIED, xdr_rejected_reply },
+	{ (int)MSG_ACCEPTED, (xdrproc_t)xdr_accepted_reply },
+	{ (int)MSG_DENIED, (xdrproc_t)xdr_rejected_reply },
 	{ __dontcare__, NULL_xdrproc_t } };
 
 /*

--- a/src/lib/rpc/svc.c
+++ b/src/lib/rpc/svc.c
@@ -80,7 +80,7 @@ static struct svc_callout {
 	struct svc_callout *sc_next;
 	rpcprog_t		    sc_prog;
 	rpcprog_t		    sc_vers;
-	void		    (*sc_dispatch)();
+	void		    (*sc_dispatch)(struct svc_req *, SVCXPRT *);
 } *svc_head;
 
 static struct svc_callout *svc_find(rpcprog_t, rpcvers_t,
@@ -162,7 +162,7 @@ svc_register(
 	SVCXPRT *xprt,
 	rpcprog_t prog,
 	rpcvers_t vers,
-	void (*dispatch)(),
+	void (*dispatch)(struct svc_req *, SVCXPRT *),
 	int protocol)
 {
 	struct svc_callout *prev;

--- a/src/lib/rpc/svc_auth_gss.c
+++ b/src/lib/rpc/svc_auth_gss.c
@@ -193,7 +193,7 @@ svcauth_gss_accept_sec_context(struct svc_req *rqst,
 	/* Deserialize arguments. */
 	memset(&recv_tok, 0, sizeof(recv_tok));
 
-	if (!svc_getargs(rqst->rq_xprt, xdr_rpc_gss_init_args,
+	if (!svc_getargs(rqst->rq_xprt, (xdrproc_t)xdr_rpc_gss_init_args,
 			 (caddr_t)&recv_tok))
 		return (FALSE);
 
@@ -209,7 +209,8 @@ svcauth_gss_accept_sec_context(struct svc_req *rqst,
 					      NULL,
 					      NULL);
 
-	svc_freeargs(rqst->rq_xprt, xdr_rpc_gss_init_args, (caddr_t)&recv_tok);
+	svc_freeargs(rqst->rq_xprt, (xdrproc_t)xdr_rpc_gss_init_args,
+		     (caddr_t)&recv_tok);
 
 	log_status("accept_sec_context", gr->gr_major, gr->gr_minor);
 	if (gr->gr_major != GSS_S_COMPLETE &&
@@ -495,7 +496,8 @@ gssrpc__svcauth_gss(struct svc_req *rqst, struct rpc_msg *msg,
 		}
 		*no_dispatch = TRUE;
 
-		call_stat = svc_sendreply(rqst->rq_xprt, xdr_rpc_gss_init_res,
+		call_stat = svc_sendreply(rqst->rq_xprt,
+					  (xdrproc_t)xdr_rpc_gss_init_res,
 					  (caddr_t)&gr);
 
 		gss_release_buffer(&min_stat, &gr.gr_token);
@@ -544,7 +546,7 @@ gssrpc__svcauth_gss(struct svc_req *rqst, struct rpc_msg *msg,
 	}
 	retstat = AUTH_OK;
 freegc:
-	xdr_free(xdr_rpc_gss_cred, gc);
+	xdr_free((xdrproc_t)xdr_rpc_gss_cred, gc);
 	log_debug("returning %d from svcauth_gss()", retstat);
 	return (retstat);
 }

--- a/src/lib/rpc/svc_simple.c
+++ b/src/lib/rpc/svc_simple.c
@@ -48,7 +48,7 @@ static char sccsid[] = "@(#)svc_simple.c 1.18 87/08/11 Copyr 1984 Sun Micro";
 #include <netdb.h>
 
 static struct proglst {
-	char *(*p_progname)();
+	char *(*p_progname)(void *);
 	int  p_prognum;
 	int  p_procnum;
 	xdrproc_t p_inproc, p_outproc;
@@ -62,7 +62,7 @@ registerrpc(
 	rpcprog_t prognum,
 	rpcvers_t versnum,
 	rpcproc_t procnum,
-	char *(*progname)(),
+	char *(*progname)(void *),
 	xdrproc_t inproc,
 	xdrproc_t outproc)
 {

--- a/src/lib/rpc/unit-test/client.c
+++ b/src/lib/rpc/unit-test/client.c
@@ -42,7 +42,7 @@ char *whoami;
 #ifdef __GNUC__
 __attribute__((noreturn))
 #endif
-static void usage()
+static void usage(void)
 {
      fprintf(stderr, "usage: %s {-t|-u} [-a] [-s num] [-m num] host service [count]\n",
 	     whoami);
@@ -50,9 +50,7 @@ static void usage()
 }
 
 int
-main(argc, argv)
-   int argc;
-   char **argv;
+main(int argc, char **argv)
 {
      char        *host, *port, *target, *echo_arg, **echo_resp, buf[BIG_BUF];
      CLIENT      *clnt;
@@ -172,7 +170,7 @@ main(argc, argv)
 	      strcmp(echo_arg, (*echo_resp) + 6) != 0)
 	       fprintf(stderr, "RPC_TEST_ECHO call %d response wrong: "
 		       "arg = %s, resp = %s\n", i, echo_arg, *echo_resp);
-	  gssrpc_xdr_free(xdr_wrapstring, echo_resp);
+	  gssrpc_xdr_free((xdrproc_t)xdr_wrapstring, echo_resp);
      }
 
      /*
@@ -194,7 +192,7 @@ main(argc, argv)
 	       clnt_perror(clnt, whoami);
      } else {
 	  fprintf(stderr, "bad seq didn't cause failure\n");
-	  gssrpc_xdr_free(xdr_wrapstring, echo_resp);
+	  gssrpc_xdr_free((xdrproc_t)xdr_wrapstring, echo_resp);
      }
 
      AUTH_PRIVATE(clnt->cl_auth)->seq_num -= 3;
@@ -207,7 +205,7 @@ main(argc, argv)
      if (echo_resp == NULL)
 	  clnt_perror(clnt, "Sequence number improperly reset");
      else
-	  gssrpc_xdr_free(xdr_wrapstring, echo_resp);
+	  gssrpc_xdr_free((xdrproc_t)xdr_wrapstring, echo_resp);
 
      /*
       * Now simulate a lost server response, and see if
@@ -219,7 +217,7 @@ main(argc, argv)
      if (echo_resp == NULL)
 	  clnt_perror(clnt, "Auto-resynchronization failed");
      else
-	  gssrpc_xdr_free(xdr_wrapstring, echo_resp);
+	  gssrpc_xdr_free((xdrproc_t)xdr_wrapstring, echo_resp);
 
      /*
       * Now make sure auto-resyncrhonization actually worked
@@ -229,7 +227,7 @@ main(argc, argv)
      if (echo_resp == NULL)
 	  clnt_perror(clnt, "Auto-resynchronization did not work");
      else
-	  gssrpc_xdr_free(xdr_wrapstring, echo_resp);
+	  gssrpc_xdr_free((xdrproc_t)xdr_wrapstring, echo_resp);
 
      if (! auth_once) {
 	  tmp_auth = clnt->cl_auth;
@@ -259,7 +257,7 @@ main(argc, argv)
 		   strcmp(echo_arg, (*echo_resp) + 6) != 0)
 		    fprintf(stderr,
 			    "RPC_TEST_LENGTHS call %d response wrong\n", i);
-	       gssrpc_xdr_free(xdr_wrapstring, echo_resp);
+	       gssrpc_xdr_free((xdrproc_t)xdr_wrapstring, echo_resp);
 	  }
 
 	  /* cycle from 1 to 255 */

--- a/src/lib/rpc/unit-test/rpc_test_clnt.c
+++ b/src/lib/rpc/unit-test/rpc_test_clnt.c
@@ -5,9 +5,7 @@
 static struct timeval TIMEOUT = { 25, 0 };
 
 char **
-rpc_test_echo_1(argp, clnt)
-	char **argp;
-	CLIENT *clnt;
+rpc_test_echo_1(char **argp, CLIENT *clnt)
 {
 	static char *clnt_res;
 

--- a/src/lib/rpc/unit-test/rpc_test_svc.c
+++ b/src/lib/rpc/unit-test/rpc_test_svc.c
@@ -14,16 +14,14 @@ static int _rpcsvcstate = _IDLE;	/* Set when a request is serviced */
 static int _rpcsvccount = 0;		/* Number of requests being serviced */
 
 void
-rpc_test_prog_1_svc(rqstp, transp)
-	struct svc_req *rqstp;
-	SVCXPRT *transp;
+rpc_test_prog_1_svc(struct svc_req *rqstp, SVCXPRT *transp)
 {
 	union {
 		char *rpc_test_echo_1_arg;
 	} argument;
 	char *result;
-	bool_t (*xdr_argument)(), (*xdr_result)();
-	char *(*local)();
+	xdrproc_t xdr_argument, xdr_result;
+	char *(*local)(char *, struct svc_req *);
 
 	_rpcsvccount++;
 	switch (rqstp->rq_proc) {
@@ -35,9 +33,9 @@ rpc_test_prog_1_svc(rqstp, transp)
 		return;
 
 	case RPC_TEST_ECHO:
-		xdr_argument = xdr_wrapstring;
-		xdr_result = xdr_wrapstring;
-		local = (char *(*)()) rpc_test_echo_1_svc;
+		xdr_argument = (xdrproc_t)xdr_wrapstring;
+		xdr_result = (xdrproc_t)xdr_wrapstring;
+		local = (char *(*)(char *, struct svc_req *)) rpc_test_echo_1_svc;
 		break;
 
 	default:
@@ -53,7 +51,7 @@ rpc_test_prog_1_svc(rqstp, transp)
 		_rpcsvcstate = _SERVED;
 		return;
 	}
-	result = (*local)(&argument, rqstp);
+	result = (*local)((char *)&argument, rqstp);
 	if (result != NULL && !svc_sendreply(transp, xdr_result, result)) {
 		svcerr_systemerr(transp);
 	}

--- a/src/lib/rpc/unit-test/server.c
+++ b/src/lib/rpc/unit-test/server.c
@@ -40,7 +40,7 @@ static void rpc_test_badverf(gss_name_t client, gss_name_t server,
 #define SERVICE_NAME "host"
 #endif
 
-static void usage()
+static void usage(void)
 {
      fprintf(stderr, "Usage: server {-t|-u} [svc-debug] [misc-debug]\n");
      exit(1);

--- a/src/lib/rpc/xdr.c
+++ b/src/lib/rpc/xdr.c
@@ -579,14 +579,14 @@ xdr_union(
 	 */
 	for (; choices->proc != NULL_xdrproc_t; choices++) {
 		if (choices->value == dscm)
-			return ((*(choices->proc))(xdrs, unp, LASTUNSIGNED));
+			return choices->proc(xdrs, unp);
 	}
 
 	/*
 	 * no match - execute the default xdr routine if there is one
 	 */
 	return ((dfault == NULL_xdrproc_t) ? FALSE :
-	    (*dfault)(xdrs, unp, LASTUNSIGNED));
+	    (*dfault)(xdrs, unp));
 }
 
 

--- a/src/lib/rpc/xdr_array.c
+++ b/src/lib/rpc/xdr_array.c
@@ -113,7 +113,7 @@ xdr_array(
 	 * now we xdr each element of array
 	 */
 	for (i = 0; (i < c) && stat; i++) {
-		stat = (*elproc)(xdrs, target, LASTUNSIGNED);
+		stat = (*elproc)(xdrs, target);
 		target += elsize;
 	}
 
@@ -150,7 +150,7 @@ xdr_vector(
 
 	elptr = basep;
 	for (i = 0; i < nelem; i++) {
-		if (! (*xdr_elem)(xdrs, elptr, LASTUNSIGNED)) {
+		if (! (*xdr_elem)(xdrs, elptr)) {
 			return(FALSE);
 		}
 		elptr += elemsize;

--- a/src/lib/rpc/xdr_rec.c
+++ b/src/lib/rpc/xdr_rec.c
@@ -99,7 +99,7 @@ typedef struct rec_strm {
 	/*
 	 * out-goung bits
 	 */
-	int (*writeit)();
+	int (*writeit)(caddr_t, caddr_t, int);
 	caddr_t out_base;	/* output buffer (points to frag header) */
 	caddr_t out_finger;	/* next output position */
 	caddr_t out_boundry;	/* data cannot up to this address */
@@ -108,7 +108,7 @@ typedef struct rec_strm {
 	/*
 	 * in-coming bits
 	 */
-	int (*readit)();
+	int (*readit)(caddr_t, caddr_t, int);
 	uint32_t in_size;	/* fixed size of the input buffer */
 	caddr_t in_base;
 	caddr_t in_finger;	/* location of next byte to be had */
@@ -140,8 +140,10 @@ xdrrec_create(
 	u_int sendsize,
 	u_int recvsize,
 	caddr_t tcp_handle,
-	int (*readit)(), /* like read, but pass it a tcp_handle, not sock */
-	int (*writeit)() /* like write, but pass it a tcp_handle, not sock */
+	/* like read, but pass it a tcp_handle, not sock */
+	int (*readit)(caddr_t, caddr_t, int),
+	 /* like write, but pass it a tcp_handle, not sock */
+	int (*writeit)(caddr_t, caddr_t, int)
 	)
 {
 	RECSTREAM *rstrm = mem_alloc(sizeof(RECSTREAM));
@@ -528,8 +530,7 @@ get_input_bytes(RECSTREAM *rstrm, caddr_t addr, int len)
 }
 
 static bool_t  /* next four bytes of input stream are treated as a header */
-set_input_fragment(rstrm)
-	RECSTREAM *rstrm;
+set_input_fragment(RECSTREAM *rstrm)
 {
 	uint32_t header;
 

--- a/src/lib/rpc/xdr_reference.c
+++ b/src/lib/rpc/xdr_reference.c
@@ -47,8 +47,6 @@ static char sccsid[] = "@(#)xdr_reference.c 1.11 87/08/11 SMI";
 #include <gssrpc/types.h>
 #include <gssrpc/xdr.h>
 
-#define LASTUNSIGNED	((u_int)0-1)
-
 /*
  * XDR an indirect pointer
  * xdr_reference is for recursively translating a structure that is
@@ -88,7 +86,7 @@ xdr_reference(
 			break;
 	}
 
-	stat = (*proc)(xdrs, loc, LASTUNSIGNED);
+	stat = (*proc)(xdrs, loc);
 
 	if (xdrs->x_op == XDR_FREE) {
 		mem_free(loc, size);

--- a/src/lib/rpc/xdr_sizeof.c
+++ b/src/lib/rpc/xdr_sizeof.c
@@ -43,9 +43,7 @@
 
 /* ARGSUSED */
 static bool_t
-x_putlong(xdrs, longp)
-	XDR *xdrs;
-	long *longp;
+x_putlong(XDR *xdrs, long *longp)
 {
 	xdrs->x_handy += BYTES_PER_XDR_UNIT;
 	return (TRUE);
@@ -53,10 +51,7 @@ x_putlong(xdrs, longp)
 
 /* ARGSUSED */
 static bool_t
-x_putbytes(xdrs, bp, len)
-	XDR *xdrs;
-	char  *bp;
-	int len;
+x_putbytes(XDR *xdrs, char *bp, u_int len)
 {
 	xdrs->x_handy += len;
 
@@ -64,26 +59,21 @@ x_putbytes(xdrs, bp, len)
 }
 
 static u_int
-x_getpostn(xdrs)
-	XDR *xdrs;
+x_getpostn(XDR *xdrs)
 {
 	return (xdrs->x_handy);
 }
 
 /* ARGSUSED */
 static bool_t
-x_setpostn(xdrs, pos)
-	XDR *xdrs;
-	u_int pos;
+x_setpostn(XDR *xdrs, u_int pos)
 {
 	/* This is not allowed */
 	return (FALSE);
 }
 
 static rpc_inline_t *
-x_inline(xdrs, len)
-	XDR *xdrs;
-	int len;
+x_inline(XDR *xdrs, int len)
 {
 	if (len == 0) {
 		return (NULL);
@@ -110,15 +100,14 @@ x_inline(xdrs, len)
 }
 
 static int
-harmless()
+harmless(void)
 {
 	/* Always return FALSE/NULL, as the case may be */
 	return (0);
 }
 
 static void
-x_destroy(xdrs)
-	XDR *xdrs;
+x_destroy(XDR *xdrs)
 {
 	xdrs->x_handy = 0;
 	xdrs->x_private = NULL;
@@ -130,9 +119,7 @@ x_destroy(xdrs)
 }
 
 unsigned long
-xdr_sizeof(func, data)
-	xdrproc_t func;
-	void *data;
+xdr_sizeof(xdrproc_t func, void *data)
 {
 	XDR x;
 	struct xdr_ops ops;

--- a/src/plugins/kdb/db2/db2_exp.c
+++ b/src/plugins/kdb/db2/db2_exp.c
@@ -68,7 +68,7 @@ k5_mutex_t *krb5_db2_mutex;
         return result;                                  \
     }                                                   \
     /* hack: decl to allow a following ";" */           \
-    static TYPE wrap_##NAME ()
+    static TYPE wrap_##NAME ARGLIST
 
 /* Two special cases: void (can't assign result), and krb5_error_code
    (return error from locking code).  */
@@ -81,7 +81,7 @@ k5_mutex_t *krb5_db2_mutex;
         k5_mutex_unlock (krb5_db2_mutex);               \
     }                                                   \
     /* hack: decl to allow a following ";" */           \
-    static void wrap_##NAME ()
+    static void wrap_##NAME ARGLIST
 
 #define WRAP_K(NAME,ARGLIST,ARGNAMES)                   \
     WRAP(NAME,krb5_error_code,ARGLIST,ARGNAMES)

--- a/src/plugins/kdb/db2/libdb2/btree/bt_close.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_close.c
@@ -61,8 +61,7 @@ static int bt_meta __P((BTREE *));
  *	RET_ERROR, RET_SUCCESS
  */
 int
-__bt_close(dbp)
-	DB *dbp;
+__bt_close(DB *dbp)
 {
 	BTREE *t;
 	int fd;
@@ -116,9 +115,7 @@ __bt_close(dbp)
  *	RET_SUCCESS, RET_ERROR.
  */
 int
-__bt_sync(dbp, flags)
-	const DB *dbp;
-	u_int flags;
+__bt_sync(const DB *dbp, u_int flags)
 {
 	BTREE *t;
 	int status;
@@ -160,8 +157,7 @@ __bt_sync(dbp, flags)
  *	RET_ERROR, RET_SUCCESS
  */
 static int
-bt_meta(t)
-	BTREE *t;
+bt_meta(BTREE *t)
 {
 	BTMETA m;
 	void *p;

--- a/src/plugins/kdb/db2/libdb2/btree/bt_conv.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_conv.c
@@ -59,10 +59,7 @@ static void mswap __P((PAGE *));
  *	h:	page to convert
  */
 void
-__bt_pgin(t, pg, pp)
-	void *t;
-	db_pgno_t pg;
-	void *pp;
+__bt_pgin(void *t, db_pgno_t pg, void *pp)
 {
 	PAGE *h;
 	indx_t i, top;
@@ -128,10 +125,7 @@ __bt_pgin(t, pg, pp)
 }
 
 void
-__bt_pgout(t, pg, pp)
-	void *t;
-	db_pgno_t pg;
-	void *pp;
+__bt_pgout(void *t, db_pgno_t pg, void *pp)
 {
 	PAGE *h;
 	indx_t i, top;
@@ -203,8 +197,7 @@ __bt_pgout(t, pg, pp)
  *	p:	page to convert
  */
 static void
-mswap(pg)
-	PAGE *pg;
+mswap(PAGE *pg)
 {
 	char *p;
 

--- a/src/plugins/kdb/db2/libdb2/btree/bt_delete.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_delete.c
@@ -59,10 +59,7 @@ static int __bt_stkacq __P((BTREE *, PAGE **, CURSOR *));
  * Return RET_SPECIAL if the key is not found.
  */
 int
-__bt_delete(dbp, key, flags)
-	const DB *dbp;
-	const DBT *key;
-	u_int flags;
+__bt_delete(const DB *dbp, const DBT *key, u_int flags)
 {
 	BTREE *t;
 	CURSOR *c;
@@ -140,10 +137,7 @@ __bt_delete(dbp, key, flags)
  *	0 on success, 1 on failure
  */
 static int
-__bt_stkacq(t, hp, c)
-	BTREE *t;
-	PAGE **hp;
-	CURSOR *c;
+__bt_stkacq(BTREE *t, PAGE **hp, CURSOR *c)
 {
 	BINTERNAL *bi;
 	EPG *e;
@@ -288,9 +282,7 @@ ret:	mpool_put(t->bt_mp, h, 0);
  *	RET_ERROR, RET_SUCCESS and RET_SPECIAL if the key not found.
  */
 static int
-__bt_bdelete(t, key)
-	BTREE *t;
-	const DBT *key;
+__bt_bdelete(BTREE *t, const DBT *key)
 {
 	EPG *e;
 	PAGE *h;
@@ -375,9 +367,7 @@ loop:	if ((e = __bt_search(t, key, &exact)) == NULL)
  *	mpool_put's the page
  */
 static int
-__bt_pdelete(t, h)
-	BTREE *t;
-	PAGE *h;
+__bt_pdelete(BTREE *t, PAGE *h)
 {
 	BINTERNAL *bi;
 	PAGE *pg;
@@ -471,11 +461,7 @@ __bt_pdelete(t, h)
  *	RET_SUCCESS, RET_ERROR.
  */
 int
-__bt_dleaf(t, key, h, idx)
-	BTREE *t;
-	const DBT *key;
-	PAGE *h;
-	u_int idx;
+__bt_dleaf(BTREE *t, const DBT *key, PAGE *h, u_int idx)
 {
 	BLEAF *bl;
 	indx_t cnt, *ip, offset;
@@ -536,11 +522,7 @@ __bt_dleaf(t, key, h, idx)
  *	RET_SUCCESS, RET_ERROR.
  */
 static int
-__bt_curdel(t, key, h, idx)
-	BTREE *t;
-	const DBT *key;
-	PAGE *h;
-	u_int idx;
+__bt_curdel(BTREE *t, const DBT *key, PAGE *h, u_int idx)
 {
 	CURSOR *c;
 	EPG e;
@@ -635,9 +617,7 @@ dup2:				c->pg.pgno = e.page->pgno;
  *	h:	page to be deleted
  */
 int
-__bt_relink(t, h)
-	BTREE *t;
-	PAGE *h;
+__bt_relink(BTREE *t, PAGE *h)
 {
 	PAGE *pg;
 

--- a/src/plugins/kdb/db2/libdb2/btree/bt_get.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_get.c
@@ -60,11 +60,7 @@ static char sccsid[] = "@(#)bt_get.c	8.6 (Berkeley) 7/20/94";
  *	RET_ERROR, RET_SUCCESS and RET_SPECIAL if the key not found.
  */
 int
-__bt_get(dbp, key, data, flags)
-	const DB *dbp;
-	const DBT *key;
-	DBT *data;
-	u_int flags;
+__bt_get(const DB *dbp, const DBT *key, DBT *data, u_int flags)
 {
 	BTREE *t;
 	EPG *e;

--- a/src/plugins/kdb/db2/libdb2/btree/bt_open.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_open.c
@@ -89,10 +89,8 @@ static int tmp __P((void));
  *
  */
 DB *
-__bt_open(fname, flags, mode, openinfo, dflags)
-	const char *fname;
-	int flags, mode, dflags;
-	const BTREEINFO *openinfo;
+__bt_open(const char *fname, int flags, int mode, const BTREEINFO *openinfo,
+	  int dflags)
 {
 	struct stat sb;
 	BTMETA m;
@@ -352,8 +350,7 @@ err:	if (t) {
  *	RET_ERROR, RET_SUCCESS
  */
 static int
-nroot(t)
-	BTREE *t;
+nroot(BTREE *t)
 {
 	PAGE *meta, *root;
 	db_pgno_t npg;
@@ -458,8 +455,7 @@ byteorder()
 }
 
 int
-__bt_fd(dbp)
-        const DB *dbp;
+__bt_fd(const DB *dbp)
 {
 	BTREE *t;
 

--- a/src/plugins/kdb/db2/libdb2/btree/bt_overflow.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_overflow.c
@@ -77,12 +77,7 @@ static char sccsid[] = "@(#)bt_overflow.c	8.5 (Berkeley) 7/16/94";
  *	RET_ERROR, RET_SUCCESS
  */
 int
-__ovfl_get(t, p, ssz, buf, bufsz)
-	BTREE *t;
-	void *p;
-	size_t *ssz;
-	void **buf;
-	size_t *bufsz;
+__ovfl_get(BTREE *t, void *p, size_t *ssz, void **buf, size_t *bufsz)
 {
 	PAGE *h;
 	db_pgno_t pg;
@@ -136,10 +131,7 @@ __ovfl_get(t, p, ssz, buf, bufsz)
  *	RET_ERROR, RET_SUCCESS
  */
 int
-__ovfl_put(t, dbt, pg)
-	BTREE *t;
-	const DBT *dbt;
-	db_pgno_t *pg;
+__ovfl_put(BTREE *t, const DBT *dbt, db_pgno_t *pg)
 {
 	PAGE *h, *last;
 	void *p;
@@ -190,9 +182,7 @@ __ovfl_put(t, dbt, pg)
  *	RET_ERROR, RET_SUCCESS
  */
 int
-__ovfl_delete(t, p)
-	BTREE *t;
-	void *p;
+__ovfl_delete(BTREE *t, void *p)
 {
 	PAGE *h;
 	db_pgno_t pg;

--- a/src/plugins/kdb/db2/libdb2/btree/bt_page.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_page.c
@@ -57,9 +57,7 @@ static char sccsid[] = "@(#)bt_page.c	8.4 (Berkeley) 11/2/95";
  *	mpool_put's the page.
  */
 int
-__bt_free(t, h)
-	BTREE *t;
-	PAGE *h;
+__bt_free(BTREE *t, PAGE *h)
 {
 	/* Insert the page at the head of the free list. */
 	h->prevpg = P_INVALID;
@@ -83,9 +81,7 @@ __bt_free(t, h)
  *	Pointer to a page, NULL on error.
  */
 PAGE *
-__bt_new(t, npg)
-	BTREE *t;
-	db_pgno_t *npg;
+__bt_new(BTREE *t, db_pgno_t *npg)
 {
 	PAGE *h;
 

--- a/src/plugins/kdb/db2/libdb2/btree/bt_put.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_put.c
@@ -64,11 +64,7 @@ static EPG *bt_fast __P((BTREE *, const DBT *, const DBT *, int *));
  *	tree and R_NOOVERWRITE specified.
  */
 int
-__bt_put(dbp, key, data, flags)
-	const DB *dbp;
-	DBT *key;
-	const DBT *data;
-	u_int flags;
+__bt_put(const DB *dbp, DBT *key, const DBT *data, u_int flags)
 {
 	BTREE *t;
 	DBT tkey, tdata;
@@ -272,10 +268,7 @@ u_long bt_cache_hit, bt_cache_miss;
  * 	EPG for new record or NULL if not found.
  */
 static EPG *
-bt_fast(t, key, data, exactp)
-	BTREE *t;
-	const DBT *key, *data;
-	int *exactp;
+bt_fast(BTREE *t, const DBT *key, const DBT *data, int *exactp)
 {
 	PAGE *h;
 	u_int32_t nbytes;

--- a/src/plugins/kdb/db2/libdb2/btree/bt_search.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_search.c
@@ -63,10 +63,7 @@ static int __bt_sprev __P((BTREE *, PAGE *, const DBT *, int *));
  *	the bt_cur field of the tree.  A pointer to the field is returned.
  */
 EPG *
-__bt_search(t, key, exactp)
-	BTREE *t;
-	const DBT *key;
-	int *exactp;
+__bt_search(BTREE *t, const DBT *key, int *exactp)
 {
 	PAGE *h;
 	indx_t base, idx, lim;
@@ -148,11 +145,7 @@ next:		BT_PUSH(t, h->pgno, idx);
  *	If an exact match found.
  */
 static int
-__bt_snext(t, h, key, exactp)
-	BTREE *t;
-	PAGE *h;
-	const DBT *key;
-	int *exactp;
+__bt_snext(BTREE *t, PAGE *h, const DBT *key, int *exactp)
 {
 	BINTERNAL *bi;
 	EPG e;
@@ -228,11 +221,7 @@ __bt_snext(t, h, key, exactp)
  *	If an exact match found.
  */
 static int
-__bt_sprev(t, h, key, exactp)
-	BTREE *t;
-	PAGE *h;
-	const DBT *key;
-	int *exactp;
+__bt_sprev(BTREE *t, PAGE *h, const DBT *key, int *exactp)
 {
 	BINTERNAL *bi;
 	EPG e;

--- a/src/plugins/kdb/db2/libdb2/btree/bt_seq.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_seq.c
@@ -102,10 +102,7 @@ static int bt_rseq_prev(BTREE *, EPG *);
  *	RET_ERROR, RET_SUCCESS or RET_SPECIAL if there's no next key.
  */
 int
-__bt_seq(dbp, key, data, flags)
-	const DB *dbp;
-	DBT *key, *data;
-	u_int flags;
+__bt_seq(const DB *dbp, DBT *key, DBT *data, u_int flags)
 {
 	BTREE *t;
 	EPG e;
@@ -179,11 +176,7 @@ __bt_seq(dbp, key, data, flags)
  *	RET_ERROR, RET_SUCCESS or RET_SPECIAL if there's no next key.
  */
 static int
-__bt_seqset(t, ep, key, flags)
-	BTREE *t;
-	EPG *ep;
-	DBT *key;
-	int flags;
+__bt_seqset(BTREE *t, EPG *ep, DBT *key, int flags)
 {
 	PAGE *h;
 	db_pgno_t pg;
@@ -273,10 +266,7 @@ __bt_seqset(t, ep, key, flags)
  *	RET_ERROR, RET_SUCCESS or RET_SPECIAL if there's no next key.
  */
 static int
-__bt_seqadv(t, ep, flags)
-	BTREE *t;
-	EPG *ep;
-	int flags;
+__bt_seqadv(BTREE *t, EPG *ep, int flags)
 {
 	CURSOR *c;
 	PAGE *h;
@@ -495,11 +485,7 @@ bt_rseq_prev(BTREE *t, EPG *ep)
  *	or RET_SPECIAL if no such key exists.
  */
 static int
-__bt_first(t, key, erval, exactp)
-	BTREE *t;
-	const DBT *key;
-	EPG *erval;
-	int *exactp;
+__bt_first(BTREE *t, const DBT *key, EPG *erval, int *exactp)
 {
 	PAGE *h, *hprev;
 	EPG *ep, save;
@@ -596,10 +582,7 @@ __bt_first(t, key, erval, exactp)
  *  index:	page index
  */
 void
-__bt_setcur(t, pgno, idx)
-	BTREE *t;
-	db_pgno_t pgno;
-	u_int idx;
+__bt_setcur(BTREE *t, db_pgno_t pgno, u_int idx)
 {
 	/* Lose any already deleted key. */
 	if (t->bt_cursor.key.data != NULL) {

--- a/src/plugins/kdb/db2/libdb2/btree/bt_split.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_split.c
@@ -79,13 +79,8 @@ u_long	bt_rootsplit, bt_split, bt_sortsplit, bt_pfxsaved;
  *	RET_ERROR, RET_SUCCESS
  */
 int
-__bt_split(t, sp, key, data, flags, ilen, argskip)
-	BTREE *t;
-	PAGE *sp;
-	const DBT *key, *data;
-	int flags;
-	size_t ilen;
-	u_int32_t argskip;
+__bt_split(BTREE *t, PAGE *sp, const DBT *key, const DBT *data, int flags,
+	   size_t ilen, u_int32_t argskip)
 {
 	BINTERNAL *bi = NULL;
 	BLEAF *bl = NULL, *tbl;
@@ -345,11 +340,7 @@ err2:	mpool_put(t->bt_mp, l, 0);
  *	Pointer to page in which to insert or NULL on error.
  */
 static PAGE *
-bt_page(t, h, lp, rp, skip, ilen)
-	BTREE *t;
-	PAGE *h, **lp, **rp;
-	indx_t *skip;
-	size_t ilen;
+bt_page(BTREE *t, PAGE *h, PAGE **lp, PAGE **rp, indx_t *skip, size_t ilen)
 {
 	PAGE *l, *r, *tp;
 	db_pgno_t npg;
@@ -450,11 +441,7 @@ bt_page(t, h, lp, rp, skip, ilen)
  *	Pointer to page in which to insert or NULL on error.
  */
 static PAGE *
-bt_root(t, h, lp, rp, skip, ilen)
-	BTREE *t;
-	PAGE *h, **lp, **rp;
-	indx_t *skip;
-	size_t ilen;
+bt_root(BTREE *t, PAGE *h, PAGE **lp, PAGE **rp, indx_t *skip, size_t ilen)
 {
 	PAGE *l, *r, *tp;
 	db_pgno_t lnpg, rnpg;
@@ -497,9 +484,7 @@ bt_root(t, h, lp, rp, skip, ilen)
  *	RET_ERROR, RET_SUCCESS
  */
 static int
-bt_rroot(t, h, l, r)
-	BTREE *t;
-	PAGE *h, *l, *r;
+bt_rroot(BTREE *t, PAGE *h, PAGE *l, PAGE *r)
 {
 	char *dest;
 
@@ -537,9 +522,7 @@ bt_rroot(t, h, l, r)
  *	RET_ERROR, RET_SUCCESS
  */
 static int
-bt_broot(t, h, l, r)
-	BTREE *t;
-	PAGE *h, *l, *r;
+bt_broot(BTREE *t, PAGE *h, PAGE *l, PAGE *r)
 {
 	BINTERNAL *bi;
 	BLEAF *bl;
@@ -617,11 +600,7 @@ bt_broot(t, h, l, r)
  *	Pointer to page in which to insert.
  */
 static PAGE *
-bt_psplit(t, h, l, r, pskip, ilen)
-	BTREE *t;
-	PAGE *h, *l, *r;
-	indx_t *pskip;
-	size_t ilen;
+bt_psplit(BTREE *t, PAGE *h, PAGE *l, PAGE *r, indx_t *pskip, size_t ilen)
 {
 	BINTERNAL *bi;
 	BLEAF *bl;
@@ -796,9 +775,7 @@ bt_psplit(t, h, l, r, pskip, ilen)
  *	RET_SUCCESS, RET_ERROR.
  */
 static int
-bt_preserve(t, pg)
-	BTREE *t;
-	db_pgno_t pg;
+bt_preserve(BTREE *t, db_pgno_t pg)
 {
 	PAGE *h;
 
@@ -824,8 +801,7 @@ bt_preserve(t, pg)
  * all the way back to bt_split/bt_rroot and it's not very clean.
  */
 static recno_t
-rec_total(h)
-	PAGE *h;
+rec_total(PAGE *h)
 {
 	recno_t recs;
 	indx_t nxt, top;

--- a/src/plugins/kdb/db2/libdb2/btree/bt_utils.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_utils.c
@@ -64,11 +64,8 @@ static char sccsid[] = "@(#)bt_utils.c	8.8 (Berkeley) 7/20/94";
  *	RET_SUCCESS, RET_ERROR.
  */
 int
-__bt_ret(t, e, key, rkey, data, rdata, copy)
-	BTREE *t;
-	EPG *e;
-	DBT *key, *rkey, *data, *rdata;
-	int copy;
+__bt_ret(BTREE *t, EPG *e, DBT *key, DBT *rkey, DBT *data, DBT *rdata,
+	 int copy)
 {
 	BLEAF *bl;
 	void *p;
@@ -150,10 +147,7 @@ dataonly:
  *	> 0 if k1 is > record
  */
 int
-__bt_cmp(t, k1, e)
-	BTREE *t;
-	const DBT *k1;
-	EPG *e;
+__bt_cmp(BTREE *t, const DBT *k1, EPG *e)
 {
 	BINTERNAL *bi;
 	BLEAF *bl;
@@ -213,8 +207,7 @@ __bt_cmp(t, k1, e)
  *	> 0 if a is > b
  */
 int
-__bt_defcmp(a, b)
-	const DBT *a, *b;
+__bt_defcmp(const DBT *a, const DBT *b)
 {
 	size_t len;
 	u_char *p1, *p2;
@@ -243,8 +236,7 @@ __bt_defcmp(a, b)
  *	Number of bytes needed to distinguish b from a.
  */
 size_t
-__bt_defpfx(a, b)
-	const DBT *a, *b;
+__bt_defpfx(const DBT *a, const DBT *b)
 {
 	u_char *p1, *p2;
 	size_t cnt, len;

--- a/src/plugins/kdb/db2/libdb2/db/db.c
+++ b/src/plugins/kdb/db2/libdb2/db/db.c
@@ -45,11 +45,8 @@ static char sccsid[] = "@(#)db.c	8.4 (Berkeley) 2/21/94";
 #include "db-int.h"
 
 DB *
-kdb2_dbopen(fname, flags, mode, type, openinfo)
-	const char *fname;
-	int flags, mode;
-	DBTYPE type;
-	const void *openinfo;
+kdb2_dbopen(const char *fname, int flags, int mode, DBTYPE type,
+	    const void *openinfo)
 {
 
 #define	DB_FLAGS	(DB_LOCK | DB_SHMEM | DB_TXN)
@@ -74,7 +71,7 @@ kdb2_dbopen(fname, flags, mode, type, openinfo)
 }
 
 static int
-__dberr()
+__dberr(void)
 {
 	return (RET_ERROR);
 }
@@ -86,14 +83,15 @@ __dberr()
  *	dbp:	pointer to the DB structure.
  */
 void
-__dbpanic(dbp)
-	DB *dbp;
+__dbpanic(DB *dbp)
 {
 	/* The only thing that can succeed is a close. */
-	dbp->del = (int (*)())__dberr;
-	dbp->fd = (int (*)())__dberr;
-	dbp->get = (int (*)())__dberr;
-	dbp->put = (int (*)())__dberr;
-	dbp->seq = (int (*)())__dberr;
-	dbp->sync = (int (*)())__dberr;
+	dbp->del = (int (*)(const struct __db *, const DBT *, u_int))__dberr;
+	dbp->fd = (int (*)(const struct __db *))__dberr;
+	dbp->get = (int (*)(const struct __db *, const DBT *, DBT *,
+			    u_int))__dberr;
+	dbp->put = (int (*)(const struct __db *, DBT *, const DBT *,
+			    u_int))__dberr;
+	dbp->seq = (int (*)(const struct __db *, DBT *, DBT *, u_int))__dberr;
+	dbp->sync = (int (*)(const struct __db *, u_int))__dberr;
 }

--- a/src/plugins/kdb/db2/libdb2/hash/dbm.c
+++ b/src/plugins/kdb/db2/libdb2/hash/dbm.c
@@ -69,8 +69,7 @@ static DBM *__cur_db;
 static void no_open_db __P((void));
 
 int
-kdb2_dbminit(file)
-	char *file;
+kdb2_dbminit(char *file)
 {
 	if (__cur_db != NULL)
 		(void)kdb2_dbm_close(__cur_db);
@@ -82,8 +81,7 @@ kdb2_dbminit(file)
 }
 
 datum
-kdb2_fetch(key)
-	datum key;
+kdb2_fetch(datum key)
 {
 	datum item;
 
@@ -111,8 +109,7 @@ kdb2_firstkey()
 }
 
 datum
-kdb2_nextkey(key)
-	datum key;
+kdb2_nextkey(datum key)
 {
 	datum item;
 
@@ -126,8 +123,7 @@ kdb2_nextkey(key)
 }
 
 int
-kdb2_delete(key)
-	datum key;
+kdb2_delete(datum key)
 {
 	if (__cur_db == NULL) {
 		no_open_db();
@@ -137,8 +133,7 @@ kdb2_delete(key)
 }
 
 int
-kdb2_store(key, dat)
-	datum key, dat;
+kdb2_store(datum key, datum dat)
 {
 	if (__cur_db == NULL) {
 		no_open_db();
@@ -159,9 +154,7 @@ no_open_db()
  *	 NULL on failure
  */
 DBM *
-kdb2_dbm_open(file, flags, mode)
-	const char *file;
-	int flags, mode;
+kdb2_dbm_open(const char *file, int flags, int mode)
 {
 	HASHINFO info;
 	char path[MAXPATHLEN];
@@ -183,8 +176,7 @@ kdb2_dbm_open(file, flags, mode)
  *	Nothing.
  */
 void
-kdb2_dbm_close(db)
-	DBM *db;
+kdb2_dbm_close(DBM *db)
 {
 	(void)(db->close)(db);
 }
@@ -195,9 +187,7 @@ kdb2_dbm_close(db)
  *	NULL on failure
  */
 datum
-kdb2_dbm_fetch(db, key)
-	DBM *db;
-	datum key;
+kdb2_dbm_fetch(DBM *db, datum key)
 {
 	datum retval;
 	int status;
@@ -226,8 +216,7 @@ kdb2_dbm_fetch(db, key)
  *	NULL on failure
  */
 datum
-kdb2_dbm_firstkey(db)
-	DBM *db;
+kdb2_dbm_firstkey(DBM *db)
 {
 	int status;
 	datum retkey;
@@ -254,8 +243,7 @@ kdb2_dbm_firstkey(db)
  *	NULL on failure
  */
 datum
-kdb2_dbm_nextkey(db)
-	DBM *db;
+kdb2_dbm_nextkey(DBM *db)
 {
 	int status;
 	datum retkey;
@@ -282,9 +270,7 @@ kdb2_dbm_nextkey(db)
  *	<0 failure
  */
 int
-kdb2_dbm_delete(db, key)
-	DBM *db;
-	datum key;
+kdb2_dbm_delete(DBM *db, datum key)
 {
 	int status;
 
@@ -310,10 +296,7 @@ kdb2_dbm_delete(db, key)
  *	 1 if DBM_INSERT and entry exists
  */
 int
-kdb2_dbm_store(db, key, content, flags)
-	DBM *db;
-	datum key, content;
-	int flags;
+kdb2_dbm_store(DBM *db, datum key, datum content, int flags)
 {
 #ifdef NEED_COPY
 	DBT k, c;
@@ -331,8 +314,7 @@ kdb2_dbm_store(db, key, content, flags)
 }
 
 int
-kdb2_dbm_error(db)
-	DBM *db;
+kdb2_dbm_error(DBM *db)
 {
 	HTAB *hp;
 
@@ -341,8 +323,7 @@ kdb2_dbm_error(db)
 }
 
 int
-kdb2_dbm_clearerr(db)
-	DBM *db;
+kdb2_dbm_clearerr(DBM *db)
 {
 	HTAB *hp;
 
@@ -352,8 +333,7 @@ kdb2_dbm_clearerr(db)
 }
 
 int
-kdb2_dbm_dirfno(db)
-	DBM *db;
+kdb2_dbm_dirfno(DBM *db)
 {
 	return(((HTAB *)db->internal)->fp);
 }

--- a/src/plugins/kdb/db2/libdb2/hash/hash.c
+++ b/src/plugins/kdb/db2/libdb2/hash/hash.c
@@ -94,10 +94,8 @@ u_int32_t hash_accesses, hash_collisions, hash_expansions, hash_overflows,
 /* OPEN/CLOSE */
 
 extern DB *
-__kdb2_hash_open(file, flags, mode, info, dflags)
-	const char *file;
-	int flags, mode, dflags;
-	const HASHINFO *info;	/* Special directives for create */
+__kdb2_hash_open(const char *file, int flags, int mode, const HASHINFO *info,
+		 int dflags)
 {
 	struct stat statbuf;
 	DB *dbp;
@@ -260,8 +258,7 @@ error0:
 }
 
 static int32_t
-hash_close(dbp)
-	DB *dbp;
+hash_close(DB *dbp)
 {
 	HTAB *hashp;
 	int32_t retval;
@@ -276,8 +273,7 @@ hash_close(dbp)
 }
 
 static int32_t
-hash_fd(dbp)
-	const DB *dbp;
+hash_fd(const DB *dbp)
 {
 	HTAB *hashp;
 
@@ -294,10 +290,7 @@ hash_fd(dbp)
 
 /************************** LOCAL CREATION ROUTINES **********************/
 static HTAB *
-init_hash(hashp, file, info)
-	HTAB *hashp;
-	const char *file;
-	const HASHINFO *info;
+init_hash(HTAB *hashp, const char *file, const HASHINFO *info)
 {
 	struct stat statbuf;
 
@@ -349,9 +342,7 @@ init_hash(hashp, file, info)
  * Returns 0 on No Error
  */
 static int32_t
-init_htab(hashp, nelem)
-	HTAB *hashp;
-	int32_t nelem;
+init_htab(HTAB *hashp, int32_t nelem)
 {
 	int32_t l2, nbuckets;
 
@@ -403,9 +394,7 @@ init_htab(hashp, nelem)
  * Functions to get/put hash header.  We access the file directly.
  */
 static u_int32_t
-hget_header(hashp, page_size)
-	HTAB *hashp;
-	u_int32_t page_size;
+hget_header(HTAB *hashp, u_int32_t page_size)
 {
 	u_int32_t num_copied;
 	u_int8_t *hdr_dest;
@@ -431,8 +420,7 @@ hget_header(hashp, page_size)
 }
 
 static void
-hput_header(hashp)
-	HTAB *hashp;
+hput_header(HTAB *hashp)
 {
 	HASHHDR *whdrp;
 #if DB_BYTE_ORDER == DB_LITTLE_ENDIAN
@@ -462,8 +450,7 @@ hput_header(hashp)
  * structure, freeing all allocated space.
  */
 static int32_t
-hdestroy(hashp)
-	HTAB *hashp;
+hdestroy(HTAB *hashp)
 {
 	int32_t save_errno;
 
@@ -549,9 +536,7 @@ hdestroy(hashp)
  *	-1 ERROR
  */
 static int32_t
-hash_sync(dbp, flags)
-	const DB *dbp;
-	u_int32_t flags;
+hash_sync(const DB *dbp, u_int32_t flags)
 {
 	HTAB *hashp;
 
@@ -570,8 +555,7 @@ hash_sync(dbp, flags)
  *	-1 indicates that errno should be set
  */
 static int32_t
-flush_meta(hashp)
-	HTAB *hashp;
+flush_meta(HTAB *hashp)
 {
 	int32_t i;
 
@@ -607,11 +591,7 @@ flush_meta(hashp)
 /* *** make sure this is true! */
 
 static int32_t
-hash_get(dbp, key, data, flag)
-	const DB *dbp;
-	const DBT *key;
-	DBT *data;
-	u_int32_t flag;
+hash_get(const DB *dbp, const DBT *key, DBT *data, u_int32_t flag)
 {
 	HTAB *hashp;
 
@@ -624,11 +604,7 @@ hash_get(dbp, key, data, flag)
 }
 
 static int32_t
-hash_put(dbp, key, data, flag)
-	const DB *dbp;
-	DBT *key;
-	const DBT *data;
-	u_int32_t flag;
+hash_put(const DB *dbp, DBT *key, const DBT *data, u_int32_t flag)
 {
 	HTAB *hashp;
 
@@ -646,10 +622,7 @@ hash_put(dbp, key, data, flag)
 }
 
 static int32_t
-hash_delete(dbp, key, flag)
-	const DB *dbp;
-	const DBT *key;
-	u_int32_t flag;		/* Ignored */
+hash_delete(const DB *dbp, const DBT *key, u_int32_t flag)
 {
 	HTAB *hashp;
 
@@ -670,11 +643,7 @@ hash_delete(dbp, key, flag)
  * Assume that hashp has been set in wrapper routine.
  */
 static int32_t
-hash_access(hashp, action, key, val)
-	HTAB *hashp;
-	ACTION action;
-	const DBT *key;
-	DBT *val;
+hash_access(HTAB *hashp, ACTION action, const DBT *key, DBT *val)
 {
 	DBT page_key, page_val;
 	CURSOR cursor;
@@ -791,8 +760,7 @@ found:	__get_item_done(hashp, &cursor);
 
 /* ****************** CURSORS ********************************** */
 CURSOR *
-__cursor_creat(dbp)
-	const DB *dbp;
+__cursor_creat(const DB *dbp)
 {
 	CURSOR *new_curs;
 	HTAB *hashp;
@@ -823,11 +791,7 @@ __cursor_creat(dbp)
 }
 
 static int32_t
-cursor_get(dbp, cursorp, key, val, flags)
-	const DB *dbp;
-	CURSOR *cursorp;
-	DBT *key, *val;
-	u_int32_t flags;
+cursor_get(const DB *dbp, CURSOR *cursorp, DBT *key, DBT *val, u_int32_t flags)
 {
 	HTAB *hashp;
 	ITEM_INFO item_info;
@@ -896,10 +860,7 @@ cursor_get(dbp, cursorp, key, val, flags)
 }
 
 static int32_t
-cursor_delete(dbp, cursor, flags)
-	const DB *dbp;
-	CURSOR *cursor;
-	u_int32_t flags;
+cursor_delete(const DB *dbp, CURSOR *cursor, u_int32_t flags)
 {
 	/* XXX this is empirically determined, so it might not be completely
 	   correct, but it seems to work.  At the very least it fixes
@@ -912,10 +873,7 @@ cursor_delete(dbp, cursor, flags)
 }
 
 static int32_t
-hash_seq(dbp, key, val, flag)
-	const DB *dbp;
-	DBT *key, *val;
-	u_int32_t flag;
+hash_seq(const DB *dbp, DBT *key, DBT *val, u_int32_t flag)
 {
 	HTAB *hashp;
 
@@ -939,8 +897,7 @@ hash_seq(dbp, key, val, flag)
  *	-1 ==> Error
  */
 int32_t
-__expand_table(hashp)
-	HTAB *hashp;
+__expand_table(HTAB *hashp)
 {
 	u_int32_t old_bucket, new_bucket;
 	int32_t spare_ndx;
@@ -979,10 +936,7 @@ __expand_table(hashp)
 }
 
 u_int32_t
-__call_hash(hashp, k, len)
-	HTAB *hashp;
-	int8_t *k;
-	int32_t len;
+__call_hash(HTAB *hashp, int8_t *k, int32_t len)
 {
 	u_int32_t n, bucket;
 
@@ -998,8 +952,7 @@ __call_hash(hashp, k, len)
  * Hashp->hdr needs to be byteswapped.
  */
 static void
-swap_header_copy(srcp, destp)
-	HASHHDR *srcp, *destp;
+swap_header_copy(HASHHDR *srcp, HASHHDR *destp)
 {
 	int32_t i;
 
@@ -1024,8 +977,7 @@ swap_header_copy(srcp, destp)
 }
 
 static void
-swap_header(hashp)
-	HTAB *hashp;
+swap_header(HTAB *hashp)
 {
 	HASHHDR *hdrp;
 	int32_t i;

--- a/src/plugins/kdb/db2/libdb2/hash/hash_bigkey.c
+++ b/src/plugins/kdb/db2/libdb2/hash/hash_bigkey.c
@@ -83,10 +83,7 @@ static int32_t collect_data __P((HTAB *, PAGE16 *, int32_t));
  *	-1 ==> ERROR
  */
 int32_t
-__big_insert(hashp, pagep, key, val)
-	HTAB *hashp;
-	PAGE16 *pagep;
-	const DBT *key, *val;
+__big_insert(HTAB *hashp, PAGE16 *pagep, const DBT *key, const DBT *val)
 {
 	size_t  key_size, val_size;
 	indx_t  key_move_bytes, val_move_bytes;
@@ -185,11 +182,7 @@ __big_delete(hashp, pagep, ndx)
  *	-1 error
  */
 int32_t
-__find_bigpair(hashp, cursorp, key, size)
-	HTAB *hashp;
-	CURSOR *cursorp;
-	int8_t *key;
-	int32_t size;
+__find_bigpair(HTAB *hashp, CURSOR *cursorp, int8_t *key, int32_t size)
 {
 	PAGE16 *pagep, *hold_pagep;
 	db_pgno_t  next_pgno;
@@ -257,11 +250,7 @@ __find_bigpair(hashp, cursorp, key, size)
  * Fill in the key and data for this big pair.
  */
 int32_t
-__big_keydata(hashp, pagep, key, val, ndx)
-	HTAB *hashp;
-	PAGE16 *pagep;
-	DBT *key, *val;
-	int32_t ndx;
+__big_keydata(HTAB *hashp, PAGE16 *pagep, DBT *key, DBT *val, int32_t ndx)
 {
 	ITEM_INFO ii;
 	PAGE16 *key_pagep;
@@ -315,11 +304,8 @@ __get_bigkey(hashp, pagep, ndx, key)
  * Return the big key and data indicated in item_info.
  */
 int32_t
-__big_return(hashp, item_info, val, on_bigkey_page)
-	HTAB *hashp;
-	ITEM_INFO *item_info;
-	DBT *val;
-	int32_t on_bigkey_page;
+__big_return(HTAB *hashp, ITEM_INFO *item_info, DBT *val,
+	     int32_t on_bigkey_page)
 {
 	PAGE16 *pagep;
 	db_pgno_t next_pgno;
@@ -366,11 +352,7 @@ __big_return(hashp, item_info, val, on_bigkey_page)
  * Return total length of data; -1 if error.
  */
 static int32_t
-collect_key(hashp, pagep, len, last_page)
-	HTAB *hashp;
-	PAGE16 *pagep;
-	int32_t len;
-	db_pgno_t *last_page;
+collect_key(HTAB *hashp, PAGE16 *pagep, int32_t len, db_pgno_t *last_page)
 {
 	PAGE16 *next_pagep;
 	int32_t totlen, retval;
@@ -434,10 +416,7 @@ collect_key(hashp, pagep, len, last_page)
  * Return total length of data; -1 if error.
  */
 static int32_t
-collect_data(hashp, pagep, len)
-	HTAB *hashp;
-	PAGE16 *pagep;
-	int32_t len;
+collect_data(HTAB *hashp, PAGE16 *pagep, int32_t len)
 {
 	PAGE16 *next_pagep;
 	int32_t totlen, retval;

--- a/src/plugins/kdb/db2/libdb2/hash/hash_func.c
+++ b/src/plugins/kdb/db2/libdb2/hash/hash_func.c
@@ -66,9 +66,7 @@ u_int32_t (*__default_hash) __P((const void *, size_t)) = hash4;
 
 #if 0
 static u_int32_t
-hash1(key, len)
-	const void *key;
-	size_t len;
+hash1(const void *key, size_t len)
 {
 	u_int32_t h;
 	u_int8_t *k;
@@ -88,9 +86,7 @@ hash1(key, len)
 #define dcharhash(h, c)	((h) = 0x63c63cd9*(h) + 0x9c39c33d + (c))
 
 static u_int32_t
-hash2(key, len)
-	const void *key;
-	size_t len;
+hash2(const void *key, size_t len)
 {
 	u_int32_t h;
 	u_int8_t *e, c, *k;
@@ -116,9 +112,7 @@ hash2(key, len)
  * Ozan Yigit's original sdbm hash.
  */
 static u_int32_t
-hash3(key, len)
-	const void *key;
-	size_t len;
+hash3(const void *key, size_t len)
 {
 	u_int32_t n, loop;
 	u_int8_t *k;
@@ -159,9 +153,7 @@ hash3(key, len)
 
 /* Chris Torek's hash function. */
 static u_int32_t
-hash4(key, len)
-	const void *key;
-	size_t len;
+hash4(const void *key, size_t len)
 {
 	u_int32_t h, loop;
 	const u_int8_t *k;

--- a/src/plugins/kdb/db2/libdb2/hash/hash_log2.c
+++ b/src/plugins/kdb/db2/libdb2/hash/hash_log2.c
@@ -44,8 +44,7 @@ static char sccsid[] = "@(#)hash_log2.c	8.4 (Berkeley) 11/7/95";
 #include "extern.h"
 
 u_int32_t
-__kdb2_log2(num)
-	u_int32_t num;
+__kdb2_log2(u_int32_t num)
 {
 	u_int32_t i, limit;
 

--- a/src/plugins/kdb/db2/libdb2/hash/hash_page.c
+++ b/src/plugins/kdb/db2/libdb2/hash/hash_page.c
@@ -84,11 +84,8 @@ static void	 account_page(HTAB *, db_pgno_t, int);
 #endif
 
 u_int32_t
-__get_item(hashp, cursorp, key, val, item_info)
-	HTAB *hashp;
-	CURSOR *cursorp;
-	DBT *key, *val;
-	ITEM_INFO *item_info;
+__get_item(HTAB *hashp, CURSOR *cursorp, DBT *key, DBT *val,
+	   ITEM_INFO *item_info)
 {
 	db_pgno_t next_pgno;
 	int32_t i;
@@ -159,9 +156,7 @@ __get_item(hashp, cursorp, key, val, item_info)
 }
 
 u_int32_t
-__get_item_reset(hashp, cursorp)
-	HTAB *hashp;
-	CURSOR *cursorp;
+__get_item_reset(HTAB *hashp, CURSOR *cursorp)
 {
 	if (cursorp->pagep)
 		__put_page(hashp, cursorp->pagep, A_RAW, 0);
@@ -174,9 +169,7 @@ __get_item_reset(hashp, cursorp)
 }
 
 u_int32_t
-__get_item_done(hashp, cursorp)
-	HTAB *hashp;
-	CURSOR *cursorp;
+__get_item_done(HTAB *hashp, CURSOR *cursorp)
 {
 	if (cursorp->pagep)
 		__put_page(hashp, cursorp->pagep, A_RAW, 0);
@@ -190,11 +183,8 @@ __get_item_done(hashp, cursorp)
 }
 
 u_int32_t
-__get_item_first(hashp, cursorp, key, val, item_info)
-	HTAB *hashp;
-	CURSOR *cursorp;
-	DBT *key, *val;
-	ITEM_INFO *item_info;
+__get_item_first(HTAB *hashp, CURSOR *cursorp, DBT *key, DBT *val,
+		 ITEM_INFO *item_info)
 {
 	__get_item_reset(hashp, cursorp);
 	cursorp->bucket = 0;
@@ -206,11 +196,8 @@ __get_item_first(hashp, cursorp, key, val, item_info)
  * just returns the page number and index of the bigkey pointer pair.
  */
 u_int32_t
-__get_item_next(hashp, cursorp, key, val, item_info)
-	HTAB *hashp;
-	CURSOR *cursorp;
-	DBT *key, *val;
-	ITEM_INFO *item_info;
+__get_item_next(HTAB *hashp, CURSOR *cursorp, DBT *key, DBT *val,
+		ITEM_INFO *item_info)
 {
 	int status;
 
@@ -224,9 +211,7 @@ __get_item_next(hashp, cursorp, key, val, item_info)
  * Put a non-big pair on a page.
  */
 static void
-putpair(p, key, val)
-	PAGE8 *p;
-	const DBT *key, *val;
+putpair(PAGE8 *p, const DBT *key, const DBT *val)
 {
 	u_int16_t *pagep, n, off;
 
@@ -275,10 +260,7 @@ prev_realkey(pagep, n)
  *      -1 error
  */
 extern int32_t
-__delpair(hashp, cursorp, item_info)
-	HTAB *hashp;
-	CURSOR *cursorp;
-	ITEM_INFO *item_info;
+__delpair(HTAB *hashp, CURSOR *cursorp, ITEM_INFO *item_info)
 {
 	PAGE16 *pagep;
 	indx_t ndx;
@@ -412,9 +394,7 @@ __delpair(hashp, cursorp, item_info)
 }
 
 extern int32_t
-__split_page(hashp, obucket, nbucket)
-	HTAB *hashp;
-	u_int32_t obucket, nbucket;
+__split_page(HTAB *hashp, u_int32_t obucket, u_int32_t nbucket)
 {
 	DBT key, val;
 	ITEM_INFO old_ii, new_ii;
@@ -661,9 +641,7 @@ add_bigptr(hashp, item_info, big_pgno)
  *      NULL on error
  */
 extern PAGE16 *
-__add_ovflpage(hashp, pagep)
-	HTAB *hashp;
-	PAGE16 *pagep;
+__add_ovflpage(HTAB *hashp, PAGE16 *pagep)
 {
 	PAGE16 *new_pagep;
 	u_int16_t ovfl_num;
@@ -768,10 +746,7 @@ page_init(hashp, pagep, pgno, type)
 }
 
 int32_t
-__new_page(hashp, addr, addr_type)
-	HTAB *hashp;
-	u_int32_t addr;
-	int32_t addr_type;
+__new_page(HTAB *hashp, u_int32_t addr, int32_t addr_type)
 {
 	db_pgno_t paddr;
 	PAGE16 *pagep;
@@ -804,10 +779,7 @@ __new_page(hashp, addr, addr_type)
 }
 
 int32_t
-__delete_page(hashp, pagep, page_type)
-	HTAB *hashp;
-	PAGE16 *pagep;
-	int32_t page_type;
+__delete_page(HTAB *hashp, PAGE16 *pagep, int32_t page_type)
 {
 	if (page_type == A_OVFL)
 		__free_ovflpage(hashp, pagep);
@@ -815,9 +787,7 @@ __delete_page(hashp, pagep, page_type)
 }
 
 static u_int8_t
-is_bitmap_pgno(hashp, pgno)
-	HTAB *hashp;
-	db_pgno_t pgno;
+is_bitmap_pgno(HTAB *hashp, db_pgno_t pgno)
 {
 	int32_t i;
 
@@ -828,10 +798,7 @@ is_bitmap_pgno(hashp, pgno)
 }
 
 void
-__pgin_routine(pg_cookie, pgno, page)
-	void *pg_cookie;
-	db_pgno_t pgno;
-	void *page;
+__pgin_routine(void *pg_cookie, db_pgno_t pgno, void *page)
 {
 	HTAB *hashp;
 	PAGE16 *pagep;
@@ -868,10 +835,7 @@ __pgin_routine(pg_cookie, pgno, page)
 }
 
 void
-__pgout_routine(pg_cookie, pgno, page)
-	void *pg_cookie;
-	db_pgno_t pgno;
-	void *page;
+__pgout_routine(void *pg_cookie, db_pgno_t pgno, void *page)
 {
 	HTAB *hashp;
 	PAGE16 *pagep;
@@ -905,10 +869,7 @@ __pgout_routine(pg_cookie, pgno, page)
  *      -1 ==>failure
  */
 extern int32_t
-__put_page(hashp, pagep, addr_type, is_dirty)
-	HTAB *hashp;
-	PAGE16 *pagep;
-	int32_t addr_type, is_dirty;
+__put_page(HTAB *hashp, PAGE16 *pagep, int32_t addr_type, int32_t is_dirty)
 {
 #if DEBUG_SLOW
 	account_page(hashp,
@@ -924,10 +885,7 @@ __put_page(hashp, pagep, addr_type, is_dirty)
  *      -1 indicates FAILURE
  */
 extern PAGE16 *
-__get_page(hashp, addr, addr_type)
-	HTAB *hashp;
-	u_int32_t addr;
-	int32_t addr_type;
+__get_page(HTAB *hashp, u_int32_t addr, int32_t addr_type)
 {
 	PAGE16 *pagep;
 	db_pgno_t paddr;
@@ -958,8 +916,7 @@ __get_page(hashp, addr, addr_type)
 }
 
 static void
-swap_page_header_in(pagep)
-	PAGE16 *pagep;
+swap_page_header_in(PAGE16 *pagep)
 {
 	u_int32_t i;
 
@@ -977,8 +934,7 @@ swap_page_header_in(pagep)
 }
 
 static void
-swap_page_header_out(pagep)
-	PAGE16 *pagep;
+swap_page_header_out(PAGE16 *pagep)
 {
 	u_int32_t i;
 
@@ -1001,9 +957,7 @@ swap_page_header_out(pagep)
  * once they are read in.
  */
 extern int32_t
-__ibitmap(hashp, pnum, nbits, ndx)
-	HTAB *hashp;
-	int32_t pnum, nbits, ndx;
+__ibitmap(HTAB *hashp, int32_t pnum, int32_t nbits, int32_t ndx)
 {
 	u_int32_t *ip;
 	int32_t clearbytes, clearints;
@@ -1027,8 +981,7 @@ __ibitmap(hashp, pnum, nbits, ndx)
 }
 
 static u_int32_t
-first_free(map)
-	u_int32_t map;
+first_free(u_int32_t map)
 {
 	u_int32_t i, mask;
 
@@ -1044,8 +997,7 @@ first_free(map)
  * returns 0 on error
  */
 static u_int16_t
-overflow_page(hashp)
-	HTAB *hashp;
+overflow_page(HTAB *hashp)
 {
 	u_int32_t *freep;
 	u_int32_t bit, first_page, free_bit, free_page, i, in_use_bits, j;
@@ -1206,9 +1158,7 @@ found:
 
 #ifdef DEBUG
 int
-bucket_to_page(hashp, n)
-	HTAB *hashp;
-	int n;
+bucket_to_page(HTAB *hashp, int n)
 {
 	int ret_val;
 
@@ -1219,9 +1169,7 @@ bucket_to_page(hashp, n)
 }
 
 int32_t
-oaddr_to_page(hashp, n)
-	HTAB *hashp;
-	int n;
+oaddr_to_page(HTAB *hashp, int n)
 {
 	int ret_val, temp;
 
@@ -1234,9 +1182,7 @@ oaddr_to_page(hashp, n)
 #endif /* DEBUG */
 
 static indx_t
-page_to_oaddr(hashp, pgno)
-	HTAB *hashp;
-	db_pgno_t pgno;
+page_to_oaddr(HTAB *hashp, db_pgno_t pgno)
 {
 	int32_t sp, ret_val;
 
@@ -1268,9 +1214,7 @@ page_to_oaddr(hashp, pgno)
  * Mark this overflow page as free.
  */
 extern void
-__free_ovflpage(hashp, pagep)
-	HTAB *hashp;
-	PAGE16 *pagep;
+__free_ovflpage(HTAB *hashp, PAGE16 *pagep)
 {
 	u_int32_t *freep;
 	u_int32_t bit_address, free_page, free_bit;
@@ -1307,9 +1251,7 @@ __free_ovflpage(hashp, pagep)
 }
 
 static u_int32_t *
-fetch_bitmap(hashp, ndx)
-	HTAB *hashp;
-	int32_t ndx;
+fetch_bitmap(HTAB *hashp, int32_t ndx)
 {
 	if (ndx >= hashp->nmaps)
 		return (NULL);
@@ -1322,10 +1264,7 @@ fetch_bitmap(hashp, ndx)
 
 #ifdef DEBUG_SLOW
 static void
-account_page(hashp, pgno, inout)
-	HTAB *hashp;
-	db_pgno_t pgno;
-	int inout;
+account_page(HTAB *hashp, db_pgno_t pgno, int inout)
 {
 	static struct {
 		db_pgno_t pgno;

--- a/src/plugins/kdb/db2/libdb2/hash/hsearch.c
+++ b/src/plugins/kdb/db2/libdb2/hash/hsearch.c
@@ -50,8 +50,7 @@ static DB *dbp = NULL;
 static ENTRY retval;
 
 extern int
-hcreate(nel)
-	u_int nel;
+hcreate(u_int nel)
 {
 	HASHINFO info;
 
@@ -66,9 +65,7 @@ hcreate(nel)
 }
 
 extern ENTRY *
-hsearch(item, action)
-	ENTRY item;
-	ACTION action;
+hsearch(ENTRY item, ACTION action)
 {
 	DBT key, val;
 	int status;
@@ -98,7 +95,7 @@ hsearch(item, action)
 }
 
 extern void
-hdestroy()
+hdestroy(void)
 {
 	if (dbp) {
 		(void)(dbp->close)(dbp);

--- a/src/plugins/kdb/db2/libdb2/mpool/mpool.c
+++ b/src/plugins/kdb/db2/libdb2/mpool/mpool.c
@@ -56,10 +56,7 @@ static int  mpool_write __P((MPOOL *, BKT *));
  *	Initialize a memory pool.
  */
 MPOOL *
-mpool_open(key, fd, pagesize, maxcache)
-	void *key;
-	int fd;
-	db_pgno_t pagesize, maxcache;
+mpool_open(void *key, int fd, db_pgno_t pagesize, db_pgno_t maxcache)
 {
 	struct stat sb;
 	MPOOL *mp;
@@ -96,11 +93,8 @@ mpool_open(key, fd, pagesize, maxcache)
  *	Initialize input/output filters.
  */
 void
-mpool_filter(mp, pgin, pgout, pgcookie)
-	MPOOL *mp;
-	void (*pgin) __P((void *, db_pgno_t, void *));
-	void (*pgout) __P((void *, db_pgno_t, void *));
-	void *pgcookie;
+mpool_filter(MPOOL *mp, void (*pgin) __P((void *, db_pgno_t, void *)),
+	     void (*pgout) __P((void *, db_pgno_t, void *)), void *pgcookie)
 {
 	mp->pgin = pgin;
 	mp->pgout = pgout;
@@ -112,10 +106,7 @@ mpool_filter(mp, pgin, pgout, pgcookie)
  *	Get a new page of memory.
  */
 void *
-mpool_new(mp, pgnoaddr, flags)
-	MPOOL *mp;
-	db_pgno_t *pgnoaddr;
-	u_int flags;
+mpool_new(MPOOL *mp, db_pgno_t *pgnoaddr, u_int flags)
 {
 	struct _hqh *head;
 	BKT *bp;
@@ -149,9 +140,7 @@ mpool_new(mp, pgnoaddr, flags)
 }
 
 int
-mpool_delete(mp, page)
-	MPOOL *mp;
-	void *page;
+mpool_delete(MPOOL *mp, void *page)
 {
 	struct _hqh *head;
 	BKT *bp;
@@ -180,10 +169,7 @@ mpool_delete(mp, page)
  *	Get a page.
  */
 void *
-mpool_get(mp, pgno, flags)
-	MPOOL *mp;
-	db_pgno_t pgno;
-	u_int flags;				/* XXX not used? */
+mpool_get(MPOOL *mp, db_pgno_t pgno, u_int flags)
 {
 	struct _hqh *head;
 	BKT *bp;
@@ -278,10 +264,7 @@ mpool_get(mp, pgno, flags)
  *	Return a page.
  */
 int
-mpool_put(mp, page, flags)
-	MPOOL *mp;
-	void *page;
-	u_int flags;
+mpool_put(MPOOL *mp, void *page, u_int flags)
 {
 	BKT *bp;
 
@@ -307,8 +290,7 @@ mpool_put(mp, page, flags)
  *	Close the buffer pool.
  */
 int
-mpool_close(mp)
-	MPOOL *mp;
+mpool_close(MPOOL *mp)
 {
 	BKT *bp;
 
@@ -328,8 +310,7 @@ mpool_close(mp)
  *	Sync the pool to disk.
  */
 int
-mpool_sync(mp)
-	MPOOL *mp;
+mpool_sync(MPOOL *mp)
 {
 	BKT *bp;
 
@@ -348,8 +329,7 @@ mpool_sync(mp)
  *	Get a page from the cache (or create one).
  */
 static BKT *
-mpool_bkt(mp)
-	MPOOL *mp;
+mpool_bkt(MPOOL *mp)
 {
 	struct _hqh *head;
 	BKT *bp;
@@ -407,9 +387,7 @@ new:	if ((bp = (BKT *)malloc(sizeof(BKT) + mp->pagesize)) == NULL)
  *	Write a page to disk.
  */
 static int
-mpool_write(mp, bp)
-	MPOOL *mp;
-	BKT *bp;
+mpool_write(MPOOL *mp, BKT *bp)
 {
 	off_t off;
 
@@ -451,9 +429,7 @@ mpool_write(mp, bp)
  *	Lookup a page in the cache.
  */
 static BKT *
-mpool_look(mp, pgno)
-	MPOOL *mp;
-	db_pgno_t pgno;
+mpool_look(MPOOL *mp, db_pgno_t pgno)
 {
 	struct _hqh *head;
 	BKT *bp;
@@ -478,8 +454,7 @@ mpool_look(mp, pgno)
  *	Print out cache statistics.
  */
 void
-mpool_stat(mp)
-	MPOOL *mp;
+mpool_stat(MPOOL *mp)
 {
 	BKT *bp;
 	int cnt;
@@ -520,8 +495,7 @@ mpool_stat(mp)
 }
 #else
 void
-mpool_stat(mp)
-	MPOOL *mp;
+mpool_stat(MPOOL *mp)
 {
 }
 #endif

--- a/src/plugins/kdb/db2/libdb2/recno/rec_close.c
+++ b/src/plugins/kdb/db2/libdb2/recno/rec_close.c
@@ -59,8 +59,7 @@ static char sccsid[] = "@(#)rec_close.c	8.9 (Berkeley) 11/18/94";
  *	RET_ERROR, RET_SUCCESS
  */
 int
-__rec_close(dbp)
-	DB *dbp;
+__rec_close(DB *dbp)
 {
 	BTREE *t;
 	int status;
@@ -108,9 +107,7 @@ __rec_close(dbp)
  *	RET_SUCCESS, RET_ERROR.
  */
 int
-__rec_sync(dbp, flags)
-	const DB *dbp;
-	u_int flags;
+__rec_sync(const DB *dbp, u_int flags)
 {
 	struct iovec iov[2];
 	BTREE *t;

--- a/src/plugins/kdb/db2/libdb2/recno/rec_delete.c
+++ b/src/plugins/kdb/db2/libdb2/recno/rec_delete.c
@@ -61,10 +61,7 @@ static int rec_rdelete __P((BTREE *, recno_t));
  *	RET_ERROR, RET_SUCCESS and RET_SPECIAL if the key not found.
  */
 int
-__rec_delete(dbp, key, flags)
-	const DB *dbp;
-	const DBT *key;
-	u_int flags;
+__rec_delete(const DB *dbp, const DBT *key, u_int flags)
 {
 	BTREE *t;
 	recno_t nrec;
@@ -117,9 +114,7 @@ einval:		errno = EINVAL;
  *	RET_ERROR, RET_SUCCESS and RET_SPECIAL if the key not found.
  */
 static int
-rec_rdelete(t, nrec)
-	BTREE *t;
-	recno_t nrec;
+rec_rdelete(BTREE *t, recno_t nrec)
 {
 	EPG *e;
 	PAGE *h;
@@ -151,10 +146,7 @@ rec_rdelete(t, nrec)
  *	RET_SUCCESS, RET_ERROR.
  */
 int
-__rec_dleaf(t, h, idx)
-	BTREE *t;
-	PAGE *h;
-	u_int32_t idx;
+__rec_dleaf(BTREE *t, PAGE *h, u_int32_t idx)
 {
 	RLEAF *rl;
 	indx_t *ip, cnt, offset;

--- a/src/plugins/kdb/db2/libdb2/recno/rec_get.c
+++ b/src/plugins/kdb/db2/libdb2/recno/rec_get.c
@@ -60,11 +60,7 @@ static char sccsid[] = "@(#)rec_get.c	8.9 (Berkeley) 8/18/94";
  *	RET_ERROR, RET_SUCCESS and RET_SPECIAL if the key not found.
  */
 int
-__rec_get(dbp, key, data, flags)
-	const DB *dbp;
-	const DBT *key;
-	DBT *data;
-	u_int flags;
+__rec_get(const DB *dbp, const DBT *key, DBT *data, u_int flags)
 {
 	BTREE *t;
 	EPG *e;
@@ -119,9 +115,7 @@ __rec_get(dbp, key, data, flags)
  *	RET_ERROR, RET_SUCCESS
  */
 int
-__rec_fpipe(t, top)
-	BTREE *t;
-	recno_t top;
+__rec_fpipe(BTREE *t, recno_t top)
 {
 	DBT data;
 	recno_t nrec;
@@ -175,9 +169,7 @@ __rec_fpipe(t, top)
  *	RET_ERROR, RET_SUCCESS
  */
 int
-__rec_vpipe(t, top)
-	BTREE *t;
-	recno_t top;
+__rec_vpipe(BTREE *t, recno_t top)
 {
 	DBT data;
 	recno_t nrec;
@@ -232,9 +224,7 @@ __rec_vpipe(t, top)
  *	RET_ERROR, RET_SUCCESS
  */
 int
-__rec_fmap(t, top)
-	BTREE *t;
-	recno_t top;
+__rec_fmap(BTREE *t, recno_t top)
 {
 	DBT data;
 	recno_t nrec;
@@ -282,9 +272,7 @@ __rec_fmap(t, top)
  *	RET_ERROR, RET_SUCCESS
  */
 int
-__rec_vmap(t, top)
-	BTREE *t;
-	recno_t top;
+__rec_vmap(BTREE *t, recno_t top)
 {
 	DBT data;
 	u_char *sp, *ep;

--- a/src/plugins/kdb/db2/libdb2/recno/rec_open.c
+++ b/src/plugins/kdb/db2/libdb2/recno/rec_open.c
@@ -55,10 +55,8 @@ static char sccsid[] = "@(#)rec_open.c	8.12 (Berkeley) 11/18/94";
 #include "recno.h"
 
 DB *
-__rec_open(fname, flags, mode, openinfo, dflags)
-	const char *fname;
-	int flags, mode, dflags;
-	const RECNOINFO *openinfo;
+__rec_open(const char *fname, int flags, int mode, const RECNOINFO *openinfo,
+	   int dflags)
 {
 	BTREE *t;
 	BTREEINFO btopeninfo;
@@ -226,8 +224,7 @@ err:	sverrno = errno;
 }
 
 int
-__rec_fd(dbp)
-	const DB *dbp;
+__rec_fd(const DB *dbp)
 {
 	BTREE *t;
 

--- a/src/plugins/kdb/db2/libdb2/recno/rec_put.c
+++ b/src/plugins/kdb/db2/libdb2/recno/rec_put.c
@@ -59,11 +59,7 @@ static char sccsid[] = "@(#)rec_put.c	8.7 (Berkeley) 8/18/94";
  *	already in the tree and R_NOOVERWRITE specified.
  */
 int
-__rec_put(dbp, key, data, flags)
-	const DB *dbp;
-	DBT *key;
-	const DBT *data;
-	u_int flags;
+__rec_put(const DB *dbp, DBT *key, const DBT *data, u_int flags)
 {
 	BTREE *t;
 	DBT fdata, tdata;
@@ -187,11 +183,7 @@ einval:		errno = EINVAL;
  *	RET_ERROR, RET_SUCCESS
  */
 int
-__rec_iput(t, nrec, data, flags)
-	BTREE *t;
-	recno_t nrec;
-	const DBT *data;
-	u_int flags;
+__rec_iput(BTREE *t, recno_t nrec, const DBT *data, u_int flags)
 {
 	DBT tdata;
 	EPG *e;

--- a/src/plugins/kdb/db2/libdb2/recno/rec_search.c
+++ b/src/plugins/kdb/db2/libdb2/recno/rec_search.c
@@ -61,10 +61,7 @@ static char sccsid[] = "@(#)rec_search.c	8.4 (Berkeley) 7/14/94";
  *	the bt_cur field of the tree.  A pointer to the field is returned.
  */
 EPG *
-__rec_search(t, recno, op)
-	BTREE *t;
-	recno_t recno;
-	enum SRCHOP op;
+__rec_search(BTREE *t, recno_t recno, enum SRCHOP op)
 {
 	indx_t idx;
 	PAGE *h;

--- a/src/plugins/kdb/db2/libdb2/recno/rec_seq.c
+++ b/src/plugins/kdb/db2/libdb2/recno/rec_seq.c
@@ -58,10 +58,7 @@ static char sccsid[] = "@(#)rec_seq.c	8.3 (Berkeley) 7/14/94";
  *	RET_ERROR, RET_SUCCESS or RET_SPECIAL if there's no next key.
  */
 int
-__rec_seq(dbp, key, data, flags)
-	const DB *dbp;
-	DBT *key, *data;
-	u_int flags;
+__rec_seq(const DB *dbp, DBT *key, DBT *data, u_int flags)
 {
 	BTREE *t;
 	EPG *e;

--- a/src/plugins/kdb/db2/libdb2/recno/rec_utils.c
+++ b/src/plugins/kdb/db2/libdb2/recno/rec_utils.c
@@ -59,11 +59,7 @@ static char sccsid[] = "@(#)rec_utils.c	8.6 (Berkeley) 7/16/94";
  *	RET_SUCCESS, RET_ERROR.
  */
 int
-__rec_ret(t, e, nrec, key, data)
-	BTREE *t;
-	EPG *e;
-	recno_t nrec;
-	DBT *key, *data;
+__rec_ret(BTREE *t, EPG *e, recno_t nrec, DBT *key, DBT *data)
 {
 	RLEAF *rl;
 	void *p;

--- a/src/plugins/kdb/db2/libdb2/test/dbtest.c
+++ b/src/plugins/kdb/db2/libdb2/test/dbtest.c
@@ -121,9 +121,7 @@ DB *XXdbp;				/* Global for gdb. */
 u_long XXlineno;			/* Fast breakpoint for gdb. */
 
 int
-main(argc, argv)
-	int argc;
-	char *argv[];
+main(int argc, char *argv[])
 {
 	extern int optind;
 	extern char *optarg;
@@ -380,8 +378,7 @@ lkey:			switch (command) {
 #define	NOOVERWRITE	"put failed, would overwrite key\n"
 
 void
-compare(db1, db2)
-	DBT *db1, *db2;
+compare(DBT *db1, DBT *db2)
 {
 	size_t len;
 	u_char *p1, *p2;
@@ -402,9 +399,7 @@ compare(db1, db2)
 }
 
 void
-get(dbp, kp)
-	DB *dbp;
-	DBT *kp;
+get(DB *dbp, DBT *kp)
 {
 	DBT data;
 
@@ -437,9 +432,7 @@ get(dbp, kp)
 }
 
 void
-getdata(dbp, kp, dp)
-	DB *dbp;
-	DBT *kp, *dp;
+getdata(DB *dbp, DBT *kp, DBT *dp)
 {
 	switch (dbp->get(dbp, kp, dp, flags)) {
 	case 0:
@@ -454,9 +447,7 @@ getdata(dbp, kp, dp)
 }
 
 void
-put(dbp, kp, dp)
-	DB *dbp;
-	DBT *kp, *dp;
+put(DB *dbp, DBT *kp, DBT *dp)
 {
 	switch (dbp->put(dbp, kp, dp, flags)) {
 	case 0:
@@ -473,9 +464,7 @@ put(dbp, kp, dp)
 }
 
 void
-rem(dbp, kp)
-	DB *dbp;
-	DBT *kp;
+rem(DB *dbp, DBT *kp)
 {
 	switch (dbp->del(dbp, kp, flags)) {
 	case 0:
@@ -502,8 +491,7 @@ rem(dbp, kp)
 }
 
 void
-synk(dbp)
-	DB *dbp;
+synk(DB *dbp)
 {
 	switch (dbp->sync(dbp, flags)) {
 	case 0:
@@ -515,9 +503,7 @@ synk(dbp)
 }
 
 void
-seq(dbp, kp)
-	DB *dbp;
-	DBT *kp;
+seq(DB *dbp, DBT *kp)
 {
 	DBT data;
 
@@ -551,10 +537,7 @@ seq(dbp, kp)
 }
 
 void
-dump(dbp, rev, recurse)
-	DB *dbp;
-	int rev;
-	int recurse;
+dump(DB *dbp, int rev, int recurse)
 {
 	DBT key, data;
 	int lflags, nflags;
@@ -588,8 +571,7 @@ done:	return;
 }
 
 void
-unlinkpg(dbp)
-	DB *dbp;
+unlinkpg(DB *dbp)
 {
 	BTREE *t = dbp->internal;
 	PAGE *h = NULL;
@@ -623,8 +605,7 @@ cleanup:
 }
 
 u_int
-setflags(s)
-	char *s;
+setflags(char *s)
 {
 	char *p;
 
@@ -648,8 +629,7 @@ setflags(s)
 }
 
 char *
-sflags(lflags)
-	int lflags;
+sflags(int lflags)
 {
 	switch (lflags) {
 	case R_CURSOR:		return ("R_CURSOR");
@@ -667,8 +647,7 @@ sflags(lflags)
 }
 
 DBTYPE
-dbtype(s)
-	char *s;
+dbtype(char *s)
 {
 	if (!strcmp(s, "btree"))
 		return (DB_BTREE);
@@ -681,9 +660,7 @@ dbtype(s)
 }
 
 void *
-setinfo(db_type, s)
-	DBTYPE db_type;
-	char *s;
+setinfo(DBTYPE db_type, char *s)
 {
 	static BTREEINFO ib;
 	static HASHINFO ih;
@@ -777,9 +754,7 @@ setinfo(db_type, s)
 }
 
 void *
-rfile(name, lenp)
-	char *name;
-	size_t *lenp;
+rfile(char *name, size_t *lenp)
 {
 	struct stat sb;
 	void *p;
@@ -806,9 +781,7 @@ rfile(name, lenp)
 }
 
 void *
-xmalloc(text, len)
-	char *text;
-	size_t len;
+xmalloc(char *text, size_t len)
 {
 	void *p;
 

--- a/src/plugins/kdb/db2/pol_xdr.c
+++ b/src/plugins/kdb/db2/pol_xdr.c
@@ -82,7 +82,7 @@ xdr_osa_policy_ent_rec(XDR *xdrs, osa_policy_ent_t objp)
         if (!xdr_short(xdrs, &objp->n_tl_data))
             return (FALSE);
         if (!xdr_nulltype(xdrs, (void **) &objp->tl_data,
-                          xdr_krb5_tl_data))
+			  (xdrproc_t)xdr_krb5_tl_data))
             return FALSE;
     }
     return (TRUE);

--- a/src/plugins/kdb/ldap/ldap_util/kdb5_ldap_util.c
+++ b/src/plugins/kdb/ldap/ldap_util/kdb5_ldap_util.c
@@ -186,8 +186,8 @@ static struct _cmd_table {
  * The function cmd_lookup returns the structure matching the
  * command name and returns NULL if nothing matches.
  */
-static struct _cmd_table *cmd_lookup(name)
-    char *name;
+static struct _cmd_table *
+cmd_lookup(const char *name)
 {
     int i;
 

--- a/src/plugins/kdb/lmdb/kdb_lmdb.c
+++ b/src/plugins/kdb/lmdb/kdb_lmdb.c
@@ -468,13 +468,13 @@ error:
 }
 
 static krb5_error_code
-klmdb_lib_init()
+klmdb_lib_init(void)
 {
     return 0;
 }
 
 static krb5_error_code
-klmdb_lib_cleanup()
+klmdb_lib_cleanup(void)
 {
     return 0;
 }

--- a/src/plugins/kdb/test/kdb_test.c
+++ b/src/plugins/kdb/test/kdb_test.c
@@ -312,13 +312,13 @@ make_strings(char **stringattrs, krb5_db_entry *ent)
 }
 
 static krb5_error_code
-test_init()
+test_init(void)
 {
     return 0;
 }
 
 static krb5_error_code
-test_cleanup()
+test_cleanup(void)
 {
     return 0;
 }

--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -3597,7 +3597,7 @@ load_pkcs11_module(krb5_context context, const char *modname,
     CK_RV (*getflist)(CK_FUNCTION_LIST_PTR_PTR);
     struct errinfo einfo = EMPTY_ERRINFO;
     const char *errmsg = NULL;
-    void (*sym)();
+    void (*sym)(void);
     long err;
     CK_RV rv;
 
@@ -3616,7 +3616,7 @@ load_pkcs11_module(krb5_context context, const char *modname,
         goto error;
     }
 
-    getflist = (CK_RV (*)())sym;
+    getflist = (CK_RV (*)(CK_FUNCTION_LIST_PTR_PTR))sym;
     rv = (*getflist)(p11p);
     if (rv != CKR_OK) {
         TRACE_PKINIT_PKCS11_GETFLIST_FAILED(context, pkcs11err(rv));

--- a/src/plugins/preauth/spake/t_vectors.c
+++ b/src/plugins/preauth/spake/t_vectors.c
@@ -464,7 +464,7 @@ run_test(const struct test *t)
 }
 
 int
-main()
+main(void)
 {
     size_t i;
 

--- a/src/tests/asn.1/krb5_decode_test.c
+++ b/src/tests/asn.1/krb5_decode_test.c
@@ -54,9 +54,8 @@ static void ktest_free_reply_key_pack(krb5_context context,
 static void ktest_free_kkdcp_message(krb5_context context,
                                      krb5_kkdcp_message *val);
 
-int main(argc, argv)
-    int argc;
-    char **argv;
+int
+main(int argc, char **argv)
 {
     krb5_data code;
     krb5_error_code retval;

--- a/src/tests/asn.1/krb5_encode_test.c
+++ b/src/tests/asn.1/krb5_encode_test.c
@@ -37,7 +37,7 @@ krb5_context test_context;
 int error_count = 0;
 int do_trval = 0;
 int first_trval = 1;
-int trval2();
+int trval2(FILE *, unsigned char *, int, int, int *);
 
 static void
 encoder_print_results(krb5_data *code, char *typestring, char *description)
@@ -51,7 +51,7 @@ encoder_print_results(krb5_data *code, char *typestring, char *description)
         else
             printf("\n");
         printf("encode_krb5_%s%s:\n", typestring, description);
-        r = trval2(stdout, code->data, code->length, 0, &rlen);
+        r = trval2(stdout, (uint8_t *)code->data, code->length, 0, &rlen);
         printf("\n");
         if (rlen < 0 || (unsigned int) rlen != code->length) {
             printf("Error: length mismatch: was %d, parsed %d\n",
@@ -72,9 +72,8 @@ encoder_print_results(krb5_data *code, char *typestring, char *description)
     ktest_destroy_data(&code);
 }
 
-static void PRS(argc, argv)
-    int argc;
-    char        **argv;
+static void
+PRS(int argc, char **argv)
 {
     extern char *optarg;
     int optchar;
@@ -107,9 +106,7 @@ static void PRS(argc, argv)
 }
 
 int
-main(argc, argv)
-    int argc;
-    char        **argv;
+main(int argc, char **argv)
 {
     krb5_data *code;
     krb5_error_code retval;

--- a/src/tests/asn.1/t_trval.c
+++ b/src/tests/asn.1/t_trval.c
@@ -36,7 +36,8 @@
    -DSTANDALONE code.  */
 #include "trval.c"
 
-static void usage()
+static void
+usage(void)
 {
     fprintf(stderr, "Usage: trval [--types] [--krb5] [--krb5decode] [--hex] [-notypebytes] [file]\n");
     exit(1);
@@ -46,10 +47,8 @@ static void usage()
  * Returns true if the option was selected.  Allow "-option" and
  * "--option" syntax, since we used to accept only "-option"
  */
-static
-int check_option(word, option)
-    char *word;
-    char *option;
+static int
+check_option(char *word, char *option)
 {
     if (word[0] != '-')
         return 0;
@@ -60,9 +59,8 @@ int check_option(word, option)
     return 1;
 }
 
-int main(argc, argv)
-    int argc;
-    char **argv;
+int
+main(int argc, char **argv)
 {
     int optflg = 1;
     FILE *fp;

--- a/src/tests/asn.1/trval.c
+++ b/src/tests/asn.1/trval.c
@@ -120,7 +120,8 @@ int trval2 (FILE *, unsigned char *, int, int, int *);
 
 /****************************************************************************/
 
-static int convert_nibble(int ch)
+static int
+convert_nibble(int ch)
 {
     if (isdigit(ch))
         return (ch - '0');
@@ -131,9 +132,8 @@ static int convert_nibble(int ch)
     return -1;
 }
 
-int trval(fin, fout)
-    FILE        *fin;
-    FILE        *fout;
+int
+trval(FILE *fin, FILE *fout)
 {
     unsigned char *p;
     unsigned int maxlen;
@@ -169,12 +169,8 @@ int trval(fin, fout)
     return(r);
 }
 
-int trval2(fp, enc, len, lev, rlen)
-    FILE *fp;
-    unsigned char *enc;
-    int len;
-    int lev;
-    int *rlen;
+int
+trval2(FILE *fp, unsigned char *enc, int len, int lev, int *rlen)
 {
     int l, eid, elen, xlen, r, rlen2 = 0;
     int rlen_ext = 0;
@@ -248,10 +244,8 @@ context_restart:
     return(r);
 }
 
-int decode_len(fp, enc, len)
-    FILE *fp;
-    unsigned char *enc;
-    int len;
+int
+decode_len(FILE *fp, unsigned char *enc, int len)
 {
     int rlen;
     int i;
@@ -270,12 +264,8 @@ int decode_len(fp, enc, len)
 /*
  * This is the printing function for bit strings
  */
-int do_prim_bitstring(fp, tag, enc, len, lev)
-    FILE *fp;
-    int tag;
-    unsigned char *enc;
-    int len;
-    int lev;
+int
+do_prim_bitstring(FILE *fp, int tag, unsigned char *enc, int len, int lev)
 {
     int i;
     long        num = 0;
@@ -297,12 +287,8 @@ int do_prim_bitstring(fp, tag, enc, len, lev)
 /*
  * This is the printing function for integers
  */
-int do_prim_int(fp, tag, enc, len, lev)
-    FILE *fp;
-    int tag;
-    unsigned char *enc;
-    int len;
-    int lev;
+int
+do_prim_int(FILE *fp, int tag, unsigned char *enc, int len, int lev)
 {
     int i;
     long        num = 0;
@@ -327,12 +313,8 @@ int do_prim_int(fp, tag, enc, len, lev)
  * This is the printing function which we use if it's a string or
  * other other type which is best printed as a string
  */
-int do_prim_string(fp, tag, enc, len, lev)
-    FILE *fp;
-    int tag;
-    unsigned char *enc;
-    int len;
-    int lev;
+int
+do_prim_string(FILE *fp, int tag, unsigned char *enc, int len, int lev)
 {
     int i;
 
@@ -349,12 +331,8 @@ int do_prim_string(fp, tag, enc, len, lev)
     return 1;
 }
 
-int do_prim(fp, tag, enc, len, lev)
-    FILE *fp;
-    int tag;
-    unsigned char *enc;
-    int len;
-    int lev;
+int
+do_prim(FILE *fp, int tag, unsigned char *enc, int len, int lev)
 {
     int n;
     int i;
@@ -396,12 +374,8 @@ int do_prim(fp, tag, enc, len, lev)
     return(OK);
 }
 
-int do_cons(fp, enc, len, lev, rlen)
-    FILE *fp;
-    unsigned char *enc;
-    int len;
-    int lev;
-    int *rlen;
+int
+do_cons(FILE *fp, unsigned char *enc, int len, int lev, int *rlen)
 {
     int n;
     int r = 0;
@@ -430,9 +404,8 @@ struct typestring_table {
     int new_appl;
 };
 
-static char *lookup_typestring(table, key1, key2)
-    struct typestring_table *table;
-    int key1, key2;
+static char *
+lookup_typestring(struct typestring_table *table, int key1, int key2)
 {
     struct typestring_table *ent;
 
@@ -700,10 +673,8 @@ struct typestring_table krb5_fields[] = {
 };
 #endif
 
-void print_tag_type(fp, eid, lev)
-    FILE *fp;
-    int     eid;
-    int     lev;
+void
+print_tag_type(FILE *fp, int eid, int lev)
 {
     int tag = eid & ID_TAG;
     int do_space = 1;

--- a/src/tests/conccache.c
+++ b/src/tests/conccache.c
@@ -110,7 +110,7 @@ refresh_cache(krb5_context context)
 }
 
 static pid_t
-spawn_cred_subprocess()
+spawn_cred_subprocess(void)
 {
     krb5_context context;
     pid_t pid;
@@ -133,7 +133,7 @@ spawn_cred_subprocess()
 }
 
 static pid_t
-spawn_refresh_subprocess()
+spawn_refresh_subprocess(void)
 {
     krb5_context context;
     pid_t pid;

--- a/src/tests/create/kdb5_mkdums.c
+++ b/src/tests/create/kdb5_mkdums.c
@@ -56,9 +56,7 @@ struct mblock {
 int set_dbname_help (char *, char *);
 
 static void
-usage(who, status)
-    char *who;
-    int status;
+usage(char *who, int status)
 {
     fprintf(stderr,
             "usage: %s -p prefix -n num_to_create [-d dbpathname] [-r realmname]\n",
@@ -83,9 +81,7 @@ static krb5_boolean manual_mkey = FALSE;
 void add_princ (krb5_context, char *);
 
 int
-main(argc, argv)
-    int argc;
-    char *argv[];
+main(int argc, char *argv[])
 {
     extern char *optarg;
     int optchar, i, n;
@@ -209,9 +205,7 @@ main(argc, argv)
 }
 
 void
-add_princ(context, str_newprinc)
-    krb5_context          context;
-    char                * str_newprinc;
+add_princ(krb5_context context, char *str_newprinc)
 {
     krb5_error_code       retval;
     krb5_principal        newprinc;
@@ -317,9 +311,7 @@ error: /* Do cleanup of newentry regardless of error */
 }
 
 int
-set_dbname_help(pname, dbname)
-    char *pname;
-    char *dbname;
+set_dbname_help(char *pname, char *dbname)
 {
     krb5_error_code retval;
     krb5_data pwd, scratch;

--- a/src/tests/forward.c
+++ b/src/tests/forward.c
@@ -51,7 +51,7 @@ check(krb5_error_code code)
 }
 
 int
-main()
+main(void)
 {
     krb5_ccache cc;
     krb5_creds mcred, tgt, *fcred;

--- a/src/tests/gss-threads/gss-client.c
+++ b/src/tests/gss-threads/gss-client.c
@@ -68,7 +68,7 @@
 static int verbose = 1;
 
 static void
-usage()
+usage(void)
 {
     fprintf(stderr, "Usage: gss-client [-port port] [-mech mechanism] [-d]\n");
     fprintf(stderr, "       [-seq] [-noreplay] [-nomutual]");
@@ -134,7 +134,7 @@ get_server_info(char *host, u_short port)
  * displayed and -1 is returned.
  */
 static int
-connect_to_server()
+connect_to_server(void)
 {
     int s;
 

--- a/src/tests/gss-threads/gss-server.c
+++ b/src/tests/gss-threads/gss-server.c
@@ -74,7 +74,7 @@
 #endif
 
 static void
-usage()
+usage(void)
 {
     fprintf(stderr, "Usage: gss-server [-port port] [-verbose] [-once]");
 #ifdef _WIN32

--- a/src/tests/gssapi/reload.c
+++ b/src/tests/gssapi/reload.c
@@ -64,7 +64,7 @@ load_gssapi(void)
 }
 
 int
-main()
+main(void)
 {
     void *support;
 

--- a/src/tests/gssapi/t_add_cred.c
+++ b/src/tests/gssapi/t_add_cred.c
@@ -43,7 +43,7 @@
 #include "common.h"
 
 int
-main()
+main(void)
 {
     OM_uint32 minor, major;
     gss_cred_id_t cred1, cred2;

--- a/src/tests/gssapi/t_enctypes.c
+++ b/src/tests/gssapi/t_enctypes.c
@@ -47,7 +47,7 @@
  */
 
 static void
-usage()
+usage(void)
 {
     errout("Usage: t_enctypes [-i initenctypes] [-a accenctypes] "
            "targetname");

--- a/src/tests/gssapi/t_invalid.c
+++ b/src/tests/gssapi/t_invalid.c
@@ -111,7 +111,7 @@ struct test {
 
 /* Fake up enough of a CFX GSS context for gss_unwrap, using an AES key. */
 static gss_ctx_id_t
-make_fake_cfx_context()
+make_fake_cfx_context(void)
 {
     gss_union_ctx_id_t uctx;
     krb5_gss_ctx_id_t kgctx;
@@ -414,7 +414,7 @@ try_accept(void *value, size_t len)
 
 /* Accept contexts using superficially valid but truncated encapsulations. */
 static void
-test_short_encapsulation()
+test_short_encapsulation(void)
 {
     /* Include just the initial application tag, to see if we overrun reading
      * the sequence length. */

--- a/src/tests/gssapi/t_oid.c
+++ b/src/tests/gssapi/t_oid.c
@@ -129,7 +129,7 @@ oid_equal(gss_OID o1, gss_OID o2)
 }
 
 int
-main()
+main(void)
 {
     size_t i;
     OM_uint32 major, minor;

--- a/src/tests/gssapi/t_spnego.c
+++ b/src/tests/gssapi/t_spnego.c
@@ -195,7 +195,7 @@ test_mskrb_oid(gss_name_t tname, gss_cred_id_t acred)
 /* Check that we return a compatibility NegTokenInit2 message containing
  * NegHints for an empty initiator token. */
 static void
-test_neghints()
+test_neghints(void)
 {
     OM_uint32 major, minor;
     gss_buffer_desc itok = GSS_C_EMPTY_BUFFER, atok;

--- a/src/tests/hammer/kdc5_hammer.c
+++ b/src/tests/hammer/kdc5_hammer.c
@@ -68,9 +68,7 @@ int get_tgt
 		   krb5_ccache);
 
 static void
-usage(who, status)
-char *who;
-int status;
+usage(char *who, int status)
 {
     fprintf(stderr,
 	    "usage: %s -p prefix -n num_to_check [-c cachename] [-r realmname]\n",
@@ -100,9 +98,7 @@ struct h_timer tgs_req_times = { 0.0, 1000000.0, -1.0, 0 };
 				     tstart_time.tv_usec))/1000000.0)))
 
 int
-main(argc, argv)
-    int argc;
-    char **argv;
+main(int argc, char **argv)
 {
     krb5_ccache ccache = NULL;
     char *cache_name = NULL;		/* -f option */
@@ -271,11 +267,8 @@ main(argc, argv)
 
 
 static krb5_error_code
-get_server_key(context, server, enctype, key)
-    krb5_context context;
-    krb5_principal server;
-    krb5_enctype enctype;
-    krb5_keyblock ** key;
+get_server_key(krb5_context context, krb5_principal server,
+	       krb5_enctype enctype, krb5_keyblock **key)
 {
     krb5_error_code retval;
     krb5_encrypt_block eblock;
@@ -311,15 +304,10 @@ cleanup_salt:
     return retval;
 }
 
-int verify_cs_pair(context, p_client_str, p_client, service, hostname,
-		   p_num, c_depth, s_depth, ccache)
-    krb5_context context;
-    char *p_client_str;
-    krb5_principal p_client;
-    char * service;
-    char * hostname;
-    int p_num, c_depth, s_depth;
-    krb5_ccache ccache;
+int
+verify_cs_pair(krb5_context context, char *p_client_str,
+	       krb5_principal p_client, char *service, char *hostname,
+	       int p_num, int c_depth, int s_depth, krb5_ccache ccache)
 {
     krb5_error_code 	  retval;
     krb5_creds 	 	  creds;
@@ -433,11 +421,9 @@ cleanup:
     return retval;
 }
 
-int get_tgt (context, p_client_str, p_client, ccache)
-    krb5_context context;
-    char *p_client_str;
-    krb5_principal *p_client;
-    krb5_ccache ccache;
+int
+get_tgt(krb5_context context, char *p_client_str, krb5_principal *p_client,
+	krb5_ccache ccache)
 {
     long lifetime = KRB5_DEFAULT_LIFE;	/* -l option */
     krb5_error_code code;

--- a/src/tests/kdbtest.c
+++ b/src/tests/kdbtest.c
@@ -271,7 +271,7 @@ iter_pol_handler(void *data, osa_policy_ent_t pol)
 }
 
 int
-main()
+main(void)
 {
     krb5_db_entry *ent;
     osa_policy_ent_t pol;

--- a/src/tests/misc/test_getpw.c
+++ b/src/tests/misc/test_getpw.c
@@ -32,7 +32,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 
-int main()
+int main(void)
 {
     uid_t my_uid;
     struct passwd *pwd, pwx;

--- a/src/tests/plugorder.c
+++ b/src/tests/plugorder.c
@@ -77,7 +77,7 @@ blt3(krb5_context context, int maj_ver, int min_ver, krb5_plugin_vtable vtable)
 }
 
 int
-main()
+main(void)
 {
     krb5_plugin_initvt_fn *modules = NULL, *mod;
     struct krb5_pwqual_vtable_st vt;

--- a/src/tests/shlib/t_loader.c
+++ b/src/tests/shlib/t_loader.c
@@ -180,7 +180,7 @@ static void do_close(void *libhandle)
 
 #endif
 
-int main()
+int main(void)
 {
     void *celib, *k5lib, *gsslib, *celib2;
 

--- a/src/tests/softpkcs11/main.c
+++ b/src/tests/softpkcs11/main.c
@@ -860,7 +860,7 @@ func_not_supported(void)
 }
 
 static char *
-get_rcfilename()
+get_rcfilename(void)
 {
     struct passwd *pw;
     const char *home = NULL;

--- a/src/tests/t_inetd.c
+++ b/src/tests/t_inetd.c
@@ -59,16 +59,15 @@
 
 char *progname;
 
-static void usage()
+static void
+usage(void)
 {
     fprintf(stderr, "%s: port program argv0 argv1 ...\n", progname);
     exit(1);
 }
 
 int
-main(argc, argv)
-    int argc;
-    char **argv;
+main(int argc, char **argv)
 {
     unsigned short port;
     char *path;

--- a/src/tests/test1.c
+++ b/src/tests/test1.c
@@ -31,7 +31,7 @@ unsigned char key_two[8] = { 0xea, 0x89, 0x57, 0x76, 0x5b, 0xcd, 0x0d, 0x34 };
 
 extern void dump_data();
 
-tkt_test_1()
+tkt_test_1(void)
 {
     krb5_data *data;
     krb5_ticket tk_in, *tk_out;
@@ -185,7 +185,7 @@ tkt_test_1()
 
 
 
-main()
+main(void)
 {
     krb5_init_ets();
     tkt_test_1();

--- a/src/tests/verify/kdb5_verify.c
+++ b/src/tests/verify/kdb5_verify.c
@@ -50,9 +50,7 @@ struct mblock {
 int set_dbname_help (krb5_context, char *, char *);
 
 static void
-usage(who, status)
-    char *who;
-    int status;
+usage(char *who, int status)
 {
     fprintf(stderr,
             "usage: %s -p prefix -n num_to_check [-d dbpathname] [-r realmname]\n",
@@ -78,9 +76,7 @@ static krb5_boolean manual_mkey = FALSE;
 int check_princ (krb5_context, char *);
 
 int
-main(argc, argv)
-    int argc;
-    char *argv[];
+main(int argc, char *argv[])
 {
     extern char *optarg;
     int optchar, i, n;
@@ -221,9 +217,7 @@ main(argc, argv)
 }
 
 int
-check_princ(context, str_princ)
-    krb5_context context;
-    char * str_princ;
+check_princ(krb5_context context, char *str_princ)
 {
     krb5_error_code retval;
     krb5_db_entry *kdbe = NULL;
@@ -343,10 +337,7 @@ out:
 }
 
 int
-set_dbname_help(context, pname, dbname)
-    krb5_context context;
-    char *pname;
-    char *dbname;
+set_dbname_help(krb5_context context, char *pname, char *dbname)
 {
     krb5_error_code retval;
     krb5_data pwd, scratch;

--- a/src/util/et/error_message.c
+++ b/src/util/et/error_message.c
@@ -82,7 +82,7 @@ void com_err_terminate(void)
 #endif
 
 static char *
-get_thread_buffer ()
+get_thread_buffer(void)
 {
     char *cp;
     cp = k5_getspecific(K5_KEY_COM_ERR);

--- a/src/util/et/test_et.c
+++ b/src/util/et/test_et.c
@@ -17,7 +17,8 @@ extern const char *error_table_name (errcode_t);
 extern int sys_nerr;
 #endif
 
-int main()
+int
+main(void)
 {
     printf("Before initiating error table:\n\n");
 #ifndef EXPORT_LIST

--- a/src/util/profile/prof_init.c
+++ b/src/util/profile/prof_init.c
@@ -103,7 +103,7 @@ init_load_module(const char *modspec, profile_t *ret_profile)
     struct errinfo einfo = { 0 };
     prf_lib_handle_t lib_handle = NULL;
     struct plugin_file_handle *plhandle = NULL;
-    void *cbdata = NULL, (*fptr)();
+    void *cbdata = NULL, (*fptr)(void);
     int have_lock = 0, have_cbdata = 0;
     struct profile_vtable vtable = { 1 };  /* Set minor_ver to 1, rest null. */
     errcode_t err;

--- a/src/util/profile/t_profile.c
+++ b/src/util/profile/t_profile.c
@@ -72,7 +72,7 @@ write_file(const char *name, int nlines, ...)
 /* Regression test for #2685 (profile iterator breaks when modifications
  * made) */
 static void
-test_iterate()
+test_iterate(void)
 {
     profile_t p;
     void *iter;
@@ -129,7 +129,7 @@ test_iterate()
  * global shared profiles list.
  */
 static void
-test_shared()
+test_shared(void)
 {
     profile_t a, b;
     struct utimbuf times;
@@ -164,7 +164,7 @@ test_shared()
 /* Regression test for #2950 (profile_clear_relation not reflected within
  * handle where deletion is performed) */
 static void
-test_clear()
+test_clear(void)
 {
     profile_t p;
     const char *names[] = { "test section 1", "quux", NULL };
@@ -183,7 +183,7 @@ test_clear()
 }
 
 static void
-test_include()
+test_include(void)
 {
     profile_t p;
     const char *names[] = { "test section 1", "bar", NULL };
@@ -237,7 +237,7 @@ test_include()
 
 /* Test syntactic independence of included profile files. */
 static void
-test_independence()
+test_independence(void)
 {
     profile_t p;
     const char *names1[] = { "sec1", "var", "a", NULL };
@@ -264,7 +264,7 @@ test_independence()
 
 /* Regression test for #7971 (deleted sections should not be iterable) */
 static void
-test_delete_section()
+test_delete_section(void)
 {
     profile_t p;
     const char *sect[] = { "test section 1", NULL };
@@ -290,7 +290,7 @@ test_delete_section()
 /* Regression test for #7971 (profile_clear_relation() error with deleted node
  * at end of value set) */
 static void
-test_delete_clear_relation()
+test_delete_clear_relation(void)
 {
     profile_t p;
     const char *names[] = { "test section 1", "testkey", NULL };
@@ -305,7 +305,7 @@ test_delete_clear_relation()
 
 /* Test that order of relations is preserved if some relations are deleted. */
 static void
-test_delete_ordering()
+test_delete_ordering(void)
 {
     profile_t p;
     const char *names[] = { "test section 1", "testkey", NULL };
@@ -329,7 +329,7 @@ test_delete_ordering()
 /* Regression test for #8431 (profile_flush_to_file erroneously changes flag
  * state on source object) */
 static void
-test_flush_to_file()
+test_flush_to_file(void)
 {
     profile_t p;
 
@@ -349,7 +349,7 @@ test_flush_to_file()
 /* Regression test for #7863 (multiply-specified subsections should
  * be merged) */
 static void
-test_merge_subsections()
+test_merge_subsections(void)
 {
     profile_t p;
     const char *n1[] = { "test section 2", "child_section2", "child", NULL };
@@ -374,7 +374,7 @@ test_merge_subsections()
 }
 
 int
-main()
+main(void)
 {
     test_iterate();
     test_shared();

--- a/src/util/profile/test_load.c
+++ b/src/util/profile/test_load.c
@@ -29,7 +29,7 @@
 #include "prof_int.h"
 
 int
-main()
+main(void)
 {
     profile_t pr, pr2;
     const char *files[] = { "./modtest.conf", NULL };

--- a/src/util/profile/test_parse.c
+++ b/src/util/profile/test_parse.c
@@ -11,9 +11,8 @@
 
 void dump_profile (struct profile_node *root, int level);
 
-int main(argc, argv)
-    int     argc;
-    char    **argv;
+int
+main(int argc, char **argv)
 {
     struct profile_node *root;
     unsigned long retval;

--- a/src/util/profile/test_profile.c
+++ b/src/util/profile/test_profile.c
@@ -19,8 +19,8 @@ const char *program_name = "test_profile";
 #define PRINT_VALUE     1
 #define PRINT_VALUES    2
 
-static void do_batchmode(profile)
-    profile_t       profile;
+static void
+do_batchmode(profile_t profile)
 {
     errcode_t       retval;
     int             argc, ret;
@@ -108,10 +108,8 @@ static void do_batchmode(profile)
 
 }
 
-
-int main(argc, argv)
-    int         argc;
-    char        **argv;
+int
+main(int argc, char **argv)
 {
     profile_t   profile;
     long        retval;

--- a/src/util/profile/test_vtable.c
+++ b/src/util/profile/test_vtable.c
@@ -232,7 +232,8 @@ struct profile_vtable full_vtable = {
     full_flush
 };
 
-int main()
+int
+main(void)
 {
     profile_t profile;
     char **values, *str, *name, *value;

--- a/src/util/ss/error.c
+++ b/src/util/ss/error.c
@@ -33,8 +33,8 @@
 #include "com_err.h"
 #include "copyright.h"
 
-char * ss_name(sci_idx)
-    int sci_idx;
+char *
+ss_name(int sci_idx)
 {
     ss_data *infop;
 
@@ -50,7 +50,8 @@ char * ss_name(sci_idx)
     }
 }
 
-void ss_error (int sci_idx, long code, const char * fmt, ...)
+void
+ss_error(int sci_idx, long code, const char *fmt, ...)
 {
     char *whoami;
     va_list pvar;
@@ -61,10 +62,8 @@ void ss_error (int sci_idx, long code, const char * fmt, ...)
     va_end(pvar);
 }
 
-void ss_perror (sci_idx, code, msg) /* for compatibility */
-    int sci_idx;
-    long code;
-    char const *msg;
+void
+ss_perror(int sci_idx, long code, char const *msg) /* for compatibility */
 {
     ss_error (sci_idx, code, "%s", msg);
 }

--- a/src/util/ss/execute_cmd.c
+++ b/src/util/ss/execute_cmd.c
@@ -52,11 +52,9 @@
  * Notes:
  */
 
-static int check_request_table (rqtbl, argc, argv, sci_idx)
-    ss_request_table *rqtbl;
-    int argc;
-    char *argv[];
-    int sci_idx;
+static int
+check_request_table(ss_request_table *rqtbl, int argc, char *argv[],
+                    int sci_idx)
 {
     ss_request_entry *request;
     ss_data *info;
@@ -101,10 +99,8 @@ static int check_request_table (rqtbl, argc, argv, sci_idx)
  * Notes:
  */
 
-static int really_execute_command (sci_idx, argc, argv)
-    int sci_idx;
-    int argc;
-    char **argv[];
+static int
+really_execute_command(int sci_idx, int argc, char **argv[])
 {
     ss_request_table **rqtbl;
     ss_data *info;
@@ -135,9 +131,7 @@ static int really_execute_command (sci_idx, argc, argv)
  */
 
 int
-ss_execute_command(sci_idx, argv)
-    int sci_idx;
-    char *argv[];
+ss_execute_command(int sci_idx, char *argv[])
 {
     unsigned int i, argc;
     char **argp;
@@ -172,9 +166,8 @@ ss_execute_command(sci_idx, argv)
  * Notes:
  */
 
-int ss_execute_line (sci_idx, line_ptr)
-    int sci_idx;
-    char *line_ptr;
+int
+ss_execute_line(int sci_idx, char *line_ptr)
 {
     char **argv;
     int argc, ret;

--- a/src/util/ss/help.c
+++ b/src/util/ss/help.c
@@ -15,11 +15,8 @@
 #include "copyright.h"
 
 
-void ss_help (argc, argv, sci_idx, info_ptr)
-    int argc;
-    char const * const *argv;
-    int sci_idx;
-    pointer info_ptr;
+void
+ss_help(int argc, char const * const *argv, int sci_idx, pointer info_ptr)
 {
     char buffer[MAXPATHLEN];
     char const *request_name;
@@ -81,15 +78,11 @@ got_it:
         ss_page_stdin();
     default:
         (void) close(fd); /* what can we do if it fails? */
-#ifdef WAIT_USES_INT
-        while (wait((int *)NULL) != child) {
-#else
-            while (wait((union wait *)NULL) != child) {
-#endif
-                /* do nothing if wrong pid */
-            };
-        }
+        while (wait(NULL) != child) {
+            /* do nothing if wrong pid */
+        };
     }
+}
 
 #ifndef USE_DIRENT_H
 #include <sys/dir.h>
@@ -97,60 +90,56 @@ got_it:
 #include <dirent.h>
 #endif
 
-    void ss_add_info_dir(sci_idx, info_dir, code_ptr)
-        int sci_idx;
-    char *info_dir;
-    int *code_ptr;
-    {
-        ss_data *info;
-        DIR *d;
-        int n_dirs;
-        char **dirs;
+void
+ss_add_info_dir(int sci_idx, char *info_dir, int *code_ptr)
+{
+    ss_data *info;
+    DIR *d;
+    int n_dirs;
+    char **dirs;
 
-        info = ss_info(sci_idx);
-        if ((info_dir == NULL) || (*info_dir == '\0')) {
-            *code_ptr = SS_ET_NO_INFO_DIR;
-            return;
-        }
-        if ((d = opendir(info_dir)) == (DIR *)NULL) {
-            *code_ptr = errno;
-            return;
-        }
-        closedir(d);
-        dirs = info->info_dirs;
-        for (n_dirs = 0; dirs[n_dirs] != (char *)NULL; n_dirs++)
-            ;               /* get number of non-NULL dir entries */
-        dirs = (char **)realloc((char *)dirs,
-                                (unsigned)(n_dirs + 2)*sizeof(char *));
-        if (dirs == (char **)NULL) {
-            info->info_dirs = (char **)NULL;
-            *code_ptr = errno;
-            return;
-        }
-        info->info_dirs = dirs;
-        dirs[n_dirs + 1] = (char *)NULL;
-        dirs[n_dirs] = strdup(info_dir);
-        *code_ptr = 0;
-    }
-
-    void ss_delete_info_dir(sci_idx, info_dir, code_ptr)
-        int sci_idx;
-    char *info_dir;
-    int *code_ptr;
-    {
-        char **i_d;
-        char **info_dirs;
-
-        info_dirs = ss_info(sci_idx)->info_dirs;
-        for (i_d = info_dirs; *i_d; i_d++) {
-            if (!strcmp(*i_d, info_dir)) {
-                while (*i_d) {
-                    *i_d = *(i_d+1);
-                    i_d++;
-                }
-                *code_ptr = 0;
-                return;
-            }
-        }
+    info = ss_info(sci_idx);
+    if ((info_dir == NULL) || (*info_dir == '\0')) {
         *code_ptr = SS_ET_NO_INFO_DIR;
+        return;
     }
+    if ((d = opendir(info_dir)) == (DIR *)NULL) {
+        *code_ptr = errno;
+        return;
+    }
+    closedir(d);
+    dirs = info->info_dirs;
+    for (n_dirs = 0; dirs[n_dirs] != (char *)NULL; n_dirs++)
+        ;               /* get number of non-NULL dir entries */
+    dirs = (char **)realloc((char *)dirs,
+                            (unsigned)(n_dirs + 2)*sizeof(char *));
+    if (dirs == (char **)NULL) {
+        info->info_dirs = (char **)NULL;
+        *code_ptr = errno;
+        return;
+    }
+    info->info_dirs = dirs;
+    dirs[n_dirs + 1] = (char *)NULL;
+    dirs[n_dirs] = strdup(info_dir);
+    *code_ptr = 0;
+}
+
+void
+ss_delete_info_dir(int sci_idx, char *info_dir, int *code_ptr)
+{
+    char **i_d;
+    char **info_dirs;
+
+    info_dirs = ss_info(sci_idx)->info_dirs;
+    for (i_d = info_dirs; *i_d; i_d++) {
+        if (!strcmp(*i_d, info_dir)) {
+            while (*i_d) {
+                *i_d = *(i_d+1);
+                i_d++;
+            }
+            *code_ptr = 0;
+            return;
+        }
+    }
+    *code_ptr = SS_ET_NO_INFO_DIR;
+}

--- a/src/util/ss/invocation.c
+++ b/src/util/ss/invocation.c
@@ -36,12 +36,10 @@
    _ss_table[sci_idx], make sure you change the allocation routine to
    not assume there are no null pointers in the middle of the
    array.  */
-int ss_create_invocation(subsystem_name, version_string, info_ptr,
-                         request_table_ptr, code_ptr)
-    char *subsystem_name, *version_string;
-    char *info_ptr;
-    ss_request_table *request_table_ptr;
-    int *code_ptr;
+int
+ss_create_invocation(char *subsystem_name, char *version_string,
+                     char *info_ptr, ss_request_table *request_table_ptr,
+                     int *code_ptr)
 {
     int sci_idx;
     ss_data *new_table;
@@ -115,8 +113,7 @@ int ss_create_invocation(subsystem_name, version_string, info_ptr,
 }
 
 void
-ss_delete_invocation(sci_idx)
-    int sci_idx;
+ss_delete_invocation(int sci_idx)
 {
     ss_data *t;
     int ignored_code;

--- a/src/util/ss/list_rqs.c
+++ b/src/util/ss/list_rqs.c
@@ -21,15 +21,8 @@ static char const twentyfive_spaces[26] =
 static char const NL[2] = "\n";
 
 void
-ss_list_requests(argc, argv, sci_idx, info_ptr)
-    int argc;
-    const char * const *argv;
-    int sci_idx;
-#ifdef __STDC__
-    void *info_ptr;
-#else
-    char *info_ptr;
-#endif
+ss_list_requests(int argc, const char * const *argv, int sci_idx,
+                 void *info_ptr)
 {
     ss_request_entry *entry;
     char const *const *name;

--- a/src/util/ss/listen.c
+++ b/src/util/ss/listen.c
@@ -28,7 +28,8 @@ static jmp_buf listen_jmpb;
 
 #ifdef NO_READLINE
 /* Dumb replacement for readline when we don't have support for a real one. */
-static char *readline(const char *prompt)
+static char *
+readline(const char *prompt)
 {
     struct termios termbuf;
     char input[BUFSIZ];
@@ -49,20 +50,21 @@ static char *readline(const char *prompt)
 }
 
 /* No-op replacement for add_history() when we have no readline support. */
-static void add_history(const char *line)
+static void
+add_history(const char *line)
 {
 }
 #endif
 
-static void listen_int_handler(signo)
-    int signo;
+static void
+listen_int_handler(int signo)
 {
     putc('\n', stdout);
     longjmp(listen_jmpb, 1);
 }
 
-int ss_listen (sci_idx)
-    int sci_idx;
+int
+ss_listen(int sci_idx)
 {
     char *cp;
     ss_data *info;
@@ -83,12 +85,12 @@ int ss_listen (sci_idx)
     info->abort = 0;
 
 #ifdef POSIX_SIGNALS
-    csig.sa_handler = (void (*)())0;
+    csig.sa_handler = (void (*)(int))0;
     sigemptyset(&nmask);
     sigaddset(&nmask, SIGINT);
     sigprocmask(SIG_BLOCK, &nmask, &omask);
 #else
-    sig_cont = (void (*)())0;
+    sig_cont = (void (*)(int))0;
     mask = sigblock(sigmask(SIGINT));
 #endif
 
@@ -115,7 +117,7 @@ int ss_listen (sci_idx)
         nsig.sa_handler = listen_int_handler;   /* fgets is not signal-safe */
         osig = csig;
         sigaction(SIGCONT, &nsig, &csig);
-        if ((void (*)())csig.sa_handler==(void (*)())listen_int_handler)
+        if ((void (*)(int))csig.sa_handler==(void (*)(int))listen_int_handler)
             csig = osig;
 #else
         old_sig_cont = sig_cont;
@@ -166,20 +168,16 @@ egress:
     return code;
 }
 
-void ss_abort_subsystem(sci_idx, code)
-    int sci_idx;
-    int code;
+void
+ss_abort_subsystem(int sci_idx, int code)
 {
     ss_info(sci_idx)->abort = 1;
     ss_info(sci_idx)->exit_status = code;
 
 }
 
-void ss_quit(argc, argv, sci_idx, infop)
-    int argc;
-    char const * const *argv;
-    int sci_idx;
-    pointer infop;
+void
+ss_quit(int argc, char const * const *argv, int sci_idx, pointer infop)
 {
     ss_abort_subsystem(sci_idx, 0);
 }

--- a/src/util/ss/pager.c
+++ b/src/util/ss/pager.c
@@ -10,13 +10,13 @@
 #include "copyright.h"
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/file.h>
 #include <signal.h>
 
 static char MORE[] = "more";
 extern char *_ss_pager_name;
-extern char *getenv();
 
 /*
  * this needs a *lot* of work....
@@ -25,10 +25,10 @@ extern char *getenv();
  * handle SIGINT sensibly
  * allow finer control -- put-page-break-here
  */
-void ss_page_stdin();
+void ss_page_stdin(void);
 
 #ifndef NO_FORK
-int ss_pager_create()
+int ss_pager_create(void)
 {
     int filedes[2];
 
@@ -56,7 +56,7 @@ int ss_pager_create()
     }
 }
 #else /* don't fork */
-int ss_pager_create()
+int ss_pager_create(void)
 {
     int fd;
     fd = open("/dev/tty", O_WRONLY, 0);
@@ -66,7 +66,7 @@ int ss_pager_create()
 }
 #endif
 
-void ss_page_stdin()
+void ss_page_stdin(void)
 {
     int i;
 #ifdef POSIX_SIGNALS

--- a/src/util/ss/parse.c
+++ b/src/util/ss/parse.c
@@ -53,10 +53,8 @@ enum parse_mode { WHITESPACE, TOKEN, QUOTED_STRING };
 #define NEW_ARGV(old,n) (char **)realloc((char *)old,                   \
                                          (unsigned)(n+2)*sizeof(char*))
 
-char **ss_parse (sci_idx, line_ptr, argc_ptr)
-    int sci_idx;
-    char *line_ptr;
-    int *argc_ptr;
+char **
+ss_parse(int sci_idx, char *line_ptr, int *argc_ptr)
 {
     char **argv, *cp;
     char **newargv;

--- a/src/util/ss/prompt.c
+++ b/src/util/ss/prompt.c
@@ -11,16 +11,13 @@
 #include "ss_internal.h"
 
 void
-ss_set_prompt(sci_idx, new_prompt)
-    int sci_idx;
-    char *new_prompt;
+ss_set_prompt(int sci_idx, char *new_prompt)
 {
     ss_info(sci_idx)->prompt = new_prompt;
 }
 
 char *
-ss_get_prompt(sci_idx)
-    int sci_idx;
+ss_get_prompt(int sci_idx)
 {
     return(ss_info(sci_idx)->prompt);
 }

--- a/src/util/ss/request_tbl.c
+++ b/src/util/ss/request_tbl.c
@@ -11,11 +11,7 @@
 #define ssrt ss_request_table   /* for some readable code... */
 
 void
-ss_add_request_table(sci_idx, rqtbl_ptr, position, code_ptr)
-    int sci_idx;
-    ssrt *rqtbl_ptr;
-    int position;           /* 1 -> becomes second... */
-    int *code_ptr;
+ss_add_request_table(int sci_idx, ssrt *rqtbl_ptr, int position, int *code_ptr)
 {
     ss_data *info;
     int i, size;
@@ -44,10 +40,7 @@ ss_add_request_table(sci_idx, rqtbl_ptr, position, code_ptr)
 }
 
 void
-ss_delete_request_table(sci_idx, rqtbl_ptr, code_ptr)
-    int sci_idx;
-    ssrt *rqtbl_ptr;
-    int *code_ptr;
+ss_delete_request_table(int sci_idx, ssrt *rqtbl_ptr, int *code_ptr)
 {
     ss_data *info;
     ssrt **rt1, **rt2;

--- a/src/util/ss/requests.c
+++ b/src/util/ss/requests.c
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include "ss_internal.h"
 
-#define DECLARE(name)   void name(argc,argv,sci_idx,info_ptr)int argc,sci_idx;const char * const *argv; pointer info_ptr;
+#define DECLARE(name)   void name(int argc, const char *const *argv, int sci_idx, pointer info_ptr)
 
 /*
  * ss_self_identify -- assigned by default to the "." request

--- a/src/util/ss/ss.h
+++ b/src/util/ss/ss.h
@@ -48,7 +48,6 @@ typedef struct _ss_rp_options { /* DEFAULT VALUES */
 void ss_help __SS_PROTO;
 void ss_list_requests __SS_PROTO;
 void ss_quit __SS_PROTO;
-char *ss_current_request();
 char *ss_name(int);
 void ss_error (int, long, char const *, ...)
 #if !defined(__cplusplus) && (__GNUC__ > 2)

--- a/src/util/ss/ss_internal.h
+++ b/src/util/ss/ss_internal.h
@@ -84,8 +84,7 @@ typedef struct _ss_data {       /* init values */
 #define ss_info(sci_idx)        (_ss_table[sci_idx])
 #define ss_current_request(sci_idx,code_ptr)            \
     (*code_ptr=0,ss_info(sci_idx)->current_request)
-void ss_unknown_function();
-void ss_delete_info_dir();
+void ss_delete_info_dir(int, char *, int *);
 char **ss_parse (int, char *, int *);
 ss_abbrev_info *ss_abbrev_initialize (char *, int *);
 void ss_page_stdin (void);

--- a/src/util/support/plugins.c
+++ b/src/util/support/plugins.c
@@ -240,13 +240,13 @@ krb5int_get_plugin_data(struct plugin_file_handle *h, const char *csymname,
 
 long KRB5_CALLCONV
 krb5int_get_plugin_func(struct plugin_file_handle *h, const char *csymname,
-                        void (**sym_out)(), struct errinfo *ep)
+                        void (**sym_out)(void), struct errinfo *ep)
 {
     void *dptr = NULL;
     long ret = get_sym(h, csymname, &dptr, ep);
 
     if (!ret)
-        *sym_out = (void (*)())dptr;
+        *sym_out = (void (*)(void))dptr;
     return ret;
 }
 
@@ -552,7 +552,7 @@ krb5int_get_plugin_dir_func (struct plugin_dir_handle *dirhandle,
                              struct errinfo *ep)
 {
     long err = 0;
-    void (**p)() = NULL;
+    void (**p)(void) = NULL;
     size_t count = 0;
 
     /* XXX Do we need to add a leading "_" to the symbol name on any
@@ -569,10 +569,10 @@ krb5int_get_plugin_dir_func (struct plugin_dir_handle *dirhandle,
         int i = 0;
 
         for (i = 0; !err && (dirhandle->files[i] != NULL); i++) {
-            void (*sym)() = NULL;
+            void (*sym)(void) = NULL;
 
             if (krb5int_get_plugin_func (dirhandle->files[i], symname, &sym, ep) == 0) {
-                void (**newp)() = NULL;
+                void (**newp)(void) = NULL;
 
                 count++;
                 newp = realloc (p, ((count + 1) * sizeof (*p))); /* +1 for NULL */

--- a/src/util/support/t_hashtab.c
+++ b/src/util/support/t_hashtab.c
@@ -104,7 +104,7 @@ const uint64_t vectors[64] = {
 };
 
 static void
-test_siphash()
+test_siphash(void)
 {
     uint8_t seq[64];
     uint64_t k0, k1, hval;
@@ -122,7 +122,7 @@ test_siphash()
 }
 
 static void
-test_hashtab()
+test_hashtab(void)
 {
     int st;
     struct k5_hashtab *ht;
@@ -168,7 +168,7 @@ test_hashtab()
 }
 
 int
-main()
+main(void)
 {
     test_siphash();
     test_hashtab();

--- a/src/util/support/t_hex.c
+++ b/src/util/support/t_hex.c
@@ -137,7 +137,8 @@ struct {
     { "F8F9FAFBFCFDFEFF", "\xF8\xF9\xFA\xFB\xFC\xFD\xFE\xFF", 8, 1 },
 };
 
-int main()
+int
+main(void)
 {
     size_t i;
     char *hex;

--- a/src/util/support/t_json.c
+++ b/src/util/support/t_json.c
@@ -86,7 +86,7 @@ check(int pred, const char *str)
 }
 
 static void
-test_array()
+test_array(void)
 {
     k5_json_string v1;
     k5_json_number v2;

--- a/src/util/support/t_k5buf.c
+++ b/src/util/support/t_k5buf.c
@@ -54,7 +54,7 @@ check_buf(struct k5buf *buf, const char *name)
 }
 
 static void
-test_basic()
+test_basic(void)
 {
     struct k5buf buf;
     char storage[1024];
@@ -76,7 +76,7 @@ test_basic()
 }
 
 static void
-test_realloc()
+test_realloc(void)
 {
     struct k5buf buf;
     char data[1024];
@@ -132,7 +132,7 @@ test_realloc()
 }
 
 static void
-test_overflow()
+test_overflow(void)
 {
     struct k5buf buf;
     char storage[10];
@@ -153,7 +153,7 @@ test_overflow()
 }
 
 static void
-test_error()
+test_error(void)
 {
     struct k5buf buf;
     char storage[1];
@@ -173,7 +173,7 @@ test_error()
 }
 
 static void
-test_truncate()
+test_truncate(void)
 {
     struct k5buf buf;
 
@@ -188,7 +188,7 @@ test_truncate()
 }
 
 static void
-test_binary()
+test_binary(void)
 {
     struct k5buf buf;
     char data[] = { 'a', 0, 'b' }, *s;
@@ -205,7 +205,7 @@ test_binary()
 }
 
 static void
-test_fmt()
+test_fmt(void)
 {
     struct k5buf buf;
     char storage[10], data[1024];
@@ -246,7 +246,7 @@ test_fmt()
 }
 
 int
-main()
+main(void)
 {
     test_basic();
     test_realloc();

--- a/src/util/support/t_unal.c
+++ b/src/util/support/t_unal.c
@@ -2,7 +2,8 @@
 #undef NDEBUG
 #include "k5-platform.h"
 
-int main ()
+int
+main(void)
 {
     /* Test some low-level assumptions the Kerberos code depends
        on.  */


### PR DESCRIPTION
The latest clang on MacOS X has started to report these warnings:

../../include/kadm5/kadm_rpc.h:390:15: warning: a function declaration without a
 prototype is deprecated in all versions of C and is not supported in C2x [-Wdep
recated-non-prototype]

This is an attempt to address this problem (I did confirm that C2x is officially dropping support for K&R prototypes).  This does not address the isses in the RPC code; unfortunately it seems xdrproc_t sometimes takes two arguments and sometimes takes three so I am unsure how to fix that.  This should address all missing prototypes that are not RPC-related. I was surprised there were so many!