### PR TITLE
Add support for PKINIT on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,8 @@ jobs:
         runs-on: windows-latest
         env:
             KRB_INSTALL_DIR: C:\kfw
+            OPENSSL_DIR: C:\Program Files\OpenSSL
+            OPENSSL_VERSION: 1_1
         steps:
             - name: Checkout repository
               uses: actions/checkout@v1

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -32,7 +32,8 @@ SUBDIRS=util include lib \
 	plugins/tls/k5tls \
 	kdc kadmin kprop clients appl tests \
 	config-files build-tools man doc @po@
-WINSUBDIRS=include util lib ccapi windows clients appl plugins\preauth\spake
+WINSUBDIRS=include util lib ccapi windows clients appl plugins\preauth\spake \
+	$(PKINIT_SUBDIR)
 BUILDTOP=$(REL).
 
 SRCS =  
@@ -106,6 +107,17 @@ config-windows: Makefile-windows
 #	cd ..
 
 #
+# Build the pkinit plugin if OpenSSL was configured
+#
+##DOS##!ifdef OPENSSL_DIR
+##DOS##PKINIT_SUBDIR=plugins\preauth\pkinit
+##DOS##PKINIT_MAKEFILE=$(PKINIT_SUBDIR)\Makefile
+##DOS##!else
+##DOS##PKINIT_SUBDIR=
+##DOS##PKINIT_MAKEFILE=
+##DOS##!endif
+
+#
 # We need outpre-dir explicitly in here because we may
 # try to build wconfig on a config-windows.
 #
@@ -154,7 +166,7 @@ WINMAKEFILES=Makefile \
 	windows\Makefile windows\lib\Makefile windows\ms2mit\Makefile \
 	windows\kfwlogon\Makefile windows\leashdll\Makefile \
 	windows\leash\Makefile windows\leash\htmlhelp\Makefile \
-	plugins\preauth\spake\Makefile
+	plugins\preauth\spake\Makefile $(PKINIT_MAKEFILE)
 
 ##DOS##Makefile-windows: $(MKFDEP) $(WINMAKEFILES)
 
@@ -277,6 +289,8 @@ WINMAKEFILES=Makefile \
 ##DOS##windows\leash\htmlhelp\Makefile: windows\leash\htmlhelp\Makefile.in $(MKFDEP)
 ##DOS##	$(WCONFIG) config < $@.in > $@
 ##DOS##plugins\preauth\spake\Makefile: plugins\preauth\spake\Makefile.in $(MKFDEP)
+##DOS##	$(WCONFIG) config < $@.in > $@
+##DOS##plugins\preauth\pkinit\Makefile: plugins\preauth\pkinit\Makefile.in $(MKFDEP)
 ##DOS##	$(WCONFIG) config < $@.in > $@
 
 clean-windows:: Makefile-windows
@@ -485,6 +499,10 @@ install-windows:
 	$(INSTALLDBGSYMS) clients\kswitch\$(OUTPRE)kswitch.pdb "$(KRB_INSTALL_DIR)\bin\."
 	copy plugins\preauth\spake\$(OUTPRE)$(SPAKELIB).dll "$(KRB_INSTALL_DIR)\bin\plugins\preauth\."
 	$(INSTALLDBGSYMS) plugins\preauth\spake\$(OUTPRE)$(SPAKELIB).pdb "$(KRB_INSTALL_DIR)\bin\plugins\preauth\."
+##DOS##!ifdef OPENSSL_DIR
+	copy plugins\preauth\pkinit\$(OUTPRE)$(PKINITLIB).dll "$(KRB_INSTALL_DIR)\bin\plugins\preauth\."
+	$(INSTALLDBGSYMS) plugins\preauth\pkinit\$(OUTPRE)$(PKINITLIB).pdb "$(KRB_INSTALL_DIR)\bin\plugins\preauth\."
+##DOS##!endif
 
 check-prerecurse: runenv.py
 	$(RM) $(SKIPTESTS)

