### PR TITLE
Replace ssl.wrap_socket() Python function

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -1157,10 +1157,9 @@ AC_SUBST(PKINIT)
 # for lib/apputils
 AC_REPLACE_FUNCS(daemon)
 
-# For Python tests.  Python version 3.2.4 is required as prior
-# versions do not accept string input to subprocess.Popen.communicate
-# when universal_newlines is set.
-PYTHON_MINVERSION=3.2.4
+# For Python tests.  Python version 3.4 is required for
+# ssl.create_default_context().
+PYTHON_MINVERSION=3.4
 AC_SUBST(PYTHON_MINVERSION)
 AC_CHECK_PROG(PYTHON,python3,python3)
 if test x"$PYTHON" = x; then
@@ -1168,7 +1167,7 @@ if test x"$PYTHON" = x; then
 fi
 HAVE_PYTHON=no
 if test x"$PYTHON" != x; then
-	wantver="(sys.hexversion >= 0x30204F0)"
+	wantver="(sys.hexversion >= 0x30400F0)"
 	if "$PYTHON" -c "import sys; sys.exit(not $wantver and 1 or 0)"; then
 		HAVE_PYTHON=yes
 	fi

--- a/src/util/wsgiref-kdcproxy.py
+++ b/src/util/wsgiref-kdcproxy.py
@@ -14,6 +14,8 @@ else:
     pem = '*'
 
 server = make_server('localhost', port, kdcproxy.Application())
-server.socket = ssl.wrap_socket(server.socket, certfile=pem, server_side=True)
+sslctx = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
+sslctx.load_cert_chain(certfile=pem)
+server.socket = sslctx.wrap_socket(server.socket, server_side=True)
 os.write(sys.stdout.fileno(), b'proxy server ready\n')
 server.serve_forever()


### PR DESCRIPTION
The `ssl.wrap_socket()` function was deprecated in Python 3.7 and [is removed in Python 3.12](https://docs.python.org/3.12/whatsnew/3.12.html#removed). It results in the following error on Fedora Rawhide:

```
PYTHONPATH=../util VALGRIND="" python3 ./t_proxy.py 
*** Failure: /usr/bin/python3 failed to start with code 1.
*** Last mark: untrusted issuer, hostname mismatch
*** Last command (#4): /usr/bin/python3 /tmp/tmp.YfMScvG3zc/krb5-tests/util/wsgiref-kdcproxy.py 61021 /tmp/tmp.YfMScvG3zc/krb5-tests/tests/proxy-certs/proxy-no-match.pem
*** Output of last command:
Traceback (most recent call last):
  File "/tmp/tmp.YfMScvG3zc/krb5-tests/util/wsgiref-kdcproxy.py", line 17, in <module>
    server.socket = ssl.wrap_socket(server.socket, certfile=pem, server_side=True)
                    ^^^^^^^^^^^^^^^
AttributeError: module 'ssl' has no attribute 'wrap_socket'
```

This PR replaces it by the [`ssl.SSLContext.wrap_socket()`](https://docs.python.org/3.12/library/ssl.html#ssl.SSLContext.wrap_socket) method.

I tested this change on Fedora Rawhide and 38, and CentOS Stream 8 and 9.