### PR TITLE
Fix Windows regression in k5_make_uri_query()

### DIFF
--- a/src/lib/krb5/os/dnssrv.c
+++ b/src/lib/krb5/os/dnssrv.c
@@ -110,7 +110,8 @@ place_srv_entry(struct srv_dns_entry **head, struct srv_dns_entry *new)
 
 krb5_error_code
 k5_make_uri_query(krb5_context context, const krb5_data *realm,
-                  const char *service, struct srv_dns_entry **answers)
+                  const char *service, const char *sitename,
+                  struct srv_dns_entry **answers)
 {
     /* Windows does not currently support the URI record type or make it
      * possible to query for a record type it does not have support for. */


### PR DESCRIPTION
Commit d035119c3b2 introduced an extra argument to the function k5_make_uri_query(), but did not add that argument to the Windows stub version of this function; that ended up causing an exception when this function was called due to a null pointer dereference.  I do not know why this didn't trigger even a warning during compilation, much less an error.