### PR TITLE
make TCP waiting time configurable

### DIFF
--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -362,6 +362,15 @@ The libdefaults section may contain any of the following relations:
     (:ref:`duration` string.)  Sets the default renewable lifetime
     for initial ticket requests.  The default value is 0.
 
+**request_timeout**
+    (:ref:`duration` string.)  Sets the maximum total time for KDC or
+    password change requests.  This timeout does not affect the
+    intervals between requests, so setting a low timeout may result in
+    fewer requests being attempted and/or some servers not being
+    contacted.  A value of 0 indicates no specific maximum, in which
+    case requests will time out if no server responds after several
+    tries.  The default value is 0.  (New in release 1.22.)
+
 **spake_preauth_groups**
     A whitespace or comma-separated list of words which specifies the
     groups allowed for SPAKE preauthentication.  The possible values

--- a/doc/admin/conf_files/krb5_conf.rst
+++ b/doc/admin/conf_files/krb5_conf.rst
@@ -363,7 +363,7 @@ The libdefaults section may contain any of the following relations:
     for initial ticket requests.  The default value is 0.
 
 **request_timeout**
-    (:ref:`duration` string.)  Sets the maximum total time for KDC or
+    (:ref:`duration` string.)  Sets the maximum total time for KDC and
     password change requests.  This timeout does not affect the
     intervals between requests, so setting a low timeout may result in
     fewer requests being attempted and/or some servers not being

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -297,6 +297,7 @@ typedef unsigned char   u_char;
 #define KRB5_CONF_SPAKE_PREAUTH_INDICATOR      "spake_preauth_indicator"
 #define KRB5_CONF_SPAKE_PREAUTH_KDC_CHALLENGE  "spake_preauth_kdc_challenge"
 #define KRB5_CONF_SPAKE_PREAUTH_GROUPS         "spake_preauth_groups"
+#define KRB5_CONF_REQUEST_TIMEOUT              "request_timeout"
 #define KRB5_CONF_TICKET_LIFETIME              "ticket_lifetime"
 #define KRB5_CONF_UDP_PREFERENCE_LIMIT         "udp_preference_limit"
 #define KRB5_CONF_UNLOCKITER                   "unlockiter"
@@ -1201,6 +1202,7 @@ struct _krb5_context {
     kdb5_dal_handle *dal_handle;
     /* allowable clock skew */
     krb5_deltat     clockskew;
+    krb5_deltat     req_timeout;
     krb5_flags      kdc_default_options;
     krb5_flags      library_options;
     krb5_boolean    profile_secure;

--- a/src/lib/krb5/krb/init_ctx.c
+++ b/src/lib/krb5/krb/init_ctx.c
@@ -158,7 +158,7 @@ krb5_init_context_profile(profile_t profile, krb5_flags flags,
     krb5_context ctx = 0;
     krb5_error_code retval;
     int tmp;
-    char *plugin_dir = NULL;
+    char *plugin_dir = NULL, *timeout_str = NULL;
 
     /* Verify some assumptions.  If the assumptions hold and the
        compiler is optimizing, this should result in no code being
@@ -251,6 +251,17 @@ krb5_init_context_profile(profile_t profile, krb5_flags flags,
     get_integer(ctx, KRB5_CONF_CLOCKSKEW, DEFAULT_CLOCKSKEW, &tmp);
     ctx->clockskew = tmp;
 
+    retval = profile_get_string(ctx->profile, KRB5_CONF_LIBDEFAULTS,
+                                KRB5_CONF_REQUEST_TIMEOUT, NULL, NULL,
+                                &timeout_str);
+    if (retval)
+        goto cleanup;
+    if (timeout_str != NULL) {
+        retval = krb5_string_to_deltat(timeout_str, &ctx->req_timeout);
+        if (retval)
+            goto cleanup;
+    }
+
     get_integer(ctx, KRB5_CONF_KDC_DEFAULT_OPTIONS, KDC_OPT_RENEWABLE_OK,
                 &tmp);
     ctx->kdc_default_options = tmp;
@@ -292,6 +303,7 @@ krb5_init_context_profile(profile_t profile, krb5_flags flags,
 
 cleanup:
     profile_release_string(plugin_dir);
+    profile_release_string(timeout_str);
     krb5_free_context(ctx);
     return retval;
 }

--- a/src/lib/krb5/os/sendto_kdc.c
+++ b/src/lib/krb5/os/sendto_kdc.c
@@ -1442,7 +1442,10 @@ service_fds(krb5_context context, struct select_state *selstate,
                 if (msg_handler != NULL) {
                     krb5_data reply = make_data(state->in.buf, state->in.pos);
 
-                    stop = (msg_handler(context, &reply, msg_handler_data) != 0);
+                    if (!msg_handler(context, &reply, msg_handler_data)) {
+                        kill_conn(context, state, selstate);
+                        stop = 0;
+                    }
                 }
 
                 if (stop) {


### PR DESCRIPTION
Currently there is a hardcoded 10s waiting time for TCP connections before other KDCs or connection types are tried.

With this patch a new libdefaults option 'tcp_waiting_time' is introduced to make this hardcode timeout configurable to either wait longer for the KDC to reply or switch faster to other options if a KDC is not responsive.