### PR TITLE
Avoid using locking krb5_crypto_us_timeofday() in krb5int_trace()

### DIFF
--- a/src/include/k5-int.h
+++ b/src/include/k5-int.h
@@ -698,6 +698,7 @@ krb5_error_code krb5int_c_copy_keyblock_contents(krb5_context context,
                                                  const krb5_keyblock *from,
                                                  krb5_keyblock *to);
 
+krb5_error_code k5_us_timeofday(krb5_timestamp *, krb5_int32 *);
 krb5_error_code krb5_crypto_us_timeofday(krb5_timestamp *, krb5_int32 *);
 
 /*

--- a/src/lib/krb5/os/c_ustime.c
+++ b/src/lib/krb5/os/c_ustime.c
@@ -73,6 +73,21 @@ get_time_now(struct time_now *n)
 
 #endif
 
+krb5_error_code
+k5_us_timeofday(krb5_timestamp *seconds, krb5_int32 *microseconds)
+{
+    struct time_now now;
+    krb5_error_code err;
+
+    err = get_time_now(&now);
+    if (err)
+        return err;
+
+    *seconds = now.sec;
+    *microseconds = now.usec;
+    return 0;
+}
+
 static struct time_now last_time;
 
 krb5_error_code

--- a/src/lib/krb5/os/trace.c
+++ b/src/lib/krb5/os/trace.c
@@ -411,7 +411,7 @@ krb5int_trace(krb5_context context, const char *fmt, ...)
     str = trace_format(context, fmt, ap);
     if (str == NULL)
         goto cleanup;
-    if (krb5_crypto_us_timeofday(&sec, &usec) != 0)
+    if (k5_us_timeofday(&sec, &usec) != 0)
         goto cleanup;
     if (asprintf(&msg, "[%d] %u.%06d: %s\n", (int)getpid(),
                  (unsigned int)sec, (int)usec, str) < 0)


### PR DESCRIPTION
Logger doesn't need unique timestamps, so expensive mutex lock within krb5_crypto_us_timeofday() makes logger slower for no reason.

New helper - krb5int_us_timeofday() - is merely a wrapper around existing get_time_now() and doesn't need to be exported. A wrapper looks better than pulling 'struct time_now' to a header.