### PR TITLE
Remove explicit use of -entry flag for DLLs on Windows

### DIFF
--- a/src/ccapi/lib/win/Makefile.in
+++ b/src/ccapi/lib/win/Makefile.in
@@ -95,7 +95,7 @@ $(CCLIBRES): $(VERSIONRC)
 	$(RC) $(RCFLAGS) -DCCAPI_LIB -fo $@ -r $**
 
 $(OUTPRE)$(CCLIB).dll: $(OBJS) $(CCLIB).def $(CCLIBRES)
-	$(LINK) $(LFLAGS) -entry:$(ENTRYPOINT) -dll /map:$*.map /out:$@ /DEF:$(CCLIB).def $(OBJS) \
+	$(LINK) $(LFLAGS) -dll /map:$*.map /out:$@ /DEF:$(CCLIB).def $(OBJS) \
 	    /implib:$(CCLIB).lib $(dllflags) $(LIBS) $(KFWLIB) $(CCLIBRES) rpcrt4.lib $(conlibsdll) $(conflags)
 
 $(CCLIB).def:

--- a/src/config/win-pre.in
+++ b/src/config/win-pre.in
@@ -125,11 +125,6 @@ CPPFLAGS=-I$(top_srcdir)\include -I$(top_srcdir)\include\krb5 $(DNSFLAGS) -DWIN3
 CCOPTS=-nologo /EHsc /W3 /we4020 /we4024 /we4047 $(PDB_OPTS) $(DLL_FILE_DEF)
 LOPTS=-nologo -incremental:no -manifest
 
-!if  ("$(BITS)" == "64" )
-ENTRYPOINT=_DllMainCRTStartup
-!else
-ENTRYPOINT=_DllMainCRTStartup@12
-!endif
 CCLINKOPTION=
 DEBUGOPT=/guard:cf /Zi
 
@@ -169,8 +164,7 @@ LOPTS=$(LOPTS) -debug
 INSTALLDBGSYMS=copy
 !endif
 
-# XXX - NOTE: We should probably use DllMainCRTStartup
-DLL_LINKOPTS=$(LOPTS) -dll -entry:DllMain
+DLL_LINKOPTS=$(LOPTS) -dll
 EXE_LINKOPTS=$(LOPTS)
 
 RM=$(BUILDTOP)\config\rm.bat

--- a/src/windows/kfwlogon/Makefile.in
+++ b/src/windows/kfwlogon/Makefile.in
@@ -34,7 +34,7 @@ $(EXERES): $(VERSIONRC)
 all-windows: $(OUTPRE)kfwlogon.dll $(OUTPRE)kfwcpcc.exe
 
 $(KFWLOGON): $(OUTPRE)kfwlogon.obj $(OUTPRE)kfwcommon.obj $(LIBRES)
-    link $(DLL_LINKOPTS) -out:$@ $(OUTPRE)kfwlogon.obj $(OUTPRE)kfwcommon.obj -entry:DllEntryPoint -def:kfwlogon.def $(SYSLIBS) $(KLIB) $(CLIB) ../lib/$(OUTPRE)libwin.lib $(LIBRES)
+    link $(DLL_LINKOPTS) -out:$@ $(OUTPRE)kfwlogon.obj $(OUTPRE)kfwcommon.obj -def:kfwlogon.def $(SYSLIBS) $(KLIB) $(CLIB) ../lib/$(OUTPRE)libwin.lib $(LIBRES)
     $(_VC_MANIFEST_EMBED_DLL)
 
 $(KFWCPCC): $(OUTPRE)kfwcpcc.obj $(OUTPRE)kfwcommon.obj $(EXERES)

--- a/src/windows/kfwlogon/kfwcommon.c
+++ b/src/windows/kfwlogon/kfwcommon.c
@@ -351,7 +351,7 @@ void DebugEvent(char *b,...)
 static HANDLE hInitMutex = NULL;
 static BOOL bInit = FALSE;
 
-/* KFW_initialize cannot be called from DllEntryPoint */
+/* KFW_initialize cannot be called from DllMain */
 void
 KFW_initialize(void)
 {

--- a/src/windows/kfwlogon/kfwlogon.c
+++ b/src/windows/kfwlogon/kfwlogon.c
@@ -41,7 +41,7 @@ static HANDLE hInitMutex = NULL;
 static BOOL bInit = FALSE;
 
 
-BOOLEAN APIENTRY DllEntryPoint(HANDLE dll, DWORD reason, PVOID reserved)
+BOOLEAN APIENTRY DllMain(HANDLE dll, DWORD reason, PVOID reserved)
 {
     hDLL = dll;
     switch (reason) {

--- a/src/windows/kfwlogon/kfwlogon.def
+++ b/src/windows/kfwlogon/kfwlogon.def
@@ -2,7 +2,6 @@ LIBRARY KFWLOGON
 
 EXPORTS
 
-    DllEntryPoint
     NPGetCaps
     NPLogonNotify
     NPPasswordChangeNotify

--- a/src/windows/kfwlogon/kfwlogon.h
+++ b/src/windows/kfwlogon/kfwlogon.h
@@ -165,7 +165,7 @@ cc_free_NC_info,
 
 #define KFW_LOGON_EVENT_NAME TEXT("MIT Kerberos")
 
-BOOLEAN APIENTRY DllEntryPoint(HANDLE dll, DWORD reason, PVOID reserved);
+BOOLEAN WINAPI DllMain(HANDLE dll, DWORD reason, PVOID reserved);
 
 DWORD APIENTRY NPGetCaps(DWORD index);
 


### PR DESCRIPTION
Remove the explicit use of the -entry flag to specify a DLL entry point on Windows; this is no longer recommended.  The default Windows entry point will call a DllMain function if one is provided; make sure we provide when necessary.