### PR TITLE
In PKINIT, check for null PKCS7 enveloped fields

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -2464,7 +2464,9 @@ cms_envelopeddata_verify(krb5_context context,
     }
 
     /* verify that the received message is PKCS7 EnvelopedData message */
-    if (OBJ_obj2nid(p7->type) != NID_pkcs7_enveloped) {
+    if (OBJ_obj2nid(p7->type) != NID_pkcs7_enveloped ||
+        p7->d.enveloped == NULL ||
+        p7->d.enveloped->enc_data->enc_data == NULL) {
         pkiDebug("Expected id-enveloped PKCS7 msg (received type = %d)\n",
                  OBJ_obj2nid(p7->type));
         krb5_set_error_message(context, retval, "wrong oid\n");


### PR DESCRIPTION
The PKCS7 ContentInfo content field and EncryptedContentInfo encryptedContent field are optional.  Check for null values in cms_envelopeddata_verify() before calling pkcs7_decrypt().  Reported by Bahaa Naamneh.
