### PR TITLE
Fix the memory leak issue when Kerberos fails to connection to OpenLDAP.

### DIFF
--- a/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap_conn.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap_conn.c
@@ -189,6 +189,7 @@ initialize_server(krb5_ldap_context *ldap_context, krb5_ldap_server_info *info)
     if (ret) {
         info->server_status = OFF;
         time(&info->downtime);
+        ldap_unbind_ext_s(server->ldap_handle);
         free(server);
         return ret;
     }


### PR DESCRIPTION
The function "initialize_server" leads to memory leak problems when the function "authenticate" returns non-success.
We should free server->ldap_handle firstly before we free sever.