### PR TITLE
db2 and klmdb: support principal aliases

### DIFF
--- a/doc/admin/admin_commands/kadmin_local.rst
+++ b/doc/admin/admin_commands/kadmin_local.rst
@@ -460,6 +460,24 @@ This command requires the **add** and **delete** privileges.
 
 Alias: **renprinc**
 
+.. _add_alias:
+
+add_alias
+~~~~~~~~~
+
+    **add_alias** *alias_princ* *target_princ*
+
+Create an alias *alias_princ* pointing to *target_princ*.  Aliases may
+be chained (that is, *target_princ* may itself be an alias) up to a
+depth of 10.
+
+This command requires the **add** privilege for *alias_princ* and the
+**modify** privilege for *target_princ*.
+
+(New in release 1.22.)
+
+Aliases: **alias**
+
 .. _delete_principal:
 
 delete_principal
@@ -467,8 +485,8 @@ delete_principal
 
     **delete_principal** [**-force**] *principal*
 
-Deletes the specified *principal* from the database.  This command
-prompts for deletion, unless the **-force** option is given.
+Deletes the specified *principal* or alias from the database.  This
+command prompts for deletion, unless the **-force** option is given.
 
 This command requires the **delete** privilege.
 

--- a/doc/admin/admin_commands/kdb5_util.rst
+++ b/doc/admin/admin_commands/kdb5_util.rst
@@ -376,6 +376,14 @@ Options:
 
 Dump types:
 
+**alias**
+    principal alias information
+
+    **aliasname**
+        the name of the alias
+    **targetname**
+        the target of the alias
+
 **keydata**
     principal encryption key information, including actual key data
     (which is still encrypted in the master key)

--- a/doc/admin/conf_ldap.rst
+++ b/doc/admin/conf_ldap.rst
@@ -112,9 +112,10 @@ Configuring Kerberos with OpenLDAP back-end
     details.
 
 With the LDAP back end it is possible to provide aliases for principal
-entries.  Currently we provide no administrative utilities for
-creating aliases, so it must be done by direct manipulation of the
-LDAP entries.
+entries.  Beginning in release 1.22, aliases can be added with the
+kadmin **add_alias** command, but it is also possible (in release 1.7
+or later) to provide aliases through direct manipulation of the LDAP
+entries.
 
 An entry with aliases contains multiple values of the
 *krbPrincipalName* attribute.  Since LDAP attribute values are not

