### PR TITLE
Remove ancient platforms from shlib.conf

### DIFF
--- a/src/config/shlib.conf
+++ b/src/config/shlib.conf
@@ -61,54 +61,6 @@ default_shared=yes
 
 # Set up architecture-specific variables.
 case $krb5_cv_host in
-alpha*-dec-osf*)
-	SHLIBVEXT='.so.$(LIBMAJOR).$(LIBMINOR)'
-	SHLIBSEXT='.so.$(LIBMAJOR)'
-	SHLIBEXT=.so
-	# Alpha OSF/1 doesn't need separate PIC objects
-	SHOBJEXT=.o
-	INIT_FINI_PREP=initfini=
-	LDCOMBINE='$(CC) $(CFLAGS) $(PTHREAD_CFLAGS) -shared -Wl,-expect_unresolved -Wl,\* -Wl,-update_registry -Wl,$(BUILDTOP)/so_locations -Wl,-soname -Wl,$(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT) -Wl,-hidden -Wl,-input,osf1.exports $$initfini'
-	SHLIB_EXPORT_FILE_DEP=osf1.exports
-	use_linker_init_option=yes
-	use_linker_fini_option=yes
-	EXTRA_FILES="$EXTRA_FILES export"
-	SHLIB_RPATH_FLAGS='-rpath $(SHLIB_RDIRS)'
-	SHLIB_EXPFLAGS='$(SHLIB_RPATH_FLAGS) $(SHLIB_DIRS) $(SHLIB_EXPLIBS)'
-	PROFFLAGS=-pg
-	RPATH_FLAG='-Wl,-rpath -Wl,'
-	PROG_RPATH_FLAGS='$(RPATH_FLAG)$(PROG_RPATH)'
-	CC_LINK_SHARED='$(CC) $(PROG_LIBPATH) $(PROG_RPATH_FLAGS) $(CFLAGS) $(PTHREAD_CFLAGS) $(LDFLAGS)'
-	CXX_LINK_SHARED='$(CXX) $(PROG_LIBPATH) $(PROG_RPATH_FLAGS) $(CXXFLAGS) $(PTHREAD_CFLAGS) $(LDFLAGS)'
-	if test "$ac_cv_c_compiler_gnu" = yes \
-		&& test "$krb5_cv_prog_gnu_ld" = yes; then
-		# Really should check for gnu ld vs system ld, too.
-		CC_LINK_STATIC='$(CC) $(PROG_LIBPATH) $(CFLAGS) $(PTHREAD_CFLAGS) $(LDFLAGS)'
-	else
-		# Need -oldstyle_liblookup to avoid picking up shared libs from
-		# other builds.  OSF/1 / Tru64 ld programs look through the entire
-		# library path for shared libs prior to looking through the
-		# entire library path for static libs.
-		CC_LINK_STATIC='$(CC) $(PROG_LIBPATH) -Wl,-oldstyle_liblookup $(CFLAGS) $(PTHREAD_CFLAGS) $(LDFLAGS)'
-	fi
-	if test "$ac_cv_cxx_compiler_gnu" = yes \
-		&& test "$krb5_cv_prog_gnu_ld" = yes; then
-		# Really should check for gnu ld vs system ld, too.
-		CXX_LINK_STATIC='$(CXX) $(PROG_LIBPATH) $(CXXFLAGS) $(PTHREAD_CFLAGS) $(LDFLAGS)'
-	else
-		# Need -oldstyle_liblookup to avoid picking up shared libs from
-		# other builds.  OSF/1 / Tru64 ld programs look through the entire
-		# library path for shared libs prior to looking through the
-		# entire library path for static libs.
-		CXX_LINK_STATIC='$(CXX) $(PROG_LIBPATH) -Wl,-oldstyle_liblookup $(CXXFLAGS) $(PTHREAD_CFLAGS) $(LDFLAGS)'
-	fi
-	# _RLD_ROOT hack needed to repoint "root" directory for purposes
-	# of searching for shared libs, since RPATHs take precedence over
-	# LD_LIBRARY_PATH.
-	RUN_ENV='LD_LIBRARY_PATH=`echo $(PROG_LIBPATH) | sed -e "s/-L//g" -e "s/ /:/g"`$${LD_LIBRARY_PATH+:$$LD_LIBRARY_PATH} _RLD_ROOT=$${_RLD_ROOT+$$_RLD_ROOT}$${_RLD_ROOT-/}'
-	RUN_VARS='LD_LIBRARY_PATH _RLD_ROOT'
-	;;
-
 # Note: "-Wl,+s" when building executables enables the use of the
 # SHLIB_PATH environment variable for finding shared libraries 
 # in non-standard directories.  If a non-standard search-path for
