### PR TITLE
Use size_t indexes for null-terminated arrays

### DIFF
--- a/src/ccapi/lib/ccapi_v2.c
+++ b/src/ccapi/lib/ccapi_v2.c
@@ -175,8 +175,8 @@ cc_result cc_get_NC_info (apiCB    *in_context,
 {
     cc_result err = CC_NOERROR;
     infoNC **info = NULL;
-    cc_uint64 count = 0; /* Preflight the size */
-    cc_uint64 i;
+    size_t count = 0; /* Preflight the size */
+    size_t i;
 
     if (!in_context) { err = cci_check_error (ccErrBadParam); }
     if (!out_info  ) { err = cci_check_error (ccErrBadParam); }
@@ -873,7 +873,7 @@ cc_result cc_free_NC_info (apiCB    *in_context,
 
     if (!err && *io_info) {
         infoNC **data = *io_info;
-        int i;
+        size_t i;
 
         for (i = 0; data[i] != NULL; i++) {
             cc_free_principal (in_context, &data[i]->principal);

--- a/src/ccapi/test/test_ccapi_v2.c
+++ b/src/ccapi/test/test_ccapi_v2.c
@@ -11,7 +11,7 @@
 static cc_result destroy_all_ccaches_v2(apiCB *context) {
     cc_result err = CC_NOERROR;
     infoNC **info = NULL;
-    int i = 0;
+    size_t i = 0;
 
     err = cc_get_NC_info(context, &info);
 

--- a/src/kadmin/cli/kadmin.c
+++ b/src/kadmin/cli/kadmin.c
@@ -298,7 +298,7 @@ kadmin_startup(int argc, char *argv[], char **request_out, char ***args_out)
     krb5_principal princ;
     kadm5_config_params params;
     char **db_args = NULL;
-    int db_args_size = 0;
+    size_t db_args_size = 0;
     char *db_name = NULL;
     char *svcname, *realm;
 
@@ -795,7 +795,7 @@ kadmin_cpw(int argc, char *argv[], int sci_idx, void *info_ptr)
     krb5_key_salt_tuple *ks_tuple = NULL;
     krb5_principal princ = NULL;
     char **db_args = NULL;
-    int db_args_size = 0;
+    size_t db_args_size = 0;
 
     if (argc < 1) {
         cpw_usage(NULL);

--- a/src/kadmin/dbutil/kdb5_util.c
+++ b/src/kadmin/dbutil/kdb5_util.c
@@ -160,7 +160,7 @@ cmd_lookup(char *name)
 #define ARG_VAL (--argc > 0 ? (koptarg = *(++argv)) : (char *)(usage(), NULL))
 
 char **db5util_db_args = NULL;
-int    db5util_db_args_size = 0;
+size_t db5util_db_args_size = 0;
 
 static void
 extended_com_err_fn(const char *myprog, errcode_t code, const char *fmt,

--- a/src/kadmin/dbutil/kdb5_util.h
+++ b/src/kadmin/dbutil/kdb5_util.h
@@ -41,7 +41,7 @@ extern kadm5_config_params global_params;
 extern int valid_master_key;
 extern krb5_db_entry master_db;
 extern char **db5util_db_args;
-extern int    db5util_db_args_size;
+extern size_t db5util_db_args_size;
 extern krb5_kvno new_mkvno;
 extern krb5_keyblock new_master_keyblock;
 extern int add_db_arg(char *arg);

--- a/src/kadmin/server/ovsec_kadmd.c
+++ b/src/kadmin/server/ovsec_kadmd.c
@@ -349,7 +349,8 @@ main(int argc, char *argv[])
     const char *pid_file = NULL;
     char **db_args = NULL, **tmpargs;
     const char *acl_file;
-    int ret, i, db_args_size = 0, proponly = 0;
+    size_t db_args_size = 0;
+    int ret, i, proponly = 0;
 
     setlocale(LC_ALL, "");
     setvbuf(stderr, NULL, _IONBF, 0);

--- a/src/kdc/main.c
+++ b/src/kdc/main.c
@@ -611,7 +611,7 @@ initialize_realms(krb5_context kcontext, int argc, char **argv,
     const char          *hierarchy[3];
     char                *no_referral = NULL;
     char                *hostbased = NULL;
-    int                  db_args_size = 0;
+    size_t               db_args_size = 0;
     char                **db_args = NULL;
 
     extern char *optarg;

--- a/src/kprop/kpropd.c
+++ b/src/kprop/kpropd.c
@@ -140,7 +140,7 @@ static krb5_address *receiver_addr;
 static const char *port = KPROP_SERVICE;
 
 static char **db_args = NULL;
-static int db_args_size = 0;
+static size_t db_args_size = 0;
 
 static void parse_args(int argc, char **argv);
 static void do_standalone(void);

--- a/src/lib/gssapi/krb5/naming_exts.c
+++ b/src/lib/gssapi/krb5/naming_exts.c
@@ -201,7 +201,7 @@ data_list_to_buffer_set(krb5_context context,
 {
     gss_buffer_set_t set = GSS_C_NO_BUFFER_SET;
     OM_uint32 minor_status;
-    int i;
+    size_t i;
     krb5_error_code code = 0;
 
     if (data == NULL)
@@ -233,8 +233,8 @@ data_list_to_buffer_set(krb5_context context,
      * NULL-terminated in case of allocation failure
      * in data_to_gss() on windows.
      */
-    for (i = set->count-1; i >= 0; i--) {
-        if (data_to_gss(&data[i], &set->elements[i])) {
+    for (i = set->count; i > 0; i--) {
+        if (data_to_gss(&data[i - 1], &set->elements[i - 1])) {
             gss_release_buffer_set(&minor_status, &set);
             code = ENOMEM;
             goto cleanup;

--- a/src/lib/kadm5/srv/server_init.c
+++ b/src/lib/kadm5/srv/server_init.c
@@ -21,7 +21,7 @@
 
 static int dup_db_args(kadm5_server_handle_t handle, char **db_args)
 {
-    int count  = 0;
+    size_t count = 0;
     int ret = 0;
 
     for (count=0; db_args && db_args[count]; count++);
@@ -57,7 +57,7 @@ clean_n_exit:
 
 static void free_db_args(kadm5_server_handle_t handle)
 {
-    int count;
+    size_t count;
 
     if (handle->db_args) {
         for (count=0; handle->db_args[count]; count++)

--- a/src/lib/kdb/kdb5.c
+++ b/src/lib/kdb/kdb5.c
@@ -849,7 +849,8 @@ krb5_db_free_principal(krb5_context kcontext, krb5_db_entry *entry)
 static void
 free_db_args(char **db_args)
 {
-    int i;
+    size_t i;
+
     if (db_args) {
         for (i = 0; db_args[i]; i++)
             free(db_args[i]);
@@ -862,7 +863,7 @@ extract_db_args_from_tl_data(krb5_context kcontext, krb5_tl_data **start,
                              krb5_int16 *count, char ***db_argsp)
 {
     char **db_args = NULL;
-    int db_args_size = 0;
+    size_t db_args_size = 0;
     krb5_tl_data *prev, *curr, *next;
     krb5_error_code status;
 

--- a/src/lib/krb5/krb/addr_srch.c
+++ b/src/lib/krb5/krb/addr_srch.c
@@ -26,10 +26,10 @@
 
 #include "k5-int.h"
 
-static unsigned int
+static size_t
 address_count(krb5_address *const *addrlist)
 {
-    unsigned int i;
+    size_t i;
 
     if (addrlist == NULL)
         return 0;

--- a/src/lib/krb5/krb/ai_authdata.c
+++ b/src/lib/krb5/krb/ai_authdata.c
@@ -79,7 +79,7 @@ authind_import_authdata(krb5_context kcontext, krb5_authdata_context context,
     struct authind_context *aictx = request_context;
     krb5_error_code ret = 0;
     krb5_data **indps = NULL;
-    int i;
+    size_t i;
 
     for (i = 0; authdata != NULL && authdata[i] != NULL; i++) {
         ret = k5_authind_decode(authdata[i], &indps);
@@ -203,7 +203,7 @@ authind_size(krb5_context kcontext, krb5_authdata_context context,
              void *plugin_context, void *request_context, size_t *sizep)
 {
     struct authind_context *aictx = request_context;
-    int i;
+    size_t i;
 
     /* Add the indicator count. */
     *sizep += sizeof(int32_t);
@@ -224,7 +224,7 @@ authind_externalize(krb5_context kcontext, krb5_authdata_context context,
     krb5_error_code ret = 0;
     uint8_t *bp = *buffer;
     size_t remain = *lenremain;
-    int i, count;
+    size_t i, count;
 
     if (aictx->indicators == NULL)
         return krb5_ser_pack_int32(0, buffer, lenremain);

--- a/src/lib/krb5/krb/authdata.c
+++ b/src/lib/krb5/krb/authdata.c
@@ -725,9 +725,9 @@ cleanup:
 }
 
 static krb5_error_code
-k5_merge_data_list(krb5_data **dst, krb5_data *src, unsigned int *len)
+k5_merge_data_list(krb5_data **dst, krb5_data *src, size_t *len)
 {
-    unsigned int i;
+    size_t i;
     krb5_data *d;
 
     if (src == NULL)
@@ -760,7 +760,7 @@ krb5_authdata_get_attribute_types(krb5_context kcontext,
     int i;
     krb5_error_code code = 0;
     krb5_data *attrs = NULL;
-    unsigned int attrs_len = 0;
+    size_t attrs_len = 0;
 
     for (i = 0; i < context->n_modules; i++) {
         struct _krb5_authdata_context_module *module = &context->modules[i];

--- a/src/lib/krb5/krb/authdata_dec.c
+++ b/src/lib/krb5/krb/authdata_dec.c
@@ -116,7 +116,7 @@ find_authdata_1(krb5_context context, krb5_authdata *const *in_authdat,
                 krb5_authdatatype ad_type, struct find_authdata_context *fctx,
                 int from_ap_req)
 {
-    int i = 0;
+    size_t i = 0;
     krb5_error_code retval = 0;
 
     for (i = 0; in_authdat[i] && retval == 0; i++) {

--- a/src/lib/krb5/krb/copy_addrs.c
+++ b/src/lib/krb5/krb/copy_addrs.c
@@ -51,7 +51,7 @@ krb5_copy_addresses(krb5_context context, krb5_address *const *inaddr, krb5_addr
 {
     krb5_error_code retval;
     krb5_address ** tempaddr;
-    unsigned int nelems = 0;
+    size_t nelems = 0;
 
     if (!inaddr) {
         *outaddr = 0;

--- a/src/lib/krb5/krb/get_creds.c
+++ b/src/lib/krb5/krb/get_creds.c
@@ -73,7 +73,7 @@ construct_matching_creds(krb5_context context, krb5_flags options,
         | KRB5_TC_SUPPORTED_KTYPES;
     if (mcreds->keyblock.enctype) {
         krb5_enctype *ktypes;
-        int i;
+        size_t i;
 
         *fields |= KRB5_TC_MATCH_KTYPE;
         ret = krb5_get_tgs_ktypes(context, mcreds->server, &ktypes);

--- a/src/lib/krb5/krb/kfree.c
+++ b/src/lib/krb5/krb/kfree.c
@@ -259,7 +259,7 @@ krb5_free_enc_data(krb5_context context, krb5_enc_data *val)
 
 void krb5_free_etype_info(krb5_context context, krb5_etype_info info)
 {
-    int i;
+    size_t i;
 
     if (info == NULL)
         return;
@@ -710,7 +710,7 @@ krb5_free_fast_armored_req(krb5_context context, krb5_fast_armored_req *val)
 void
 k5_free_data_ptr_list(krb5_data **list)
 {
-    int i;
+    size_t i;
 
     for (i = 0; list != NULL && list[i] != NULL; i++)
         krb5_free_data(NULL, list[i]);
@@ -720,7 +720,7 @@ k5_free_data_ptr_list(krb5_data **list)
 void KRB5_CALLCONV
 krb5int_free_data_list(krb5_context context, krb5_data *data)
 {
-    int i;
+    size_t i;
 
     if (data == NULL)
         return;

--- a/src/lib/krb5/krb/pac.c
+++ b/src/lib/krb5/krb/pac.c
@@ -958,7 +958,7 @@ mspac_get_attribute_types(krb5_context context, krb5_authdata_context actx,
                           krb5_data **attrs_out)
 {
     struct mspac_context *pacctx = (struct mspac_context *)request_context;
-    unsigned int i, j;
+    size_t i, j;
     krb5_data *attrs;
     krb5_error_code ret;
 

--- a/src/lib/krb5/krb/preauth_otp.c
+++ b/src/lib/krb5/krb/preauth_otp.c
@@ -214,7 +214,7 @@ codec_encode_challenge(krb5_context ctx, krb5_pa_otp_challenge *chl,
     k5_json_string str = NULL;
     k5_json_array arr = NULL;
     krb5_error_code retval;
-    int i;
+    size_t i;
 
     retval = k5_json_object_create(&obj);
     if (retval != 0)
@@ -378,8 +378,9 @@ codec_decode_answer(krb5_context context, const char *answer,
 {
     krb5_error_code retval;
     k5_json_value val = NULL;
-    krb5_int32 indx, i;
+    krb5_int32 indx;
     krb5_data tmp;
+    size_t i;
 
     if (answer == NULL)
         return EBADMSG;
@@ -396,7 +397,7 @@ codec_decode_answer(krb5_context context, const char *answer,
         goto cleanup;
 
     for (i = 0; tis[i] != NULL; i++) {
-        if (i == indx) {
+        if (i == (size_t)indx) {
             retval = codec_value_to_data(val, "value", &tmp);
             if (retval != 0 && retval != ENOENT)
                 goto cleanup;
@@ -508,12 +509,12 @@ prompt_for_tokeninfo(krb5_context context, krb5_prompter_fct prompter,
     krb5_otp_tokeninfo *ti = NULL;
     krb5_error_code retval = 0;
     struct k5buf buf;
-    int i = 0, j = 0;
+    size_t i = 0, j = 0;
 
     k5_buf_init_dynamic(&buf);
     k5_buf_add(&buf, _("Please choose from the following:\n"));
     for (i = 0; tis[i] != NULL; i++) {
-        k5_buf_add_fmt(&buf, "\t%d. %s ", i + 1, _("Vendor:"));
+        k5_buf_add_fmt(&buf, "\t%ld. %s ", (long)(i + 1), _("Vendor:"));
         k5_buf_add_len(&buf, tis[i]->vendor.data, tis[i]->vendor.length);
         k5_buf_add(&buf, "\n");
     }
@@ -528,7 +529,7 @@ prompt_for_tokeninfo(krb5_context context, krb5_prompter_fct prompter,
             goto cleanup;
 
         errno = 0;
-        j = strtol(response, NULL, 0);
+        j = strtoul(response, NULL, 0);
         if (errno != 0) {
             retval = errno;
             goto cleanup;
@@ -731,7 +732,7 @@ prompt_for_token(krb5_context context, krb5_prompter_fct prompter,
     krb5_otp_tokeninfo **filtered = NULL;
     krb5_otp_tokeninfo *ti = NULL;
     krb5_error_code retval;
-    int i, challengers = 0;
+    size_t i, challengers = 0;
     char *challenge = NULL;
     char otpvalue[1024];
     krb5_data value, pin;

--- a/src/lib/krb5/krb/preauth_pkinit.c
+++ b/src/lib/krb5/krb/preauth_pkinit.c
@@ -48,7 +48,7 @@ get_one_challenge(void *arg, const char *key, k5_json_value val)
 {
     struct get_one_challenge_data *data;
     unsigned long token_flags;
-    int i;
+    size_t i;
 
     data = arg;
     if (data->err != 0)
@@ -191,7 +191,7 @@ krb5_responder_pkinit_challenge_free(krb5_context ctx,
                                      krb5_responder_context rctx,
                                      krb5_responder_pkinit_challenge *chl)
 {
-   unsigned int i;
+   size_t i;
 
    if (chl == NULL)
        return;

--- a/src/lib/krb5/krb/s4u_creds.c
+++ b/src/lib/krb5/krb/s4u_creds.c
@@ -205,7 +205,7 @@ build_pa_s4u_x509_user(krb5_context context,
     krb5_pa_s4u_x509_user *s4u_user = (krb5_pa_s4u_x509_user *)gcvt_data;
     krb5_data *data = NULL;
     krb5_cksumtype cksumtype;
-    int i;
+    size_t i;
 
     assert(s4u_user->cksum.contents == NULL);
 

--- a/src/lib/krb5/os/hostaddr.c
+++ b/src/lib/krb5/os/hostaddr.c
@@ -35,7 +35,8 @@ k5_os_hostaddr(krb5_context context, const char *name,
 {
     krb5_error_code     retval;
     krb5_address        **addrs = NULL;
-    int                 i, j, r;
+    size_t              i, j;
+    int                 r;
     struct addrinfo hints, *ai = NULL, *aip;
 
     if (!name)

--- a/src/lib/krb5/os/localaddr.c
+++ b/src/lib/krb5/os/localaddr.c
@@ -1095,7 +1095,8 @@ int main (void)
 #else /* not TESTing */
 
 struct localaddr_data {
-    int count, mem_err, cur_idx, cur_size;
+    size_t count, cur_idx, cur_size;
+    int mem_err;
     krb5_address **addr_temp;
 };
 
@@ -1123,7 +1124,7 @@ allocate (void *P_data)
 /*@*/
 {
     struct localaddr_data *data = P_data;
-    int i;
+    size_t i;
     void *n;
 
     n = realloc (data->addr_temp,
@@ -1248,7 +1249,7 @@ krb5_os_localaddr_profile (krb5_context context, struct localaddr_data *datap)
 
     for (iter = values; *iter; iter++) {
         char *cp = *iter, *next, *current;
-        int i, count;
+        size_t i, count;
 
 #ifdef DEBUG
         fprintf (stderr, "  found line: '%s'\n", cp);
@@ -1329,7 +1330,7 @@ get_localaddrs (krb5_context context, krb5_address ***addr, int use_profile)
 
     r = foreach_localaddr (&data, count_addrs, allocate, add_addr);
     if (r != 0) {
-        int i;
+        size_t i;
         if (data.addr_temp) {
             for (i = 0; i < data.count; i++)
                 free (data.addr_temp[i]);
@@ -1360,7 +1361,7 @@ get_localaddrs (krb5_context context, krb5_address ***addr, int use_profile)
 
 #ifdef DEBUG
     {
-        int j;
+        size_t j;
         fprintf (stderr, "addresses:\n");
         for (j = 0; addr[0][j]; j++) {
             struct sockaddr_storage ss;
@@ -1465,7 +1466,8 @@ krb5_error_code KRB5_CALLCONV
 krb5_os_localaddr (krb5_context context, krb5_address ***addr) {
     char host[64];                              /* Name of local machine */
     struct hostent *hostrec;
-    int err, count, i;
+    size_t count, i;
+    int err;
     krb5_address ** paddr;
 
     *addr = 0;

--- a/src/lib/krb5/os/locate_kdc.c
+++ b/src/lib/krb5/os/locate_kdc.c
@@ -260,7 +260,8 @@ locate_srv_conf_1(krb5_context context, const krb5_data *realm,
     char **hostlist = NULL, *realmstr = NULL, *host = NULL;
     const char *hostspec;
     krb5_error_code code;
-    int i, default_port;
+    size_t i;
+    int default_port;
 
     Tprintf("looking in krb5.conf for realm %s entry %s; ports %d,%d\n",
             realm->data, name, udpport);
@@ -428,7 +429,8 @@ module_locate_server(krb5_context ctx, const krb5_data *realm,
     struct krb5plugin_service_locate_ftable *vtbl = NULL;
     void **ptrs;
     char *realmz;               /* NUL-terminated realm */
-    int socktype, i;
+    size_t i;
+    int socktype;
     struct module_callback_data cbdata = { 0, };
     const char *msg;
 

--- a/src/plugins/kdb/ldap/ldap_util/kdb5_ldap_realm.c
+++ b/src/plugins/kdb/ldap/ldap_util/kdb5_ldap_realm.c
@@ -701,7 +701,7 @@ kdb5_ldap_modify(int argc, char *argv[])
         goto cleanup;
     /* Parse the arguments */
     for (i = 1; i < argc; i++) {
-        int k = 0;
+        size_t k = 0;
         if (!strcmp(argv[i], "-subtrees")) {
             if (++i > argc-1)
                 goto err_usage;

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.c
@@ -46,7 +46,7 @@
 extern char *strptime(const char *, const char *, struct tm *);
 #endif
 
-static void remove_overlapping_subtrees(char **listin, int *subtcount,
+static void remove_overlapping_subtrees(char **listin, size_t *subtcount,
                                         int sscope);
 
 /* Set an extended error message about being unable to read name. */
@@ -439,7 +439,7 @@ krb5_ldap_read_server_params(krb5_context context, char *conf_section,
 void
 krb5_ldap_free_server_context_params(krb5_ldap_context *ctx)
 {
-    int i;
+    size_t i;
     krb5_ldap_server_info **list;
     krb5_ldap_server_handle *h, *next;
 
@@ -518,10 +518,11 @@ is_principal_in_realm(krb5_ldap_context *ldap_context,
  */
 krb5_error_code
 krb5_get_subtree_info(krb5_ldap_context *ldap_context, char ***subtreearr,
-                      unsigned int *ntree)
+                      size_t *ntree)
 {
     krb5_error_code ret;
-    int subtreecount, count = 0, search_scope;
+    size_t subtreecount, count = 0;
+    int search_scope;
     char **subtree, *realm_cont_dn, *containerref;
     char **subtarr = NULL;
 
@@ -860,7 +861,8 @@ checkattributevalue(LDAP *ld, char *dn, char *attribute, char **attrvalues,
                     int *mask)
 {
     krb5_error_code ret;
-    int one = 1, i, j;
+    size_t i, j;
+    int one = 1;
     char **values = NULL, *attributes[2] = { NULL };
     LDAPMessage *result = NULL, *entry;
 
@@ -1153,7 +1155,7 @@ krb5_ldap_get_reference_count(krb5_context context, char *dn, char *refattr,
                               int *count, LDAP *ld)
 {
     int n, st, tempst, gothandle = 0;
-    unsigned int i, ntrees = 0;
+    size_t i, ntrees = 0;
     char *refcntattr[2];
     char *filter = NULL, *corrected = NULL, **subtree = NULL;
     kdb5_dal_handle *dal_handle = NULL;
@@ -1317,11 +1319,9 @@ is_subtree(const char *dn1, size_t len1, const char *dn2, size_t len2)
 /* Remove overlapping and repeated subtree entries from the list of subtrees.
  * If sscope is not 2 (sub), only remove repeated entries. */
 static void
-remove_overlapping_subtrees(char **list, int *subtcount, int sscope)
+remove_overlapping_subtrees(char **list, size_t *subtcount, int sscope)
 {
-    size_t ilen, jlen;
-    int i, j;
-    int count = *subtcount;
+    size_t ilen, jlen, i, j, count = *subtcount;
 
     for (i = 0; i < count && list[i] != NULL; i++) {
         ilen = strlen(list[i]);
@@ -1369,7 +1369,7 @@ get_ldap_auth_ind(krb5_context context, LDAP *ld, LDAPMessage *ldap_ent,
                   krb5_db_entry *entry, unsigned int *mask)
 {
     krb5_error_code ret;
-    int i;
+    size_t i;
     char **auth_inds = NULL, *indstr;
     struct k5buf buf = EMPTY_K5BUF;
 
@@ -1414,7 +1414,8 @@ populate_krb5_db_entry(krb5_context context, krb5_ldap_context *ldap_context,
 {
     krb5_error_code ret;
     unsigned int mask = 0;
-    int val, i, pcount, objtype;
+    size_t i;
+    int val, pcount, objtype;
     krb5_boolean attr_present;
     krb5_kvno mkvno = 0;
     krb5_timestamp lastpwdchange, unlock_time;

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.h
@@ -67,7 +67,7 @@ krb5_error_code
 store_tl_data(krb5_tl_data *, int, void *);
 
 krb5_error_code
-krb5_get_subtree_info(krb5_ldap_context *, char ***, unsigned int *);
+krb5_get_subtree_info(krb5_ldap_context *, char ***, size_t *);
 
 krb5_error_code
 krb5_ldap_parse_db_params(krb5_context, char **);

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.c
@@ -137,7 +137,7 @@ krb5_ldap_iterate(krb5_context context, char *match_expr,
     krb5_db_entry            entry;
     krb5_principal           principal;
     char                     **subtree=NULL, *princ_name=NULL, *realm=NULL, **values=NULL, *filter=NULL;
-    unsigned int             tree=0, ntree=1, i=0;
+    size_t                   tree=0, ntree=1, i=0;
     krb5_error_code          st=0, tempst=0;
     LDAP                     *ld=NULL;
     LDAPMessage              *result=NULL, *ent=NULL;
@@ -237,7 +237,8 @@ krb5_ldap_delete_principal(krb5_context context,
     char                      *user=NULL, *DN=NULL, *strval[10] = {NULL};
     LDAPMod                   **mods=NULL;
     LDAP                      *ld=NULL;
-    int                       j=0, ptype=0, pcount=0, attrsetmask=0;
+    size_t                    j=0;
+    int                       ptype=0, pcount=0, attrsetmask=0;
     krb5_error_code           st=0;
     krb5_boolean              singleentry=FALSE;
     kdb5_dal_handle           *dal_handle=NULL;

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
@@ -107,7 +107,7 @@ krb5_ldap_get_principal(krb5_context context, krb5_const_principal searchfor,
                         unsigned int flags, krb5_db_entry **entry_ptr)
 {
     char                        *user=NULL, *filter=NULL, *filtuser=NULL;
-    unsigned int                tree=0, ntrees=1, princlen=0;
+    size_t                      tree=0, ntrees=1, princlen=0;
     krb5_error_code             tempst=0, st=0;
     char                        **values=NULL, **subtree=NULL, *cname=NULL;
     LDAP                        *ld=NULL;
@@ -168,7 +168,7 @@ krb5_ldap_get_principal(krb5_context context, krb5_const_principal searchfor,
 
             /* get the associated directory user information */
             if ((values=ldap_get_values(ld, ent, "krbprincipalname")) != NULL) {
-                int i;
+                size_t i;
 
                 /* a wild-card in a principal name can return a list of kerberos principals.
                  * Make sure that the correct principal is returned.
@@ -284,11 +284,10 @@ static krb5_error_code
 process_db_args(krb5_context context, char **db_args, xargs_t *xargs,
                 OPERATION optype)
 {
-    int                   i=0;
+    size_t                i=0, arg_val_len=0;
     krb5_error_code       st=0;
     char                  *arg=NULL, *arg_val=NULL;
     char                  **dptr=NULL;
-    unsigned int          arg_val_len=0;
 
     if (db_args) {
         for (i=0; db_args[i]; ++i) {
@@ -429,7 +428,7 @@ asn1_decode_sequence_of_keys(krb5_data *in, ldap_seqof_key_data *out)
 void
 free_berdata(struct berval **array)
 {
-    int i;
+    size_t i;
 
     if (array != NULL) {
         for (i = 0; array[i] != NULL; i++) {
@@ -622,12 +621,12 @@ static krb5_error_code
 update_ldap_mod_auth_ind(krb5_context context, krb5_db_entry *entry,
                          LDAPMod ***mods)
 {
-    int i = 0;
     krb5_error_code ret;
     char *auth_ind = NULL;
     char *strval[10] = { 0 };
     char *ai, *ai_save = NULL;
-    int mask, sv_num = sizeof(strval) / sizeof(*strval);
+    size_t i = 0, sv_num = sizeof(strval) / sizeof(*strval);
+    int mask;
 
     ret = krb5_dbe_get_string(context, entry, KRB5_KDB_SK_REQUIRE_AUTH,
                               &auth_ind);
@@ -658,10 +657,9 @@ update_ldap_mod_auth_ind(krb5_context context, krb5_db_entry *entry,
 
 static krb5_error_code
 check_dn_in_container(krb5_context context, const char *dn,
-                      char *const *subtrees, unsigned int ntrees)
+                      char *const *subtrees, size_t ntrees)
 {
-    unsigned int i;
-    size_t dnlen = strlen(dn), stlen;
+    size_t dnlen = strlen(dn), stlen, i;
 
     for (i = 0; i < ntrees; i++) {
         if (subtrees[i] == NULL || *subtrees[i] == '\0')
@@ -719,7 +717,7 @@ static krb5_error_code
 validate_xargs(krb5_context context,
                krb5_ldap_server_handle *ldap_server_handle,
                const xargs_t *xargs, const char *standalone_dn,
-               char *const *subtrees, unsigned int ntrees)
+               char *const *subtrees, size_t ntrees)
 {
     krb5_error_code st;
 
@@ -761,8 +759,8 @@ krb5_error_code
 krb5_ldap_put_principal(krb5_context context, krb5_db_entry *entry,
                         char **db_args)
 {
-    int                         l=0, kerberos_principal_object_type=0;
-    unsigned int                ntrees=0, tre=0;
+    int                         kerberos_principal_object_type=0;
+    size_t                      l=0, ntrees=0, tre=0;
     krb5_error_code             st=0, tempst=0;
     LDAP                        *ld=NULL;
     LDAPMessage                 *result=NULL, *ent=NULL;
@@ -832,7 +830,7 @@ krb5_ldap_put_principal(krb5_context context, krb5_db_entry *entry,
         goto cleanup;
 
     if (entry->mask & KADM5_LOAD) {
-        unsigned int     tree = 0;
+        size_t           tree = 0;
         int              numlentries = 0;
 
         /*  A load operation is special, will do a mix-in (add krbprinc
@@ -1000,7 +998,7 @@ krb5_ldap_put_principal(krb5_context context, krb5_db_entry *entry,
          */
         {
             char **linkdns=NULL;
-            int  j=0;
+            size_t j=0;
 
             if ((st=krb5_get_linkdn(context, entry, &linkdns)) != 0) {
                 snprintf(errbuf, sizeof(errbuf),
@@ -1256,7 +1254,7 @@ krb5_ldap_put_principal(krb5_context context, krb5_db_entry *entry,
 
     /* Set tl_data */
     if (entry->tl_data != NULL) {
-        int count = 0;
+        size_t count = 0;
         struct berval **ber_tl_data = NULL;
         krb5_tl_data *ptr;
         krb5_timestamp unlock_time;
@@ -1280,7 +1278,7 @@ krb5_ldap_put_principal(krb5_context context, krb5_db_entry *entry,
             count++;
         }
         if (count != 0) {
-            int j;
+            size_t j;
             ber_tl_data = (struct berval **) calloc (count + 1,
                                                      sizeof (struct berval*));
             if (ber_tl_data == NULL) {
@@ -1411,7 +1409,8 @@ krb5_ldap_put_principal(krb5_context context, krb5_db_entry *entry,
          */
         {
             char *attrvalues[] = {"krbprincipalaux", "krbTicketPolicyAux", NULL};
-            int p, q, r=0, amask=0;
+            size_t q, r=0;
+            int p, amask=0;
 
             if ((st=checkattributevalue(ld, (xargs.dn) ? xargs.dn : principal_dn,
                                         "objectclass", attrvalues, &amask)) != 0)
@@ -1576,7 +1575,8 @@ decode_keys(struct berval **bvalues, ldap_seqof_key_data **keysets_out,
             krb5_int16 *n_keysets_out, krb5_int16 *total_keys_out)
 {
     krb5_error_code err = 0;
-    krb5_int16 n_keys, i, ki, total_keys;
+    size_t n_keys, i;
+    krb5_int16 ki, total_keys;
     ldap_seqof_key_data *keysets = NULL;
 
     *keysets_out = NULL;
@@ -1589,6 +1589,8 @@ decode_keys(struct berval **bvalues, ldap_seqof_key_data **keysets_out,
         if (bvalues[i]->bv_len > 0)
             n_keys++;
     }
+    if (n_keys > INT16_MAX / 2)
+        return EOVERFLOW;
 
     keysets = k5calloc(n_keys, sizeof(ldap_seqof_key_data), &err);
     if (keysets == NULL)

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_realm.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_realm.c
@@ -117,7 +117,7 @@ krb5_error_code
 krb5_ldap_list_realm(krb5_context context, char ***realms)
 {
     char                        **values = NULL;
-    unsigned int                i = 0;
+    size_t                      i = 0;
     int                         count = 0;
     krb5_error_code             st = 0, tempst = 0;
     LDAP                        *ld = NULL;
@@ -209,8 +209,8 @@ krb5_ldap_delete_realm (krb5_context context, char *lrealm)
     char                        **values=NULL, **subtrees=NULL, **policy=NULL;
     LDAPMessage                 **result_arr=NULL, *result = NULL, *ent = NULL;
     krb5_principal              principal;
-    unsigned int                l=0, ntree=0;
-    int                         i=0, j=0, mask=0;
+    size_t                      i=0, j=0, l=0, ntree=0;
+    int                         mask=0;
     kdb5_dal_handle             *dal_handle = NULL;
     krb5_ldap_context           *ldap_context = NULL;
     krb5_ldap_server_handle     *ldap_server_handle = NULL;
@@ -348,7 +348,8 @@ krb5_ldap_modify_realm(krb5_context context, krb5_ldap_realm_params *rparams,
     krb5_error_code       st=0;
     char                  **strval=NULL, *strvalprc[5]={NULL};
     LDAPMod               **mods = NULL;
-    int                   objectmask=0,k=0;
+    size_t                k=0;
+    int                   objectmask=0;
     kdb5_dal_handle       *dal_handle=NULL;
     krb5_ldap_context     *ldap_context=NULL;
     krb5_ldap_server_handle *ldap_server_handle=NULL;
@@ -582,7 +583,8 @@ krb5_ldap_create_realm(krb5_context context, krb5_ldap_realm_params *rparams,
     char                        *strval[4]={NULL};
     char                        *contref[2]={NULL};
     LDAPMod                     **mods = NULL;
-    int                         i=0, objectmask=0, subtreecount=0;
+    size_t                      i=0, subtreecount=0;
+    int                         objectmask=0;
     kdb5_dal_handle             *dal_handle=NULL;
     krb5_ldap_context           *ldap_context=NULL;
     krb5_ldap_server_handle     *ldap_server_handle=NULL;
@@ -722,7 +724,7 @@ krb5_ldap_read_realm_params(krb5_context context, char *lrealm,
     kdb5_dal_handle        *dal_handle=NULL;
     krb5_ldap_context      *ldap_context=NULL;
     krb5_ldap_server_handle *ldap_server_handle=NULL;
-    int x=0;
+    size_t x=0;
 
     SETUP_CONTEXT ();
 
@@ -865,7 +867,7 @@ cleanup:
 void
 krb5_ldap_free_realm_params(krb5_ldap_realm_params *rparams)
 {
-    int i=0;
+    size_t i=0;
 
     if (rparams) {
         if (rparams->realmdn)

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_realm.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_realm.h
@@ -58,7 +58,7 @@ typedef struct _krb5_ldap_realm_params {
     char          *containerref;
     int           search_scope;
     int           upenabled;
-    int           subtreecount;
+    size_t        subtreecount;
     krb5_int32    max_life;
     krb5_int32    max_renewable_life;
     krb5_int32    tktflags;

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_tkt_policy.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_tkt_policy.c
@@ -38,7 +38,7 @@
 static void
 free_list(char **list)
 {
-    int i;
+    size_t i;
 
     for (i = 0; list != NULL && list[i] != NULL; i++)
         free(list[i]);
@@ -355,7 +355,7 @@ cleanup:
 krb5_error_code
 krb5_ldap_list_policy(krb5_context context, char *containerdn, char ***policy)
 {
-    int                         i, j, count;
+    size_t                      i, j, count;
     char                        **list = NULL;
     char                        *policycontainerdn = containerdn;
     kdb5_dal_handle             *dal_handle=NULL;

--- a/src/plugins/kdb/lmdb/kdb_lmdb.c
+++ b/src/plugins/kdb/lmdb/kdb_lmdb.c
@@ -145,7 +145,8 @@ configure_context(krb5_context context, const char *conf_section,
     char *pval = NULL;
     const char *path = NULL;
     profile_t profile = context->profile;
-    int i, bval, ival;
+    size_t i;
+    int bval, ival;
 
     dbc = k5alloc(sizeof(*dbc), &ret);
     if (dbc == NULL)

--- a/src/plugins/kdb/test/kdb_test.c
+++ b/src/plugins/kdb/test/kdb_test.c
@@ -615,7 +615,8 @@ static void
 change_auth_indicators(krb5_context context, krb5_data ***auth_indicators)
 {
     krb5_data **inds, d;
-    int i, val;
+    size_t i;
+    int val;
 
     /* If we see an auth indicator "dbincrX", replace the whole indicator list
      * with "dbincr{X+1}". */

--- a/src/plugins/preauth/pkinit/pkinit_clnt.c
+++ b/src/plugins/preauth/pkinit/pkinit_clnt.c
@@ -361,7 +361,7 @@ verify_kdc_san(krb5_context context,
     char **certhosts = NULL, **cfghosts = NULL, **hostptr;
     krb5_principal *princs = NULL;
     unsigned char ***get_dns;
-    int i, j;
+    size_t i, j;
 
     *valid_san = 0;
     *need_eku_checking = 1;
@@ -758,7 +758,7 @@ pkinit_client_prep_questions(krb5_context context,
     krb5_error_code retval;
     pkinit_context plgctx = (pkinit_context)moddata;
     pkinit_req_context reqctx = (pkinit_req_context)modreq;
-    int i, n;
+    size_t i, n;
     const pkinit_deferred_id *deferred_ids;
     const char *identity;
     unsigned long ck_flags;

--- a/src/plugins/preauth/pkinit/pkinit_identity.c
+++ b/src/plugins/preauth/pkinit/pkinit_identity.c
@@ -35,7 +35,7 @@
 static void
 free_list(char **list)
 {
-    int i;
+    size_t i;
 
     if (list == NULL)
         return;
@@ -48,7 +48,7 @@ free_list(char **list)
 static krb5_error_code
 copy_list(char ***dst, char **src)
 {
-    int i;
+    size_t i;
     char **newlist;
 
     if (dst == NULL)
@@ -517,7 +517,7 @@ pkinit_identity_initialize(krb5_context context,
                            krb5_principal princ)
 {
     krb5_error_code retval = EINVAL;
-    int i;
+    size_t i;
 
     pkiDebug("%s: %p %p %p\n", __FUNCTION__, context, idopts, id_cryptoctx);
     if (!(princ &&
@@ -582,7 +582,7 @@ pkinit_identity_prompt(krb5_context context,
     krb5_error_code retval = 0;
     const char *signer_identity;
     krb5_boolean valid;
-    int i;
+    size_t i;
 
     pkiDebug("%s: %p %p %p\n", __FUNCTION__, context, idopts, id_cryptoctx);
     if (!(princ &&
@@ -686,7 +686,7 @@ pkinit_set_deferred_id(pkinit_deferred_id **identities,
                        const char *identity, unsigned long ck_flags,
                        const char *password)
 {
-    int i;
+    size_t i;
     pkinit_deferred_id *out = NULL, *ids;
     char *tmp;
 
@@ -748,7 +748,7 @@ const char *
 pkinit_find_deferred_id(pkinit_deferred_id *identities,
                         const char *identity)
 {
-    int i;
+    size_t i;
 
     for (i = 0; identities != NULL && identities[i] != NULL; i++) {
         if (strcmp(identities[i]->identity, identity) == 0)
@@ -765,7 +765,7 @@ unsigned long
 pkinit_get_deferred_id_flags(pkinit_deferred_id *identities,
                              const char *identity)
 {
-    int i;
+    size_t i;
 
     for (i = 0; identities != NULL && identities[i] != NULL; i++) {
         if (strcmp(identities[i]->identity, identity) == 0)
@@ -780,7 +780,7 @@ pkinit_get_deferred_id_flags(pkinit_deferred_id *identities,
 void
 pkinit_free_deferred_ids(pkinit_deferred_id *identities)
 {
-    int i;
+    size_t i;
 
     for (i = 0; identities != NULL && identities[i] != NULL; i++) {
         free(identities[i]->identity);

--- a/src/plugins/preauth/pkinit/pkinit_srv.c
+++ b/src/plugins/preauth/pkinit/pkinit_srv.c
@@ -73,7 +73,7 @@ pkinit_find_realm_context(krb5_context context,
 static void
 free_realm_contexts(krb5_context context, pkinit_kdc_context *realm_contexts)
 {
-    int i;
+    size_t i;
 
     if (realm_contexts == NULL)
         return;
@@ -86,7 +86,7 @@ free_realm_contexts(krb5_context context, pkinit_kdc_context *realm_contexts)
 static void
 free_certauth_handles(krb5_context context, certauth_handle *list)
 {
-    int i;
+    size_t i;
 
     if (list == NULL)
         return;
@@ -181,7 +181,7 @@ verify_client_san(krb5_context context,
     krb5_principal *princs = NULL, upn;
     krb5_boolean match;
     char **upns = NULL;
-    int i;
+    size_t i;
 #ifdef DEBUG_SAN_INFO
     char *client_string = NULL, *san_string;
 #endif
@@ -711,7 +711,7 @@ pkinit_pick_kdf_alg(krb5_context context, krb5_data **kdf_list,
     krb5_data *req_oid = NULL;
     const krb5_data *supp_oid = NULL;
     krb5_data *tmp_oid = NULL;
-    int i, j = 0;
+    size_t i, j = 0;
 
     /* if we don't find a match, return NULL value */
     *alg_oid = NULL;
@@ -1068,7 +1068,7 @@ pkinit_find_realm_context(krb5_context context,
                           krb5_kdcpreauth_moddata moddata,
                           krb5_principal princ)
 {
-    int i;
+    size_t i;
     pkinit_kdc_context *realm_contexts;
 
     if (moddata == NULL)

--- a/src/tests/asn.1/ktest.c
+++ b/src/tests/asn.1/ktest.c
@@ -1068,7 +1068,7 @@ ktest_destroy_keyblock(krb5_keyblock **kb)
 void
 ktest_empty_authorization_data(krb5_authdata **ad)
 {
-    int i;
+    size_t i;
 
     if (*ad != NULL) {
         for (i=0; ad[i] != NULL; i++)
@@ -1097,7 +1097,7 @@ ktest_destroy_authdata(krb5_authdata **ad)
 void
 ktest_empty_pa_data_array(krb5_pa_data **pad)
 {
-    int i;
+    size_t i;
 
     for (i=0; pad[i] != NULL; i++)
         ktest_destroy_pa_data(&pad[i]);
@@ -1134,7 +1134,7 @@ ktest_destroy_address(krb5_address **a)
 void
 ktest_empty_addresses(krb5_address **a)
 {
-    int i;
+    size_t i;
 
     for (i=0; a[i] != NULL; i++)
         ktest_destroy_address(&a[i]);
@@ -1173,7 +1173,7 @@ ktest_destroy_sequence_of_integer(long **soi)
 void
 ktest_destroy_sequence_of_ticket(krb5_ticket ***sot)
 {
-    int i;
+    size_t i;
 
     for (i=0; (*sot)[i] != NULL; i++)
         ktest_destroy_ticket(&(*sot)[i]);
@@ -1220,7 +1220,7 @@ ktest_destroy_etype_info_entry(krb5_etype_info_entry *i)
 void
 ktest_destroy_etype_info(krb5_etype_info_entry **info)
 {
-    int i;
+    size_t i;
 
     for (i = 0; info[i] != NULL; i++)
         ktest_destroy_etype_info_entry(info[i]);
@@ -1371,7 +1371,7 @@ ktest_destroy_cred_info(krb5_cred_info **ci)
 void
 ktest_destroy_sequence_of_cred_info(krb5_cred_info ***soci)
 {
-    int i;
+    size_t i;
 
     for (i = 0; (*soci)[i] != NULL; i++)
         ktest_destroy_cred_info(&(*soci)[i]);
@@ -1413,7 +1413,7 @@ ktest_empty_cred(krb5_cred *c)
 void
 ktest_destroy_last_req(krb5_last_req_entry ***lr)
 {
-    int i;
+    size_t i;
 
     if (*lr) {
         for (i=0; (*lr)[i] != NULL; i++)

--- a/src/util/profile/prof_init.c
+++ b/src/util/profile/prof_init.c
@@ -326,7 +326,7 @@ profile_init_path(const_profile_filespec_list_t filepath,
                   profile_t *ret_profile)
 {
     unsigned int n_entries;
-    int i;
+    size_t i;
     unsigned int ent_len;
     const char *s, *t;
     profile_filespec_t *filenames;
@@ -349,7 +349,8 @@ profile_init_path(const_profile_filespec_list_t filepath,
         filenames[i] = (char*) malloc(ent_len + 1);
         if (filenames[i] == 0) {
             /* if malloc fails, free the ones that worked */
-            while(--i >= 0) free(filenames[i]);
+            while (i > 0)
+                free(filenames[--i]);
             free(filenames);
             return ENOMEM;
         }
@@ -367,7 +368,8 @@ profile_init_path(const_profile_filespec_list_t filepath,
                                 ret_profile);
 
     /* count back down and free the entries */
-    while(--i >= 0) free(filenames[i]);
+    while (i > 0)
+        free(filenames[--i]);
     free(filenames);
 
     return retval;

--- a/src/util/support/plugins.c
+++ b/src/util/support/plugins.c
@@ -292,8 +292,9 @@ krb5int_plugin_file_handle_array_add (struct plugin_file_handle ***harray, size_
 static void
 krb5int_plugin_file_handle_array_free (struct plugin_file_handle **harray)
 {
+    size_t i;
+
     if (harray != NULL) {
-        int i;
         for (i = 0; harray[i] != NULL; i++) {
             krb5int_close_plugin (harray[i]);
         }
@@ -313,8 +314,9 @@ krb5int_plugin_file_handle_array_free (struct plugin_file_handle **harray)
 static void
 krb5int_free_plugin_filenames (char **filenames)
 {
+    size_t i;
+
     if (filenames != NULL) {
-        int i;
         for (i = 0; filenames[i] != NULL; i++) {
             free (filenames[i]);
         }
@@ -382,7 +384,7 @@ krb5int_open_plugin_dirs (const char * const *dirnames,
     struct plugin_file_handle **h = NULL;
     size_t count = 0;
     char **filenames = NULL;
-    int i;
+    size_t i;
 
     if (!err) {
         err = krb5int_plugin_file_handle_array_init (&h);
@@ -395,7 +397,7 @@ krb5int_open_plugin_dirs (const char * const *dirnames,
     for (i = 0; !err && dirnames[i] != NULL; i++) {
         if (filenames != NULL) {
             /* load plugins with names from filenames from each directory */
-            int j;
+            size_t j;
 
             for (j = 0; !err && filenames[j] != NULL; j++) {
                 struct plugin_file_handle *handle = NULL;
@@ -419,7 +421,7 @@ krb5int_open_plugin_dirs (const char * const *dirnames,
             }
         } else {
             char **fnames = NULL;
-            int j;
+            size_t j;
 
             err = k5_dir_filenames(dirnames[i], &fnames);
             for (j = 0; !err && fnames[j] != NULL; j++) {
@@ -469,8 +471,9 @@ krb5int_open_plugin_dirs (const char * const *dirnames,
 void KRB5_CALLCONV
 krb5int_close_plugin_dirs (struct plugin_dir_handle *dirhandle)
 {
+    size_t i;
+
     if (dirhandle->files != NULL) {
-        int i;
         for (i = 0; dirhandle->files[i] != NULL; i++) {
             krb5int_close_plugin (dirhandle->files[i]);
         }
@@ -507,7 +510,7 @@ krb5int_get_plugin_dir_data (struct plugin_dir_handle *dirhandle,
     }
 
     if (!err && (dirhandle != NULL) && (dirhandle->files != NULL)) {
-        int i = 0;
+        size_t i = 0;
 
         for (i = 0; !err && (dirhandle->files[i] != NULL); i++) {
             void *sym = NULL;
@@ -566,7 +569,7 @@ krb5int_get_plugin_dir_func (struct plugin_dir_handle *dirhandle,
     }
 
     if (!err && (dirhandle != NULL) && (dirhandle->files != NULL)) {
-        int i = 0;
+        size_t i = 0;
 
         for (i = 0; !err && (dirhandle->files[i] != NULL); i++) {
             void (*sym)(void) = NULL;

--- a/src/windows/kfwlogon/kfwcommon.c
+++ b/src/windows/kfwlogon/kfwcommon.c
@@ -489,7 +489,7 @@ KFW_kinit( krb5_context alt_ctx,
     krb5_creds			        my_creds;
     krb5_get_init_creds_opt     options;
     krb5_address **             addrs = NULL;
-    int                         i = 0, addr_count = 0;
+    size_t                      i = 0, addr_count = 0;
 
     if (!pkrb5_init_context)
         return 0;

--- a/src/windows/leashdll/krb5routines.c
+++ b/src/windows/leashdll/krb5routines.c
@@ -180,7 +180,7 @@ DWORD                       publicIP
     krb5_creds			        my_creds;
     krb5_get_init_creds_opt *   options = NULL;
     krb5_address **             addrs = NULL;
-    int                         i = 0, addr_count = 0;
+    size_t                      i = 0, addr_count = 0;
     int                         cc_new = 0;
     const char *                deftype = NULL;
 


### PR DESCRIPTION
When operating on arrays that don't have a specified integer bound, use size_t indexes for improved safety.  Reported by James Watt.

[This was prompted by mail from James noting that we had a function similar to the one at issue in MongoDB's CVE-2024-6381 .  I did a review of unbounded arrays in the code base and didn't come up with anything that looked exploitable, since we put a 1MB limit on messages.  But the safety of the code shouldn't depend on such long-range assumptions.]
