### PR TITLE
Fix recently-introduced profile parsing bugs

### DIFF
--- a/src/util/profile/final6.ini
+++ b/src/util/profile/final6.ini
@@ -25,6 +25,13 @@
 	bb = {
 		bba = 2
 	}
+	# Regression test for a bug where each subsection within a
+	# discarded section caused the parser to ascend into the
+	# parent node without descending into a child node first.
+	bb = {
+	}
+	bb = {
+	}
 
 [c]
 	ca* = {


### PR DESCRIPTION
When parsing a "}", do not ascend to the parent node if we are still within a discarded section after decrementing group_level, as we did not descend into a child node at the beginning of the subsection. (Discovered by OSS-Fuzz.)

Also adjust the level check to take into account the shifted meaning of state->group_level, so that we properly reject a "}" within a top-level section.

Both bugs were introduced in commit
f951625e6bd3ff44f1056958b56e35a1a043e362.