### PR TITLE
Refactor GSS token header parsing

### DIFF
--- a/src/lib/gssapi/generic/gssapiP_generic.h
+++ b/src/lib/gssapi/generic/gssapiP_generic.h
@@ -47,6 +47,7 @@
 
 #include "k5-platform.h"
 #include "k5-buf.h"
+#include "k5-input.h"
 
 /** helper macros **/
 
@@ -69,6 +70,7 @@
 #define g_make_string_buffer    gssint_g_make_string_buffer
 #define g_token_size            gssint_g_token_size
 #define g_make_token_header     gssint_g_make_token_header
+#define g_get_token_header      gssint_g_get_token_header
 #define g_verify_token_header   gssint_g_verify_token_header
 #define g_display_major_status  gssint_g_display_major_status
 #define g_display_com_err_status gssint_g_display_com_err_status
@@ -89,14 +91,10 @@ unsigned int g_token_size (const gss_OID_desc * mech, unsigned int body_size);
 void g_make_token_header (struct k5buf *buf, const gss_OID_desc *mech,
                           size_t body_size, int tok_type);
 
-/* flags for g_verify_token_header() */
-#define G_VFY_TOKEN_HDR_WRAPPER_REQUIRED        0x01
+int g_get_token_header (struct k5input *in, gss_OID oid_out,
+                        size_t *token_len_out);
 
-gss_int32 g_verify_token_header (const gss_OID_desc * mech,
-                                 unsigned int *body_size,
-                                 unsigned char **buf, int tok_type,
-                                 unsigned int toksize_in,
-                                 int flags);
+int g_verify_token_header(struct k5input *in, gss_const_OID expected_mech);
 
 OM_uint32 g_display_major_status (OM_uint32 *minor_status,
                                   OM_uint32 status_value,

--- a/src/lib/gssapi/krb5/accept_sec_context.c
+++ b/src/lib/gssapi/krb5/accept_sec_context.c
@@ -625,6 +625,44 @@ fail:
     return status;
 }
 
