### PR TITLE
Minimize mutex assertion errors at process exit

### DIFF
--- a/src/aclocal.m4
+++ b/src/aclocal.m4
@@ -139,6 +139,9 @@ fi
 if test "$use_linker_fini_option" = yes; then
   AC_DEFINE(USE_LINKER_FINI_OPTION,1,[Define if link-time options for library finalization will be used])
 fi
+if test "$lib_unload_prevented" = yes; then
+  AC_DEFINE(LIB_UNLOAD_PREVENTED,1,[Define if library unloading is prevented])
+fi
 ])
 
 dnl find dlopen

--- a/src/config/shlib.conf
+++ b/src/config/shlib.conf
@@ -32,9 +32,15 @@ DYNOBJEXT='$(SHLIBEXT)'
 MAKE_DYNOBJ_COMMAND='$(MAKE_SHLIB_COMMAND)'
 DYNOBJ_EXPDEPS='$(SHLIB_EXPDEPS)'
 DYNOBJ_EXPFLAGS='$(SHLIB_EXPFLAGS)'
-#
+# On some platforms we will instruct the linker to run named functions
+# (specified by LIBINITFUNC and LIBFINIFUNC in each library's Makefile.in) as
+# initializers or finalizers.
 use_linker_init_option=no
 use_linker_fini_option=no
+# Where possible we will prevent unloading of the libraries we build, in which
+# case we can skip running finalizers.  Do not set use_linker_fini_option if
+# setting lib_unload_prevented.
+lib_unload_prevented=no
 
 STOBJEXT=.o
 SHOBJEXT=.so
@@ -280,7 +286,7 @@ mips-*-netbsd*)
 	SHLIBVEXT='.so.$(LIBMAJOR).$(LIBMINOR)'
 	SHLIBSEXT='.so.$(LIBMAJOR)'
 	SHLIBEXT=.so
-	LDCOMBINE='ld -shared -soname $(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT)'
+	LDCOMBINE='ld -shared -soname $(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT) -z nodelete'
 	SHLIB_RPATH_FLAGS='-R$(SHLIB_RDIRS)'
 	SHLIB_EXPFLAGS='$(SHLIB_RPATH_FLAGS) $(SHLIB_DIRS) $(SHLIB_EXPLIBS)'
 	RPATH_FLAG='-Wl,-rpath -Wl,'
@@ -292,13 +298,14 @@ mips-*-netbsd*)
 	RUN_ENV='LD_LIBRARY_PATH=`echo $(PROG_LIBPATH) | sed -e "s/-L//g" -e "s/ /:/g"`'
 	RUN_VARS='LD_LIBRARY_PATH'
 	PROFFLAGS=-pg
+	lib_unload_prevented=yes
 	;;
 
 *-*-netbsd*)
 	PICFLAGS=-fPIC
 	SHLIBVEXT='.so.$(LIBMAJOR).$(LIBMINOR)'
 	SHLIBEXT=.so
-	LDCOMBINE='$(CC) -shared'
+	LDCOMBINE='$(CC) -shared -Wl,-z,nodelete'
 	SHLIB_RPATH_FLAGS='-R$(SHLIB_RDIRS)'
 	SHLIB_EXPFLAGS='$(SHLIB_RPATH_FLAGS) $(SHLIB_DIRS) $(SHLIB_EXPLIBS)'
 	RPATH_FLAG=-R
@@ -310,6 +317,7 @@ mips-*-netbsd*)
 	RUN_ENV='LD_LIBRARY_PATH=`echo $(PROG_LIBPATH) | sed -e "s/-L//g" -e "s/ /:/g"`'
 	RUN_VARS='LD_LIBRARY_PATH'
 	PROFFLAGS=-pg
+	lib_unload_prevented=yes
 	;;
 
 *-*-freebsd*)
