### PR TITLE
Fix: two use-of-uninitialized-value bug

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -466,7 +466,7 @@ AC_CONFIG_HEADERS(include/autoconf.h, [echo timestamp > include/autoconf.stamp])
 AC_C_CONST
 AC_HEADER_DIRENT
 AC_FUNC_STRERROR_R
-AC_CHECK_FUNCS(strdup setvbuf seteuid setresuid setreuid setegid setresgid setregid setsid flock fchmod chmod strptime geteuid setenv unsetenv getenv gmtime_r localtime_r bswap16 bswap64 mkstemp getusershell access getcwd srand48 srand srandom stat strchr strerror timegm explicit_bzero explicit_memset getresuid getresgid)
+AC_CHECK_FUNCS(strdup setvbuf seteuid setresuid setreuid setegid setresgid setregid setsid flock fchmod chmod strptime geteuid setenv unsetenv getenv gmtime_r localtime_r bswap16 bswap64 mkstemp getusershell access getcwd srand48 srand srandom stat strchr strerror timegm explicit_bzero explicit_memset getresuid getresgid getentropy)
 
 AC_CHECK_FUNC(mkstemp,
 [MKSTEMP_ST_OBJ=

--- a/src/kdc/replay.c
+++ b/src/kdc/replay.c
@@ -130,7 +130,7 @@ krb5_error_code
 kdc_init_lookaside(krb5_context context)
 {
     krb5_error_code ret;
-    uint8_t seed[K5_HASH_SEED_LEN];
+    uint8_t seed[K5_HASH_SEED_LEN] = {0};
     krb5_data d = make_data(seed, sizeof(seed));
 
     ret = krb5_c_random_make_octets(context, &d);

--- a/src/lib/crypto/krb/prng.c
+++ b/src/lib/crypto/krb/prng.c
@@ -96,7 +96,27 @@ cleanup:
 static krb5_boolean
 get_os_entropy(unsigned char *buf, size_t len)
 {
-#if defined(__linux__) && defined(SYS_getrandom)
+#if defined(HAVE_GETENTROPY)
+    int r;
+    size_t seg;
+
+    /* getentropy() has a maximum length of 256. */
+    while (len > 0) {
+        seg = (len > 256) ? 256 : len;
+        r = getentropy(buf, len);
+        if (r != 0)
+            break;
+        len -= seg;
+        buf += seg;
+    }
+    if (len == 0)
+        return TRUE;
+#elif defined(__linux__) && defined(SYS_getrandom)
+    /*
+     * Linux added SYS_getrandom in 3.17 (2014), but glibc did not have a
+     * wrapper until 2.25 (2017).  This block can be deleted when that interval
+     * is far in the past.
+     */
     int r;
 
     while (len > 0) {
@@ -104,9 +124,6 @@ get_os_entropy(unsigned char *buf, size_t len)
          * Pull from the /dev/urandom pool, but require it to have been seeded.
          * This ensures strong randomness while only blocking during first
          * system boot.
-         *
-         * glibc does not currently provide a binding for getrandom:
-         * https://sourceware.org/bugzilla/show_bug.cgi?id=17252
          */
         errno = 0;
         r = syscall(SYS_getrandom, buf, len, 0);

--- a/src/lib/krb5/keytab/ktdefault.c
+++ b/src/lib/krb5/keytab/ktdefault.c
@@ -37,7 +37,7 @@
 krb5_error_code KRB5_CALLCONV
 krb5_kt_default(krb5_context context, krb5_keytab *id)
 {
-    char defname[BUFSIZ];
+    char defname[BUFSIZ] = {0};
     krb5_error_code retval;
 
     if ((retval = krb5_kt_default_name(context, defname, sizeof(defname))))


### PR DESCRIPTION
## 1-Fix https://github.com/krb5/krb5/pull/1386/commits/06fa148feecb6094042dec64b710fbc2dc3053a5

```bash
./tests/fuzzing/fuzz_kdc crash-fuzz_kdc.zip
```
### MSan log
```log
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 1221491691
INFO: Loaded 1 modules   (14578 inline 8-bit counters): 14578 [0xaec580, 0xaefe72), 
INFO: Loaded 1 PC tables (14578 PCs): 14578 [0xa65188,0xa9e0a8), 
./tests/fuzzing/fuzz_kdc: Running 1 inputs 1 time(s) each.
Running: crash-fuzz_kdc.zip
==1722250==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x9fde48 in load_64_le /home/magic/krb5.review/krb5.chnages/build/util/support/../.././../src/include/k5-platform.h:718:5
    #1 0x9fe95a in k5_hashtab_create /home/magic/krb5.review/krb5.chnages/build/util/support/../.././../src/util/support/hashtab.c:136:18
    #2 0x505f1a in kdc_init_lookaside /home/magic/krb5.review/krb5.chnages/build/tests/fuzzing/../.././../src/tests/fuzzing/../../kdc/replay.c:139:11
    #3 0x509716 in LLVMFuzzerTestOneInput /home/magic/krb5.review/krb5.chnages/build/tests/fuzzing/../.././../src/tests/fuzzing/fuzz_kdc.c:56:11
    #4 0x4518a4 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/magic/krb5.review/krb5.chnages/build/tests/fuzzing/fuzz_kdc+0x4518a4) (BuildId: 2317b0e6f782d90b77a32ca501d194fe93307392)
    #5 0x43a6fa in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/home/magic/krb5.review/krb5.chnages/build/tests/fuzzing/fuzz_kdc+0x43a6fa) (BuildId: 2317b0e6f782d90b77a32ca501d194fe93307392)
    #6 0x440040 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/magic/krb5.review/krb5.chnages/build/tests/fuzzing/fuzz_kdc+0x440040) (BuildId: 2317b0e6f782d90b77a32ca501d194fe93307392)
    #7 0x46bdb6 in main (/home/magic/krb5.review/krb5.chnages/build/tests/fuzzing/fuzz_kdc+0x46bdb6) (BuildId: 2317b0e6f782d90b77a32ca501d194fe93307392)
    #8 0x7fa00b639087 in __libc_start_call_main (/lib64/libc.so.6+0x2a087) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)
    #9 0x7fa00b63914a in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x2a14a) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)
    #10 0x434d14 in _start (/home/magic/krb5.review/krb5.chnages/build/tests/fuzzing/fuzz_kdc+0x434d14) (BuildId: 2317b0e6f782d90b77a32ca501d194fe93307392)

SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/magic/krb5.review/krb5.chnages/build/util/support/../.././../src/include/k5-platform.h:718:5 in load_64_le
Exiting
```

## 2-Fix https://github.com/krb5/krb5/pull/1386/commits/770332ff2d9d5c5324c6aef5923a7311ad87576a

```bash
./tests/fuzzing/fuzz_gss crash-fuzz_gss.zip
```

### MSan log
```log
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 1839722398
INFO: Loaded 1 modules   (24216 inline 8-bit counters): 24216 [0xdde2a0, 0xde4138), 
INFO: Loaded 1 PC tables (24216 PCs): 24216 [0xd21db8,0xd80738), 
./tests/fuzzing/fuzz_gss: Running 1 inputs 1 time(s) each.
Running: crash-fuzz_gss.zip
Uninitialized bytes in strchr at offset 0 inside [0x7ffc34512650, 5)
==1728296==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x7df026 in krb5_kt_resolve /home/magic/krb5.review/krb5.chnages/build/lib/krb5/keytab/../../.././../src/lib/krb5/keytab/ktbase.c:163:10
    #1 0x7e0efa in krb5_kt_default /home/magic/krb5.review/krb5.chnages/build/lib/krb5/keytab/../../.././../src/lib/krb5/keytab/ktdefault.c:45:12
    #2 0x73d7d2 in acquire_accept_cred /home/magic/krb5.review/krb5.chnages/build/lib/gssapi/krb5/../../.././../src/lib/gssapi/krb5/acquire_cred.c:190:20
    #3 0x73b2e7 in acquire_cred_context /home/magic/krb5.review/krb5.chnages/build/lib/gssapi/krb5/../../.././../src/lib/gssapi/krb5/acquire_cred.c:845:15
    #4 0x732548 in acquire_cred /home/magic/krb5.review/krb5.chnages/build/lib/gssapi/krb5/../../.././../src/lib/gssapi/krb5/acquire_cred.c:948:11
    #5 0x731dc5 in krb5_gss_acquire_cred /home/magic/krb5.review/krb5.chnages/build/lib/gssapi/krb5/../../.././../src/lib/gssapi/krb5/acquire_cred.c:1102:12
    #6 0x715a66 in kg_accept_krb5 /home/magic/krb5.review/krb5.chnages/build/lib/gssapi/krb5/../../.././../src/lib/gssapi/krb5/accept_sec_context.c:734:24
    #7 0x7134f2 in krb5_gss_accept_sec_context_ext /home/magic/krb5.review/krb5.chnages/build/lib/gssapi/krb5/../../.././../src/lib/gssapi/krb5/accept_sec_context.c:1286:12
    #8 0x71fa4e in krb5_gss_accept_sec_context /home/magic/krb5.review/krb5.chnages/build/lib/gssapi/krb5/../../.././../src/lib/gssapi/krb5/accept_sec_context.c:1308:12
    #9 0x508672 in gss_accept_sec_context /home/magic/krb5.review/krb5.chnages/build/lib/gssapi/mechglue/../../.././../src/lib/gssapi/mechglue/g_accept_sec_context.c:249:15
    #10 0x5060e5 in LLVMFuzzerTestOneInput /home/magic/krb5.review/krb5.chnages/build/tests/fuzzing/../.././../src/tests/fuzzing/fuzz_gss.c:62:5
    #11 0x4518d4 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/home/magic/krb5.review/krb5.chnages/build/tests/fuzzing/fuzz_gss+0x4518d4) (BuildId: 43732c7c14fc2a79b0ca258f30f0284a5e0996b8)
    #12 0x43a72a in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/home/magic/krb5.review/krb5.chnages/build/tests/fuzzing/fuzz_gss+0x43a72a) (BuildId: 43732c7c14fc2a79b0ca258f30f0284a5e0996b8)
    #13 0x440070 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/home/magic/krb5.review/krb5.chnages/build/tests/fuzzing/fuzz_gss+0x440070) (BuildId: 43732c7c14fc2a79b0ca258f30f0284a5e0996b8)
    #14 0x46bde6 in main (/home/magic/krb5.review/krb5.chnages/build/tests/fuzzing/fuzz_gss+0x46bde6) (BuildId: 43732c7c14fc2a79b0ca258f30f0284a5e0996b8)
    #15 0x7fa912639087 in __libc_start_call_main (/lib64/libc.so.6+0x2a087) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)
    #16 0x7fa91263914a in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x2a14a) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)
    #17 0x434d44 in _start (/home/magic/krb5.review/krb5.chnages/build/tests/fuzzing/fuzz_gss+0x434d44) (BuildId: 43732c7c14fc2a79b0ca258f30f0284a5e0996b8)

SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/magic/krb5.review/krb5.chnages/build/lib/krb5/keytab/../../.././../src/lib/krb5/keytab/ktbase.c:163:10 in krb5_kt_resolve
Exiting
```


[crash-fuzz_kdc.zip](https://github.com/user-attachments/files/17554579/crash-fuzz_kdc.zip)
[crash-fuzz_gss.zip](https://github.com/user-attachments/files/17554681/crash-fuzz_gss.zip)
