### PR TITLE
Fix -Werror=strict-prototypes error in aes.c

### DIFF
--- a/src/clients/kcpytkt/kcpytkt.c
+++ b/src/clients/kcpytkt/kcpytkt.c
@@ -10,7 +10,7 @@ static char *prog;
 static int quiet = 0;
 
 static void
-xusage()
+xusage(void)
 {
     fprintf(stderr, "xusage: %s [-c from_ccache] [-e etype] [-f flags] "
             "dest_ccache service1 service2 ...\n", prog);

--- a/src/clients/kdeltkt/kdeltkt.c
+++ b/src/clients/kdeltkt/kdeltkt.c
@@ -10,7 +10,7 @@ static char *prog;
 static int quiet = 0;
 
 static void
-xusage()
+xusage(void)
 {
     fprintf(stderr, "xusage: %s [-c ccache] [-e etype] [-f flags] service1 "
             "service2 ...\n", prog);

--- a/src/clients/kinit/kinit.c
+++ b/src/clients/kinit/kinit.c
@@ -55,7 +55,7 @@ get_name_from_os(void)
 #else /* HAVE_PWD_H */
 #ifdef _WIN32
 static char *
-get_name_from_os()
+get_name_from_os(void)
 {
     static char name[1024];
     DWORD name_size = sizeof(name);
@@ -69,7 +69,7 @@ get_name_from_os()
 }
 #else /* _WIN32 */
 static char *
-get_name_from_os()
+get_name_from_os(void)
 {
     return NULL;
 }

--- a/src/clients/kinit/kinit_kdb.c
+++ b/src/clients/kinit/kinit_kdb.c
@@ -69,7 +69,7 @@ kinit_kdb_init(krb5_context *pcontext, char *realm)
 }
 
 void
-kinit_kdb_fini()
+kinit_kdb_fini(void)
 {
     kadm5_destroy(server_handle);
 }

--- a/src/clients/klist/klist.c
+++ b/src/clients/klist/klist.c
@@ -358,7 +358,7 @@ do_keytab(const char *name)
 }
 
 static void
-list_all_ccaches()
+list_all_ccaches(void)
 {
     krb5_error_code ret;
     krb5_ccache cache;
@@ -450,7 +450,7 @@ show_all_ccaches(void)
 }
 
 static void
-do_ccache()
+do_ccache(void)
 {
     krb5_error_code ret;
     krb5_ccache cache;

--- a/src/kadmin/cli/kadmin.c
+++ b/src/kadmin/cli/kadmin.c
@@ -607,7 +607,7 @@ kadmin_startup(int argc, char *argv[], char **request_out, char ***args_out)
 }
 
 int
-quit()
+quit(void)
 {
     kadm5_ret_t retval;
 

--- a/src/kadmin/dbutil/kdb5_util.c
+++ b/src/kadmin/dbutil/kdb5_util.c
@@ -367,7 +367,7 @@ main(int argc, char *argv[])
  * program is run).
  */
 static int
