### PR TITLE
Prevent late initialization of GSS error map

### DIFF
--- a/src/lib/gssapi/generic/Makefile.in
+++ b/src/lib/gssapi/generic/Makefile.in
@@ -1,6 +1,6 @@
 mydir=lib$(S)gssapi$(S)generic
 BUILDTOP=$(REL)..$(S)..$(S)..
-LOCALINCLUDES = -I. -I$(srcdir) -I$(srcdir)/..
+LOCALINCLUDES = -I. -I$(srcdir) -I$(srcdir)/../mechglue
 
 ##DOS##BUILDTOP = ..\..\..
 ##DOS##PREFIXDIR=generic

--- a/src/lib/gssapi/generic/deps
+++ b/src/lib/gssapi/generic/deps
@@ -59,12 +59,13 @@ util_buffer_set.so util_buffer_set.po $(OUTPRE)util_buffer_set.$(OBJEXT): \
   gssapi_generic.h util_buffer_set.c
 util_errmap.so util_errmap.po $(OUTPRE)util_errmap.$(OBJEXT): \
   $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/gssapi/gssapi.h \
-  $(BUILDTOP)/include/gssapi/gssapi_alloc.h $(BUILDTOP)/include/krb5/krb5.h \
-  $(COM_ERR_DEPS) $(top_srcdir)/include/k5-buf.h $(top_srcdir)/include/k5-input.h \
-  $(top_srcdir)/include/k5-platform.h $(top_srcdir)/include/k5-thread.h \
-  $(top_srcdir)/include/krb5.h errmap.h gssapiP_generic.h \
-  gssapi_err_generic.h gssapi_ext.h gssapi_generic.h \
-  util_errmap.c
+  $(BUILDTOP)/include/gssapi/gssapi_alloc.h $(BUILDTOP)/include/gssapi/gssapi_ext.h \
+  $(BUILDTOP)/include/krb5/krb5.h $(COM_ERR_DEPS) $(srcdir)/../mechglue/mechglue.h \
+  $(srcdir)/../mechglue/mglueP.h $(top_srcdir)/include/k5-buf.h \
+  $(top_srcdir)/include/k5-input.h $(top_srcdir)/include/k5-platform.h \
+  $(top_srcdir)/include/k5-thread.h $(top_srcdir)/include/krb5.h \
+  errmap.h gssapiP_generic.h gssapi_err_generic.h gssapi_ext.h \
+  gssapi_generic.h util_errmap.c
 util_seqstate.so util_seqstate.po $(OUTPRE)util_seqstate.$(OBJEXT): \
   $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/gssapi/gssapi.h \
   $(BUILDTOP)/include/gssapi/gssapi_alloc.h $(COM_ERR_DEPS) \

--- a/src/lib/gssapi/generic/util_errmap.c
+++ b/src/lib/gssapi/generic/util_errmap.c
@@ -25,6 +25,7 @@
  */
 
 #include "gssapiP_generic.h"
+#include <mglueP.h>
 #include <string.h>
 #ifndef _WIN32
 #include <unistd.h>
@@ -181,6 +182,9 @@ OM_uint32 gssint_mecherrmap_map(OM_uint32 minor, const gss_OID_desc * oid)
         f = stderr;
 #endif
 
+    if (gssint_mechglue_initialize_library() != 0)
+        return 0;
+
     me.code = minor;
     me.mech = *oid;
     k5_mutex_lock(&mutex);
@@ -249,7 +253,7 @@ int gssint_mecherrmap_get(OM_uint32 minor, gss_OID mech_oid,
 {
     const struct mecherror *p;
 
-    if (minor == 0) {
+    if (minor == 0 || gssint_mechglue_initialize_library() != 0) {
         return EINVAL;
     }
     k5_mutex_lock(&mutex);


### PR DESCRIPTION
Some of the peripheral libgssapi_krb5 utility functions, such as gss_str_to_oid(), do not access the mechanism list and therefore do not reach any of the current calls to
gssint_mechglue_initialize_library().  If one of these functions is called early and produces an error, its call to map_error() will operate on the uninitialized error map.  When the library is later initialized, any entries added to the error map this way will be leaked.

Add library initialization calls to gssint_mecherrmap_map() and gssint_mecherrmap_get() to ensure that the error map is initialized before it is operated on.