### PR TITLE
Allow null keyblocks in IOV checksum functions

### DIFF
--- a/src/lib/crypto/krb/make_checksum_iov.c
+++ b/src/lib/crypto/krb/make_checksum_iov.c
@@ -81,12 +81,14 @@ krb5_c_make_checksum_iov(krb5_context context,
                          krb5_crypto_iov *data,
                          size_t num_data)
 {
-    krb5_key key;
+    krb5_key key = NULL;
     krb5_error_code ret;
 
-    ret = krb5_k_create_key(context, keyblock, &key);
-    if (ret != 0)
-        return ret;
+    if (keyblock != NULL) {
+        ret = krb5_k_create_key(context, keyblock, &key);
+        if (ret != 0)
+            return ret;
+    }
     ret = krb5_k_make_checksum_iov(context, cksumtype, key, usage,
                                    data, num_data);
     krb5_k_free_key(context, key);

--- a/src/lib/crypto/krb/verify_checksum_iov.c
+++ b/src/lib/crypto/krb/verify_checksum_iov.c
@@ -88,12 +88,14 @@ krb5_c_verify_checksum_iov(krb5_context context,
                            size_t num_data,
                            krb5_boolean *valid)
 {
-    krb5_key key;
+    krb5_key key = NULL;
     krb5_error_code ret;
 
-    ret = krb5_k_create_key(context, keyblock, &key);
-    if (ret != 0)
-        return ret;
+    if (keyblock != NULL) {
+        ret = krb5_k_create_key(context, keyblock, &key);
+        if (ret != 0)
+            return ret;
+    }
     ret = krb5_k_verify_checksum_iov(context, checksum_type, key, usage, data,
                                      num_data, valid);
     krb5_k_free_key(context, key);


### PR DESCRIPTION
Null keyblocks are allowed by the libk5crypto checksum functions when the checksum type is not keyed.  However, krb5_c_make_checksum_iov() and krb5_c_verify_checksum_iov() crash on null keyblock inputs because they do not check before converting to krb5_key as their non-IOV variants do.  Add the null checks.

[Prompted by a comment by @jrisc in one of the libkrad PR threads]