@@ -166,119 +118,6 @@ alpha*-dec-osf*)
 	# Not setting use_linker_init_option here should cause compilation
 	# failures if the user tries to disable delayed initialization.
 	use_linker_fini_option=yes
-	;;
-
-mips-sgi-irix6.3)	# This is a Kludge; see below
-	SHLIBVEXT='.so.$(LIBMAJOR).$(LIBMINOR)'
-	SHLIBSEXT='.so.$(LIBMAJOR)'
-	SHLIBEXT=.so
-	SHOBJEXT=.o
-	# Kludge follows: (gcc makes n32 object files but ld expects o32, so we reeducate ld)
-	if test "$ac_cv_c_compiler_gnu" = yes; then
-		LDCOMBINE='ld -n32 -shared -ignore_unresolved -update_registry $(BUILDTOP)/so_locations -soname $(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT)'
-	else
-		LDCOMBINE='ld -shared -ignore_unresolved -update_registry $(BUILDTOP)/so_locations -soname $(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT)'
-	fi
-	SHLIB_RPATH_FLAGS='-rpath $(SHLIB_RDIRS)'
-	SHLIB_EXPFLAGS='$(SHLIB_RPATH_FLAGS) $(SHLIB_DIRS) $(SHLIB_EXPLIBS)'
-	# no gprof for Irix...
-	PROFFLAGS=-p
-	RPATH_FLAG='-Wl,-rpath -Wl,'
-	PROG_RPATH_FLAGS='$(RPATH_FLAG)$(PROG_RPATH)'
-	CC_LINK_SHARED='$(CC) $(PROG_LIBPATH) $(PROG_RPATH_FLAGS) $(CFLAGS) $(LDFLAGS)'
-	CC_LINK_STATIC='$(CC) $(PROG_LIBPATH) $(CFLAGS) $(LDFLAGS)'
-	CXX_LINK_SHARED='$(CXX) $(PROG_LIBPATH) $(PROG_RPATH_FLAGS) $(CXXFLAGS) $(LDFLAGS)'
-	CXX_LINK_STATIC='$(CXX) $(PROG_LIBPATH) $(CXXFLAGS) $(LDFLAGS)'
-	# This grossness is necessary due to the presence of *three*
-	# supported ABIs on Irix, and the precedence of the rpath over
-	# LD_LIBRARY*_PATH.  Like OSF/1, _RLD*_ROOT needs to be set to
-	# work around this lossage.
-	#
-	# Set the N32 and 64 variables first because the unqualified
-	# variables affect all three and can cause the sed command to fail.
-	#
-	# This loop is to reduce the clutter a slight bit.
-	add='`echo $(PROG_LIBPATH) | sed -e "s/-L//g" -e "s/ /:/g"`'
-	RUN_ENV=
-	for i in N32 64 ''; do
-		RUN_ENV="${RUN_ENV+$RUN_ENV }LD_LIBRARY${i}_PATH=$add\$\${LD_LIBRARY${i}_PATH+:\$\$LD_LIBRARY${i}_PATH}"
-		RUN_ENV="${RUN_ENV} _RLD${i}_ROOT=\$\${_RLD${i}_ROOT+\$\${_RLD${i}_ROOT}}\$\${_RLD${i}_ROOT-/}"
-		RUN_VARS="$RUN_VARS LD_LIBRARY${i}_PATH _RLD${i}_ROOT"
-	done
-	;;
-
-mips-sgi-irix*)
-	SHLIBVEXT='.so.$(LIBMAJOR).$(LIBMINOR)'
-	SHLIBSEXT='.so.$(LIBMAJOR)'
-	SHLIBEXT=.so
-	SHOBJEXT=.o
-	if test "$ac_cv_c_compiler_gnu" = yes; then
-		LDCOMBINE_TAIL=""
-		INIT_FINI_PREP="initfini="
-	else
-		use_linker_init_option=yes
-		use_linker_fini_option=yes
-		INIT_FINI_PREP='initfini=; for f in . $(LIBINITFUNC); do if test $$f = .; then :; else initfini="$$initfini -Wl,-init,$${f}__auxinit"; fi; done; for f in . $(LIBFINIFUNC); do if test $$f = .; then :; else initfini="$$initfini -Wl,-fini,$${f}"; fi; done'
-		LDCOMBINE_TAIL='-Wl,-exports_file -Wl,$(SHLIB_EXPORT_FILE)'
-	fi
-	opts='-Wl,-ignore_unresolved -Wl,-update_registry -Wl,$(BUILDTOP)/so_locations'
-
-	if test "$ac_cv_c_compiler_gnu" = yes \
-		&& test "$krb5_cv_prog_gnu_ld" = yes; then
-		opts=''
-	fi
-	LDCOMBINE='$(CC) -shared '$opts' -Wl,-soname -Wl,$(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT) $$initfini'
-	SHLIB_RPATH_FLAGS='-rpath $(SHLIB_RDIRS)'
-	SHLIB_EXPFLAGS='$(SHLIB_RPATH_FLAGS) $(SHLIB_DIRS) $(SHLIB_EXPLIBS)'
-	# no gprof for Irix...
-	PROFFLAGS=-p
-	RPATH_FLAG='-Wl,-rpath -Wl,'
-	PROG_RPATH_FLAGS='$(RPATH_FLAG)$(PROG_RPATH)'
-	CC_LINK_SHARED='$(CC) $(PROG_LIBPATH) $(PROG_RPATH_FLAGS) $(CFLAGS) $(LDFLAGS)'
-	CC_LINK_STATIC='$(CC) $(PROG_LIBPATH) $(CFLAGS) $(LDFLAGS)'
-	CXX_LINK_SHARED='$(CXX) $(PROG_LIBPATH) $(PROG_RPATH_FLAGS) $(CXXFLAGS) $(LDFLAGS)'
-	CXX_LINK_STATIC='$(CXX) $(PROG_LIBPATH) $(CXXFLAGS) $(LDFLAGS)'
-	# This grossness is necessary due to the presence of *three*
-	# supported ABIs on Irix, and the precedence of the rpath over
-	# LD_LIBRARY*_PATH.  Like OSF/1, _RLD*_ROOT needs to be set to
-	# work around this lossage.
-	#
-	# Set the N32 and 64 variables first because the unqualified
-	# variables affect all three and can cause the sed command to fail.
-	#
-	# This loop is to reduce the clutter a slight bit.
-	add='`echo $(PROG_LIBPATH) | sed -e "s/-L//g" -e "s/ /:/g"`'
-	RUN_ENV=
-	for i in N32 64 ''; do
-		RUN_ENV="${RUN_ENV+$RUN_ENV }LD_LIBRARY${i}_PATH=$add\$\${LD_LIBRARY${i}_PATH+:\$\$LD_LIBRARY${i}_PATH}"
-		RUN_ENV="${RUN_ENV} _RLD${i}_ROOT=\$\${_RLD${i}_ROOT+\$\${_RLD${i}_ROOT}}\$\${_RLD${i}_ROOT-/}"
-		RUN_VARS="$RUN_VARS LD_LIBRARY${i}_PATH _RLD${i}_ROOT"
-	done
-	;;
-
-# untested...
-mips-sni-sysv4)
-	if test "$ac_cv_c_compiler_gnu" = yes; then
-		PICFLAGS=-fpic
-		LDCOMBINE='$(CC) -G -Wl,-h -Wl,$(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT)'
-	else
-		PICFLAGS=-Kpic
-		LDCOMBINE='$(CC) -G -h $(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT)'
-	fi
-	SHLIB_RPATH_FLAGS='-R$(SHLIB_RDIRS)'
-	SHLIB_EXPFLAGS='$(SHLIB_RPATH_FLAGS) $(SHLIB_DIRS) $(SHLIB_EXPLIBS)'
-	SHLIBEXT=.so
-	SHLIBVEXT='.so.$(LIBMAJOR).$(LIBMINOR)'
-	SHLIBSEXT='.so.$(LIBMAJOR)'
-	RPATH_FLAG=-R
-	PROG_RPATH_FLAGS='$(RPATH_FLAG)$(PROG_RPATH)'
-	CC_LINK_SHARED='$(CC) $(PROG_LIBPATH) $(PROG_RPATH_FLAGS) $(CFLAGS) $(LDFLAGS)'
-	CC_LINK_STATIC='$(CC) $(PROG_LIBPATH) $(CFLAGS) $(LDFLAGS)'
-	CXX_LINK_SHARED='$(CXX) $(PROG_LIBPATH) $(PROG_RPATH_FLAGS) $(CXXFLAGS) $(LDFLAGS)'
-	CXX_LINK_STATIC='$(CXX) $(PROG_LIBPATH) $(CXXFLAGS) $(LDFLAGS)'
-	RUN_ENV='LD_LIBRARY_PATH=`echo $(PROG_LIBPATH) | sed -e "s/-L//g" -e "s/ /:/g"`'
-	RUN_VARS='LD_LIBRARY_PATH'
-	PROFFLAGS=-pg
 	;;
 
 mips-*-netbsd*)
