### PR TITLE
gssapi:iakerb: Do not fail if we have an initial empty buffer

### DIFF
--- a/src/lib/gssapi/krb5/iakerb.c
+++ b/src/lib/gssapi/krb5/iakerb.c
@@ -523,7 +523,7 @@ iakerb_initiator_step(iakerb_ctx_id_t ctx,
     output_token->length = 0;
     output_token->value = NULL;
 
-    if (input_token != GSS_C_NO_BUFFER) {
+    if (input_token != GSS_C_NO_BUFFER && input_token->length > 0) {
         code = iakerb_parse_token(ctx, 0, input_token, NULL, &cookie, &in);
         if (code != 0)
             goto cleanup;


### PR DESCRIPTION
RFC2744 about gss_init_sec_context states:

Initially, the input_token parameter should be specified either as GSS_C_NO_BUFFER, or as a pointer to a gss_buffer_desc object whose length field contains the value zero.