@@ -327,7 +335,7 @@ mips-*-netbsd*)
 	CC_LINK_SHARED='$(CC) $(PROG_LIBPATH) $(PROG_RPATH_FLAGS) $(CFLAGS) $(LDFLAGS)'
 	CXX_LINK_SHARED='$(CXX) $(PROG_LIBPATH) $(PROG_RPATH_FLAGS) $(CXXFLAGS) $(LDFLAGS)'
 	SHLIBEXT=.so
-	LDCOMBINE='ld -Bshareable'
+	LDCOMBINE='ld -Bshareable -z nodelete'
 	SHLIB_RPATH_FLAGS='--enable-new-dtags -rpath $(SHLIB_RDIRS)'
 	SHLIB_EXPFLAGS='$(SHLIB_RPATH_FLAGS) $(SHLIB_DIRS) $(SHLIB_EXPLIBS)'
 	CC_LINK_STATIC='$(CC) $(PROG_LIBPATH) $(CFLAGS) $(LDFLAGS)'
@@ -335,13 +343,14 @@ mips-*-netbsd*)
 	RUN_ENV='LD_LIBRARY_PATH=`echo $(PROG_LIBPATH) | sed -e "s/-L//g" -e "s/ /:/g"`'
 	RUN_VARS='LD_LIBRARY_PATH'
 	PROFFLAGS=-pg
+	lib_unload_prevented=yes
 	;;
 
 *-*-openbsd*)
 	PICFLAGS=-fpic
 	SHLIBVEXT='.so.$(LIBMAJOR).$(LIBMINOR)'
 	SHLIBEXT=.so
-	LDCOMBINE='ld -Bshareable'
+	LDCOMBINE='ld -Bshareable -z nodelete'
 	SHLIB_RPATH_FLAGS='-R$(SHLIB_RDIRS)'
 	SHLIB_EXPFLAGS='$(SHLIB_RPATH_FLAGS) $(SHLIB_DIRS) $(SHLIB_EXPLIBS)'
 	RPATH_FLAG=-R
@@ -353,6 +362,7 @@ mips-*-netbsd*)
 	RUN_ENV='LD_LIBRARY_PATH=`echo $(PROG_LIBPATH) | sed -e "s/-L//g" -e "s/ /:/g"`'
 	RUN_VARS='LD_LIBRARY_PATH'
 	PROFFLAGS=-pg
+	lib_unload_prevented=yes
 	;;
 
 *-*-darwin* | *-*-rhapsody*)
@@ -383,20 +393,19 @@ mips-*-netbsd*)
 *-*-solaris*)
 	if test "$ac_cv_c_compiler_gnu" = yes; then
 		PICFLAGS=-fPIC
-		LDCOMBINE='$(CC) $(CFLAGS) -shared -h $(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT)'
+		LDCOMBINE='$(CC) $(CFLAGS) -shared -Wl,-z,nodelete -h $(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT)'
 	else
 		PICFLAGS=-KPIC
 		# Solaris cc doesn't default to stuffing the SONAME field...
-		LDCOMBINE='$(CC) $(CFLAGS) -dy -G -z text -h $(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT) $$initfini'
+		LDCOMBINE='$(CC) $(CFLAGS) -dy -G -z text -z nodelete -h $(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT) $$initfini'
 		#
 		case $krb5_cv_host in
 		*-*-solaris2.[1-7] | *-*-solaris2.[1-7].*)
 		    # Did Solaris 7 and earlier have a linker option for this?
 		    ;;
 		*)
-		    INIT_FINI_PREP='initfini=; for f in . $(LIBINITFUNC); do if test $$f = .; then :; else initfini="$$initfini -Wl,-z,initarray=$${f}__auxinit"; fi; done; for f in . $(LIBFINIFUNC); do if test $$f = .; then :; else initfini="$$initfini -Wl,-z,finiarray=$$f"; fi; done'
+		    INIT_FINI_PREP='initfini=; for f in . $(LIBINITFUNC); do if test $$f = .; then :; else initfini="$$initfini -Wl,-z,initarray=$${f}__auxinit"; fi; done;'
 		    use_linker_init_option=yes