@@ -466,26 +305,7 @@ mips-*-netbsd*)
 
 	;;
 
-*-*-bsdi4*)
-	PICFLAGS=-fpic
-	SHLIBVEXT='.so.$(LIBMAJOR)'
-	SHLIBEXT=.so
-	LDCOMBINE='ld -Bshareable -z nodelete'
-	SHLIB_RPATH_FLAGS='-R$(SHLIB_RDIRS)'
-	SHLIB_EXPFLAGS='$(SHLIB_RPATH_FLAGS) $(SHLIB_DIRS) $(SHLIB_EXPLIBS)'
-	PROG_RPATH_FLAGS='-Wl,-rpath,$(PROG_RPATH)'
-	CC_LINK_SHARED='$(CC) $(PROG_LIBPATH) $(PROG_RPATH_FLAGS)'
-	CC_LINK_STATIC='$(CC) $(PROG_LIBPATH)'
-	CXX_LINK_SHARED='$(CXX) $(PROG_LIBPATH) $(PROG_RPATH_FLAGS)'
-	CXX_LINK_STATIC='$(CXX) $(PROG_LIBPATH)'
-	RUN_ENV='LD_LIBRARY_PATH=`echo $(PROG_LIBPATH) | sed -e "s/-L//g" -e "s/
-/:/g"`'
-	RUN_VARS='LD_LIBRARY_PATH'
-	PROFFLAGS=-pg
-	lib_unload_prevented=yes
-	;;
-
-*-*-aix5*)
+*-*-aix*)
 	SHLIBVEXT='.so.$(LIBMAJOR).$(LIBMINOR)'
 	SHLIBEXT=.so
 	# AIX doesn't need separate PIC objects
