### PR TITLE
Restore test coverage for old session key types

### DIFF
--- a/src/util/k5test.py
+++ b/src/util/k5test.py
@@ -1339,14 +1339,14 @@ _passes = [
 
     # Exercise the DES3 enctype.
     ('des3', None,
-     {'libdefaults': {'permitted_enctypes': 'des3 aes256-sha1'}},
+     {'libdefaults': {'permitted_enctypes': 'des3', 'allow_des3': 'true'}},
      {'realms': {'$realm': {
                     'supported_enctypes': 'des3-cbc-sha1:normal',
                     'master_key_type': 'des3-cbc-sha1'}}}),
 
     # Exercise the arcfour enctype.
     ('arcfour', None,
-     {'libdefaults': {'permitted_enctypes': 'rc4 aes256-sha1'}},
+     {'libdefaults': {'permitted_enctypes': 'rc4', 'allow_rc4': 'true'}},
      {'realms': {'$realm': {
                     'supported_enctypes': 'arcfour-hmac:normal',
                     'master_key_type': 'arcfour-hmac'}}}),


### PR DESCRIPTION
Commit 1b57a4d134bbd0e7c52d5885a92eccc815726463 made the KDC stop issuing des3 and rc4 session keys by default.  To make the des3 and arcfour passes of the test suite work, it added aes256-sha1 to the permitted enctypes for those passes.  Negotiating AES session keys reduces coverage of pre-CFX GSSAPI code and other uses of the older enctypes.  Instead set the enable_des3 and enable_rc4 variables.