--- a/src/config/win-pre.in
+++ b/src/config/win-pre.in
@@ -117,7 +117,7 @@ KFWFLAGS=-DUSE_LEASH=1 -DDEBUG -D_CRTDBG_MAP_ALLOC
 CC=cl
 
 PDB_OPTS=-Fd$(OUTPRE)\ -FD
-CPPFLAGS=-I$(top_srcdir)\include -I$(top_srcdir)\include\krb5 $(DNSFLAGS) -DWIN32_LEAN_AND_MEAN -DKRB5_DEPRECATED=1 -DKRB5_PRIVATE -D_CRT_SECURE_NO_DEPRECATE $(KFWFLAGS) $(TIME_T_FLAGS)
+CPPFLAGS=-I$(top_srcdir)\include -I$(top_srcdir)\include\krb5 $(DNSFLAGS) -DWIN32_LEAN_AND_MEAN -DKRB5_DEPRECATED=1 -DKRB5_PRIVATE -D_CRT_SECURE_NO_DEPRECATE $(KFWFLAGS) $(TIME_T_FLAGS) $(OSSLINCLUDE)
 # Treat the following warnings as errors:
 #  4020: too many actual parameters
 #  4024: different types for formal and actual parameter
@@ -188,6 +188,16 @@ SLIB=$(BUILDTOP)\lib\$(OUTPRE)k5sprt$(BITS).lib
 GLIB=$(BUILDTOP)\lib\$(OUTPRE)gssapi$(BITS).lib
 CCLIB=krbcc$(BITS)
 SPAKELIB=spake$(BITS)
+
+!ifdef OPENSSL_DIR
+OSSLLIB="$(OPENSSL_DIR)\lib\libcrypto.lib"
+OSSLINC="-I$(OPENSSL_DIR)\include"
+PKINITLIB=pkinit$(BITS)
+!else
+OSSLLIB=
+OSSLINC=
+PKINITLIB=
+!endif
 
 KRB4_INCLUDES=-I$(BUILDTOP)/include/kerberosIV
 

--- a/src/include/win-mac.h
+++ b/src/include/win-mac.h
@@ -236,4 +236,8 @@ HINSTANCE get_lib_instance(void);
 #define KRB5_CALLCONV_C
 #endif
 
+#ifndef PKCS11_MODNAME
+#define PKCS11_MODNAME "C:\\Program Files\\OpenSC Project\\OpenSC\\pkcs11\\opensc-pkcs11.dll"
+#endif
+
 #endif /* _KRB5_WIN_MAC_H */

--- a/src/lib/krb5_32.def
+++ b/src/lib/krb5_32.def
@@ -510,3 +510,10 @@ EXPORTS
 	k5_sname_compare				@474 ; PRIVATE GSSAPI
 	krb5_kdc_sign_ticket                            @475 ;
 	krb5_kdc_verify_ticket                          @476 ;
+
+; new in 1.22
+; private symbols used by PKINIT module
+	encode_krb5_sp80056a_other_info			@477 ; PRIVATE
+	encode_krb5_pkinit_supp_pub_info		@478 ; PRIVATE
+	krb5int_copy_data_contents			@479 ; PRIVATE
+	krb5_free_pa_data				@480 ; PRIVATE

--- a/src/plugins/preauth/pkinit/Makefile.in
+++ b/src/plugins/preauth/pkinit/Makefile.in
@@ -12,6 +12,9 @@ SHLIB_EXPDEPS = \
 	$(TOPLIBD)/libkrb5$(SHLIBEXT)
 SHLIB_EXPLIBS= -lkrb5 $(COM_ERR_LIB) -lk5crypto -lcrypto $(DL_LIB) $(SUPPORT_LIB) $(LIBS)
 
+WINLIBS = $(KLIB) $(SLIB) $(PLIB) $(CLIB) $(OSSLLIB)
+OSSLINCLUDE = $(OSSLINC)
+
 STLIBOBJS= \
 	pkinit_accessor.o \
 	pkinit_srv.o \
@@ -35,6 +38,19 @@ SRCS= \
 	$(srcdir)/pkinit_matching.c \
 	$(srcdir)/pkinit_crypto_openssl.c
 
