### PR TITLE
Fix the memory leak issue when Kerberos fails to connect to OpenLDAP.

### DIFF
--- a/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap_conn.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap_conn.c
@@ -189,6 +189,7 @@ initialize_server(krb5_ldap_context *ldap_context, krb5_ldap_server_info *info)
     if (ret) {
         info->server_status = OFF;
         time(&info->downtime);
+        ldap_unbind_ext_s(server->ldap_handle, NULL, NULL);
         free(server);
         return ret;
     }


### PR DESCRIPTION
The function "initialize_server" leads to memory leak when the function "authenticate" returns non-success.
We forget to free the memory of "server->ldap_handle".
We should free "server->ldap_handle" before we free "server".