### PR TITLE
Allow modifications of empty profiles

### DIFF
--- a/src/util/profile/prof_int.h
+++ b/src/util/profile/prof_int.h
@@ -214,6 +214,8 @@ errcode_t profile_open_file
 	(const_profile_filespec_t file, prf_file_t *ret_prof,
 	 char **ret_modspec);
 
+prf_file_t profile_open_memory(void);
+
 #define profile_update_file(P, M) profile_update_file_data((P)->data, M)
 errcode_t profile_update_file_data
 	(prf_data_t profile, char **ret_modspec);

--- a/src/util/profile/prof_set.c
+++ b/src/util/profile/prof_set.c
@@ -24,13 +24,19 @@
 static errcode_t rw_setup(profile_t profile)
 {
     prf_file_t      file;
-    errcode_t       retval = 0;
+    prf_data_t      new_data;
 
     if (!profile)
         return PROF_NO_PROFILE;
 
     if (profile->magic != PROF_MAGIC_PROFILE)
         return PROF_MAGIC_PROFILE;
+
+    /* If the profile has no files, create a memory-only data object. */
+    if (profile->first_file == NULL) {
+        profile->first_file = profile_open_memory();
+        return (profile->first_file == NULL) ? ENOMEM : 0;
+    }
 
     file = profile->first_file;
 
@@ -43,33 +49,22 @@ static errcode_t rw_setup(profile_t profile)
     }
 
     if ((file->data->flags & PROFILE_FILE_SHARED) != 0) {
-        prf_data_t new_data;
         new_data = profile_make_prf_data(file->data->filespec);
         if (new_data == NULL) {
-            retval = ENOMEM;
-        } else {
-            retval = k5_mutex_init(&new_data->lock);
-            if (retval == 0) {
-                new_data->root = NULL;
-                new_data->flags = file->data->flags & ~PROFILE_FILE_SHARED;
-                new_data->timestamp = 0;
-                new_data->upd_serial = file->data->upd_serial;
-            }
-        }
-
-        if (retval != 0) {
             profile_unlock_global();
-            free(new_data);
-            return retval;
+            return ENOMEM;
         }
+        new_data->root = NULL;
+        new_data->flags = file->data->flags & ~PROFILE_FILE_SHARED;
+        new_data->timestamp = 0;
+        new_data->upd_serial = file->data->upd_serial;
+
         profile_dereference_data_locked(file->data);
         file->data = new_data;
     }
 
     profile_unlock_global();
-    retval = profile_update_file(file, NULL);
-
-    return retval;
+    return profile_update_file(file, NULL);
 }
 
 

--- a/src/util/profile/t_profile.c
+++ b/src/util/profile/t_profile.c
@@ -373,6 +373,33 @@ test_merge_subsections(void)
     profile_release(p);
 }
 
+/* Regression test for #9110 (null dereference when modifying an empty
+ * profile), and various other operations on an initially empty profile. */
+static void
+test_empty(void)
+{
+    profile_t p;
+    const char *n1[] = { "section", NULL };
+    const char *n2[] = { "section", "var", NULL };
+    char **values;
+
+    check(profile_init(NULL, &p));
+    check(profile_add_relation(p, n1, NULL));
+    check(profile_add_relation(p, n2, "value"));
+    check(profile_flush(p));    /* should succeed but do nothing */
+    check(profile_get_values(p, n2, &values));
+    assert(strcmp(values[0], "value") == 0 && values[1] == NULL);
+    profile_free_list(values);
+    profile_flush_to_file(p, "test3.ini");
+    profile_release(p);
+
+    profile_init_path("test3.ini", &p);
+    check(profile_get_values(p, n2, &values));
+    assert(strcmp(values[0], "value") == 0 && values[1] == NULL);
+    profile_free_list(values);
+    profile_release(p);
+}
+
 int
 main(void)
 {
@@ -386,4 +413,5 @@ main(void)
     test_delete_ordering();
     test_flush_to_file();
     test_merge_subsections();
+    test_empty();
 }


### PR DESCRIPTION
Add the notion of a memory-only prf_data_t object, indicated by an empty filespec field and appropriate flags (do not reload, always dirty, not part of shared trees).  Do nothing when flushing a memory-only data object to its backing file.  When setting up an empty profile for read/write access, create a memory-only data object instead of crashing.

Move prf_data_t mutex initialization into profile_make_prf_data(), simplifying its callers.

[The immediate motivation here is https://github.com/FreeRDP/FreeRDP/issues/9766 .  The less immediate motivation is  https://mailman.mit.edu/pipermail/kerberos/2023-April/022957.html , which proposed that we allow callers to modify the default profile in memory and pass that to krb5_init_context_profile().  The default profile could be empty, so we need this fix.  We also need profile_copy() to work properly on dirty profiles, and we need some way to prevent libprofile from attempting to flush the changes to the backing file when the profile handle is released--either an outright behavior change or a new API.]