### PR TITLE
Add acceptor-side IAKERB realm discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -463,6 +463,7 @@ local.properties
 /src/tests/gssapi/t_export_cred
 /src/tests/gssapi/t_export_name
 /src/tests/gssapi/t_gssexts
+/src/tests/gssapi/t_iakerb
 /src/tests/gssapi/t_imp_cred
 /src/tests/gssapi/t_imp_name
 /src/tests/gssapi/t_invalid

--- a/src/tests/gssapi/Makefile.in
+++ b/src/tests/gssapi/Makefile.in
@@ -13,9 +13,9 @@ SRCS=	$(srcdir)/ccinit.c $(srcdir)/ccrefresh.c $(srcdir)/common.c \
 	$(srcdir)/t_bindings.c $(srcdir)/t_ccselect.c $(srcdir)/t_ciflags.c \
 	$(srcdir)/t_context.c $(srcdir)/t_credstore.c $(srcdir)/t_enctypes.c \
 	$(srcdir)/t_err.c $(srcdir)/t_export_cred.c $(srcdir)/t_export_name.c \
-	$(srcdir)/t_gssexts.c $(srcdir)/t_imp_cred.c $(srcdir)/t_imp_name.c \
-	$(srcdir)/t_invalid.c $(srcdir)/t_inq_cred.c $(srcdir)/t_inq_ctx.c \
-	$(srcdir)/t_inq_mechs_name.c $(srcdir)/t_iov.c \
+	$(srcdir)/t_gssexts.c $(srcdir)/t_iakerb.c $(srcdir)/t_imp_cred.c \
+	$(srcdir)/t_imp_name.c $(srcdir)/t_invalid.c $(srcdir)/t_inq_cred.c \
+	$(srcdir)/t_inq_ctx.c $(srcdir)/t_inq_mechs_name.c $(srcdir)/t_iov.c \
 	$(srcdir)/t_lifetime.c $(srcdir)/t_namingexts.c $(srcdir)/t_oid.c \
 	$(srcdir)/t_pcontok.c $(srcdir)/t_prf.c $(srcdir)/t_s4u.c \
 	$(srcdir)/t_s4u2proxy_krb5.c $(srcdir)/t_saslname.c \
@@ -24,20 +24,20 @@ SRCS=	$(srcdir)/ccinit.c $(srcdir)/ccrefresh.c $(srcdir)/common.c \
 OBJS=	ccinit.o ccrefresh.o common.o reload.o t_accname.o t_add_cred.o \
 	t_bindings.o t_ccselect.o t_ciflags.o t_context.o t_credstore.o \
 	t_enctypes.o t_err.o t_export_cred.o t_export_name.o t_gssexts.o \
-	t_imp_cred.o t_imp_name.o t_invalid.o t_inq_cred.o t_inq_ctx.o \
-	t_inq_mechs_name.o t_iov.o t_lifetime.o t_namingexts.o t_oid.o \
-	t_pcontok.o t_prf.o t_s4u.o t_s4u2proxy_krb5.o t_saslname.o \
-	t_spnego.o t_srcattrs.o t_store_cred.o
+	t_iakerb.o t_imp_cred.o t_imp_name.o t_invalid.o t_inq_cred.o \
+	t_inq_ctx.o t_inq_mechs_name.o t_iov.o t_lifetime.o t_namingexts.o \
+	t_oid.o t_pcontok.o t_prf.o t_s4u.o t_s4u2proxy_krb5.o t_saslname.o \
+	t_spnego.o t_srcattrs.o t_store_cred.o t_iakerb.o
 
 COMMON_DEPS= common.o $(GSS_DEPLIBS) $(KRB5_BASE_DEPLIBS)
 COMMON_LIBS= common.o $(GSS_LIBS) $(KRB5_BASE_LIBS)
 
 all: ccinit ccrefresh reload t_accname t_add_cred t_bindings t_ccselect \
 	t_ciflags t_context t_credstore t_enctypes t_err t_export_cred \
