### PR TITLE
Fix type mismatches detected by LTO

### DIFF
--- a/src/kadmin/cli/kadmin.c
+++ b/src/kadmin/cli/kadmin.c
@@ -633,7 +633,7 @@ quit(void)
 }
 
 void
-kadmin_lock(int argc, char *argv[])
+kadmin_lock(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     kadm5_ret_t retval;
 
@@ -648,7 +648,7 @@ kadmin_lock(int argc, char *argv[])
 }
 
 void
-kadmin_unlock(int argc, char *argv[])
+kadmin_unlock(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     kadm5_ret_t retval;
 
@@ -663,7 +663,7 @@ kadmin_unlock(int argc, char *argv[])
 }
 
 void
-kadmin_delprinc(int argc, char *argv[])
+kadmin_delprinc(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     kadm5_ret_t retval;
     krb5_principal princ = NULL;
@@ -711,7 +711,7 @@ cleanup:
 }
 
 void
-kadmin_renameprinc(int argc, char *argv[])
+kadmin_renameprinc(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     kadm5_ret_t retval;
     krb5_principal oprinc = NULL, nprinc = NULL;
@@ -784,7 +784,7 @@ cpw_usage(const char *str)
 }
 
 void
-kadmin_cpw(int argc, char *argv[])
+kadmin_cpw(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     kadm5_ret_t retval;
     static char newpw[1024];
@@ -1190,7 +1190,7 @@ prepare_dummy_password(char *buf, size_t sz)
 }
 
 void
-kadmin_addprinc(int argc, char *argv[])
+kadmin_addprinc(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     kadm5_principal_ent_rec princ;
     long mask;
@@ -1313,7 +1313,7 @@ cleanup:
 }
 
 void
-kadmin_modprinc(int argc, char *argv[])
+kadmin_modprinc(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     kadm5_principal_ent_rec princ, oldprinc;
     krb5_principal kprinc = NULL;
@@ -1386,7 +1386,7 @@ cleanup:
 }
 
 void
-kadmin_getprinc(int argc, char *argv[])
+kadmin_getprinc(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     kadm5_principal_ent_rec dprinc;
     krb5_principal princ = NULL;
@@ -1522,7 +1522,7 @@ cleanup:
 }
 
 void
-kadmin_getprincs(int argc, char *argv[])
+kadmin_getprincs(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     krb5_error_code retval;
     char *expr, **names;
@@ -1659,7 +1659,7 @@ kadmin_addmodpol_usage(char *func)
 }
 
 void
-kadmin_addpol(int argc, char *argv[])
+kadmin_addpol(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     krb5_error_code retval;
     long mask;
@@ -1680,7 +1680,7 @@ kadmin_addpol(int argc, char *argv[])
 }
 
 void
-kadmin_modpol(int argc, char *argv[])
+kadmin_modpol(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     krb5_error_code retval;
     long mask;
@@ -1701,7 +1701,7 @@ kadmin_modpol(int argc, char *argv[])
 }
 
 void
-kadmin_delpol(int argc, char *argv[])
+kadmin_delpol(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     krb5_error_code retval;
     char reply[5];
@@ -1727,7 +1727,7 @@ kadmin_delpol(int argc, char *argv[])
 }
 
 void
-kadmin_getpol(int argc, char *argv[])
+kadmin_getpol(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     krb5_error_code retval;
     kadm5_policy_ent_rec policy;
@@ -1773,7 +1773,7 @@ kadmin_getpol(int argc, char *argv[])
 }
 
 void
-kadmin_getpols(int argc, char *argv[])
+kadmin_getpols(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     krb5_error_code retval;
     char *expr, **names;
@@ -1795,7 +1795,7 @@ kadmin_getpols(int argc, char *argv[])
 }
 
 void
-kadmin_getprivs(int argc, char *argv[])
+kadmin_getprivs(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     static char *privs[] = {"INQUIRE", "ADD", "MODIFY", "DELETE"};
     krb5_error_code retval;
@@ -1820,7 +1820,7 @@ kadmin_getprivs(int argc, char *argv[])
 }
 
 void
-kadmin_purgekeys(int argc, char *argv[])
+kadmin_purgekeys(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     kadm5_ret_t retval;
     int keepkvno = -1;
@@ -1872,7 +1872,7 @@ cleanup:
 }
 
 void