-		    use_linker_fini_option=yes
 		    ;;
 		esac
 	fi
@@ -414,6 +423,7 @@ mips-*-netbsd*)
 	CXX_LINK_STATIC='$(PURE) $(CXX) $(PROG_LIBPATH) $(CXXFLAGS) $(LDFLAGS)'
 	RUN_ENV='LD_LIBRARY_PATH=`echo $(PROG_LIBPATH) | sed -e "s/-L//g" -e "s/ /:/g"`'
 	RUN_VARS='LD_LIBRARY_PATH'
+	lib_unload_prevented=yes
 	;;
 
 *-*-linux* | *-*-gnu* | *-*-k*bsd*-gnu)
@@ -424,7 +434,7 @@ mips-*-netbsd*)
 	# Linux ld doesn't default to stuffing the SONAME field...
 	# Use objdump -x to examine the fields of the library
 	# UNDEF_CHECK is suppressed by --enable-asan
-	LDCOMBINE='$(CC) -shared -fPIC -Wl,-h,$(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT) $(UNDEF_CHECK)'
+	LDCOMBINE='$(CC) -shared -fPIC -Wl,-z,nodelete -Wl,-h,$(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT) $(UNDEF_CHECK)'
 	UNDEF_CHECK='-Wl,--no-undefined'
 	# $(EXPORT_CHECK) runs export-check.pl when in maintainer mode.
 	LDCOMBINE_TAIL='-Wl,--version-script binutils.versions $(EXPORT_CHECK)'
@@ -442,6 +452,7 @@ mips-*-netbsd*)
 	CXX_LINK_STATIC='$(CXX) $(PROG_LIBPATH) $(CXXFLAGS) $(LDFLAGS)'
 	RUN_ENV='LD_LIBRARY_PATH=`echo $(PROG_LIBPATH) | sed -e "s/-L//g" -e "s/ /:/g"`'
 	RUN_VARS='LD_LIBRARY_PATH'
+	lib_unload_prevented=yes
 
 	## old version:
 	# Linux libc does weird stuff at shlib link time, must be
@@ -459,7 +470,7 @@ mips-*-netbsd*)
 	PICFLAGS=-fpic
 	SHLIBVEXT='.so.$(LIBMAJOR)'
 	SHLIBEXT=.so
-	LDCOMBINE='ld -Bshareable'
+	LDCOMBINE='ld -Bshareable -z nodelete'
 	SHLIB_RPATH_FLAGS='-R$(SHLIB_RDIRS)'
 	SHLIB_EXPFLAGS='$(SHLIB_RPATH_FLAGS) $(SHLIB_DIRS) $(SHLIB_EXPLIBS)'
 	PROG_RPATH_FLAGS='-Wl,-rpath,$(PROG_RPATH)'
@@ -471,6 +482,7 @@ mips-*-netbsd*)
 /:/g"`'
 	RUN_VARS='LD_LIBRARY_PATH'
 	PROFFLAGS=-pg
+	lib_unload_prevented=yes
 	;;
 
 *-*-aix5*)

--- a/src/include/k5-platform.h
+++ b/src/include/k5-platform.h
@@ -153,6 +153,9 @@
    doing the pthread test at run time on systems where that works, so
    we use the k5_once_t stuff instead.)
 
+   UNIX, with library unloading prevented or when building static
+   libraries: we don't need to run finalizers.
+
    UNIX, with compiler support: MAKE_FINI_FUNCTION declares the
    function as a destructor, and the run time linker support or
    whatever will cause it to be invoked when the library is unloaded,
@@ -398,7 +401,7 @@ typedef struct { int error; unsigned char did_run; } k5_init_t;
 
 # endif
 