-	t_export_name t_gssexts t_imp_cred t_imp_name t_invalid t_inq_cred \
-	t_inq_ctx t_inq_mechs_name t_iov t_lifetime t_namingexts t_oid \
-	t_pcontok t_prf t_s4u t_s4u2proxy_krb5 t_saslname t_spnego t_srcattrs \
-	t_store_cred
+	t_export_name t_gssexts t_iakerb t_imp_cred t_imp_name t_invalid \
+	t_inq_cred t_inq_ctx t_inq_mechs_name t_iov t_lifetime t_namingexts \
+	t_oid t_pcontok t_prf t_s4u t_s4u2proxy_krb5 t_saslname t_spnego \
+	t_srcattrs t_store_cred
 
 check-unix: t_invalid t_oid t_prf t_imp_name reload
 	$(RUN_TEST) ./t_invalid
@@ -93,6 +93,8 @@ t_export_name: t_export_name.o $(COMMON_DEPS)
 	$(CC_LINK) -o $@ t_export_name.o $(COMMON_LIBS)
 t_gssexts: t_gssexts.o $(COMMON_DEPS)
 	$(CC_LINK) -o $@ t_gssexts.o $(COMMON_LIBS)
+t_iakerb: t_iakerb.o $(COMMON_DEPS)
+	$(CC_LINK) -o $@ t_iakerb.o $(COMMON_LIBS)
 t_imp_cred: t_imp_cred.o $(COMMON_DEPS)
 	$(CC_LINK) -o $@ t_imp_cred.o $(COMMON_LIBS)
 t_imp_name: t_imp_name.o $(COMMON_DEPS)
@@ -133,7 +135,7 @@ t_store_cred: t_store_cred.o $(COMMON_DEPS)
 clean:
 	$(RM) ccinit ccrefresh reload t_accname t_add_cred t_bindings
 	$(RM) t_ccselect t_ciflags t_context t_credstore t_enctypes t_err
-	$(RM) t_export_cred t_export_name t_gssexts t_imp_cred t_imp_name
-	$(RM) t_invalid t_inq_cred t_inq_ctx t_inq_mechs_name t_iov t_lifetime
-	$(RM) t_namingexts t_oid t_pcontok t_prf t_s4u t_s4u2proxy_krb5
-	$(RM) t_saslname t_spnego t_srcattrs t_store_cred
+	$(RM) t_export_cred t_export_name t_gssexts t_iakerb t_imp_cred
+	$(RM) t_imp_name t_invalid t_inq_cred t_inq_ctx t_inq_mechs_name t_iov
+	$(RM) t_lifetime t_namingexts t_oid t_pcontok t_prf t_s4u
+	$(RM) t_s4u2proxy_krb5 t_saslname t_spnego t_srcattrs t_store_cred

--- a/src/tests/gssapi/t_gssapi.py
+++ b/src/tests/gssapi/t_gssapi.py
@@ -13,6 +13,8 @@ realm = K5Realm()
 # Test gss_add_cred().
 realm.run(['./t_add_cred'])
 
+realm.run(['./t_iakerb'])
+
 ### Test acceptor name behavior.
 
 # Create some host-based principals and put most of them into the

