### PR TITLE
Attempt to improve cross-compilation support

### DIFF
--- a/src/aclocal.m4
+++ b/src/aclocal.m4
@@ -892,7 +892,7 @@ if test "x$enable_rpath" != xyes ; then
 	PROG_RPATH_FLAGS=
 fi
 
-if test "$SHLIBEXT" = ".so-nobuild"; then
+if test "x$enable_shared" = xyes && test "$SHLIBEXT" = ".so-nobuild"; then
    AC_MSG_ERROR([Shared libraries are not yet supported on this platform.])
 fi
 

--- a/src/include/k5-platform.h
+++ b/src/include/k5-platform.h
@@ -1013,6 +1013,7 @@ extern int krb5int_gettimeofday(struct timeval *tp, void *ignore);
  * may have been written into swap space....
  */
 #ifdef _WIN32
+#include <windows.h>
 # define zap(ptr, len) SecureZeroMemory(ptr, len)
 #elif defined(__STDC_LIB_EXT1__)
 /*

--- a/src/include/win-mac.h
+++ b/src/include/win-mac.h
@@ -183,8 +183,8 @@ typedef _W64 int         ssize_t;
  * routines directly. Rather, they only export the _<function> version.
  * The following defines works around this problem.
  */
-#include <sys\types.h>
-#include <sys\stat.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <fcntl.h>
 #include <io.h>
 #include <process.h>

--- a/src/util/support/gmt_mktime.c
+++ b/src/util/support/gmt_mktime.c
@@ -3,6 +3,7 @@
 
 #include "autoconf.h"
 #include <stdio.h>
+#include <stdint.h>
 
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>

--- a/src/util/support/secure_getenv.c
+++ b/src/util/support/secure_getenv.c
@@ -65,6 +65,8 @@
 
 static int elevated_privilege = 0;
 
+#if !defined(_WIN32)
+
 MAKE_INIT_FUNCTION(k5_secure_getenv_init);
 
 int
@@ -109,3 +111,5 @@ k5_secure_getenv(const char *name)
         return NULL;
     return elevated_privilege ? NULL : getenv(name);
 }
+
+#endif // !defined(_WIN32)

--- a/src/util/support/threads.c
+++ b/src/util/support/threads.c
@@ -49,6 +49,7 @@ int krb5int_pthread_loaded (void)
 }
 
 #elif defined(_WIN32)
+#include <windows.h>
 
 static DWORD tls_idx;
 static CRITICAL_SECTION key_lock;


### PR DESCRIPTION
These were found when trying to cross-compile to Windows from a Linux host with BinaryBuilder.jl.

Changes:
- `aclocal.m4`: building shared libraries apparently isn't supported on Windows, but passing `--disable-shared --enable-static` still gave an error about shared libraries not being supported. Now the check will only be done if building shared libraries is enabled.
- `k5-platform.h`: compilation failed because the `SecureZeroMemory()` function wasn't found. Fixed by including `windows.h`.
- `win-mac.h`: gcc got confused by the backslashes. AFAIK all compilers support mapping forward slashes to the right paths on Windows though.
- `gmt-mktime.c`: this file uses `uint32_t`, which requires including `stdint.h`.
- `secure_getenv.c`: `k5_secure_getenv_init()` uses functions like `getuid()` which are POSIX-only, which caused compilation errors when building for Windows, even though it's not used on Windows at all (see `k5-platform.h`). I figured the easiest way to disable it is by ifdef-ing the whole thing. Another alternative would be to exclude it from the Makefile on Windows, but I couldn't figure out how to get that to work.
- `threads.c`: `DWORD` requires the `windows.h` header.

Disclaimer: I barely know what I'm doing, or how much krb5 supports cross-compilation :upside_down_face: And cross-compiling still doesn't work, now I'm hitting errors with `libev` from `libverto`.