### PR TITLE
Do not reload a modified profile data object

### DIFF
--- a/src/util/profile/prof_file.c
+++ b/src/util/profile/prof_file.c
@@ -301,7 +301,12 @@ errcode_t profile_update_file_data_locked(prf_data_t data, char **ret_modspec)
     FILE *f;
     int isdir = 0;
 
+    /* Don't reload if the backing file isn't a regular file. */
     if ((data->flags & PROFILE_FILE_NO_RELOAD) && data->root != NULL)
+        return 0;
+    /* Don't reload a modified data object, as the modifications may be
+     * important for this object's use. */
+    if (data->flags & PROFILE_FILE_DIRTY)
         return 0;
 
 #ifdef HAVE_STAT
@@ -358,7 +363,6 @@ errcode_t profile_update_file_data_locked(prf_data_t data, char **ret_modspec)
     }
 
     data->upd_serial++;
-    data->flags &= ~PROFILE_FILE_DIRTY;
 
     if (isdir) {
         retval = profile_process_directory(data->filespec, &data->root);


### PR DESCRIPTION
The profile library normally attempts to reload a profile data tree if the backing file has changed.  Reloading a dirty profile object discards any modifications made by the caller.  If we assume that the modifications are destined to be flushed back out to the backing file, then there is no good answer--one or the other set of changes will be lost.  But the caller may have a different intended use for the modified tree (profile_flush_to_file(), profile_flush_to_buffer(), krb5_init_context_profile()), for which the caller's modifications may be critical.