--- a/src/tests/gssapi/t_iakerb.c
+++ b/src/tests/gssapi/t_iakerb.c
@@ -1,0 +1,88 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* tests/gssapi/t_iakerb.c - IAKERB tests */
+/*
+ * Copyright (C) 2024 by the Massachusetts Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include "common.h"
+
+static uint8_t
+realm_query[] = {
+    /* ASN.1 wrapper for IAKERB mech */
+    0x60, 0x10,
+    0x06, 0x06, 0x2B, 0x06, 0x01, 0x05, 0x02, 0x05,
+    /* IAKERB_PROXY token type */
+    0x05, 0x01,
+    /* IAKERB-HEADER with empty target-realm */
+    0x30, 0x04,
+    0xA1, 0x02, 0x0C, 0x00
+};
+
+static uint8_t
+realm_response[] = {
+    /* ASN.1 wrapper for IAKERB mech */
+    0x60, 0x1B,
+    0x06, 0x06, 0x2B, 0x06, 0x01, 0x05, 0x02, 0x05,
+    /* IAKERB_PROXY token type */
+    0x05, 0x01,
+    /* IAKERB-HEADER with configured realm */
+    0x30, 0x0F,
+    0xA1, 0x0D, 0x0C, 0x0B,
+    'K', 'R', 'B', 'T', 'E', 'S', 'T', '.', 'C', 'O', 'M'
+};
+
+int
+main(void)
+{
+    OM_uint32 major, minor;
+    gss_cred_id_t cred;
+    gss_buffer_desc in, out;
+    gss_ctx_id_t ctx = GSS_C_NO_CONTEXT;
+
+    major = gss_acquire_cred(&minor, GSS_C_NO_NAME, 0, &mechset_iakerb,
+                             GSS_C_ACCEPT, &cred, NULL, NULL);
+    check_gsserr("gss_acquire_cred", major, minor);
+
+    in.value = realm_query;
+    in.length = sizeof(realm_query);
+    major = gss_accept_sec_context(&minor, &ctx, cred, &in,
+                                   GSS_C_NO_CHANNEL_BINDINGS, NULL, NULL, &out,
+                                   NULL, NULL, NULL);
+    check_gsserr("gss_accept_sec_context", major, minor);
+    assert(out.length == sizeof(realm_response));
+    assert(memcmp(out.value, realm_response, out.length) == 0);
+
+    gss_release_buffer(&minor, &out);
+    gss_delete_sec_context(&minor, &ctx, NULL);
+    gss_release_cred(&minor, &cred);
+    return 0;
+}


### PR DESCRIPTION
@abbra mentioned IAKERB realm discovery in PR #1335.   https://datatracker.ietf.org/doc/html/draft-ietf-kitten-iakerb-03#section-3.1 says:
```
A client using IAKERB may not have any realm information, even for
the realm of the client's host, or may know that the client host's
realm is not appropriate for a given enterprise principal name.  In
such cases, the client can retrieve the realm of the GSS-API acceptor
as follows: the client returns GSS_S_CONTINUE_NEEDED with the output
token containing an IAKERB message with an empty target-realm in the
IAKERB-HEADER and no Kerberos message following the IAKERB-HEADER
structure.  Upon receipt of the realm request, the GSS-API acceptor
fills out an IAKERB_PROXY response message, filling the target-realm
field with the realm of the acceptor, and returns
GSS_S_CONTINUE_NEEDED with the output token containing the IAKERB
message with the server's realm and no Kerberos message following the
IAKERB-HEADER header.
```
The PR branch currently does the easy part of acceptor support, but there are two tricky problems:

* Getting "the realm of the acceptor".  Right now the PR branch queries the configured default realm, which I think could  suffice but isn't a great fit.  A krb5 acceptor doesn't necessarily need a configured realm, and there could be acceptors for services in different realms on the same host (even in the same process).  I do wonder if the alternatives would just be adding more code without arriving at a robust solution, though.  The verifier credential probably won't have realm information (only if the application used a Kerberos principal as the verifier name; it's much more common to use a host-based name or the default name or the default verifier cred).  We could look at the keytab with k5_kt_get_principal(), but the first entry in the keytab isn't guaranteed to be the one that the client plans to contact.

* If we can't determine the realm name, what should we do?  The draft doesn't specify error behavior, and the two error codes it defines (KRB_AP_ERR_IAKERB_KDC_NOT_FOUND and KRB_AP_ERR_IAKERB_KDC_NO_RESPONSE) aren't applicable, nor is any existing protocol error as far as I can tell.  So I guess we respond with KRB_ERR_GENERIC.

If we want to add initiator support, we need to figure out what circumstances (API calls and environment) should trigger it.  Section 3.1 of the draft says "A client using IAKERB may not have any realm information, even for the realm of the client's host, or may know that the client host's realm is not appropriate for a given enterprise principal name."  I'm not aware of any current API signalling we could use for knowing that the client host's realm is inappropriate, but it seems reasonable to use realm discovery if the application specifies an enterprise name and the client has no default_realm.  Unfortunately, I think currently we won't get as far as IAKERB in this case, as the krb5 gss_import_name() call will fail, so we'd have to start thinking about more wide-ranging changes to the krb5 mechanism.

(Also tagging @cryptomilk)