+#
+# Don't include pkinit_srv.c in the Windows object list since we
+# don't need it.
+#
+OBJS=	$(OUTPRE)pkinit_accessor.$(OBJEXT) \
+	$(OUTPRE)pkinit_lib.$(OBJEXT) \
+	$(OUTPRE)pkinit_clnt.$(OBJEXT) \
+	$(OUTPRE)pkinit_constants.$(OBJEXT) \
+	$(OUTPRE)pkinit_profile.$(OBJEXT) \
+	$(OUTPRE)pkinit_identity.$(OBJEXT) \
+	$(OUTPRE)pkinit_matching.$(OBJEXT) \
+	$(OUTPRE)pkinit_crypto_openssl.$(OBJEXT)
+
 all-unix: all-liblinks
 install-unix: install-libs
 clean-unix:: clean-liblinks clean-libs clean-libobjs
@@ -47,6 +63,13 @@ check-unix: pkinit_kdf_test
 
 pkinit_kdf_test: pkinit_kdf_test.o $(STLIBOBJS) $(SHLIB_EXPDEPS)
 	$(CC_LINK) -o $@ pkinit_kdf_test.o $(STLIBOBJS) $(SHLIB_EXPLIBS)
+
+all-windows: $(OUTPRE)$(PKINITLIB).dll
+clean-windows::
+	$(RM) $(OUTPRE)$(PKINITLIB).dll
+
+$(OUTPRE)$(PKINITLIB).dll: pkinit.def $(OBJS)
+	link /dll $(LOPTS) -def:pkinit.def -out:$*.dll $(OBJS) $(WINLIBS)
 
 @libnover_frag@
 @libobj_frag@

--- a/src/plugins/preauth/pkinit/pkinit.def
+++ b/src/plugins/preauth/pkinit/pkinit.def
@@ -1,0 +1,3 @@
+EXPORTS
+
+	clpreauth_pkinit_initvt

--- a/src/plugins/preauth/pkinit/pkinit.h
+++ b/src/plugins/preauth/pkinit/pkinit.h
@@ -97,7 +97,9 @@ static inline void pkiDebug (const char *fmt, ...) { }
 
 /* Solaris compiler doesn't grok __FUNCTION__
  * hack for now.  Fix all the uses eventually. */
+#ifndef _WIN32
 #define __FUNCTION__ __func__
+#endif
 
 /* Macros to deal with converting between various data types... */
 #define PADATA_TO_KRB5DATA(pad, k5d) \

--- a/src/plugins/preauth/pkinit/pkinit_accessor.c
+++ b/src/plugins/preauth/pkinit/pkinit_accessor.c
@@ -69,8 +69,8 @@ krb5_error_code
 krb5_error_code
 (*k5int_encode_krb5_kdc_req_body)(const krb5_kdc_req *rep, krb5_data **code);
 
-void KRB5_CALLCONV
-(*k5int_krb5_free_kdc_req)(krb5_context, krb5_kdc_req * );
+void
+(KRB5_CALLCONV *k5int_krb5_free_kdc_req)(krb5_context, krb5_kdc_req * );
 
 void
 (*k5int_set_prompt_types)(krb5_context, krb5_prompt_type *);

--- a/src/plugins/preauth/pkinit/pkinit_accessor.h
+++ b/src/plugins/preauth/pkinit/pkinit_accessor.h
@@ -66,7 +66,7 @@ extern krb5_error_code (*k5int_decode_krb5_td_trusted_certifiers)
 
 extern krb5_error_code (*k5int_encode_krb5_kdc_req_body)
 	(const krb5_kdc_req *rep, krb5_data **code);
-extern void KRB5_CALLCONV (*k5int_krb5_free_kdc_req)
+extern void (KRB5_CALLCONV *k5int_krb5_free_kdc_req)
 	(krb5_context, krb5_kdc_req * );
 extern void (*k5int_set_prompt_types)
 	(krb5_context, krb5_prompt_type *);

--- a/src/plugins/preauth/pkinit/pkinit_clnt.c
+++ b/src/plugins/preauth/pkinit/pkinit_clnt.c
@@ -33,7 +33,6 @@
 #include "pkinit.h"
 #include "k5-json.h"
 