-kadmin_getstrings(int argc, char *argv[])
+kadmin_getstrings(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     kadm5_ret_t retval;
     char *pname, *canon = NULL;
@@ -1918,7 +1918,7 @@ cleanup:
 }
 
 void
-kadmin_setstring(int argc, char *argv[])
+kadmin_setstring(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     kadm5_ret_t retval;
     char *pname, *canon = NULL, *key, *value;
@@ -1959,7 +1959,7 @@ cleanup:
 }
 
 void
-kadmin_delstring(int argc, char *argv[])
+kadmin_delstring(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     kadm5_ret_t retval;
     char *pname, *canon = NULL, *key;

--- a/src/kadmin/cli/kadmin.h
+++ b/src/kadmin/cli/kadmin.h
@@ -36,27 +36,41 @@
 extern void kadmin_startup(int argc, char *argv[], char **request_out,
                            char ***args_out);
 extern int quit (void);
-extern void kadmin_lock(int argc, char *argv[]);
-extern void kadmin_unlock(int argc, char *argv[]);
-extern void kadmin_delprinc(int argc, char *argv[]);
-extern void kadmin_renameprinc(int argc, char *argv[]);
-extern void kadmin_cpw(int argc, char *argv[]);
-extern void kadmin_addprinc(int argc, char *argv[]);
-extern void kadmin_modprinc(int argc, char *argv[]);
-extern void kadmin_getprinc(int argc, char *argv[]);
-extern void kadmin_getprincs(int argc, char *argv[]);
-extern void kadmin_addpol(int argc, char *argv[]);
-extern void kadmin_modpol(int argc, char *argv[]);
-extern void kadmin_delpol(int argc, char *argv[]);
-extern void kadmin_getpol(int argc, char *argv[]);
-extern void kadmin_getpols(int argc, char *argv[]);
-extern void kadmin_getprivs(int argc, char *argv[]);
-extern void kadmin_keytab_add(int argc, char *argv[]);
-extern void kadmin_keytab_remove(int argc, char *argv[]);
-extern void kadmin_purgekeys(int argc, char *argv[]);
-extern void kadmin_getstrings(int argc, char *argv[]);
-extern void kadmin_setstring(int argc, char *argv[]);
-extern void kadmin_delstring(int argc, char *argv[]);
+extern void kadmin_lock(int argc, char *argv[], int sci_idx, void *info_ptr);
+extern void kadmin_unlock(int argc, char *argv[], int sci_idx, void *info_ptr);
+extern void kadmin_delprinc(int argc, char *argv[], int sci_idx,
+                            void *info_ptr);
+extern void kadmin_renameprinc(int argc, char *argv[], int sci_idx,
+                               void *info_ptr);
+extern void kadmin_cpw(int argc, char *argv[], int sci_idx, void *info_ptr);
+extern void kadmin_addprinc(int argc, char *argv[], int sci_idx,
+                            void *info_ptr);
+extern void kadmin_modprinc(int argc, char *argv[], int sci_idx,
+                            void *info_ptr);
+extern void kadmin_getprinc(int argc, char *argv[], int sci_idx,
+                            void *info_ptr);
+extern void kadmin_getprincs(int argc, char *argv[], int sci_idx,
+                             void *info_ptr);
+extern void kadmin_addpol(int argc, char *argv[], int sci_idx, void *info_ptr);
+extern void kadmin_modpol(int argc, char *argv[], int sci_idx, void *info_ptr);
+extern void kadmin_delpol(int argc, char *argv[], int sci_idx, void *info_ptr);
+extern void kadmin_getpol(int argc, char *argv[], int sci_idx, void *info_ptr);
+extern void kadmin_getpols(int argc, char *argv[], int sci_idx,
+                           void *info_ptr);
+extern void kadmin_getprivs(int argc, char *argv[], int sci_idx,
+                            void *info_ptr);
+extern void kadmin_keytab_add(int argc, char *argv[], int sci_idx,
+                              void *info_ptr);
+extern void kadmin_keytab_remove(int argc, char *argv[], int sci_idx,
+                                 void *info_ptr);
+extern void kadmin_purgekeys(int argc, char *argv[], int sci_idx,
+                             void *info_ptr);
+extern void kadmin_getstrings(int argc, char *argv[], int sci_idx,
+                              void *info_ptr);
+extern void kadmin_setstring(int argc, char *argv[], int sci_idx,
+                             void *info_ptr);
+extern void kadmin_delstring(int argc, char *argv[], int sci_idx,
+                             void *info_ptr);
 
 #include <kdb.h>
 

--- a/src/kadmin/cli/keytab.c
+++ b/src/kadmin/cli/keytab.c
@@ -111,7 +111,7 @@ process_keytab(krb5_context my_context, char **keytab_str,
 }
 
 void
-kadmin_keytab_add(int argc, char **argv)
+kadmin_keytab_add(int argc, char **argv, int sci_idx, void *info_ptr)
 {
     krb5_keytab keytab = 0;
     char *keytab_str = NULL, **princs;
@@ -203,7 +203,7 @@ kadmin_keytab_add(int argc, char **argv)
 }
 
 void
-kadmin_keytab_remove(int argc, char **argv)
+kadmin_keytab_remove(int argc, char **argv, int sci_idx, void *info_ptr)
 {
     krb5_keytab keytab = 0;
     char *keytab_str = NULL;

--- a/src/kadmin/ktutil/ktutil.c
+++ b/src/kadmin/ktutil/ktutil.c
@@ -63,7 +63,7 @@ main(int argc, char *argv[])
 }
 
 void
-ktutil_clear_list(int argc, char *argv[])
+ktutil_clear_list(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     krb5_error_code retval;
 
@@ -78,7 +78,7 @@ ktutil_clear_list(int argc, char *argv[])
 }
 
 void
-ktutil_read_v5(int argc, char *argv[])
+ktutil_read_v5(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     krb5_error_code retval;
 
@@ -92,14 +92,14 @@ ktutil_read_v5(int argc, char *argv[])
 }
 
 void
-ktutil_read_v4(int argc, char *argv[])
+ktutil_read_v4(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     fprintf(stderr, _("%s: reading srvtabs is no longer supported\n"),
             argv[0]);
 }
 
 void
-ktutil_write_v5(int argc, char *argv[])
+ktutil_write_v5(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     krb5_error_code retval;
 
@@ -113,14 +113,14 @@ ktutil_write_v5(int argc, char *argv[])
 }
 
 void
-ktutil_write_v4(int argc, char *argv[])
+ktutil_write_v4(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     fprintf(stderr, _("%s: writing srvtabs is no longer supported\n"),
             argv[0]);
 }
 
 void
-ktutil_add_entry(int argc, char *argv[])
+ktutil_add_entry(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     krb5_error_code retval;
     char *princ = NULL;
@@ -177,7 +177,7 @@ ktutil_add_entry(int argc, char *argv[])
 }
 
 void
-ktutil_delete_entry(int argc, char *argv[])
+ktutil_delete_entry(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     krb5_error_code retval;
 
@@ -191,7 +191,7 @@ ktutil_delete_entry(int argc, char *argv[])
 }
 
 void
-ktutil_list(int argc, char *argv[])
+ktutil_list(int argc, char *argv[], int sci_idx, void *info_ptr)
 {
     krb5_error_code retval;
     krb5_kt_list lp;

--- a/src/kadmin/ktutil/ktutil.h
+++ b/src/kadmin/ktutil/ktutil.h
@@ -50,18 +50,18 @@ krb5_error_code ktutil_write_keytab (krb5_context,
                                      krb5_kt_list,
                                      char *);
 
-void ktutil_add_entry (int, char *[]);
+void ktutil_add_entry (int, char *[], int, void *);
 
-void ktutil_clear_list (int, char *[]);
+void ktutil_clear_list (int, char *[], int, void *);
 
-void ktutil_read_v5 (int, char *[]);
+void ktutil_read_v5 (int, char *[], int, void *);
 
-void ktutil_read_v4 (int, char *[]);
+void ktutil_read_v4 (int, char *[], int, void *);
 
-void ktutil_write_v5 (int, char *[]);
+void ktutil_write_v5 (int, char *[], int, void *);
 
-void ktutil_write_v4 (int, char *[]);
+void ktutil_write_v4 (int, char *[], int, void *);
 
-void ktutil_delete_entry (int, char *[]);
+void ktutil_delete_entry (int, char *[], int, void *);
 
-void ktutil_list (int, char *[]);
+void ktutil_list (int, char *[], int, void *);

--- a/src/lib/krb5/krb/ser_ctx.c
+++ b/src/lib/krb5/krb/ser_ctx.c
@@ -27,11 +27,9 @@
 #include "k5-int.h"
 #include "int-proto.h"
 
-krb5_error_code profile_ser_size(krb5_context, profile_t, size_t *);
-krb5_error_code profile_ser_externalize(krb5_context, profile_t,
-                                        krb5_octet **, size_t *);
-krb5_error_code profile_ser_internalize(krb5_context, profile_t *,
-                                        krb5_octet **, size_t *);
+errcode_t profile_ser_size(profile_t, size_t *);
+errcode_t profile_ser_externalize(profile_t, krb5_octet **, size_t *);
+errcode_t profile_ser_internalize(profile_t *, krb5_octet **, size_t *);
 
 static krb5_error_code size_oscontext(krb5_os_context os_ctx, size_t *sizep);
 static krb5_error_code externalize_oscontext(krb5_os_context os_ctx,
@@ -83,7 +81,7 @@ k5_size_context(krb5_context context, size_t *sizep)
 
         /* Calculate size required by profile, if appropriate */
         if (!kret && context->profile)
-            kret = profile_ser_size(NULL, context->profile, &required);
+            kret = profile_ser_size(context->profile, &required);
     }
     if (!kret)
         *sizep += required;
@@ -186,7 +184,7 @@ k5_externalize_context(krb5_context context,
 
     /* Finally, handle profile, if appropriate */
     if (context->profile != NULL) {
-        kret = profile_ser_externalize(NULL, context->profile, &bp, &remain);
+        kret = profile_ser_externalize(context->profile, &bp, &remain);
         if (kret)
             return (kret);
     }
@@ -310,7 +308,7 @@ k5_internalize_context(krb5_context *argp,
     }
 
     /* Attempt to read in the profile */
-    kret = profile_ser_internalize(NULL, &context->profile, &bp, &remain);
+    kret = profile_ser_internalize(&context->profile, &bp, &remain);
     if (kret && (kret != EINVAL) && (kret != ENOENT))
         goto cleanup;
 

--- a/src/util/profile/prof_init.c
+++ b/src/util/profile/prof_init.c
@@ -521,8 +521,7 @@ profile_release(profile_t profile)
 /*
  * Here begins the profile serialization functions.
  */
-errcode_t profile_ser_size(const char *unused, profile_t profile,
-                           size_t *sizep)
+errcode_t profile_ser_size(profile_t profile, size_t *sizep)
 {
     size_t      required;
     prf_file_t  pfp;
@@ -543,7 +542,7 @@ static void pack_int32(int32_t oval, unsigned char **bufpp, size_t *remainp)
     *remainp -= sizeof(int32_t);
 }
 
-errcode_t profile_ser_externalize(const char *unused, profile_t profile,
+errcode_t profile_ser_externalize(profile_t profile,
                                   unsigned char **bufpp, size_t *remainp)
 {
     errcode_t           retval;
@@ -559,7 +558,7 @@ errcode_t profile_ser_externalize(const char *unused, profile_t profile,
     retval = EINVAL;
     if (profile) {
         retval = ENOMEM;
-        (void) profile_ser_size(unused, profile, &required);
+        (void) profile_ser_size(profile, &required);
         if (required <= remain) {
             fcount = 0;
             for (pfp = profile->first_file; pfp; pfp = pfp->next)
@@ -597,7 +596,7 @@ static int unpack_int32(int32_t *intp, unsigned char **bufpp,
         return 1;
 }
 
-errcode_t profile_ser_internalize(const char *unused, profile_t *profilep,
+errcode_t profile_ser_internalize(profile_t *profilep,
                                   unsigned char **bufpp, size_t *remainp)
 {
     errcode_t               retval;

--- a/src/util/profile/prof_int.h
+++ b/src/util/profile/prof_int.h
@@ -249,13 +249,13 @@ void profile_unlock_global (void);
 
 /* prof_init.c -- included from profile.h */
 errcode_t profile_ser_size
-        (const char *, profile_t, size_t *);
+	(profile_t, size_t *);
 
 errcode_t profile_ser_externalize
-        (const char *, profile_t, unsigned char **, size_t *);
+	(profile_t, unsigned char **, size_t *);
 
 errcode_t profile_ser_internalize
-        (const char *, profile_t *, unsigned char **, size_t *);
+	(profile_t *, unsigned char **, size_t *);
 
 /* prof_get.c */
 


### PR DESCRIPTION
Building with link-time optimization reveals some type mismatches in the interface between libkrb5 serialization and the profile library, as well as in consumers of the SS library.  Fix them.  Reported by Eli Schwartz.
