### PR TITLE
Don't flush libkrb5 context profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -358,6 +358,7 @@ local.properties
 /src/lib/krb5/krb/t_sname_match
 /src/lib/krb5/krb/t_valid_times
 
+/src/lib/krb5/os/t_ctxprf
 /src/lib/krb5/os/t_expand_path
 /src/lib/krb5/os/t_locate_kdc
 /src/lib/krb5/os/t_std_conf

--- a/src/lib/krb5/os/Makefile.in
+++ b/src/lib/krb5/os/Makefile.in
@@ -2,7 +2,6 @@ mydir=lib$(S)krb5$(S)os
 BUILDTOP=$(REL)..$(S)..$(S)..
 DEFINES=-DLIBDIR=\"$(KRB5_LIBDIR)\" -DBINDIR=\"$(CLIENT_BINDIR)\" \
 	-DSBINDIR=\"$(ADMIN_BINDIR)\"
-LOCALINCLUDES= -I$(top_srcdir)/util/profile
 
 # Like RUN_TEST, but use td_krb5.conf from this directory.
 RUN_TEST_LOCAL_CONF=$(RUN_SETUP) KRB5_CONFIG=$(srcdir)/td_krb5.conf LC_ALL=C \
@@ -154,7 +153,8 @@ SRCS= \
 	$(srcdir)/write_msg.c
 
 EXTRADEPSRCS = \
-	t_expand_path.c t_gifconf.c t_locate_kdc.c t_std_conf.c t_trace.c
+	t_ctxprf.c t_expand_path.c t_gifconf.c t_locate_kdc.c t_std_conf.c \
+	t_trace.c
 
 ##DOS##LIBOBJS = $(OBJS)
 
@@ -164,7 +164,7 @@ clean-unix:: clean-libobjs
 shared:
 	mkdir shared
 
-TEST_PROGS= t_std_conf t_locate_kdc t_trace t_expand_path
+TEST_PROGS= t_std_conf t_locate_kdc t_trace t_expand_path t_ctxprf
 
 T_STD_CONF_OBJS= t_std_conf.o 
 
@@ -190,6 +190,9 @@ t_trace: $(T_TRACE_OBJS) $(KRB5_BASE_DEPLIBS)
 t_expand_path: t_expand_path.o $(KRB5_BASE_DEPLIBS)
 	$(CC_LINK) -o $@ t_expand_path.o $(KRB5_BASE_LIBS)
 
+t_ctxprf: t_ctxprf.o $(KRB5_BASE_DEPLIBS)
+	$(CC_LINK) -o $@ t_ctxprf.o $(KRB5_BASE_LIBS)
+
 LCLINT=lclint
 LCLINTOPTS= -warnposix \
 	-usedef +charintliteral +ignoresigns -predboolint +boolint \
@@ -200,7 +203,7 @@ lclint-localaddr: localaddr.c
 		-DTEST $(srcdir)/localaddr.c
 
 check-unix: check-unix-stdconf check-unix-locate check-unix-trace \
-	check-unix-expand check-unix-uri
+	check-unix-expand check-unix-uri check-unix-ctxprf
 
 check-unix-stdconf: t_std_conf
 	$(RUN_TEST_LOCAL_CONF) ./t_std_conf  -d -s NEW.DEFAULT.REALM -d \
@@ -259,9 +262,12 @@ check-unix-expand: t_expand_path
 		'the %{animal}%{s} on the %{place}%{s}' \
 		'the frogs on the pads'
 
+check-unix-ctxprf: t_ctxprf
+	$(RUNPYTEST) $(srcdir)/t_ctxprf.py $(PYTESTFLAGS)
+
 clean:
 	$(RM) $(TEST_PROGS) test.out t_std_conf.o t_locate_kdc.o t_trace.o
-	$(RM) t_expand_path.o
+	$(RM) t_expand_path.o t_ctxprf.o
 
 @libobj_frag@
 

--- a/src/lib/krb5/os/deps
+++ b/src/lib/krb5/os/deps
@@ -211,8 +211,7 @@ init_os_ctx.so init_os_ctx.po $(OUTPRE)init_os_ctx.$(OBJEXT): \
   $(top_srcdir)/include/krb5.h $(top_srcdir)/include/krb5/authdata_plugin.h \
   $(top_srcdir)/include/krb5/locate_plugin.h $(top_srcdir)/include/krb5/plugin.h \
   $(top_srcdir)/include/port-sockets.h $(top_srcdir)/include/socket-utils.h \
-  $(top_srcdir)/util/profile/prof_int.h init_os_ctx.c \
-  os-proto.h
+  init_os_ctx.c os-proto.h
 krbfileio.so krbfileio.po $(OUTPRE)krbfileio.$(OBJEXT): \
   $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/krb5/krb5.h \
   $(BUILDTOP)/include/osconf.h $(BUILDTOP)/include/profile.h \
@@ -519,6 +518,17 @@ write_msg.so write_msg.po $(OUTPRE)write_msg.$(OBJEXT): \
   $(top_srcdir)/include/krb5/authdata_plugin.h $(top_srcdir)/include/krb5/locate_plugin.h \
   $(top_srcdir)/include/krb5/plugin.h $(top_srcdir)/include/port-sockets.h \
   $(top_srcdir)/include/socket-utils.h os-proto.h write_msg.c
