### PR TITLE
kdc: Fix double free in free_req_info()

### DIFF
--- a/src/kdc/do_tgs_req.c
+++ b/src/kdc/do_tgs_req.c
@@ -1010,8 +1010,9 @@ tgs_issue_ticket(kdc_realm_t *realm, struct tgs_req_info *t,
     }
 
     if (t->req->kdc_options & (KDC_OPT_VALIDATE | KDC_OPT_RENEW)) {
-        /* Copy the whole header ticket except for authorization data. */
-        ticket_reply = *t->header_tkt;
+        /* Copy the header ticket server and all enc-part fields except for
+         * authorization data. */
+        ticket_reply.server = t->header_tkt->server;
         enc_tkt_reply = *t->header_tkt->enc_part2;
         enc_tkt_reply.authorization_data = NULL;
     } else {


### PR DESCRIPTION
Reproducer in Samba:
`make test TESTS=samba.tests.krb5.kdc_tgs_tests`

```
/usr/sbin/krb5kdc: ================================================================= /usr/sbin/krb5kdc: ==6492==ERROR: AddressSanitizer: attempting double-free on 0x61a00025e080 in thread T0:
/usr/sbin/krb5kdc:     #0 0x7f5c932dad08  (/usr/lib64/libasan.so.8.0.0+0xdad08) (BuildId: a24a20df2a1331371c666de9135abab342429d43)
/usr/sbin/krb5kdc:     #1 0x7f5c9317df72 in krb5_free_ticket krb/kfree.c:455
/usr/sbin/krb5kdc:     #2 0x7f5c9317df72 in krb5_free_ticket krb/kfree.c:450
/usr/sbin/krb5kdc:     #3 0x417fb6 in free_req_info ../../src/kdc/do_tgs_req.c:1144
/usr/sbin/krb5kdc:     #4 0x417fb6 in process_tgs_req ../../src/kdc/do_tgs_req.c:1225
/usr/sbin/krb5kdc:     #5 0x40c35f in dispatch ../../src/kdc/dispatch.c:163
/usr/sbin/krb5kdc:     #6 0x449411 in process_tcp_connection_read ../../../src/lib/apputils/net-server.c:1363
/usr/sbin/krb5kdc:     #7 0x7f5c931053a7 in verto_fire (/lib64/libverto.so.1+0x43a7) (BuildId: dce5099f3ddd23bf63050ec1bd9f959814a709ee)
/usr/sbin/krb5kdc:     #8 0x7f5c8d8f9625 in ev_invoke_pending (/lib64/libev.so.4+0x5625) (BuildId: db2a80899176970d5ae46767b5ba351c27607fd5)
/usr/sbin/krb5kdc:     #9 0x7f5c8d8fd1cb in ev_run (/lib64/libev.so.4+0x91cb) (BuildId: db2a80899176970d5ae46767b5ba351c27607fd5)
/usr/sbin/krb5kdc:     #10 0x4344a5 in main ../../src/kdc/main.c:1039
/usr/sbin/krb5kdc:     #11 0x7f5c92a2abef in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
/usr/sbin/krb5kdc:     #12 0x7f5c92a2acb8 in __libc_start_main_impl ../csu/libc-start.c:360
/usr/sbin/krb5kdc:     #13 0x4097a4 in _start ../sysdeps/x86_64/start.S:115
/usr/sbin/krb5kdc:
/usr/sbin/krb5kdc: 0x61a00025e080 is located 0 bytes inside of 1188-byte region [0x61a00025e080,0x61a00025e524)
/usr/sbin/krb5kdc: freed by thread T0 here:
/usr/sbin/krb5kdc:     #0 0x7f5c932dad08  (/usr/lib64/libasan.so.8.0.0+0xdad08) (BuildId: a24a20df2a1331371c666de9135abab342429d43)
/usr/sbin/krb5kdc:     #1 0x4170ce in zapfree ../../src/include/k5-int.h:664
/usr/sbin/krb5kdc:     #2 0x4170ce in tgs_issue_ticket ../../src/kdc/do_tgs_req.c:1128
/usr/sbin/krb5kdc:     #3 0x4170ce in process_tgs_req ../../src/kdc/do_tgs_req.c:1195
/usr/sbin/krb5kdc:     #4 0x40c35f in dispatch ../../src/kdc/dispatch.c:163
/usr/sbin/krb5kdc:     #5 0x449411 in process_tcp_connection_read ../../../src/lib/apputils/net-server.c:1363
/usr/sbin/krb5kdc:     #6 0x7f5c931053a7 in verto_fire (/lib64/libverto.so.1+0x43a7) (BuildId: dce5099f3ddd23bf63050ec1bd9f959814a709ee)
/usr/sbin/krb5kdc:
/usr/sbin/krb5kdc: previously allocated by thread T0 here:
/usr/sbin/krb5kdc:     #0 0x7f5c932dc03f in malloc (/usr/lib64/libasan.so.8.0.0+0xdc03f) (BuildId: a24a20df2a1331371c666de9135abab342429d43)
/usr/sbin/krb5kdc:     #1 0x7f5c93158f5d in k5_asn1_decode_bytestring asn.1/asn1_encode.c:232
/usr/sbin/krb5kdc:     #2 0x6030000aaeef  (<unknown module>)
/usr/sbin/krb5kdc:
/usr/sbin/krb5kdc: SUMMARY: AddressSanitizer: double-free (/usr/lib64/libasan.so.8.0.0+0xdad08) (BuildId: a24a20df2a1331371c666de9135abab342429d43)
/usr/sbin/krb5kdc: ==6492==ABORTING
```