### PR TITLE
Replace direct use of getopt.h in favor of a HAVE_GETOPT aware solution

### DIFF
--- a/src/appl/simple/client/sim_client.c
+++ b/src/appl/simple/client/sim_client.c
@@ -39,10 +39,7 @@
 #include <string.h>
 #include <errno.h>
 #include <netdb.h>
-#include <getopt.h>
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
-#endif
 
 #include "simple.h"
 


### PR DESCRIPTION
Since a code refactoring in 9139a60c94c24e41109574e84e7cda9c2dc3fb38 getopt.h has not been removed which causes compilation failures on systems without getopt.h being present, .e.g., HP-UX.

Original request, the isser tracker did not accept my report appearantly:

Folks,

with the above change (from 1.21.1) an oversight has been introduced by 
retaining getopt.h include. This fails on HP-UX since there is no 
default getopt library:
```
/opt/aCC/bin/aCC -Ae -DHAVE_CONFIG_H  -I../../../include -I../../../include -I./.. -DKRB5_DEPRECATED=1 -DKRB5_PRIVATE -I/opt/ports/include +We901  -D_REENTRANT -D_THREAD_SAFE -D_POSIX_C_SOURCE=199506L  -c sim_client.c
"sim_client.c", line 42: error #3696-D: cannot open source file "getopt.h"
  #include <getopt.h>
                     ^

"sim_client.c", line 234: warning #2167-D: argument of type "socklen_t *" is
          incompatible with parameter of type "int *"
      if (getsockname(sock, (struct sockaddr *)&c_sock, &len) < 0) {
                                                        ^

1 error detected in the compilation of "sim_client.c".
```

As soon as I delete the include the module compiles:
```
# cd src
# sed -i"" -e "42d" ./appl/simple/client/sim_client.c
```

given that krb5 has an internal getopt if no external getopt library is 
available:
```
root@deblndw002x:/var/tmp/ports/work/krb5-1.21.2/src
# find . -name sim_client
./appl/simple/client/sim_client
root@deblndw002x:/var/tmp/ports/work/krb5-1.21.2/src
# ./appl/simple/client/sim_client
You must specify a hostname to contact.

usage: ./appl/simple/client/sim_client [-p port] [-h host] [-m message] [-s service] [host]
root@deblndw002x:/var/tmp/ports/work/krb5-1.21.2/src
# file ./appl/simple/client/sim_client
./appl/simple/client/sim_client:        ELF-32 executable object file - IA64
```