-#elif !defined(SHARED)
+#elif !defined(SHARED) || defined(LIB_UNLOAD_PREVENTED)
 
 /*
  * In this case, we just don't care about finalization.  The code will still

--- a/src/lib/win_glue.c
+++ b/src/lib/win_glue.c
@@ -401,7 +401,7 @@ control(int mode)
 
 #ifdef _WIN32
 
-BOOL WINAPI DllMain (HANDLE hModule, DWORD fdwReason, LPVOID lpReserved)
+BOOL WINAPI DllMain (HANDLE hModule, DWORD fdwReason, LPVOID lpvReserved)
 {
     switch (fdwReason)
     {
@@ -420,6 +420,10 @@ BOOL WINAPI DllMain (HANDLE hModule, DWORD fdwReason, LPVOID lpReserved)
 	    break;
 
         case DLL_PROCESS_DETACH:
+	    /* If lpvReserved is non-null, the process is exiting and we do not
+	     * need to clean up library memory. */
+	    if (lpvReserved != NULL)
+		break;
 	    if (control(DLL_SHUTDOWN))
 		return FALSE;
 	    break;


### PR DESCRIPTION
In this PR I want to consider approaches to minimizing the chance of k5_mutex_lock() assertion errors at process exit.  These happen when a krb5 or GSS library function that uses a singleton mutex (like cc_typelist_lock)I is called after library finalization.  I believe we have seen that in the past due to platform bugs with unloading order; recently @nicowilliams stated in a Rust issue that he sees it happen when a multithreaded program exits the process from one thread while another thread is still working.  I don't think we can make that scenario truly safe, but we can probably squash the problem in practice.

Candidate solutions:

1. In the Rust issue, Nico suggested we not destroy mutexes in library finalizers, saying that there is "zero value in doing so".  While that's true for process exit, I don't think it's true for library unload; we can't really say that our libraries should never be unloaded (I am told that PAM frameworks do it) or that it's okay if they leak memory each time they are.
2. We could revert commit 6350fd0c909d84c00200885e722cc902049ada05 ("Assume mutex locking cannot fail").  I would rather not do this as in some functions it can add significantly to the complexity of ensuring consistent states on function return.
3. We could make k5_mutex_lock() return an error code again, but continue to keep k5_mutex_unlock() as returning void, and make it stop checking the error.  This would still be somewhat painful.
4. We could have checked and unchecked (asserting) variants of k5_mutex_lock(), and use the checked variant for singleton mutexes that get destroyed by library finalizers.
5. We could add a k5_mutex_check() and use it along the code paths that lock singleton mutexes.  This leaves open a race window (library is finalized between k5_mutex_check() and k5_mutex_lock()), so probably would not fully solve the problem in practice.
6. We could set a global on library destruction, and check it along the code paths that lock singleton mutexes.  Same race problem as (5), and is maybe less clear anyway as it isn't clearly connected to the mutex resource.  Plus it's itself not thread-safe.
7. We could stop destroying mutexes (or just singleton mutexes) on platforms that we believe don't associate dynamic resources with mutexes.  glibc documents that this is the case for the LinuxThreads implementation, for instance.  This requires layer-crossing assumptions and wouldn't be a comprehensive solution.

Any of the following external changes would make this problem easy, but we can't expect any of them to happen:

* Programs could stop exiting while more than one thread is running.
* Platforms could suspend threads other than the current one when a program begins exiting.  (Could create deadlocks in existing code.)
* Platforms could robustly guarantee that library code is not invoked during or after execution of that library's finalizers.
* Platforms could provide an indication of whether the process is currently exiting.  If it is, our finalizers could decline to destroy mutexes.  (raeburn wanted this back in 2004, based on the comments about PROGRAM_EXITING in k5-threads.h.)
* Platforms could stop implementing library unloading.  (This apparently true for musl libc: https://wiki.musl-libc.org/functional-differences-from-glibc.html#Unloading_libraries )
* Mutex interfaces (pthreads and Windows) could require that mutexes are of constant size and do not require destruction.  A slightly more achievable variant of this is that implementations' pthread_mutex_destroy() could avoid changing the state of the mutex, so that ensuing calls to pthread_mutex_lock() don't fail.  Even that's pretty unlikely, and I don't think there is a similarly minimal change for Windows.
