### PR TITLE
Fix wrong detection of moving backwards microseconds

### DIFF
--- a/src/lib/krb5/os/c_ustime.c
+++ b/src/lib/krb5/os/c_ustime.c
@@ -106,14 +106,14 @@ krb5_crypto_us_timeofday(krb5_timestamp *seconds, krb5_int32 *microseconds)
        need to properly handle the case where the administrator intentionally
        adjusted time backwards. */
     if (now.sec == ts_incr(last_time.sec, -1) ||
-        (now.sec == last_time.sec && !ts_after(last_time.usec, now.usec))) {
+        (now.sec == last_time.sec && now.usec <= last_time.usec)) {
         /* Correct 'now' to be exactly one microsecond later than 'last_time'.
            Note that _because_ we perform this hack, 'now' may be _earlier_
            than 'last_time', even though the system time is monotonically
            increasing. */
 
         now.sec = last_time.sec;
-        now.usec = ts_incr(last_time.usec, 1);
+        now.usec = last_time.usec + 1;
         if (now.usec >= 1000000) {
             now.sec = ts_incr(now.sec, 1);
             now.usec = 0;


### PR DESCRIPTION
in `krb5_crypto_us_timeofday()`

Condition is expected to check for "microseconds are moving backwards" but actual code checks an opposite thing:
 !ts_after(last_time.usec, now.usec) => !(last_time.usec > now.usec)
 => last_time.usec <= now.usec

This results in ts always being forced to `ts_incr(last_time.usec, 1)` within same second.

Can be illustrated by following strace example:
```
11:12:52.734330 write(32, "... [15981] 1727950372.024394: SPAKE challenge received ...", 233) = 233
11:12:52.909504 getrandom("...", 32, 0) = 32
11:12:52.936009 getpid()                = 15981
11:12:52.995094 write(32, "... [15981] 1727950372.024395: SPAKE key generated ...", 219) = 219
```
 - internal libkrb5 ts changed by 0.000001 when only between call to `getrandom()` (used in calculation of SPAKE key) and call to `getpid()` (from `krb5int_trace()`) elapsed 0.26505

Looks like bug was introduced in a60db180211a383bd382afe729e9309acb8dcf53 where original condition `(now.usec <= last_time.usec)` was inverted.