### PR TITLE
Make profile_copy() work on dirty profiles

### DIFF
--- a/src/util/profile/prof_int.h
+++ b/src/util/profile/prof_int.h
@@ -139,6 +139,9 @@ errcode_t profile_create_node
 	(const char *name, const char *value,
 		   struct profile_node **ret_node);
 
+struct profile_node *profile_copy_node
+	(struct profile_node *oldnode);
+
 errcode_t profile_verify_node
 	(struct profile_node *node);
 
@@ -208,8 +211,6 @@ errcode_t profile_rename_node
 
 /* prof_file.c */
 
-errcode_t KRB5_CALLCONV profile_copy (profile_t, profile_t *);
-
 errcode_t profile_open_file
 	(const_profile_filespec_t file, prf_file_t *ret_prof,
 	 char **ret_modspec);
@@ -233,6 +234,9 @@ errcode_t profile_flush_file_data_to_file
 
 errcode_t profile_flush_file_data_to_buffer
 	(prf_data_t data, char **bufp);
+
+prf_file_t profile_copy_file
+	(prf_file_t oldfile);
 
 void profile_free_file
 	(prf_file_t profile);

--- a/src/util/profile/profile.hin
+++ b/src/util/profile/profile.hin
@@ -51,6 +51,9 @@ long KRB5_CALLCONV profile_init_flags
 long KRB5_CALLCONV profile_init_path
 	(const_profile_filespec_list_t filelist, profile_t *ret_profile);
 
+long KRB5_CALLCONV profile_copy
+	(profile_t, profile_t *);
+
 long KRB5_CALLCONV profile_flush
 	(profile_t profile);
 long KRB5_CALLCONV profile_flush_to_file

--- a/src/util/profile/t_profile.c
+++ b/src/util/profile/t_profile.c
@@ -378,7 +378,7 @@ test_merge_subsections(void)
 static void
 test_empty(void)
 {
-    profile_t p;
+    profile_t p, p2;
     const char *n1[] = { "section", NULL };
     const char *n2[] = { "section", "var", NULL };
     char **values;
@@ -390,6 +390,13 @@ test_empty(void)
     check(profile_get_values(p, n2, &values));
     assert(strcmp(values[0], "value") == 0 && values[1] == NULL);
     profile_free_list(values);
+
+    check(profile_copy(p, &p2));
+    check(profile_get_values(p2, n2, &values));
+    assert(strcmp(values[0], "value") == 0 && values[1] == NULL);
+    profile_free_list(values);
+    profile_release(p2);
+
     profile_flush_to_file(p, "test3.ini");
     profile_release(p);
 


### PR DESCRIPTION
Replace the current implementation of profile_copy() with one that copies the in-memory tree structure of non-shared data objects.  Make profile_copy() a public function.
