### PR TITLE
Remove unused GSS mechglue source file

### DIFF
--- a/src/lib/gssapi/mechglue/Makefile.in
+++ b/src/lib/gssapi/mechglue/Makefile.in
@@ -49,7 +49,6 @@ SRCS = \
 	$(srcdir)/g_map_name_to_any.c \
 	$(srcdir)/g_mech_invoke.c \
 	$(srcdir)/g_mechattr.c \
-	$(srcdir)/g_mechname.c \
 	$(srcdir)/g_negoex.c \
 	$(srcdir)/g_oid_ops.c \
 	$(srcdir)/g_prf.c \
@@ -114,7 +113,6 @@ OBJS = \
 	$(OUTPRE)g_map_name_to_any.$(OBJEXT) \
 	$(OUTPRE)g_mech_invoke.$(OBJEXT) \
 	$(OUTPRE)g_mechattr.$(OBJEXT) \
-	$(OUTPRE)g_mechname.$(OBJEXT) \
 	$(OUTPRE)g_negoex.$(OBJEXT) \
 	$(OUTPRE)g_oid_ops.$(OBJEXT) \
 	$(OUTPRE)g_prf.$(OBJEXT) \
@@ -179,7 +177,6 @@ STLIBOBJS = \
 	g_map_name_to_any.o \
 	g_mech_invoke.o \
 	g_mechattr.o \
-	g_mechname.o \
 	g_negoex.o \
 	g_oid_ops.o \
 	g_prf.o \

--- a/src/lib/gssapi/mechglue/deps
+++ b/src/lib/gssapi/mechglue/deps
@@ -352,15 +352,6 @@ g_mechattr.so g_mechattr.po $(OUTPRE)g_mechattr.$(OBJEXT): \
   $(top_srcdir)/include/k5-platform.h $(top_srcdir)/include/k5-thread.h \
   ../generic/gssapi_err_generic.h g_mechattr.c mechglue.h \
   mglueP.h
-g_mechname.so g_mechname.po $(OUTPRE)g_mechname.$(OBJEXT): \
-  $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/gssapi/gssapi.h \
-  $(BUILDTOP)/include/gssapi/gssapi_alloc.h $(BUILDTOP)/include/gssapi/gssapi_ext.h \
-  $(COM_ERR_DEPS) $(srcdir)/../generic/gssapiP_generic.h \
-  $(srcdir)/../generic/gssapi_ext.h $(srcdir)/../generic/gssapi_generic.h \
-  $(top_srcdir)/include/k5-buf.h $(top_srcdir)/include/k5-input.h \
-  $(top_srcdir)/include/k5-platform.h $(top_srcdir)/include/k5-thread.h \
-  ../generic/gssapi_err_generic.h g_mechname.c mechglue.h \
-  mglueP.h
 g_negoex.so g_negoex.po $(OUTPRE)g_negoex.$(OBJEXT): \
   $(BUILDTOP)/include/autoconf.h $(BUILDTOP)/include/gssapi/gssapi.h \
   $(BUILDTOP)/include/gssapi/gssapi_alloc.h $(BUILDTOP)/include/gssapi/gssapi_ext.h \

--- a/src/lib/gssapi/mechglue/mglueP.h
+++ b/src/lib/gssapi/mechglue/mglueP.h
@@ -799,14 +799,6 @@ OM_uint32 gssint_create_union_context(
 	gss_union_ctx_id_t *	/* ctx_out */
 );
 
-gss_OID gss_find_mechanism_from_name_type (gss_OID); /* name_type */
-
-OM_uint32 gss_add_mech_name_type
-	   (OM_uint32 *,	/* minor_status */
-	    gss_OID,		/* name_type */
-	    gss_OID		/* mech */
-	       );
-
 /*
  * Sun extensions to GSS-API v2
  */


### PR DESCRIPTION
The functions in g_mechname.c have been unused since release 1.5. Remove the file.