-#include <unistd.h>
 #include <sys/stat.h>
 
 /**

--- a/src/plugins/preauth/pkinit/pkinit_identity.c
+++ b/src/plugins/preauth/pkinit/pkinit_identity.c
@@ -30,7 +30,6 @@
  */
 
 #include "pkinit.h"
-#include <dirent.h>
 
 static void
 free_list(char **list)

--- a/src/plugins/preauth/pkinit/pkinit_matching.c
+++ b/src/plugins/preauth/pkinit/pkinit_matching.c
@@ -33,9 +33,8 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
-#include <regex.h>
 #include "pkinit.h"
+#include "k5-regex.h"
 
 typedef struct _pkinit_cert_info pkinit_cert_info;
 

--- a/src/windows/README
+++ b/src/windows/README
@@ -10,13 +10,24 @@ To build Kerberos 5 on Windows, you will need the following:
 
 * A version of Visual Studio (at least 2013) which includes the
   Microsoft Foundation Classes libraries.  These instructions will
-  work for Visual Studio 2017 Community or Professional, both of which
-  include the MFC libraries if the "Visual C++ MFC" checkbox is
-  selected after enabling the "Desktop development with C++" workload.
-  If you do not plan to build the graphical ticket manager
-  application, the MFC libraries are not required.
+  work for Visual Studio 2022 Community or Professional.  Include
+  the following components:
 
-* A version of Perl.
+  - Under Workloads, select Desktop development with C++
+  - Under Individual components -> SDKs, libraries, and frameworks,
+    select "C++ MFC for latest v*** build tools (x86 & x64)".  This
+    component is not required if you do not wish to build the
+    graphical ticket manager.
+  - Under Individual components -> Compilers, build tools, and
+    runtimes, select "C++ 20** Redistributable MSMs".  This component
+    is not required if you do not wish to build the installer.
+
+* An OpenSSL installation, including the headers, DLLs, and import
+  .LIB files.  This dependency is optional if you are not building
+  PKINIT.  We recommend building OpenSSL from source code.
+
+* A version of Perl.  We recommend Strawberry Perl as it will work
+  to build OpenSSL.
 
 * Some common Unix utilities such as sed/awk/cp/cat installed in the
   command-line path.
@@ -28,20 +39,12 @@ To build Kerberos 5 on Windows, you will need the following:
 
 A simple way to get the necessary Unix utilities is to install Git
 BASH from https://gitforwindows.org and configure it to add the Unix
-utilities to the command-line path.  In some versions of Windows (not
-the most current versions), the Unix utilities can alternatively be
-obtained via the Utilities and SDK for UNIX-based Applications, which
-may be enabled as a Windows feature and then the components installed.
-Note that the Windows nmake will not find the SUA awk utility in the
-path unless it is named awk.exe; the permissions on the utility may
-need correcting if awk.exe is created as a copy of the original awk.
+utilities to the command-line path.
 
-Git BASH contains a version of Perl, which will work to build krb5 if
-the newlines in the source tree are not translated to native newlines.
-Strawberry Perl will work regardless of whether newlines are
-translated.  If both Git BASH and Strawberry Perl are installed, you
-may need to adjust the command line path to ensure that the preferred
-Perl appears first.
+Git BASH contains a version of Perl, which will work to build krb5,
+but not to build OpenSSL from source.  If both Git BASH and Strawberry
+Perl are installed, you may need to adjust the command line path to
+ensure that the preferred Perl appears first when building OpenSSL.
 
 The krb5 source tree may be obtained either directly on the Windows
 machine with a native git client cloning the krb5 public mirror at
@@ -75,6 +78,14 @@ the MSI installer, this directory should be a temporary staging area in or
 near your build tree.  The directory must exist before nmake install
 is run.
 
+Set the environment variable OPENSSL_DIR to point to the root of the
+OpenSSL install tree, and the environment variable OPENSSL_VERSION to
+the version string as it apears in the DLL names (such as "1_1" or
+"3").  Include files should be in %OPENSSL_DIR%\include, import .LIB
+files should be in %OPENSSL_DIR%\lib, and the libcrypto DLL should be
+in %OPENSSL_DIR%\bin\libcrypto-%OPENSSL_VERSION%-x64.dll.  These steps
+are optional if you do not wish to build PKINIT.
+
 To skip building the graphical ticket manager, run "set NO_LEASH=1"
 before building, and do not build the installer.
 
