### PR TITLE
Properly quote command strings in k5test.py

### DIFF
--- a/src/util/k5test.py
+++ b/src/util/k5test.py
@@ -672,11 +672,10 @@ def _cfg_merge(cfg1, cfg2):
     return result
 
 
-# Python gives us shlex.split() to turn a shell command into a list of
-# arguments, but oddly enough, not the easier reverse operation.  For
-# now, do a bad job of faking it.
+# We would like to use shlex.join() from Python 3.8.  For now use
+# shlex.quote() from Python 3.3.
 def _shell_equiv(args):
-    return " ".join(args)
+    return ' '.join(shlex.quote(x) for x in args)
 
 
 # Add a valgrind prefix to the front of args if specified in the


### PR DESCRIPTION
Requiring Python 3.4 gives us shlex.quote() (added in Python 3.3). Use it in _shell_equiv() to quote command arguments.

[I also looked into using subprocess.check_output() for _run_cmd().  It isn't quite a better fit than the existing Popen() and communicate() calls, because it throws an exception on a non-zero status.  subprocess.run() should be a good fit once we require Python 3.5 for the tests.]
