### PR TITLE
Add cifuzz workflow for PR fuzzing

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,38 @@
+name: CIFuzz
+
+on:
+    pull_request: {paths: [src/**, .github/workflows/build.yml]}
+
+permissions: {}
+jobs:
+    Fuzzing:
+        runs-on: ubuntu-latest
+        permissions:
+            security-events: write
+        steps:
+        - name: Build Fuzzers
+          id: build
+          uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+          with:
+            oss-fuzz-project-name: 'krb5'
+            language: c
+        - name: Run Fuzzers
+          uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+          with:
+            oss-fuzz-project-name: 'krb5'
+            language: c
+            fuzz-seconds: 300
+            output-sarif: true
+        - name: Upload Crash
+          uses: actions/upload-artifact@v3
+          if: failure() && steps.build.outcome == 'success'
+          with:
+            name: artifacts
+            path: ./out/artifacts
+        - name: Upload Sarif
+          if: always() && steps.build.outcome == 'success'
+          uses: github/codeql-action/upload-sarif@v2
+          with:
+            # Path to SARIF file relative to the root of the repository
+            sarif_file: cifuzz-sarif/results.sarif
+            checkout_path: cifuzz-sarif


### PR DESCRIPTION
Continuing the fuzzing integration: https://github.com/krb5/krb5/pull/1346.

Adding [cifuzz](https://google.github.io/oss-fuzz/getting-started/continuous-integration) for checking build failures and PR fuzzing.
Using the main [example](https://github.com/google/oss-fuzz/blob/master/infra/cifuzz/example_cifuzz.yml) provided by the OSS-Fuzz team, with an updated time of only 300 seconds.