@@ -82,11 +93,14 @@ Run the following commands in a Visual Studio command prompt:
 
  1) set PATH=%PATH%;"%WindowsSdkVerBinPath%"\x86  # To get uicc.exe
  2) set KRB_INSTALL_DIR=\path\to\dir    # Where bin/include/lib lives
- 3) cd xxx\src                          # Go to where source lives
- 4) nmake [NODEBUG=1]                   # Build the sources
- 5) nmake install [NODEBUG=1]           # Copy libraries/executables
- 6) cd windows\installer\wix            # Go to the installer source
- 7) nmake [NODEBUG=1]                   # Build the installer
+ 3) set OPENSSL_DIR=\path\to\openssl    # Where OpenSSL lives
+ 4) set OPENSSL_VERSION=3               # Version of OpenSSL DLLs
+ 5) cd xxx\src                          # Go to where source lives
+ 6) nmake -f Makefile.in prep-windows   # Create Makefile for Windows
+ 7) nmake [NODEBUG=1]                   # Build the sources
+ 8) nmake install [NODEBUG=1]           # Copy libraries/executables
+ 9) cd windows\installer\wix            # Go to the installer source
+10) nmake [NODEBUG=1]                   # Build the installer
 
 Step 1 may be skipped if uicc is already in the command-line path (try
 running "uicc" to see if you get a usage message or a not-found

--- a/src/windows/installer/wix/config.wxi
+++ b/src/windows/installer/wix/config.wxi
@@ -38,6 +38,8 @@
     <?define BinDir="$(env.KRB_INSTALL_DIR)\bin\"?>
     <?define PreauthDir=$(env.KRB_INSTALL_DIR)\bin\plugins\preauth?>
     <?define LibDir="$(env.KRB_INSTALL_DIR)\lib\"?>
+    <?define OpenSSLDir="$(env.OPENSSL_DIR)\bin"?>
+    <?define OpenSSLVer="$(env.OPENSSL_VERSION)"?>
     <?define InstallerVersion="450"?>
     <?ifndef env.VISUALSTUDIOVERSION?>
         <?define VCVer="100"?>

--- a/src/windows/installer/wix/features.wxi
+++ b/src/windows/installer/wix/features.wxi
@@ -63,7 +63,9 @@
             <ComponentRef Id="cmf_krbcc64_dll" />
             <ComponentRef Id="cmf_leashw64_dll" />
             <ComponentRef Id="cmf_xpprof64_dll" />
+            <ComponentRef Id="cmf_openssl_crypto64_dll" />
             <ComponentRef Id="cmf_spake64_dll" />
+            <ComponentRef Id="cmf_pkinit64_dll" />
             <ComponentRef Id="cmf_gss_client_exe" />
             <ComponentRef Id="cmf_gss_server_exe" />
             <ComponentRef Id="cmf_kdestroy_exe" />

--- a/src/windows/installer/wix/files.wxi
+++ b/src/windows/installer/wix/files.wxi
@@ -272,6 +272,9 @@
                   <Component Id="cmf_xpprof64_dll" Guid="$(var.cmf_xpprof64_dll_guid)" DiskId="1">
                     <File Id="fil_xpprof64_dll" Name="$(var.cmf_xpprof64_dll_name)" KeyPath="yes" />
                   </Component>
+                  <Component Id="cmf_openssl_crypto64_dll" Guid="$(var.cmf_openssl_crypto64_dll)" DiskId="1">
+                    <File Id="fil_openssl_crypto64_dll" Name="$(var.cmf_openssl_crypto64_dll_name)" Source="$(var.OpenSSLDir)\libcrypto-$(var.OpenSSLVer)-x64.dll" KeyPath="yes" />
+                  </Component>
 
                   <!-- Debug symbols -->
                 <?ifdef DebugSyms?>
@@ -305,8 +308,12 @@
                       <Component Id="cmf_spake64_dll" Guid="$(var.cmf_spake64_dll_guid)" DiskId="1">
                         <File Id="fil_spake64_dll" Name="$(var.cmf_spake64_dll_name)" KeyPath="yes" />
                       </Component>
+                      <Component Id="cmf_pkinit64_dll" Guid="$(var.cmf_pkinit64_dll_guid)" DiskId="1">
+                        <File Id="fil_pkinit64_dll" Name="$(var.cmf_pkinit64_dll_name)" KeyPath="yes" />
+                      </Component>
                       <?ifdef DebugSyms?>
                         <Component Id="cmf_preauth_debug" Guid="$(var.cmf_preauth_debug_guid)" DiskId="1">
+                          <File Id="fil_pkinit64_pdb" Name="pkinit64.pdb" />
                           <File Id="fil_spake64_pdb" Name="spake64.pdb" />
                         </Component>
                       <?endif?>

--- a/src/windows/installer/wix/platform.wxi
+++ b/src/windows/installer/wix/platform.wxi
@@ -73,6 +73,10 @@
   <?define cmf_xpprof64_dll_name="xpprof64.dll"?>
   <?define cmf_spake64_dll_guid="0E97B52A-EC8E-494C-BF5D-83AAACFEFDBA"?>
   <?define cmf_spake64_dll_name="spake64.dll"?>
+  <?define cmf_pkinit64_dll_guid="5F7A1656-5A55-4067-842D-73380DF57442"?>
+  <?define cmf_pkinit64_dll_name="pkinit64.dll"?>
+  <?define cmf_openssl_crypto64_dll="6762F903-0B15-4F29-9128-1CEB4AFB99B3"?>
+  <?define cmf_openssl_crypto64_dll_name="libcrypto-$(var.OpenSSLVer)-x64.dll"?>
   <?define cmf_krb5cred_dll_guid="CC182AB1-E333-4501-8DEA-5A8D4FD36D0D"?>
   <?define cmf_krb5cred_dll_name="krb5cred.dll"?>
   <?define cmf_krb5cred_en_us_dll_guid="223B7E9D-290F-40b8-89B3-F8337A8E082D"?>


### PR DESCRIPTION
These changes implement support for the PKINIT plugin on Windows platforms

This has been split into two parts: the aforementioned std::regex glue code for Windows platforms and the actual building of the PKINIT plugin.

The ```std::regex``` changes were as discussed previously, except that the question I posed on ```krbdev``` regarding specifying the ```-entry:DllMain``` option was never answered. My solution here is to remove this for building the krb5 DLLs; since the system default DLL entry point automatically calls ```DllMain``` if one is provided, it seems like this isn't necessary and things seem to work fine (you get unknown symbols when building the DLL otherwise). The use of ```-entry``` for building the CCAPI DLL and KFWLogin DLL has not been changed, but probably should be looked at by someone smarter than I.

Building the PKINIT plugin is mostly straightforward; there are some generic changes that need to be made, like converting the certificate loading routines that scan directories to the ```k5_dir_filenames``` interface. I also had to add a ```DllMain``` function to the pkinit plugin so it would call the plugin DLL initializer function; I decided not to use the routines that did that in ```win_glue.c``` as that seemed to be overkill for this. I also had to change a ```free()``` call to ```OPENSSL_free()``` as an exception was generated otherwise.

My current solution for the OpenSSL dependency is to require the setting of a variable ```OPENSSL_DIR``` when building Kerberos; that has to point to the root of a OpenSSL install tree; it is expected that include files are under ```%OPENSSL_DIR%\include``` and the import ```LIB``` files are under ```%OPENSSL_DIR%\lib```. If that variable isn't set then the plugin will not be built. This was tested with OpenSSL 3.4.0.

I haven't yet updated the build instructions or done anything about the installer; I wanted to get some feedback first on the direction of these changes. I tested this in our realm with a PKCS#11 library that interfaces with my work-issued smartcard; works fine.

I expect Leash will need some changes as it requires a password; if you give it a dummy password it will do PKINIT fine. That is also TBD.

Feedback is welcome.