### PR TITLE
Double free in klist's show_ccache()

### DIFF
--- a/src/clients/klist/klist.c
+++ b/src/clients/klist/klist.c
@@ -53,7 +53,6 @@ int show_flags = 0, show_time = 0, status_only = 0, show_keys = 0;
 int show_etype = 0, show_addresses = 0, no_resolve = 0, print_version = 0;
 int show_adtype = 0, show_all = 0, list_all = 0, use_client_keytab = 0;
 int show_config = 0;
-char *defname;
 char *progname;
 krb5_timestamp now;
 unsigned int timestamp_width;
@@ -62,7 +61,7 @@ krb5_context context;
 
 static krb5_boolean is_local_tgt(krb5_principal princ, krb5_data *realm);
 static char *etype_string(krb5_enctype );
-static void show_credential(krb5_creds *);
+static void show_credential(krb5_creds *, const char *);
 
 static void list_all_ccaches(void);
 static int list_ccache(krb5_ccache);
@@ -473,6 +472,7 @@ show_ccache(krb5_ccache cache)
     krb5_creds creds;
     krb5_principal princ = NULL;
     krb5_error_code ret;
+    char *defname = NULL;
     int status = 1;
 
     ret = krb5_cc_get_principal(context, cache, &princ);
@@ -503,7 +503,7 @@ show_ccache(krb5_ccache cache)
     }
     while ((ret = krb5_cc_next_cred(context, cache, &cur, &creds)) == 0) {
         if (show_config || !krb5_is_config_principal(context, creds.server))
-            show_credential(&creds);
+            show_credential(&creds, defname);
         krb5_free_cred_contents(context, &creds);
     }
     if (ret == KRB5_CC_END) {
@@ -676,7 +676,7 @@ print_config_data(int col, krb5_data *data)
 }
 
 static void
-show_credential(krb5_creds *cred)
+show_credential(krb5_creds *cred, const char *defname)
 {
     krb5_error_code ret;
     krb5_ticket *tkt = NULL;


### PR DESCRIPTION
Addition of a `cleanup` section in kinit's `show_ccache()` function as part of 6c5471176f introduced a bug. The `defname` global variable is never explicitly initialized. As a global variable, it implicitly initialized to 0, but in case of a first call to `show_ccache()`, where `krb5_cc_get_principal()` succeeded, a second call occurs where `krb5_cc_get_principal()` failed, it will lead to `free()` being called with the already freed default principal name.

I think we missed this case while working on #1306 because we were doing the assumption `defname` was a local variable. Given the fact the only place were it is used outside of `show_ccache()` is the `show_credential()` function (which is called by `show_ccache()` only), I think we should simply turns `defname` into a local variable initialized at the beginning of `show_ccache()`.

This issue was reported by @dtardon ([Fedora bug report](https://bugzilla.redhat.com/show_bug.cgi?id=2257301)). It seems it could occur when running `klist -A`.