-open_db_and_mkey()
+open_db_and_mkey(void)
 {
     krb5_error_code retval;
     krb5_data scratch, pwd, seed;
@@ -489,7 +489,7 @@ open_db_and_mkey()
 #endif
 
 int
-quit()
+quit(void)
 {
     krb5_error_code retval;
     static krb5_boolean finished = 0;

--- a/src/kdc/main.c
+++ b/src/kdc/main.c
@@ -854,7 +854,7 @@ write_pid_file(const char *path)
 }
 
 static void
-finish_realms()
+finish_realms(void)
 {
     int i;
 

--- a/src/kprop/kpropd.c
+++ b/src/kprop/kpropd.c
@@ -376,7 +376,7 @@ get_wildcard_addr(struct addrinfo **res)
 }
 
 static void
-do_standalone()
+do_standalone(void)
 {
     struct sockaddr_in frominet;
     struct addrinfo *res;
@@ -630,7 +630,7 @@ full_resync(CLIENT *clnt)
  * Returns non-zero on failure due to errors.
  */
 krb5_error_code
-do_iprop()
+do_iprop(void)
 {
     kadm5_ret_t retval;
     krb5_principal iprop_svc_principal = NULL;

--- a/src/lib/crypto/builtin/enc_provider/aes.c
+++ b/src/lib/crypto/builtin/enc_provider/aes.c
@@ -69,7 +69,7 @@ void k5_iEnc256_CBC(struct aes_data *data);
 void k5_iDec256_CBC(struct aes_data *data);
 
 static krb5_boolean
-aesni_supported_by_cpu()
+aesni_supported_by_cpu(void)
 {
     unsigned int a, b, c, d;
 

--- a/src/lib/crypto/openssl/hmac.c
+++ b/src/lib/crypto/openssl/hmac.c
@@ -70,7 +70,7 @@
 
 #define HMAC_CTX_new compat_hmac_ctx_new
 static HMAC_CTX *
-compat_hmac_ctx_new()
+compat_hmac_ctx_new(void)
 {
     HMAC_CTX *ctx;
 

--- a/src/lib/krb5/ccache/t_memory.c
+++ b/src/lib/krb5/ccache/t_memory.c
@@ -85,7 +85,7 @@ krb5_creds test_creds = {
 };
 
 void
-init_test_cred()
+init_test_cred(void)
 {
     test_creds.client = (krb5_principal) malloc(sizeof(krb5_data *)*3);
     test_creds.client[0] = &client1;
@@ -104,7 +104,7 @@ init_test_cred()
     };
 
 void
-mcc_test()
+mcc_test(void)
 {
     krb5_ccache id;
     krb5_creds creds;

--- a/src/lib/krb5/ccache/t_stdio.c
+++ b/src/lib/krb5/ccache/t_stdio.c
@@ -98,7 +98,7 @@ krb5_creds test_creds = {
 };
 
 void
-init_test_cred()
+init_test_cred(void)
 {
     test_creds.client = (krb5_principal) malloc(sizeof(krb5_data *)*3);
     test_creds.client[0] = &client1;
@@ -118,7 +118,7 @@ init_test_cred()
 
 int flags = 0;
 void
-scc_test()
+scc_test(void)
 {
     krb5_ccache id;
     krb5_creds creds;

--- a/src/plugins/kdb/db2/libdb2/btree/bt_debug.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_debug.c
@@ -56,7 +56,7 @@ static FILE *tracefp;
  *	initialize debugging.
  */
 static void
-__bt_dinit()
+__bt_dinit(void)
 {
 	static int first = 1;
 

--- a/src/plugins/kdb/db2/libdb2/btree/bt_open.c
+++ b/src/plugins/kdb/db2/libdb2/btree/bt_open.c
@@ -390,7 +390,7 @@ nroot(BTREE *t)
 }
 
 static int
-tmp()
+tmp(void)
 {
 #ifdef SIG_BLOCK
 	sigset_t set, oset;
@@ -437,7 +437,7 @@ tmp()
 }
 
 static int
-byteorder()
+byteorder(void)
 {
 	u_int32_t x;
 	u_char *p;

--- a/src/plugins/kdb/db2/libdb2/hash/dbm.c
+++ b/src/plugins/kdb/db2/libdb2/hash/dbm.c
@@ -143,7 +143,7 @@ kdb2_store(datum key, datum dat)
 }
 
 static void
-no_open_db()
+no_open_db(void)
 {
 	(void)fprintf(stderr, "dbm: no open database.\n");
 }

--- a/src/plugins/kdb/db2/libdb2/test/btree.tests/main.c
+++ b/src/plugins/kdb/db2/libdb2/test/btree.tests/main.c
@@ -908,7 +908,7 @@ keydata(key, data)
 }
 
 void
-usage()
+usage(void)
 {
 	(void)fprintf(stderr,
 	    "usage: %s [-bdluw] [-c cache] [-i file] [-p page] [file]\n",

--- a/src/plugins/kdb/db2/libdb2/test/dbtest.c
+++ b/src/plugins/kdb/db2/libdb2/test/dbtest.c
@@ -792,7 +792,7 @@ xmalloc(char *text, size_t len)
 }
 
 void
-usage()
+usage(void)
 {
 	(void)fprintf(stderr,
 	    "usage: dbtest [-l] [-f file] [-i info] [-o file] type script\n");

--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -3119,7 +3119,7 @@ cleanup:
 }
 
 int
-pkinit_openssl_init()
+pkinit_openssl_init(void)
 {
     /* Initialize OpenSSL. */
     ERR_load_crypto_strings();

--- a/src/plugins/tls/k5tls/openssl.c
+++ b/src/plugins/tls/k5tls/openssl.c
@@ -49,7 +49,7 @@ static int ex_handle_id = -1;
 MAKE_INIT_FUNCTION(init_openssl);
 
 int
-init_openssl()
+init_openssl(void)
 {
     SSL_library_init();
     SSL_load_error_strings();

--- a/src/tests/asn.1/make-vectors.c
+++ b/src/tests/asn.1/make-vectors.c
@@ -224,7 +224,7 @@ printbuf(void)
 }
 
 int
-main()
+main(void)
 {
     /* Initialize values which can't use static initializers. */
     asn_long2INTEGER(&otp_format, 2);  /* Alphanumeric */


### PR DESCRIPTION
In commit 4b9d7f7c107f01a61600fddcd8cde3812d0366a2 the `-Werror=strict-prototypes` parameter was added to the build process, but `src/lib/crypto/builtin/enc_provider/aes.c` still contained a non-prototype function declaration. This commit fixes the declaration.

The declaration was probably missed because the code is not always build.