### PR TITLE
Replace Windows installer FilesInUse dialog text

### DIFF
--- a/src/windows/installer/wix/lang/ui_1033.wxi
+++ b/src/windows/installer/wix/lang/ui_1033.wxi
@@ -360,7 +360,7 @@
         </Control>
         <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="374" Height="44" TabSkip="no" Text="[BannerBitmap]" />
         <Control Id="Text" Type="Text" X="20" Y="55" Width="330" Height="30">
-          <Text>The following applications are using files that need to be updated by this setup. Close these applications and then click Retry to continue the installation or Cancel to exit it.</Text>
+          <Text>Some updated files are in use by the following applications.  Click Ignore to continue installation, then reboot the system to replace the affected files.</Text>
         </Control>
         <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="374" Height="0" />
         <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="374" Height="0" />


### PR DESCRIPTION
Windows installers must provide a FilesInUse dialog, with the intent of minimizing the need to restart the system after software installations.  For reasons related to the LSA cache, the KfW installer always schedules a post-installation reboot (see commit 50a3c3cbeab32577fba2b21deb72a64015c48ec7).  Reword the FilesInUse dialog text to recommend clicking Ignore, causing the conflicting files to replaced on the reboot.  (The affected files are likely C runtime DLLs, and the existing versions will almost certainly suffice if KfW programs are run prior to a reboot.)