@@ -505,44 +325,6 @@ mips-*-netbsd*)
 	INIT_FINI_PREP="wl=${wl_prefix}; "'i=1; initfini=; for f in . $(LIBFINIFUNC); do if test $$f != .; then initfini="$$initfini $${wl}-binitfini::$$f:$$i"; else :; fi; i=`expr $$i + 1`; done'
 	use_linker_fini_option=yes
 	MAKE_SHLIB_COMMAND="${INIT_FINI_PREP} && ${LDCOMBINE}"
-	RPATH_TAIL=:/usr/lib:/lib
-	PROG_RPATH_FLAGS='$(RPATH_FLAG)$(PROG_RPATH):'"$RPATH_TAIL"
-	CC_LINK_SHARED='$(CC) $(PROG_LIBPATH) $(PROG_RPATH_FLAGS) $(CFLAGS) $(LDFLAGS)'
-	CC_LINK_STATIC='$(CC) $(PROG_LIBPATH) $(CFLAGS) $(LDFLAGS)'
-	CXX_LINK_SHARED='$(CXX) $(PROG_LIBPATH) $(PROG_RPATH_FLAGS) $(CXXFLAGS) $(LDFLAGS)'
-	CXX_LINK_STATIC='$(CXX) $(PROG_LIBPATH) $(CXXFLAGS) $(LDFLAGS)'
-	# $(PROG_RPATH) is here to handle things like a shared tcl library
-	RUN_ENV='LIBPATH=`echo $(PROG_LIBPATH) | sed -e "s/-L//g" -e "s/ /:/g"`:$(PROG_RPATH):/usr/lib:/usr/local/lib'
-	RUN_VARS='LIBPATH'
-	;;
-
-*-*-aix4.*)
-	SHLIBVEXT='.a.$(LIBMAJOR).$(LIBMINOR)'
-	SHLIBEXT=.a
-	# AIX doesn't need separate PIC objects
-	SHOBJEXT=.o
-	SHLIB_EXPFLAGS='  $(SHLIB_DIRS) $(SHLIB_EXPLIBS)'
-	PROFFLAGS=-pg
-	# Dynamically loaded object can have whatever suffix, but don't
-	# make archives like for shared libraries.
-	DYNOBJEXT=.so
-	#
-	if test "$ac_cv_c_compiler_gnu" = "yes" ; then
-	  wl_prefix=-Wl,
-	  RPATH_FLAG='-Wl,-blibpath:'
-	  LDCOMBINE='$(CC) -shared -v -o shr.o.$(LIBMAJOR).$(LIBMINOR) $$objlist -nostartfiles -Xlinker -bgcbypass:1 -Xlinker -bfilelist -Xlinker -bM:SRE -Xlinker -bE:$(SHLIB_EXPORT_FILE) -Xlinker -bernotok $(SHLIB_EXPFLAGS) $(LDFLAGS) -lc $$initfini'
-	  LDCOMBINE_DYN='$(CC) -shared -v -o $@ $$objlist -nostartfiles -Xlinker -bgcbypass:1 -Xlinker -bfilelist -Xlinker -bM:SRE -Xlinker -bE:$(SHLIB_EXPORT_FILE) -Xlinker -bernotok $(SHLIB_EXPFLAGS) $(LDFLAGS) -lc $$initfini'
-	else
-	  wl_prefix=
-	  RPATH_FLAG=-blibpath:
-	  LDCOMBINE='/bin/ld -o shr.o.$(LIBMAJOR).$(LIBMINOR) $$objlist -H512 -T512 -bnoentry -bgcbypass:1 -bnodelcsect -bfilelist -bM:SRE -bE:$(SHLIB_EXPORT_FILE) -bernotok $(SHLIB_EXPFLAGS) $(LDFLAGS) -lc $$initfini'
-	  LDCOMBINE_DYN='/bin/ld -o $@ $$objlist -H512 -T512 -bnoentry -bgcbypass:1 -bnodelcsect -bfilelist -bM:SRE -bE:$(SHLIB_EXPORT_FILE) -bernotok $(SHLIB_EXPFLAGS) $(LDFLAGS) -lc $$initfini'
-	fi
-	# Assume initialization always delayed.
-	INIT_FINI_PREP="wl=${wl_prefix}; "'i=1; initfini=; for f in . $(LIBFINIFUNC); do if test $$f != .; then initfini="$$initfini $${wl}-binitfini::$$f:$$i"; else :; fi; i=`expr $$i + 1`; done'
-	use_linker_fini_option=yes
-	MAKE_SHLIB_COMMAND="${INIT_FINI_PREP} && ${LDCOMBINE}"' && ar cq $@ shr.o.$(LIBMAJOR).$(LIBMINOR) && chmod +x $@ && rm -f shr.o.$(LIBMAJOR).$(LIBMINOR)'
-	MAKE_DYNOBJ_COMMAND="${INIT_FINI_PREP} && ${LDCOMBINE_DYN}"
 	RPATH_TAIL=:/usr/lib:/lib
 	PROG_RPATH_FLAGS='$(RPATH_FLAG)$(PROG_RPATH):'"$RPATH_TAIL"
 	CC_LINK_SHARED='$(CC) $(PROG_LIBPATH) $(PROG_RPATH_FLAGS) $(CFLAGS) $(LDFLAGS)'


### PR DESCRIPTION
Remove the handling of DEC OSF (last release in 1992), SINIX (1995), AIX 4 (1999), BSD/OS (2003), and IRIX (2006).