### PR TITLE
Update upload action versions in CI scripts

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,7 +1,7 @@
 name: CIFuzz
 
 on:
-    pull_request: {paths: [src/**, .github/workflows/build.yml]}
+    pull_request: {paths: [src/**, .github/workflows/cifuzz.yml]}
 
 permissions: {}
 jobs:
@@ -31,7 +31,7 @@ jobs:
             path: ./out/artifacts
         - name: Upload Sarif
           if: always() && steps.build.outcome == 'success'
-          uses: github/codeql-action/upload-sarif@v2
+          uses: github/codeql-action/upload-sarif@v3
           with:
             # Path to SARIF file relative to the root of the repository
             sarif_file: cifuzz-sarif/results.sarif

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -34,7 +34,7 @@ jobs:
                 cd src/doc
                 make -f Makefile.in SPHINX_ARGS=-W htmlsrc
             - name: Upload HTML
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                   name: html
                   path: doc/html


### PR DESCRIPTION
Increment the versions of the upload actions in doc.yml and cifuzz.yml as documented in:

https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/ https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/

Also fix the conditional in cifuzz.yml to react to changes in itself, not in build.yml.