### PR TITLE
Make krb5_get_default_config_files() public

### DIFF
--- a/doc/appdev/refs/api/index.rst
+++ b/doc/appdev/refs/api/index.rst
@@ -25,6 +25,7 @@ Frequently used public interfaces
    krb5_change_password.rst
    krb5_chpw_message.rst
    krb5_expand_hostname.rst
+   krb5_free_config_files.rst
    krb5_free_context.rst
    krb5_free_error_message.rst
    krb5_free_principal.rst
@@ -33,6 +34,7 @@ Frequently used public interfaces
    krb5_get_error_message.rst
    krb5_get_host_realm.rst
    krb5_get_credentials.rst
+   krb5_get_default_config_files.rst
    krb5_get_fallback_host_realm.rst
    krb5_get_init_creds_keytab.rst
    krb5_get_init_creds_opt_alloc.rst

--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -2143,10 +2143,6 @@ void KRB5_CALLCONV krb5_free_tkt_authent(krb5_context, krb5_tkt_authent *);
 void KRB5_CALLCONV krb5_free_enc_data(krb5_context, krb5_enc_data *);
 krb5_error_code krb5_set_config_files(krb5_context, const char **);
 
-krb5_error_code KRB5_CALLCONV krb5_get_default_config_files(char ***filenames);
-
-void KRB5_CALLCONV krb5_free_config_files(char **filenames);
-
 krb5_error_code krb5_rd_req_decoded(krb5_context, krb5_auth_context *,
                                     const krb5_ap_req *, krb5_const_principal,
                                     krb5_keytab, krb5_flags *, krb5_ticket **);

--- a/src/include/krb5/krb5.hin
+++ b/src/include/krb5/krb5.hin
@@ -2936,6 +2936,33 @@ krb5_error_code KRB5_CALLCONV
 krb5_copy_context(krb5_context ctx, krb5_context *nctx_out);
 
 /**
+ * Return a list of default configuration filenames
+ *
+ * @param [out] filenames       Configuration filename list
+ *
+ * Fill in @a filenames with a null-terminated list of configuration files
+ * which will be read by krb5_init_context() in the current process
+ * environment.
+ *
+ * Use krb5_free_config_files() to free @a filenames when it is no longer
+ * needed.
+ *
+ * @version New in 1.22
+ */
+krb5_error_code KRB5_CALLCONV
+krb5_get_default_config_files(char ***filenames);
+
+/**
+ * Free a list allocated by krb5_get_default_config_files()
+ *
+ * @param [in]  filenames       Configuration filename list
+ *
+ * @version New in 1.22
+ */
+void KRB5_CALLCONV
+krb5_free_config_files(char **filenames);
+
+/**
  * Set default TGS encryption types in a krb5_context structure.
  *
  * @param [in] context          Library context


### PR DESCRIPTION
Add krb5_get_default_config_files() to the public API; it was already in the library export list and the DLL export list.  Also add krb5_free_config_files().

[See also https://krbdev.mit.edu/rt/Ticket/Display.html?id=9130 ]
