### PR TITLE
Draft: iakerb: The target-realm in the IAKERB-HEADER should be an utf8string

### DIFF
--- a/src/lib/krb5/asn.1/asn1_k_encode.c
+++ b/src/lib/krb5/asn.1/asn1_k_encode.c
@@ -1092,7 +1092,7 @@ DEFOPTIONALEMPTYTYPE(opt_ptr_seqof_princ_plus_realm,
                      ptr_seqof_princ_plus_realm);
 
 /* First context tag is 1, not 0. */
-DEFFIELD(iakerb_header_1, krb5_iakerb_header, target_realm, 1, ostring_data);
+DEFFIELD(iakerb_header_1, krb5_iakerb_header, target_realm, 1, opt_utf8_data);
 DEFFIELD(iakerb_header_2, krb5_iakerb_header, cookie, 2, opt_ostring_data_ptr);
 static const struct atype_info *iakerb_header_fields[] = {
     &k5_atype_iakerb_header_1, &k5_atype_iakerb_header_2


### PR DESCRIPTION
```
IAKERB-HEADER ::= SEQUENCE {
    -- Note that the tag numbers start at 1, not 0, which would
    -- be more conventional for Kerberos.
    target-realm      [1] UTF8String,
       -- The name of the target realm.
    cookie            [2] OCTET STRING OPTIONAL,
       -- Opaque data, if sent by the server,
       -- MUST be copied by the client verbatim into
       -- the next IAKRB_PROXY message.
    ...
}
```

target-realm is a UTF8String since draft-ietf-kitten-iakerb-00. I guess if we just fix this, we would break communication with older MIT Kerberos versions?