+/*
+ * Verify the ASN.1 framing and token type in an RFC 4121 initiator token.  Set
+ * *mech_used_out to the mechanism in the framing, as a pointer to a global OID
+ * for one of the expected mechanisms.  Set *ap_req_out to the portion of the
+ * token containing the AP-REQ encoding.  Return G_BAD_TOK_HEADER if the
+ * framing is invalid.  Return G_WRONG_TOKID if the token type is incorrect.
+ * Return G_WRONG_MECH if the mechanism OID in the framing is not one of the
+ * expected Kerberos mechanisms.
+ */
+static OM_uint32
+parse_init_token(gss_buffer_t input_token, gss_const_OID *mech_used_out,
+                 krb5_data *ap_req_out)
+{
+    struct k5input in;
+    gss_OID_desc mech;
+    size_t tlen;
+
+    k5_input_init(&in, input_token->value, input_token->length);
+    if (!g_get_token_header(&in, &mech, &tlen) || tlen != input_token->length)
+        return G_BAD_TOK_HEADER;
+    if (k5_input_get_uint16_be(&in) != KG_TOK_CTX_AP_REQ)
+        return G_WRONG_TOKID;
+
+    if (g_OID_equal(&mech, gss_mech_krb5))
+        *mech_used_out = gss_mech_krb5;
+    else if (g_OID_equal(&mech, gss_mech_iakerb))
+        *mech_used_out = gss_mech_iakerb;
+    else if (g_OID_equal(&mech, gss_mech_krb5_wrong))
+        *mech_used_out = gss_mech_krb5_wrong;
+    else if (g_OID_equal(&mech, gss_mech_krb5_old))
+        *mech_used_out = gss_mech_krb5_old;
+    else
+        return G_WRONG_MECH;
+
+    *ap_req_out = make_data((uint8_t *)in.ptr, in.len);
+    return 0;
+}
+
 static OM_uint32
 kg_accept_krb5(OM_uint32 *minor_status, gss_ctx_id_t *context_handle,
                gss_cred_id_t verifier_cred_handle, gss_buffer_t input_token,
@@ -635,7 +673,6 @@ kg_accept_krb5(OM_uint32 *minor_status, gss_ctx_id_t *context_handle,
                krb5_gss_ctx_ext_t exts)
 {
     krb5_context context;
-    unsigned char *ptr;
     krb5_gss_cred_id_t cred = 0;
     krb5_data ap_rep, ap_req;
     krb5_error_code code;
@@ -723,56 +760,21 @@ kg_accept_krb5(OM_uint32 *minor_status, gss_ctx_id_t *context_handle,
         goto fail;
     }
 
-    /* verify the token's integrity, and leave the token in ap_req.
-       figure out which mech oid was used, and save it */
-
-    ptr = (unsigned char *) input_token->value;
-
-    if (!(code = g_verify_token_header(gss_mech_krb5,
-                                       &(ap_req.length),
-                                       &ptr, KG_TOK_CTX_AP_REQ,
-                                       input_token->length, 1))) {
-        mech_used = gss_mech_krb5;
-    } else if ((code == G_WRONG_MECH)
-               &&!(code = g_verify_token_header((gss_OID) gss_mech_iakerb,
-                                                &(ap_req.length),
-                                                &ptr, KG_TOK_CTX_AP_REQ,
-                                                input_token->length, 1))) {
-        mech_used = gss_mech_iakerb;
-    } else if ((code == G_WRONG_MECH)
-               &&!(code = g_verify_token_header((gss_OID) gss_mech_krb5_wrong,
-                                                &(ap_req.length),
-                                                &ptr, KG_TOK_CTX_AP_REQ,
-                                                input_token->length, 1))) {
-        mech_used = gss_mech_krb5_wrong;
-    } else if ((code == G_WRONG_MECH) &&
-               !(code = g_verify_token_header(gss_mech_krb5_old,
-                                              &(ap_req.length),
-                                              &ptr, KG_TOK_CTX_AP_REQ,
-                                              input_token->length, 1))) {
-        /*
-         * Previous versions of this library used the old mech_id
-         * and some broken behavior (wrong IV on checksum
-         * encryption).  We support the old mech_id for
-         * compatibility, and use it to decide when to use the
-         * old behavior.
-         */
-        mech_used = gss_mech_krb5_old;
-    } else if (code == G_WRONG_TOKID) {
+    code = parse_init_token(input_token, &mech_used, &ap_req);
+    if (code == G_WRONG_TOKID) {
         major_status = GSS_S_CONTINUE_NEEDED;
         code = KRB5KRB_AP_ERR_MSG_TYPE;
         mech_used = gss_mech_krb5;
         goto fail;
     } else if (code == G_BAD_TOK_HEADER) {
         /* DCE style not encapsulated */
-        ap_req.length = input_token->length;
+        ap_req = make_data(input_token->value, input_token->length);
         mech_used = gss_mech_krb5;
         no_encap = 1;
-    } else {
+    } else if (code) {
         major_status = GSS_S_DEFECTIVE_TOKEN;
         goto fail;
     }
-    ap_req.data = (char *)ptr;
 
     /* construct the sender_addr */
 

--- a/src/lib/gssapi/krb5/k5unseal.c
+++ b/src/lib/gssapi/krb5/k5unseal.c
@@ -358,12 +358,9 @@ kg_unseal(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
           int *conf_state, gss_qop_t *qop_state, int toktype)
 {
     krb5_gss_ctx_id_rec *ctx;
-    unsigned char *ptr;
-    unsigned int bodysize;
-    int err;
     int toktype2;
-    int vfyflags = 0;
     OM_uint32 ret;
+    struct k5input in;
 
     ctx = (krb5_gss_ctx_id_rec *) context_handle;
 
@@ -376,42 +373,25 @@ kg_unseal(OM_uint32 *minor_status, gss_ctx_id_t context_handle,
 
     /* verify the header */
 
-    ptr = (unsigned char *) input_token_buffer->value;
-
-
-    err = g_verify_token_header(ctx->mech_used,
-                                &bodysize, &ptr, -1,
-                                input_token_buffer->length,
-                                vfyflags);
-    if (err) {
-        *minor_status = err;
-        return GSS_S_DEFECTIVE_TOKEN;
-    }
-
-    if (bodysize < 2) {
-        *minor_status = (OM_uint32)G_BAD_TOK_HEADER;
-        return GSS_S_DEFECTIVE_TOKEN;
-    }
-
-    toktype2 = load_16_be(ptr);
-
-    ptr += 2;
-    bodysize -= 2;
+    k5_input_init(&in, input_token_buffer->value, input_token_buffer->length);
+    (void)g_verify_token_header(&in, ctx->mech_used);
+    toktype2 = k5_input_get_uint16_be(&in);
 
     switch (toktype2) {
     case KG2_TOK_MIC_MSG:
     case KG2_TOK_WRAP_MSG:
     case KG2_TOK_DEL_CTX:
         ret = gss_krb5int_unseal_token_v3(&ctx->k5_context, minor_status, ctx,
-                                          ptr, bodysize, message_buffer,
-                                          conf_state, qop_state, toktype);
+                                          (uint8_t *)in.ptr, in.len,
+                                          message_buffer, conf_state,
+                                          qop_state, toktype);
         break;
     case KG_TOK_MIC_MSG:
     case KG_TOK_WRAP_MSG:
     case KG_TOK_DEL_CTX:
-        ret = kg_unseal_v1(ctx->k5_context, minor_status, ctx, ptr, bodysize,
-                           message_buffer, conf_state, qop_state,
-                           toktype);
+        ret = kg_unseal_v1(ctx->k5_context, minor_status, ctx,
+                           (uint8_t *)in.ptr, in.len, message_buffer,
+                           conf_state, qop_state, toktype);
         break;
     default:
         *minor_status = (OM_uint32)G_BAD_TOK_HEADER;

--- a/src/lib/gssapi/mechglue/mglueP.h
+++ b/src/lib/gssapi/mechglue/mglueP.h
@@ -79,8 +79,6 @@ typedef struct gss_cred_id_struct {
 /* it to initialize the GSSAPI library		  */
 int gssint_mechglue_initialize_library(void);
 
-OM_uint32 gssint_get_mech_type_oid(gss_OID OID, gss_buffer_t token);
-
 /*
  * This table is used to access mechanism-specific versions of the GSSAPI
  * functions.  It contains all of the functions defined in gssapi.h except for


### PR DESCRIPTION
[This is kind of a minimum viable refactor to clean up the code duplication added in the recent security commit.  I would like to do a more complete refactor of the per-token processing functions, but may not be able to finish that.]

Rewrite g_verify_token_header() to use k5input and to not handle two-byte token IDs.  Add a more general g_get_token_header() which can handle detached wrappers and cases where the mech is not known in advance.  Adjust all current callers, and get rid of the duplicate DER parsing code added in commit b0a2f8a5365f2eec3e27d78907de9f9d2c80505a.

In k5-input.h, split out tag and length parsing into k5_der_get_taglen(), needed by g_get_token_header().