### PR TITLE
Add support for systemd socket activation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,6 +258,7 @@ local.properties
 /src/kdc/rtest
 /src/kdc/t_ndr
 /src/kdc/t_replay
+/src/kdc/t_sockact
 
 /src/lib/k5sprt32.def
 

--- a/doc/admin/admin_commands/kadmind.rst
+++ b/doc/admin/admin_commands/kadmind.rst
@@ -121,6 +121,14 @@ ENVIRONMENT
 See :ref:`kerberos(7)` for a description of Kerberos environment
 variables.
 
+As of release 1.22, kadmind supports systemd socket activation via the
+LISTEN_PID and LISTEN_FDS environment variables.  Sockets provided by
+the caller must correspond to configured listener addresses (via the
+**kadmind_listen** or **kpasswd_listen** variables or equivalents) or
+they will be ignored.  Any configured listener addresses that do not
+correspond to caller-provided sockets will be ignored if socket
+activation is used.
+
 
 SEE ALSO
 --------

--- a/doc/admin/admin_commands/krb5kdc.rst
+++ b/doc/admin/admin_commands/krb5kdc.rst
@@ -106,6 +106,13 @@ ENVIRONMENT
 See :ref:`kerberos(7)` for a description of Kerberos environment
 variables.
 
+As of release 1.22, krb5kdc supports systemd socket activation via the
+LISTEN_PID and LISTEN_FDS environment variables.  Sockets provided by
+the caller must correspond to configured listener addresses (via the
+**kdc_listen** variable or equivalent) or they will be ignored.  Any
+configured listener addresses that do not correspond to
+caller-provided sockets will be ignored if socket activation is used.
+
 
 SEE ALSO
 --------

--- a/src/kdc/Makefile.in
+++ b/src/kdc/Makefile.in
@@ -31,7 +31,8 @@ SRCS= \
 
 EXTRADEPSRCS= \
 	$(srcdir)/t_ndr.c \
-	$(srcdir)/t_replay.c
+	$(srcdir)/t_replay.c \
+	$(srcdir)/t_sockact.c
 
 OBJS= \
 	authind.o \
@@ -78,16 +79,21 @@ T_REPLAY_OBJS=t_replay.o
 t_replay: $(T_REPLAY_OBJS) replay.o $(KRB5_BASE_DEPLIBS)
 	$(CC_LINK) -o $@ $(T_REPLAY_OBJS) $(CMOCKA_LIBS) $(KRB5_BASE_LIBS)
 
+t_sockact: t_sockact.o $(KRB5_BASE_DEPLIBS)
+	$(CC_LINK) -o $@ t_sockact.o $(KRB5_BASE_LIBS)
+
 check-cmocka: t_replay
 	$(RUN_TEST) ./t_replay > /dev/null
 
-check-pytests:
+check-pytests: t_sockact
 	$(RUNPYTEST) $(srcdir)/t_workers.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_emptytgt.py $(PYTESTFLAGS)
 	$(RUNPYTEST) $(srcdir)/t_bigreply.py $(PYTESTFLAGS)
+	$(RUNPYTEST) $(srcdir)/t_sockact.py $(PYTESTFLAGS)
 
 install:
 	$(INSTALL_PROGRAM) krb5kdc ${DESTDIR}$(SERVER_BINDIR)/krb5kdc
 
 clean:
 	$(RM) krb5kdc rtest.o rtest t_replay.o t_replay t_ndr.o t_ndr
+	$(RM) t_sockact.o t_sockact

--- a/src/kdc/deps
+++ b/src/kdc/deps
@@ -427,3 +427,13 @@ $(OUTPRE)t_replay.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
   $(top_srcdir)/include/port-sockets.h $(top_srcdir)/include/socket-utils.h \
   extern.h kdc_util.h realm_data.h replay.c reqstate.h \
   t_replay.c
+$(OUTPRE)t_sockact.$(OBJEXT): $(BUILDTOP)/include/autoconf.h \
+  $(BUILDTOP)/include/krb5/krb5.h $(BUILDTOP)/include/osconf.h \
+  $(BUILDTOP)/include/profile.h $(COM_ERR_DEPS) $(top_srcdir)/include/k5-buf.h \
+  $(top_srcdir)/include/k5-err.h $(top_srcdir)/include/k5-gmt_mktime.h \
+  $(top_srcdir)/include/k5-int-pkinit.h $(top_srcdir)/include/k5-int.h \
+  $(top_srcdir)/include/k5-platform.h $(top_srcdir)/include/k5-plugin.h \
+  $(top_srcdir)/include/k5-thread.h $(top_srcdir)/include/k5-trace.h \
+  $(top_srcdir)/include/krb5.h $(top_srcdir)/include/krb5/authdata_plugin.h \
+  $(top_srcdir)/include/krb5/plugin.h $(top_srcdir)/include/port-sockets.h \
+  $(top_srcdir)/include/socket-utils.h t_sockact.c

