### PR TITLE
Profile: Enable OSS-Fuzz build macro And  Fix: Pac memory leak & Off-by-one  

### DIFF
--- a/src/lib/krb5/krb/pac.c
+++ b/src/lib/krb5/krb/pac.c
@@ -146,7 +146,7 @@ k5_pac_locate_buffer(krb5_context context, const krb5_pac pac, uint32_t type,
     if (buffer == NULL)
         return ENOENT;
 
-    assert(buffer->offset < pac->data.length);
+    assert(buffer->offset <= pac->data.length);
     assert(buffer->size <= pac->data.length - buffer->offset);
 
     if (data_out != NULL)

--- a/src/lib/krb5/krb/pac.c
+++ b/src/lib/krb5/krb/pac.c
@@ -557,9 +557,11 @@ verify_pac_checksums(krb5_context context, const krb5_pac pac,
         ret = k5_pac_locate_buffer(context, pac, KRB5_PAC_SERVER_CHECKSUM,
                                    &server_checksum);
         if (ret)
-            return ret;
-        if (server_checksum.length < PAC_SIGNATURE_DATA_LENGTH)
-            return KRB5_BAD_MSIZE;
+            goto cleanup;
+        if (server_checksum.length < PAC_SIGNATURE_DATA_LENGTH) {
+            ret = KRB5_BAD_MSIZE;
+            goto cleanup;
+        }
         server_checksum.data += PAC_SIGNATURE_DATA_LENGTH;
         server_checksum.length -= PAC_SIGNATURE_DATA_LENGTH;
 

--- a/src/util/profile/prof_parse.c
+++ b/src/util/profile/prof_parse.c
@@ -292,6 +292,7 @@ static errcode_t parse_line(char *line, struct parse_state *state,
 {
     char    *cp;
 
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (strncmp(line, "include", 7) == 0 && isspace(line[7])) {
         cp = skip_over_blanks(line + 7);
         strip_line(cp);
@@ -302,6 +303,7 @@ static errcode_t parse_line(char *line, struct parse_state *state,
         strip_line(cp);
         return parse_include_dir(cp, state->root_section);
     }
+#endif
     switch (state->state) {
     case STATE_INIT_COMMENT:
         if (strncmp(line, "module", 6) == 0 && isspace(line[6])) {


### PR DESCRIPTION
First: https://github.com/krb5/krb5/commit/3911709d968926659ead530a08aaa2bbce640f01

While it is not an issue for fuzz_profile to handle non-existent paths or directories and return an error, when I was looking at code coverage reports https://github.com/google/oss-fuzz/issues/12282, I think there is a problem with the coverage sanitizer.

Second and Third: https://github.com/krb5/krb5/commit/9cbcbf451a8cbebb0e6a41da9816ca562d176d97 https://github.com/krb5/krb5/commit/7fc776398eca8bc8cc1931f762033c85d60d1993

These are new bugs that form PR https://github.com/krb5/krb5/pull/1366
I am making a separate PR, because I think my last PR is bloated.

Reproduce:
```bash
./tests/fuzzing/fuzz_pac leak-e5067f20c8a4c43c783ed8e754fb4608e12cd6ac.zip
./tests/fuzzing/fuzz_pac crash-ec1315e247fe542b4376085207e7e3c6dfcb14da.zip
```

[leak-e5067f20c8a4c43c783ed8e754fb4608e12cd6ac.zip](https://github.com/user-attachments/files/17337272/leak-e5067f20c8a4c43c783ed8e754fb4608e12cd6ac.zip)
[crash-ec1315e247fe542b4376085207e7e3c6dfcb14da.zip](https://github.com/user-attachments/files/17337274/crash-ec1315e247fe542b4376085207e7e3c6dfcb14da.zip)

#### Foot-Note 
- `crash-ec1315e247fe542b4376085207e7e3c6dfcb14da.zip`
-  `leak-e5067f20c8a4c43c783ed8e754fb4608e12cd6ac.zip`
 Are not zip files, I changed the extension because GitHub doesn't allow me to upload files with no extension.


## HOW-to-merge
1. https://github.com/krb5/krb5/pull/1378
2. https://github.com/krb5/krb5/pull/1379
3. https://github.com/krb5/krb5/pull/1366