### PR TITLE
Add fortify flag to gcc CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
                     - name: linux-gcc
                       os: ubuntu-latest
                       compiler: gcc
+                      makevars: CPPFLAGS=-D_FORTIFY_SOURCE=3
         steps:
             - name: Checkout repository
               uses: actions/checkout@v1


### PR DESCRIPTION
I read a few Red Hat blog posts about FORTIFY_SOURCE, and it seems like an easy thing to add to our CI, if only because Fedora is using it in package builds.  It doesn't currently seem to find anything that we haven't already ironed out with asan.
