### PR TITLE
Check for sys/random.h

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -490,7 +490,7 @@ AC_SUBST(GETTIMEOFDAY_ST_OBJ)
 AC_SUBST(EXTRA_SUPPORT_SYMS)
 
 DECLARE_SYS_ERRLIST
-AC_CHECK_HEADERS(unistd.h paths.h regex.h regexpr.h fcntl.h memory.h ifaddrs.h sys/filio.h byteswap.h machine/endian.h machine/byte_order.h sys/bswap.h endian.h pwd.h arpa/inet.h alloca.h dlfcn.h limits.h)
+AC_CHECK_HEADERS(unistd.h paths.h regex.h regexpr.h fcntl.h memory.h ifaddrs.h sys/filio.h byteswap.h machine/endian.h machine/byte_order.h sys/bswap.h endian.h pwd.h arpa/inet.h alloca.h dlfcn.h limits.h sys/random.h)
 AC_CHECK_HEADER(regexp.h, [], [],
 [#define INIT char *sp = instring;
 #define GETC() (*sp++)

--- a/src/lib/crypto/krb/prng.c
+++ b/src/lib/crypto/krb/prng.c
@@ -56,6 +56,9 @@ get_os_entropy(unsigned char *buf, size_t len)
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
+#ifdef HAVE_SYS_RANDOM_H
+#include <sys/random.h>
+#endif
 #ifdef __linux__
 #include <sys/syscall.h>
 #endif /* __linux__ */


### PR DESCRIPTION
The function getentropy() is supported on newer versions of MacOS X, but requires the include file sys/random.h.  Check for that and include it where getentroy() is used.