### PR TITLE
Remove missing SecurID header file

### DIFF
--- a/src/plugins/preauth/securid_sam2/securid2.c
+++ b/src/plugins/preauth/securid_sam2/securid2.c
@@ -45,7 +45,6 @@
 #include <syslog.h>
 #include <acexport.h>
 #include <sdi_defs.h>
-#include <sdi_athd.h>
 #include "extern.h"
 
 #define KRB5_SAM_SECURID_NEXT_CHALLENGE_MAGIC 0x5ec1d000


### PR DESCRIPTION
It turns out the SecurID SDK no longer provides sdi_athd.h, so remove our include of it.