--- a/src/kdc/t_sockact.c
+++ b/src/kdc/t_sockact.c
@@ -1,0 +1,121 @@
+/* -*- mode: c; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/* kdc/t_sockact.c - socket activation test harness */
+/*
+ * Copyright (C) 2025 by the Massachusetts Institute of Technology.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Usage: t_sockact address... -- program args...
+ *
+ * This program simulates systemd socket activation by creating one or more
+ * listener sockets at the specified addresses, setting LISTEN_FDS and
+ * LISTEN_PID in the environment, and executing the specified command.  (The
+ * real systemd would not execute the program until there is input on one of
+ * the listener sockets, but we do not need to simulate that, and executing the
+ * command immediately allow easier integration with k5test.py.)
+ */
+
+#include "k5-int.h"
+#include "socket-utils.h"
+
+static int max_fd;
+
+static void
+create_socket(const struct sockaddr *addr)
+{
+    int fd, one = 1;
+
+    fd = socket(addr->sa_family, SOCK_STREAM, 0);
+    if (fd < 0)
+        abort();
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) != 0)
+        abort();
+#ifdef SO_REUSEPORT
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one)) != 0)
+        abort();
+#endif
+#if defined(IPV6_V6ONLY)
+    if (addr->sa_family == AF_INET6) {
+        if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &one, sizeof(one)) != 0)
+            abort();
+    }
+#endif
+    if (bind(fd, addr, sa_socklen(addr)) != 0)
+        abort();
+    if (listen(fd, 5) != 0)
+        abort();
+    max_fd = fd;
+}
+
+int
+main(int argc, char **argv)
+{
+    const char *addrstr;
+    struct sockaddr_storage ss = { 0 };
+    struct addrinfo hints = { 0 }, *ai_list = NULL, *ai = NULL;
+    char *host, nbuf[128];
+    int i, port;
+
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--") == 0)
+            break;
+        addrstr = argv[i];
+        if (*addrstr == '/') {
+            ss.ss_family = AF_UNIX;
+            strlcpy(ss2sun(&ss)->sun_path, addrstr,
+                    sizeof(ss2sun(&ss)->sun_path));
+            create_socket(ss2sa(&ss));
+        } else {
+            if (k5_parse_host_string(addrstr, 0, &host, &port) != 0 || !port)
+                abort();
+            hints.ai_socktype = SOCK_STREAM;
+            hints.ai_family = AF_UNSPEC;
+            hints.ai_flags = AI_PASSIVE;
+#ifdef AI_NUMERICSERV
+            hints.ai_flags |= AI_NUMERICSERV;
+#endif
+            (void)snprintf(nbuf, sizeof(nbuf), "%d", port);
+            if (getaddrinfo(host, nbuf, &hints, &ai_list) != 0)
+                abort();
+            for (ai = ai_list; ai != NULL; ai = ai->ai_next)
+                create_socket(ai->ai_addr);
+            freeaddrinfo(ai_list);
+            free(host);
+        }
+    }
+    argv += i + 1;
+
+    (void)snprintf(nbuf, sizeof(nbuf), "%d", max_fd - 2);
+    setenv("LISTEN_FDS", nbuf, 1);
+    (void)snprintf(nbuf, sizeof(nbuf), "%lu", (unsigned long)getpid());
+    setenv("LISTEN_PID", nbuf, 1);
+    execv(argv[0], argv);
+    abort();
+    return 1;
+}

--- a/src/kdc/t_sockact.py
+++ b/src/kdc/t_sockact.py
@@ -1,0 +1,43 @@
+from k5test import *
+
+if not which('systemd-socket-activate'):
+    skip_rest('socket activation tests', 'systemd-socket-activate not found')
+
+# Configure listeners for two UNIX domain sockets and two ports.
+kdc_conf = {'realms': {'$realm': {
+    'kdc_listen': '$testdir/sock1 $testdir/sock2',
+    'kdc_tcp_listen': '$port7 $port8'}}}
+realm = K5Realm(kdc_conf=kdc_conf, start_kdc=False)
+
+# Create socket activation fds for just one of the UNIX domain sockets
+# and one of the ports.
+realm.start_server(['./t_sockact', os.path.join(realm.testdir, 'sock1'),
+                    str(realm.portbase + 8), '--', krb5kdc, '-n'],
+                   'starting...')
+
+mark('UNIX socket 1')
+cconf1 = {'realms': {'$realm': {'kdc': '$testdir/sock1'}}}
+env1 = realm.special_env('sock1', False, krb5_conf=cconf1)
+realm.kinit(realm.user_princ, password('user'), env=env1)
+
+mark('port8')
+cconf2 = {'realms': {'$realm': {'kdc': '$hostname:$port8'}}}
+env2 = realm.special_env('sock1', False, krb5_conf=cconf2)
+realm.kinit(realm.user_princ, password('user'), env=env2)
+
+# Test that configured listener addresses are ignored if they don't
+# match caller-provided sockets.
+
+mark('UNIX socket 2')
+cconf3 = {'realms': {'$realm': {'kdc': '$testdir/sock2'}}}
+env3 = realm.special_env('sock2', False, krb5_conf=cconf3)
+realm.kinit(realm.user_princ, password('user'), env=env3, expected_code=1,
+            expected_msg='Cannot contact any KDC')
+
+mark('port7')
+cconf4 = {'realms': {'$realm': {'kdc': '$hostname:$port7'}}}
+env4 = realm.special_env('sock1', False, krb5_conf=cconf4)
+realm.kinit(realm.user_princ, password('user'), env=env3, expected_code=1,
+            expected_msg='Cannot contact any KDC')
+
+success('systemd socket activation tests')


### PR DESCRIPTION
This adds support for systemd socket activation.

See https://0pointer.de/blog/projects/socket-activation.html

This requires PR #1359 to be merged first.