### PR TITLE
Prevent undefined shift in decode_krb5_flags()

### DIFF
--- a/src/lib/krb5/asn.1/asn1_k_encode.c
+++ b/src/lib/krb5/asn.1/asn1_k_encode.c
@@ -250,7 +250,7 @@ decode_krb5_flags(const taginfo *t, const uint8_t *asn1, size_t len, void *val)
         return ret;
     /* Copy up to 32 bits into f, starting at the most significant byte. */
     for (i = 0; i < blen && i < 4; i++)
-        f |= bits[i] << (8 * (3 - i));
+        f |= (uint32_t)bits[i] << (8 * (3 - i));
     *(krb5_flags *)val = f;
     free(bits);
     return 0;


### PR DESCRIPTION
In the statement "f |= bits[i] << (8 * (3 - i))", bits[i] is implicitly promoted from uint8_t to int according to the integer promotion rules (C99 6.3.1.1).  If i is 0 and bits[i] >= 128, the result cannot be represented as an int and the behavior of the shift is undefined (C99 6.5.7).  To ensure that the shift operation is defined, cast bits[i] to uint32_t.

(f and the function output are int32_t, but the conversion of uint32_t to int32_t is implementation-defined when the value cannot be represented, not undefined.  We check in configure.ac that the platform is two's complement.)