+t_ctxprf.so t_ctxprf.po $(OUTPRE)t_ctxprf.$(OBJEXT): \
+  $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/krb5/krb5.h \
+  $(BUILDTOP)/include/osconf.h $(BUILDTOP)/include/profile.h \
+  $(COM_ERR_DEPS) $(top_srcdir)/include/k5-buf.h $(top_srcdir)/include/k5-err.h \
+  $(top_srcdir)/include/k5-gmt_mktime.h $(top_srcdir)/include/k5-int-pkinit.h \
+  $(top_srcdir)/include/k5-int.h $(top_srcdir)/include/k5-platform.h \
+  $(top_srcdir)/include/k5-plugin.h $(top_srcdir)/include/k5-thread.h \
+  $(top_srcdir)/include/k5-trace.h $(top_srcdir)/include/krb5.h \
+  $(top_srcdir)/include/krb5/authdata_plugin.h $(top_srcdir)/include/krb5/locate_plugin.h \
+  $(top_srcdir)/include/krb5/plugin.h $(top_srcdir)/include/port-sockets.h \
+  $(top_srcdir)/include/socket-utils.h os-proto.h t_ctxprf.c
 t_expand_path.so t_expand_path.po $(OUTPRE)t_expand_path.$(OBJEXT): \
   $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/krb5/krb5.h \
   $(BUILDTOP)/include/osconf.h $(BUILDTOP)/include/profile.h \

--- a/src/lib/krb5/os/init_os_ctx.c
+++ b/src/lib/krb5/os/init_os_ctx.c
@@ -29,7 +29,6 @@
 #include "k5-int.h"
 #include "os-proto.h"
 #include "../krb/int-proto.h"
-#include "prof_int.h"        /* XXX for profile_copy, not public yet */
 
 #if defined(_WIN32)
 #include <winsock.h>
@@ -468,7 +467,7 @@ krb5_set_config_files(krb5_context ctx, const char **filenames)
         return retval;
 
     if (ctx->profile)
-        profile_release(ctx->profile);
+        profile_abandon(ctx->profile);
     ctx->profile = profile;
 
     return 0;
@@ -503,7 +502,7 @@ k5_os_free_context(krb5_context ctx)
     os_ctx->magic = 0;
 
     if (ctx->profile) {
-        profile_release(ctx->profile);
+        profile_abandon(ctx->profile);
         ctx->profile = 0;
     }
 

--- a/src/lib/krb5/os/t_ctxprf.c
+++ b/src/lib/krb5/os/t_ctxprf.c
@@ -1,0 +1,79 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* lib/krb5/krb/t_ctxprf.c - krb5_init_context_profile() test */
+/*
+ * Copyright (C) 2024 by the Massachusetts Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This program tests the use of krb5_init_context_profile() with a modified
+ * profile object.  If run with the single argument "empty", we create and
+ * modifiemodify an empty profile; otherwise, we retrieve and modify the
+ * profile for a normally created libkrb5 context.  In both cases, we set a
+ * realm KDC value in the profile and use k5_locate_kdc() to verify that the
+ * setting is reflected in a libkrb5 context created using the modified
+ * profile.
+ */
+
+#include "k5-int.h"
+#include "os-proto.h"
+
+static void
+check(long code)
+{
+    assert(code == 0);
+}
+
+int
+main(int argc, char **argv)
+{
+    profile_t p;
+    krb5_context ctx;
+    const char *names[] = { "realms", "KRBTEST.COM", "kdc", NULL };
+    krb5_data realm = string2data("KRBTEST.COM");
+    struct serverlist sl;
+
+    if (argc > 1 && strcmp(argv[1], "empty") == 0) {
+        check(profile_init(NULL, &p));
+    } else {
+        check(krb5_init_context(&ctx));
+        check(krb5_get_profile(ctx, &p));
+        krb5_free_context(ctx);
+        profile_clear_relation(p, names);
+    }
+    check(profile_add_relation(p, names, "ctx.prf.test"));
+
+    check(krb5_init_context_profile(p, 0, &ctx));
+    check(k5_locate_kdc(ctx, &realm, &sl, FALSE, FALSE));
+    assert(sl.nservers == 1);
+    assert(strcmp(sl.servers[0].hostname, "ctx.prf.test") == 0);
+
+    profile_abandon(p);
+    k5_free_serverlist(&sl);
+    krb5_free_context(ctx);
+}

--- a/src/lib/krb5/os/t_ctxprf.py
+++ b/src/lib/krb5/os/t_ctxprf.py
@@ -1,0 +1,15 @@
+from k5test import *
+
+realm = K5Realm(create_kdb=False)
+
+mark('initially empty profile')
+realm.run(['./t_ctxprf', 'empty'])
+
+mark('modified single-file profile')
+realm.run(['./t_ctxprf'])
+with open(os.path.join(realm.testdir, 'krb5.conf')) as f:
+    contents = f.read()
+    if 'ctx.prf.test' in contents:
+        fail('profile changes unexpectedly flushed')
+
+success('krb5_init_context_profile() tests')


### PR DESCRIPTION
The profile library has two deconstructors, profile_release() and profile_abandon().  profile_release() flushes in-memory changes to backing files, while profile_abandon() does not.  If a krb5_context profile contains in-memory changes, they were copied from a profile supplied to krb5_init_context_profile(), and the caller can decide whether to flush them.

As profile_copy() is now a public function, remove the include of prof_int.h and the associated LOCALINCLUDES setting in Makefile.in.

ticket: 9121 (new)