--- a/doc/admin/database.rst
+++ b/doc/admin/database.rst
@@ -93,6 +93,10 @@ To view the attributes of a principal, use the kadmin`
 To generate a listing of principals, use the kadmin
 **list_principals** command.
 
+To give a principal additional names, use the kadmin **add_alias**
+command to create aliases to the principal (new in release 1.22).
+Aliases can be removed with the **delete_principal** command.
+
 
 .. _policies:
 

--- a/src/include/krb5/kadm5_auth_plugin.h
+++ b/src/include/krb5/kadm5_auth_plugin.h
@@ -34,7 +34,7 @@
  *
  * The kadm5_auth pluggable interface currently has only one supported major
  * version, which is 1.  Major version 1 has a current minor version number of
- * 1.
+ * 2.
  *
  * kadm5_auth plugin modules should define a function named
  * kadm5_auth_<modulename>_initvt, matching the signature:
@@ -244,6 +244,13 @@ typedef krb5_error_code
 (*kadm5_auth_iprop_fn)(krb5_context context, kadm5_auth_moddata data,
                        krb5_const_principal client);
 
+/* Optional: authorize an add-alias operation. */
+typedef krb5_error_code
+(*kadm5_auth_addalias_fn)(krb5_context context, kadm5_auth_moddata data,
+                          krb5_const_principal client,
+                          krb5_const_principal alias_princ,
+                          krb5_const_principal target_princ);
+
 /*
  * Optional: receive a notification that the most recent authorized operation
  * has ended.  If a kadm5_auth module is also a KDB module, it can assume that
@@ -301,6 +308,8 @@ typedef struct kadm5_auth_vtable_st {
 
     kadm5_auth_free_restrictions_fn free_restrictions;
     /* Minor version 1 ends here. */
+    kadm5_auth_addalias_fn addalias;
+    /* Minor version 2 ends here. */
 } *kadm5_auth_vtable;
 
 #endif /* KRB5_KADM5_AUTH_PLUGIN_H */

--- a/src/include/krb5/kadm5_hook_plugin.h
+++ b/src/include/krb5/kadm5_hook_plugin.h
@@ -47,7 +47,7 @@
  * does not provide strong guarantees of ABI stability.
  *
  * The kadm5_hook interface currently has only one supported major version,
- * which is 1.  Major version 1 has a current minor version number of 2.
+ * which is 1.  Major version 1 has a current minor version number of 3.
  *
  * kadm5_hook plugins should:
  * kadm5_hook_<modulename>_initvt, matching the signature:
@@ -148,6 +148,12 @@ typedef struct kadm5_hook_vtable_1_st {
                           int stage, krb5_principal, krb5_principal);
 
     /* End of minor version 2. */
+
+    kadm5_ret_t (*alias)(krb5_context context, kadm5_hook_modinfo *modinfo,
+                         int stage, krb5_principal alias,
+                         krb5_principal target);
+
+    /* End of minor version 3. */
 
 } kadm5_hook_vftable_1;
 

--- a/src/kadmin/cli/kadmin.c
+++ b/src/kadmin/cli/kadmin.c
@@ -774,6 +774,55 @@ cleanup:
     free(ocanon);
 }
 
+void
+kadmin_addalias(int argc, char *argv[], int sci_idx, void *info_ptr)
+{
+    kadm5_ret_t retval;
+    krb5_principal alias = NULL, target = NULL;
+    char *acanon = NULL, *tcanon = NULL;
+
+    if (argc != 3) {
+        error(_("usage: add_alias alias_principal target_principal\n"));
+        return;
+    }
+    retval = kadmin_parse_name(argv[1], &alias);
+    if (retval) {
+        com_err("add_alias", retval, _("while parsing alias principal name"));
+        goto cleanup;
+    }
+    retval = kadmin_parse_name(argv[2], &target);
+    if (retval) {
+        com_err("add_alias", retval, _("while parsing target principal name"));
+        goto cleanup;
+    }
+    retval = krb5_unparse_name(context, alias, &acanon);
+    if (retval) {
+        com_err("add_alias", retval,
+                _("while canonicalizing alias principal"));
+        goto cleanup;
+    }
+    retval = krb5_unparse_name(context, target, &tcanon);
+    if (retval) {
+        com_err("add_alias", retval,
+                _("while canonicalizing target principal"));
+        goto cleanup;
+    }
+    retval = kadm5_create_alias(handle, alias, target);
+    if (retval) {
+        com_err("add_alias", retval,
+                _("while aliasing principal \"%s\" to \"%s\""),
+                acanon, tcanon);
+        goto cleanup;
+    }
+    info(_("Principal \"%s\" aliased to \"%s\".\n"), acanon, tcanon);
+
+cleanup:
+    krb5_free_principal(context, alias);
+    krb5_free_principal(context, target);
+    free(acanon);
+    free(tcanon);
+}
+
 static void
 cpw_usage(const char *str)
 {

--- a/src/kadmin/cli/kadmin.h
+++ b/src/kadmin/cli/kadmin.h
@@ -42,6 +42,8 @@ extern void kadmin_delprinc(int argc, char *argv[], int sci_idx,
                             void *info_ptr);
 extern void kadmin_renameprinc(int argc, char *argv[], int sci_idx,
                                void *info_ptr);
+extern void kadmin_addalias(int argc, char *argv[], int sci_idx,
+                            void *info_ptr);
 extern void kadmin_cpw(int argc, char *argv[], int sci_idx, void *info_ptr);
 extern void kadmin_addprinc(int argc, char *argv[], int sci_idx,
                             void *info_ptr);

--- a/src/kadmin/cli/kadmin_ct.ct
+++ b/src/kadmin/cli/kadmin_ct.ct
@@ -38,6 +38,9 @@ request kadmin_modprinc, "Modify principal",
 request kadmin_renameprinc, "Rename principal",
 	rename_principal, renprinc;
 
+request kadmin_addalias, "Add alias",
+	add_alias, alias;
+
 request kadmin_cpw, "Change password",
 	change_password, cpw;
 

--- a/src/kadmin/server/auth.h
+++ b/src/kadmin/server/auth.h
@@ -52,6 +52,7 @@
 #define OP_GETPOL      17
 #define OP_LISTPOLS    18
 #define OP_IPROP       19
+#define OP_ADDALIAS    20
 
 /* Initialize all authorization modules. */
 krb5_error_code auth_init(krb5_context context, const char *acl_file);
@@ -70,6 +71,7 @@ krb5_boolean auth(krb5_context context, int opcode,
  * restrictions to ent and mask if any modules supply them. */
 krb5_boolean auth_restrict(krb5_context context, int opcode,
                            krb5_const_principal client,
+                           krb5_const_principal target,
                            kadm5_principal_ent_t ent, long *mask);
 
 /* Notify modules that the most recent authorized operation has ended. */

--- a/src/kadmin/server/auth_acl.c
+++ b/src/kadmin/server/auth_acl.c
@@ -720,6 +720,19 @@ acl_iprop(krb5_context context, kadm5_auth_moddata data,
     return acl_check(data, ACL_IPROP, client, NULL, NULL);
 }
 
+static krb5_error_code
+acl_addalias(krb5_context context, kadm5_auth_moddata data,
+             krb5_const_principal client, krb5_const_principal alias,
+             krb5_const_principal target)
+{
+    struct kadm5_auth_restrictions *rs;
+
+    if (acl_check(data, ACL_ADD, client, alias, &rs) == 0 && rs == NULL &&
+        acl_check(data, ACL_MODIFY, client, target, &rs) == 0)
+        return 0;
+    return KRB5_PLUGIN_NO_HANDLE;
+}
+
 krb5_error_code
 kadm5_auth_acl_initvt(krb5_context context, int maj_ver, int min_ver,
                       krb5_plugin_vtable vtable)
@@ -751,5 +764,6 @@ kadm5_auth_acl_initvt(krb5_context context, int maj_ver, int min_ver,
     vt->getpol = acl_getpol;
     vt->listpols = acl_listpols;
     vt->iprop = acl_iprop;
+    vt->addalias = acl_addalias;
     return 0;
 }

--- a/src/kadmin/server/kadm_rpc_svc.c
+++ b/src/kadmin/server/kadm_rpc_svc.c
@@ -59,6 +59,7 @@ kadm_1(struct svc_req *rqstp, SVCXPRT *transp)
 	  setkey3_arg setkey_principal3_2_arg;
 	  setkey4_arg setkey_principal4_2_arg;
 	  getpkeys_arg get_principal_keys_2_arg;
+	  calias_arg create_alias_2_arg;
      } argument;
      union {
 	  generic_ret gen_ret;
@@ -239,6 +240,12 @@ kadm_1(struct svc_req *rqstp, SVCXPRT *transp)
 	  xdr_argument = (xdrproc_t)xdr_getpkeys_arg;
 	  xdr_result = (xdrproc_t)xdr_getpkeys_ret;
 	  local = (bool_t (*)(char *, void *, struct svc_req *))get_principal_keys_2_svc;
+	  break;
+
+     case CREATE_ALIAS:
+	  xdr_argument = (xdrproc_t)xdr_calias_arg;
+	  xdr_result = (xdrproc_t)xdr_generic_ret;
+	  local = (bool_t (*)(char *, void *, struct svc_req *))create_alias_2_svc;
 	  break;
 
      default:

--- a/src/lib/kadm5/admin.h
+++ b/src/lib/kadm5/admin.h
@@ -495,6 +495,9 @@ kadm5_ret_t    kadm5_free_strings(void *server_handle,
 kadm5_ret_t    kadm5_free_kadm5_key_data(krb5_context context, int n_key_data,
                                          kadm5_key_data *key_data);
 
+kadm5_ret_t    kadm5_create_alias(void *server_handle, krb5_principal alias,
+                                  krb5_principal target);
+
 KADM5INT_END_DECLS
 
 #endif /* __KADM5_ADMIN_H__ */

--- a/src/lib/kadm5/admin_xdr.h
+++ b/src/lib/kadm5/admin_xdr.h
@@ -71,3 +71,4 @@ bool_t      xdr_osa_pw_hist_ent(XDR *xdrs, osa_pw_hist_ent *objp);
 bool_t      xdr_kadm5_key_data(XDR *xdrs, kadm5_key_data *objp);
 bool_t      xdr_getpkeys_arg(XDR *xdrs, getpkeys_arg *objp);
 bool_t      xdr_getpkeys_ret(XDR *xdrs, getpkeys_ret *objp);
+bool_t      xdr_calias_arg(XDR *xdrs, calias_arg *objp);

--- a/src/lib/kadm5/clnt/client_principal.c
+++ b/src/lib/kadm5/clnt/client_principal.c
@@ -526,3 +526,23 @@ kadm5_get_principal_keys(void *server_handle, krb5_principal princ,
     }
     return r.code;
 }
+
+kadm5_ret_t
+kadm5_create_alias(void *server_handle, krb5_principal alias,
+                   krb5_principal target)
+{
+    calias_arg          arg;
+    generic_ret         r = { 0, 0 };
+    kadm5_server_handle_t handle = server_handle;
+
+    CHECK_HANDLE(server_handle);
+
+    arg.alias = alias;
+    arg.target = target;
+    arg.api_version = handle->api_version;
+    if (alias == NULL || target == NULL)
+        return EINVAL;
+    if (create_alias_2(&arg, &r, handle->clnt))
+        eret();
+    return r.code;
+}

--- a/src/lib/kadm5/clnt/client_rpc.c
+++ b/src/lib/kadm5/clnt/client_rpc.c
@@ -212,3 +212,11 @@ get_principal_keys_2(getpkeys_arg *argp, getpkeys_ret *res, CLIENT *clnt)
 			 (xdrproc_t)xdr_getpkeys_arg, (caddr_t)argp,
 			 (xdrproc_t)xdr_getpkeys_ret, (caddr_t)res, TIMEOUT);
 }
+
+enum clnt_stat
+create_alias_2(calias_arg *argp, generic_ret *res, CLIENT *clnt)
+{
+	return clnt_call(clnt, CREATE_ALIAS,
+			 (xdrproc_t)xdr_calias_arg, (caddr_t)argp,
+			 (xdrproc_t)xdr_generic_ret, (caddr_t)res, TIMEOUT);
+}

--- a/src/lib/kadm5/clnt/libkadm5clnt_mit.exports
+++ b/src/lib/kadm5/clnt/libkadm5clnt_mit.exports
@@ -3,6 +3,7 @@ _kadm5_chpass_principal_util
 kadm5_chpass_principal
 kadm5_chpass_principal_3
 kadm5_chpass_principal_util
+kadm5_create_alias
 kadm5_create_policy
 kadm5_create_principal
 kadm5_create_principal_3
@@ -62,6 +63,7 @@ krb5_klog_reopen
 krb5_klog_set_context
 krb5_klog_syslog
 krb5_string_to_keysalts
+xdr_calias_arg
 xdr_chpass3_arg
 xdr_chpass_arg
 xdr_chrand3_arg

--- a/src/lib/kadm5/kadm_err.et
+++ b/src/lib/kadm5/kadm_err.et
@@ -67,4 +67,5 @@ error_code KADM5_SETKEY_BAD_KVNO, "Invalid multiple or duplicate kvnos in setkey
 error_code KADM5_AUTH_EXTRACT, "Operation requires ``extract-keys'' privilege"
 error_code KADM5_PROTECT_KEYS, "Principal keys are locked down"
 error_code KADM5_AUTH_INITIAL, "Operation requires initial ticket"
+error_code KADM5_ALIAS_REALM, "Alias target must be within the same realm"
 end

--- a/src/lib/kadm5/kadm_rpc.h
+++ b/src/lib/kadm5/kadm_rpc.h
@@ -246,6 +246,13 @@ struct getpkeys_ret {
 };
 typedef struct getpkeys_ret getpkeys_ret;
 
+struct calias_arg {
+	krb5_ui_4 api_version;
+	krb5_principal alias;
+	krb5_principal target;
+};
+typedef struct calias_arg calias_arg;
+
 #define KADM 2112
 #define KADMVERS 2
 #define CREATE_PRINCIPAL 1
@@ -360,4 +367,9 @@ extern enum clnt_stat get_principal_keys_2(getpkeys_arg *, getpkeys_ret *,
 					   CLIENT *);
 extern  bool_t get_principal_keys_2_svc(getpkeys_arg *, getpkeys_ret *,
 					struct svc_req *);
+
+#define CREATE_ALIAS 27
+extern enum clnt_stat create_alias_2(calias_arg *, generic_ret *, CLIENT *);
+extern  bool_t create_alias_2_svc(calias_arg *, generic_ret *,
+				  struct svc_req *);
 #endif /* __KADM_RPC_H__ */

--- a/src/lib/kadm5/kadm_rpc_xdr.c
+++ b/src/lib/kadm5/kadm_rpc_xdr.c
@@ -1209,3 +1209,18 @@ xdr_getpkeys_ret(XDR *xdrs, getpkeys_ret *objp)
 	}
 	return TRUE;
 }
+
+bool_t
+xdr_calias_arg(XDR *xdrs, calias_arg *objp)
+{
+	if (!xdr_ui_4(xdrs, &objp->api_version)) {
+		return (FALSE);
+	}
+	if (!xdr_krb5_principal(xdrs, &objp->alias)) {
+		return (FALSE);
+	}
+	if (!xdr_krb5_principal(xdrs, &objp->target)) {
+		return (FALSE);
+	}
+	return (TRUE);
+}

--- a/src/lib/kadm5/server_internal.h
+++ b/src/lib/kadm5/server_internal.h
@@ -264,6 +264,13 @@ k5_kadm5_hook_rename (krb5_context context,
                       int stage,
                       krb5_principal oprinc, krb5_principal nprinc);
 
+/** Call alias kadm5_hook entry point. */
+kadm5_ret_t
+k5_kadm5_hook_alias (krb5_context context,
+                     kadm5_hook_handle *handles,
+                     int stage,
+                     krb5_principal alias, krb5_principal target);
+
 /** @}*/
 
 #endif /* __KADM5_SERVER_INTERNAL_H__ */

--- a/src/lib/kadm5/srv/kadm5_hook.c
+++ b/src/lib/kadm5/srv/kadm5_hook.c
@@ -64,7 +64,7 @@ k5_kadm5_hook_load(krb5_context context,
         handle = k5alloc(sizeof(*handle), &ret);
         if (handle == NULL)
             goto cleanup;
-        ret = (*mod)(context, 1, 2, (krb5_plugin_vtable)&handle->vt);
+        ret = (*mod)(context, 1, 3, (krb5_plugin_vtable)&handle->vt);
         if (ret != 0) {         /* Failed vtable init is non-fatal. */
             free(handle);
             handle = NULL;
@@ -182,5 +182,13 @@ k5_kadm5_hook_remove(krb5_context context, kadm5_hook_handle *handles,
                      int stage, krb5_principal princ)
 {
     ITERATE(remove, (context, h->data, stage, princ));
+    return 0;
+}
+
+kadm5_ret_t
+k5_kadm5_hook_alias(krb5_context context, kadm5_hook_handle *handles,
+                    int stage, krb5_principal alias, krb5_principal target)
+{
+    ITERATE(alias, (context, h->data, stage, alias, target));
     return 0;
 }

--- a/src/lib/kadm5/srv/libkadm5srv_mit.exports
+++ b/src/lib/kadm5/srv/libkadm5srv_mit.exports
@@ -4,6 +4,7 @@ hist_princ
 kadm5_chpass_principal
 kadm5_chpass_principal_3
 kadm5_chpass_principal_util
+kadm5_create_alias
 kadm5_create_policy
 kadm5_create_principal
 kadm5_create_principal_3
@@ -74,6 +75,7 @@ master_db
 master_princ
 osa_free_princ_ent
 passwd_check
+xdr_calias_arg
 xdr_chpass3_arg
 xdr_chpass_arg
 xdr_chrand3_arg

--- a/src/lib/kadm5/srv/server_kdb.c
+++ b/src/lib/kadm5/srv/server_kdb.c
@@ -410,9 +410,7 @@ kdb_delete_entry(kadm5_server_handle_t handle, krb5_principal name)
     krb5_error_code ret;
 
     ret = krb5_db_delete_principal(handle->context, name);
-    if (ret == KRB5_KDB_NOENTRY)
-        ret = 0;
-    return ret;
+    return (ret == KRB5_KDB_NOENTRY) ? KADM5_UNK_PRINC : ret;
 }
 
 typedef struct _iter_data {

--- a/src/lib/kdb/libkdb5.exports
+++ b/src/lib/kdb/libkdb5.exports
@@ -107,3 +107,5 @@ ulog_replay
 ulog_set_last
 xdr_kdb_incr_update_t
 krb5_dbe_sort_key_data
+krb5_dbe_make_alias_entry
+krb5_dbe_read_alias

--- a/src/lib/krb5/error_tables/kdb5_err.et
+++ b/src/lib/krb5/error_tables/kdb5_err.et
@@ -85,5 +85,6 @@ ec KRB5_LOG_ERROR,		"Generic update log error"
 ec KRB5_KDB_DBTYPE_MISMATCH,    "Database module does not match KDC version"
 ec KRB5_KDB_POLICY_REF,		"Policy is in use"
 ec KRB5_KDB_STRINGS_TOOLONG,    "Too much string mapping data"
+ec KRB5_KDB_ALIAS_UNSUPPORTED,  "Operation unsupported on alias principal name"
 
 end

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.c
@@ -128,6 +128,76 @@ krb5_dbe_free_contents(krb5_context context, krb5_db_entry *entry)
     return;
 }
 
+static krb5_error_code
+iterate_entry(krb5_context context, krb5_ldap_context *ldap_context,
+              LDAP *ld, LDAPMessage *ent,
+              krb5_error_code (*func)(krb5_pointer, krb5_db_entry *),
+              krb5_pointer func_arg)
+{
+    krb5_error_code ret = 0;
+    krb5_principal cprinc = NULL, nprinc = NULL;
+    krb5_db_entry entry = { 0 }, *entptr;
+    char **canon = NULL, **names = NULL, **list;
+    size_t i;
+
+    canon = ldap_get_values(ld, ent, "krbCanonicalName");
+    names = ldap_get_values(ld, ent, "krbPrincipalName");
+    if (canon == NULL && names == NULL)
+        return 0;
+
+    /* Output an entry for the canonical name if one is given.  Otherwise
+     * output an entry for the first name within the realm. */
+    list = (canon != NULL) ? canon : names;
+    for (i = 0; list[i] != NULL; i++) {
+        krb5_free_principal(context, nprinc);
+        nprinc = NULL;
+        ret = krb5_ldap_parse_name(context, list[i], &nprinc);
+        if (ret)
+            goto cleanup;
+
+        if (is_principal_in_realm(ldap_context, nprinc)) {
+            ret = populate_krb5_db_entry(context, ldap_context, ld, ent,
+                                         nprinc, &entry);
+            if (ret)
+                goto cleanup;
+            ret = (*func)(func_arg, &entry);
+            krb5_dbe_free_contents(context, &entry);
+            if (ret)
+                goto cleanup;
+            break;
+        }
+    }
+
+    /* Output alias entries for each non-canonical name. */
+    if (canon != NULL && names != NULL) {
+        ret = krb5_ldap_parse_name(context, canon[0], &cprinc);
+        if (ret)
+            goto cleanup;
+        for (i = 0; names[i] != NULL; i++) {
+            if (strcmp(names[i], canon[0]) == 0)
+                continue;
+            krb5_free_principal(context, nprinc);
+            nprinc = NULL;
+            ret = krb5_ldap_parse_name(context, names[i], &nprinc);
+            if (ret)
+                goto cleanup;
+            ret = krb5_dbe_make_alias_entry(context, nprinc, cprinc, &entptr);
+            if (ret)
+                goto cleanup;
+            ret = (*func)(func_arg, entptr);
+            krb5_db_free_principal(context, entptr);
+            if (ret)
+                goto cleanup;
+        }
+    }
+
+cleanup:
+    krb5_free_principal(context, cprinc);
+    krb5_free_principal(context, nprinc);
+    ldap_value_free(canon);
+    ldap_value_free(names);
+    return ret;
+}
 
 krb5_error_code
 krb5_ldap_iterate(krb5_context context, char *match_expr,
@@ -135,9 +205,8 @@ krb5_ldap_iterate(krb5_context context, char *match_expr,
                   krb5_pointer func_arg, krb5_flags iterflags)
 {
     krb5_db_entry            entry;
-    krb5_principal           principal;
-    char                     **subtree=NULL, *princ_name=NULL, *realm=NULL, **values=NULL, *filter=NULL;
-    size_t                   tree=0, ntree=1, i=0;
+    char                     **subtree=NULL, *realm=NULL, *filter=NULL;
+    size_t                   tree=0, ntree=1;
     krb5_error_code          st=0, tempst=0;
     LDAP                     *ld=NULL;
     LDAPMessage              *result=NULL, *ent=NULL;
@@ -181,33 +250,10 @@ krb5_ldap_iterate(krb5_context context, char *match_expr,
 
         LDAP_SEARCH(subtree[tree], ldap_context->lrparams->search_scope, filter, principal_attributes);
         for (ent=ldap_first_entry(ld, result); ent != NULL; ent=ldap_next_entry(ld, ent)) {
-            values=ldap_get_values(ld, ent, "krbcanonicalname");
-            if (values == NULL)
-                values=ldap_get_values(ld, ent, "krbprincipalname");
-            if (values != NULL) {
-                for (i=0; values[i] != NULL; ++i) {
-                    if (krb5_ldap_parse_principal_name(values[i], &princ_name) != 0)
-                        continue;
-                    st = krb5_parse_name(context, princ_name, &principal);
-                    free(princ_name);
-                    if (st)
-                        continue;
-
-                    if (is_principal_in_realm(ldap_context, principal)) {
-                        st = populate_krb5_db_entry(context, ldap_context, ld,
-                                                    ent, principal, &entry);
-                        krb5_free_principal(context, principal);
-                        if (st)
-                            goto cleanup;
-                        (*func)(func_arg, &entry);
-                        krb5_dbe_free_contents(context, &entry);
-                        break;
-                    }
-                    (void) krb5_free_principal(context, principal);
-                }
-                ldap_value_free(values);
-            }
-        } /* end of for (ent= ... */
+            st = iterate_entry(context, ldap_context, ld, ent, func, func_arg);
+            if (st)
+                goto cleanup;
+        }
         ldap_msgfree(result);
         result = NULL;
     } /* end of for (tree= ... */
@@ -268,15 +314,17 @@ krb5_ldap_delete_principal(krb5_context context,
 
     GET_HANDLE();
 
-    if (ptype == KDB_STANDALONE_PRINCIPAL_OBJECT) {
+    if (ptype == KDB_STANDALONE_PRINCIPAL_OBJECT &&
+        (pcount == 1 ||
+         krb5_principal_compare(context, searchfor, entry->princ))) {
         st = ldap_delete_ext_s(ld, DN, NULL, NULL);
         if (st != LDAP_SUCCESS) {
             st = set_ldap_error (context, st, OP_DEL);
             goto cleanup;
         }
     } else {
-        if (((st=krb5_unparse_name(context, searchfor, &user)) != 0)
-            || ((st=krb5_ldap_unparse_principal_name(user)) != 0))
+        st = krb5_ldap_unparse_name(context, searchfor, &user);
+        if (st)
             goto cleanup;
 
         memset(strval, 0, sizeof(strval));
@@ -360,35 +408,6 @@ is_standalone_principal(krb5_context kcontext, krb5_db_entry *entry, int *res)
     if (!code)
         *res = (*res == KDB_STANDALONE_PRINCIPAL_OBJECT) ? 1 : 0;
     return code;
-}
-
-/*
- * Unparse princ in the format used for LDAP attributes, and set *user to the
- * result.
- */
-static krb5_error_code
-unparse_principal_name(krb5_context context, krb5_const_principal princ,
-                       char **user_out)
-{
-    krb5_error_code st;
-    char *luser = NULL;
-
-    *user_out = NULL;
-
-    st = krb5_unparse_name(context, princ, &luser);
-    if (st)
-        goto cleanup;
-
-    st = krb5_ldap_unparse_principal_name(luser);
-    if (st)
-        goto cleanup;
-
-    *user_out = luser;
-    luser = NULL;
-
-cleanup:
-    free(luser);
-    return st;
 }
 
 /*
@@ -478,10 +497,10 @@ krb5_ldap_rename_principal(krb5_context context, krb5_const_principal source,
         goto cleanup;
     }
 
-    st = unparse_principal_name(context, source, &suser);
+    st = krb5_ldap_unparse_name(context, source, &suser);
     if (st)
         goto cleanup;
-    st = unparse_principal_name(context, target, &tuser);
+    st = krb5_ldap_unparse_name(context, target, &tuser);
     if (st)
         goto cleanup;
 
@@ -565,65 +584,63 @@ cleanup:
     return st;
 }
 
-/*
- * Function: krb5_ldap_unparse_principal_name
- *
- * Purpose: Removes '\\' that comes before every occurrence of '@'
- *          in the principal name component.
- *
- * Arguments:
- *       user_name     (input/output)      Principal name
- *
- */
-
+/* Unparse princ in the format used for krb5 principal names within LDAP
+ * attributes. */
 krb5_error_code
-krb5_ldap_unparse_principal_name(char *user_name)
+krb5_ldap_unparse_name(krb5_context context, krb5_const_principal princ,
+                       char **user_out)
 {
-    char *in, *out;
+    krb5_error_code ret;
+    char *p, *q;
 
-    out = user_name;
-    for (in = user_name; *in; in++) {
-        if (*in == '\\' && *(in + 1) == '@')
+    ret = krb5_unparse_name(context, princ, user_out);
+    if (ret)
+        return ret;
+
+    /* Remove backslashes preceding at-signs in the unparsed string. */
+    for (q = p = *user_out; *p != '\0'; p++) {
+        if (*p == '\\' && *(p + 1) == '@')
             continue;
-        *out++ = *in;
+        *q++ = *p;
     }
-    *out = '\0';
+    *q = '\0';
 
     return 0;
 }
 
-
-/*
- * Function: krb5_ldap_parse_principal_name
- *
- * Purpose: Inserts '\\' before every occurrence of '@'
- *          in the principal name component.
- *
- * Arguments:
- *       i_princ_name     (input)      Principal name without '\\'
- *       o_princ_name     (output)     Principal name with '\\'
- *
- * Note: The caller has to free the memory allocated for o_princ_name.
- */
-
+/* Parse username in the format used for krb5 principal names within LDAP
+ * attributes. */
 krb5_error_code
-krb5_ldap_parse_principal_name(char *i_princ_name, char **o_princ_name)
+krb5_ldap_parse_name(krb5_context context, const char *username,
+                     krb5_principal *out)
 {
-    const char *at_rlm_name, *p;
+    krb5_error_code ret;
+    const char *at_realm, *p;
+    char *princstr;
     struct k5buf buf;
 
-    at_rlm_name = strrchr(i_princ_name, '@');
-    if (!at_rlm_name) {
-        *o_princ_name = strdup(i_princ_name);
+    *out = NULL;
+
+    /* Make a copy of username, inserting a backslash before each '@'
+     * before the last one. */
+    at_realm = strrchr(username, '@');
+    if (at_realm == NULL) {
+        princstr = strdup(username);
     } else {
         k5_buf_init_dynamic(&buf);
-        for (p = i_princ_name; p < at_rlm_name; p++) {
+        for (p = username; p < at_realm; p++) {
             if (*p == '@')
                 k5_buf_add(&buf, "\\");
             k5_buf_add_len(&buf, p, 1);
         }
-        k5_buf_add(&buf, at_rlm_name);
-        *o_princ_name = k5_buf_cstring(&buf);
+        k5_buf_add(&buf, at_realm);
+        princstr = k5_buf_cstring(&buf);
     }
-    return (*o_princ_name == NULL) ? ENOMEM : 0;
+
+    if (princstr == NULL)
+        return ENOMEM;
+
+    ret = krb5_parse_name(context, princstr, out);
+    free(princstr);
+    return ret;
 }

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal.h
@@ -124,10 +124,12 @@ void
 krb5_dbe_free_contents(krb5_context, krb5_db_entry *);
 
 krb5_error_code
-krb5_ldap_unparse_principal_name(char *);
+krb5_ldap_unparse_name(krb5_context context, krb5_const_principal princ,
+                       char **user_out);
 
 krb5_error_code
-krb5_ldap_parse_principal_name(char *, char **);
+krb5_ldap_parse_name(krb5_context context, const char *username,
+                     krb5_principal *out);
 
 struct berval**
 krb5_encode_krbsecretkey(krb5_key_data *key_data, int n_key_data,

--- a/src/tests/Makefile.in
+++ b/src/tests/Makefile.in
@@ -192,6 +192,7 @@ check-pytests: responder s2p s4u2proxy unlockiter s4u2self
 	$(RUNPYTEST) $(srcdir)/t_kdcoptions.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_replay.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_sendto_kdc.py $(PYTESTFLAGS)
+	$(RUNPYTEST) $(srcdir)/t_alias.py $(PYTESTFLAGS)
 
 clean:
 	$(RM) adata conccache etinfo forward gcred hist hooks hrealm

--- a/src/tests/t_alias.py
+++ b/src/tests/t_alias.py
@@ -1,0 +1,124 @@
+from k5test import *
+
+realm = K5Realm(create_host=False)
+
+mark('getprinc')
+realm.addprinc('canon')
+realm.run([kadminl, 'alias', 'alias', 'canon@KRBTEST.COM'])
+realm.run([kadminl, 'getprinc', 'alias'],
+          expected_msg='Principal: canon@KRBTEST.COM')
+
+mark('delprinc')
+realm.run([kadminl, 'delprinc', 'alias'])
+realm.run([kadminl, 'getprinc', 'alias'], expected_code=1,
+          expected_msg='does not exist')
+realm.run([kadminl, 'getprinc', 'canon'], expected_msg=': canon@KRBTEST.COM')
+
+mark('no specified realm')
+realm.run([kadminl, 'alias', 'alias', 'canon'])
+realm.run([kadminl, 'getprinc', 'alias'], expected_msg=': canon@KRBTEST.COM')
+
+mark('cross-realm')
+realm.run([kadminl, 'alias', 'x', 'y@OTHER.REALM'], expected_code=1,
+          expected_msg='Alias target must be within the same realm')
+
+mark('alias as service principal')
+realm.extract_keytab('alias', realm.keytab)
+realm.run([kvno, 'alias'])
+realm.klist('user@KRBTEST.COM', 'alias@KRBTEST.COM')
+
+mark('alias as client principal')
+realm.kinit('alias', flags=['-k'])
+realm.klist('alias@KRBTEST.COM')
+realm.kinit('alias', flags=['-k', '-C'])
+realm.klist('canon@KRBTEST.COM')
+
+mark('chain')
+realm.run([kadminl, 'alias', 'a1', 'canon'])
+realm.run([kadminl, 'alias', 'a2', 'a1'])
+realm.run([kadminl, 'alias', 'a3', 'a2'])
+realm.run([kadminl, 'alias', 'a4', 'a3'])
+realm.run([kadminl, 'alias', 'a5', 'a4'])
+realm.run([kadminl, 'alias', 'a6', 'a5'])
+realm.run([kadminl, 'alias', 'a7', 'a6'])
+realm.run([kadminl, 'alias', 'a8', 'a7'])
+realm.run([kadminl, 'alias', 'a9', 'a8'])
+realm.run([kadminl, 'alias', 'a10', 'a9'])
+realm.run([kadminl, 'alias', 'a11', 'a10'])
+realm.run([kvno, 'a1'])
+realm.run([kvno, 'a2'])
+realm.run([kvno, 'a3'])
+realm.run([kvno, 'a4'])
+realm.run([kvno, 'a5'])
+realm.run([kvno, 'a6'])
+realm.run([kvno, 'a7'])
+realm.run([kvno, 'a8'])
+realm.run([kvno, 'a9'])
+realm.run([kvno, 'a10'])
+realm.run([kvno, 'a11'], expected_code=1,
+          expected_msg='Server a11@KRBTEST.COM not found in Kerberos database')
+
+mark('circular chain')
+realm.run([kadminl, 'alias', 'selfalias', 'selfalias'])
+realm.run([kvno, 'selfalias'], expected_code=1,
+          expected_msg='Server selfalias@KRBTEST.COM not found')
+
+mark('blocking creations')
+realm.run([kadminl, 'addprinc', '-nokey', 'alias'], expected_code=1,
+          expected_msg='already exists')
+realm.run([kadminl, 'alias', 'alias', 'canon'], expected_code=1,
+          expected_msg='already exists')
+realm.run([kadminl, 'renprinc', 'user', 'alias'], expected_code=1,
+          expected_msg='already exists')
+
+# Non-resolving aliases being overwritable is emergent behavior;
+# change the tests if the behavior changes.
+mark('not blocking creations')
+realm.run([kadminl, 'alias', 'xa1', 'x'])
+realm.run([kadminl, 'alias', 'xa2', 'x'])
+realm.run([kadminl, 'alias', 'xa3', 'x'])
+realm.addprinc('xa1')
+realm.run([kadminl, 'getprinc', 'xa1'], expected_msg=': xa1@KRBTEST.COM')
+realm.run([kadminl, 'alias', 'xa2', 'canon'])
+realm.run([kadminl, 'getprinc', 'xa2'], expected_msg=': canon@KRBTEST.COM')
+realm.run([kadminl, 'renprinc', 'xa1', 'xa3'])
+realm.run([kadminl, 'getprinc', 'xa3'], expected_msg=': xa3@KRBTEST.COM')
+
+mark('renprinc')
+realm.run([kadminl, 'renprinc', 'alias', 'nalias'], expected_code=1,
+          expected_msg='Operation unsupported on alias principal name')
+
+mark('modprinc')
+realm.run([kadminl, 'modprinc', '+preauth', 'alias'])
+realm.run([kadminl, 'getprinc', 'canon'], expected_msg='REQUIRES_PRE_AUTH')
+
+mark('cpw')
+realm.run([kadminl, 'cpw', '-pw', 'pw', 'alias'])
+realm.run([kadminl, 'getprinc', 'canon'], expected_msg='vno 2,')
+realm.run([kadminl, 'cpw', '-e', 'aes256-cts', '-pw', 'pw', 'alias'])
+realm.run([kadminl, 'getprinc', 'canon'], expected_msg='vno 3,')
+realm.run([kadminl, 'cpw', '-randkey', 'alias'])
+realm.run([kadminl, 'getprinc', 'canon'], expected_msg='vno 4,')
+realm.run([kadminl, 'cpw', '-e', 'aes256-cts', '-randkey', 'alias'])
+realm.run([kadminl, 'getprinc', 'canon'], expected_msg='vno 5,')
+
+mark('listprincs')
+realm.run([kadminl, 'listprincs'], expected_msg='alias@KRBTEST.COM')
+
+mark('purgekeys')
+realm.run([kadminl, 'purgekeys', '-all', 'alias'])
+realm.run([kadminl, 'getprinc', 'canon'], expected_msg='Number of keys: 0')
+
+mark('setstr')
+realm.run([kadminl, 'setstr', 'alias', 'key', 'value'])
+realm.run([kadminl, 'getstrs', 'canon'], expected_msg='key: value')
+
+mark('getstrs')
+realm.run([kadminl, 'getstrs', 'alias'], expected_msg='key: value')
+
+mark('delstr')
+realm.run([kadminl, 'delstr', 'alias', 'key'])
+realm.run([kadminl, 'getstrs', 'canon'],
+          expected_msg='(No string attributes.)')
+
+success('alias tests')

--- a/src/tests/t_kdb.py
+++ b/src/tests/t_kdb.py
@@ -360,14 +360,14 @@ mark('LDAP service principal aliases')
 
 # Test service principal aliases.
 realm.addprinc('canon', password('canon'))
-ldap_modify('dn: krbPrincipalName=canon@KRBTEST.COM,cn=t1,cn=krb5\n'
-            'changetype: modify\n'
-            'add: krbPrincipalName\n'
-            'krbPrincipalName: alias@KRBTEST.COM\n'
-            'krbPrincipalName: ent@abc@KRBTEST.COM\n'
-            '-\n'
-            'add: krbCanonicalName\n'
-            'krbCanonicalName: canon@KRBTEST.COM\n')
+realm.run([kadminl, 'alias', 'alias', 'canon'])
+realm.run([kadminl, 'alias', 'ent\\@abc', 'canon'])
+out = ldap_search('(krbPrincipalName=canon*)')
+if ('krbPrincipalName: canon@KRBTEST.COM' not in out or
+    'krbPrincipalName: alias@KRBTEST.COM' not in out or
+    'krbPrincipalName: ent@abc@KRBTEST.COM' not in out or
+    'krbCanonicalName: canon@KRBTEST.COM' not in out):
+    fail('expected names not found in canon object')
 realm.run([kadminl, 'getprinc', 'alias'],
           expected_msg='Principal: canon@KRBTEST.COM\n')
 realm.run([kadminl, 'getprinc', 'ent\\@abc'],
@@ -382,14 +382,7 @@ realm.kinit(realm.user_princ, password('user'), ['-S', 'alias'])
 realm.klist(realm.user_princ, 'alias@KRBTEST.COM')
 
 # Make sure an alias to the local TGS is still treated like an alias.
-ldap_modify('dn: krbPrincipalName=krbtgt/KRBTEST.COM@KRBTEST.COM,'
-            'cn=KRBTEST.COM,cn=krb5\n'
-            'changetype: modify\n'
-            'add:krbPrincipalName\n'
-            'krbPrincipalName: tgtalias@KRBTEST.COM\n'
-            '-\n'
-            'add: krbCanonicalName\n'
-            'krbCanonicalName: krbtgt/KRBTEST.COM@KRBTEST.COM\n')
+realm.run([kadminl, 'alias', 'tgtalias', 'krbtgt/KRBTEST.COM'])
 realm.run([kadminl, 'getprinc', 'tgtalias'],
           expected_msg='Principal: krbtgt/KRBTEST.COM@KRBTEST.COM')
 realm.kinit(realm.user_princ, password('user'))
@@ -428,6 +421,23 @@ realm.klist('ent\\@abc@KRBTEST.COM', 'alias@KRBTEST.COM')
 
 # Test client name canonicalization in non-krbtgt AS reply
 realm.kinit('alias', password('canon'), ['-C', '-S', 'kadmin/changepw'])
+
+# Test deleting an alias.
+mark('LDAP alias deletion')
+realm.run([kadminl, 'delprinc', 'alias'])
+realm.run([kadminl, 'getprinc', 'alias'], expected_code=1,
+          expected_msg='Principal does not exist')
+realm.run([kadminl, 'getprinc', 'ent\\@abc'],
+          expected_msg='Principal: canon@KRBTEST.COM\n')
+realm.run([kadminl, 'getprinc', 'canon'],
+          expected_msg='Principal: canon@KRBTEST.COM\n')
+
+# Test deleting a canonical name when an alias is present.
+realm.run([kadminl, 'delprinc', 'canon'])
+realm.run([kadminl, 'getprinc', 'canon'], expected_code=1,
+          expected_msg='Principal does not exist')
+realm.run([kadminl, 'getprinc', 'ent\\@abc'], expected_code=1,
+          expected_msg='Principal does not exist')
 
 mark('LDAP password history')
 
@@ -551,6 +561,8 @@ realm.run([kdb5_util, 'load', '-update', dumpfile])
 out = realm.run([kadminl, 'getprinc', 'pwuser'])
 if 'Password expiration date: [never]' in out:
     fail('pw_expiration not preserved across dump and load')
+realm.run([kadminl, 'getprinc', 'tgtalias'],
+          expected_msg='Principal: krbtgt/KRBTEST.COM@KRBTEST.COM')
 
 # Destroy the realm.
 kldaputil(['destroy', '-f'])

--- a/src/tests/t_tabdump.py
+++ b/src/tests/t_tabdump.py
@@ -19,7 +19,13 @@ def checkkeys(rows, dumptype, names):
 
 
 realm = K5Realm(start_kdc=False, get_creds=False)
+realm.run([kadminl, 'alias', 'useralias', 'user'])
 
+rows = getrows('alias')
+checkkeys(rows, 'alias', ["aliasname", "targetname"])
+if (rows[0]['aliasname'] != 'useralias@KRBTEST.COM' or
+    rows[0]['targetname'] != 'user@KRBTEST.COM'):
+    fail('tabdump alias principal names')
 
 rows = getrows('keyinfo')
 checkkeys(rows, 'keyinfo',


### PR DESCRIPTION
Allow specifying existing Kerberos principal as an alias when creating a principal via principal DB argument 'alias=existing.principal@REALM'.

DB arguments get stored as TL data with a tag KRB5_TL_DB_ARGS. As LMDB stores DB entries by using principal name as the key, in get_principal() we can check if retrieved entry has TL data of KRB5_TL_DB_ARGS with 'alias=' prefix and retrieve this new entry instead.

TODO: take flags into account when resolving aliases