### PR TITLE
WIP: Fix CI errors on Ubuntu 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,13 @@ jobs:
             matrix:
                 name: [linux-clang, linux-clang-openssl, linux-gcc]
                 include:
+                    # llvm-symbolizer fails on Ubuntu 24.04 until we
+                    # can avoid using LD_LIBRARY_PATH in the test
+                    # suite.  This causes test suite failures due to
+                    # SIGPIPE exits from test programs.  See
+                    # https://github.com/llvm/llvm-project/issues/120915
                     - name: linux-clang
-                      os: ubuntu-latest
+                      os: ubuntu-22.04
                       compiler: clang
                       makevars: CPPFLAGS=-Werror
                       configureopts: --enable-asan

--- a/src/lib/krb5/krb/x-deltat.y
+++ b/src/lib/krb5/krb/x-deltat.y
@@ -44,6 +44,7 @@
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuninitialized"
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 #endif
 
 #include "k5-int.h"

--- a/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.c
@@ -43,10 +43,7 @@
  * ldap get age
  */
 krb5_error_code
-krb5_ldap_get_age(context, db_name, age)
-    krb5_context context;
-    char *db_name;
-    time_t *age;
+krb5_ldap_get_age(krb5_context context, char *db_name, time_t *age)
 {
     time (age);
     return 0;

--- a/src/tests/asn.1/krb5_decode_test.c
+++ b/src/tests/asn.1/krb5_decode_test.c
@@ -51,6 +51,10 @@ static void ktest_free_pa_pk_as_rep(krb5_context context,
 static void ktest_free_reply_key_pack(krb5_context context,
                                       krb5_reply_key_pack *val);
 #endif
+#ifdef ENABLE_LDAP
+static void ktest_free_ldap_seqof_key_data(krb5_context context,
+                                           ldap_seqof_key_data *val);
+#endif
 static void ktest_free_kkdcp_message(krb5_context context,
                                      krb5_kkdcp_message *val);
 
@@ -1210,6 +1214,7 @@ main(int argc, char **argv)
         ktest_make_sample_principal(&ref);
         decode_run("krb5_principal_name","","30 2E A0 10 1B 0E 41 54 48 45 4E 41 2E 4D 49 54 2E 45 44 55 A1 1A 30 18 A0 03 02 01 01 A1 11 30 0F 1B 06 68 66 74 73 61 69 1B 05 65 78 74 72 61",
                    acc.decode_krb5_principal_name,equal_principal,krb5_free_principal);
+        ktest_destroy_principal(&ref);
     }
 
 #endif /* not DISABLE_PKINIT */
@@ -1218,8 +1223,8 @@ main(int argc, char **argv)
     /* ldap sequence_of_keys */
     {
         setup(ldap_seqof_key_data,ktest_make_sample_ldap_seqof_key_data);
-        decode_run("ldap_seqof_key_data","","30 81 87 A0 03 02 01 01 A1 03 02 01 01 A2 03 02 01 2A A3 03 02 01 0E A4 71 30 6F 30 23 A0 10 30 0E A0 03 02 01 00 A1 07 04 05 73 61 6C 74 30 A1 0F 30 0D A0 03 02 01 02 A1 06 04 04 6B 65 79 30 30 23 A0 10 30 0E A0 03 02 01 01 A1 07 04 05 73 61 6C 74 31 A1 0F 30 0D A0 03 02 01 02 A1 06 04 04 6B 65 79 31 30 23 A0 10 30 0E A0 03 02 01 02 A1 07 04 05 73 61 6C 74 32 A1 0F 30 0D A0 03 02 01 02 A1 06 04 04 6B 65 79 32",acc.asn1_ldap_decode_sequence_of_keys,ktest_equal_ldap_sequence_of_keys,ktest_empty_ldap_seqof_key_data);
-        ktest_empty_ldap_seqof_key_data(test_context, &ref);
+        decode_run("ldap_seqof_key_data","","30 81 87 A0 03 02 01 01 A1 03 02 01 01 A2 03 02 01 2A A3 03 02 01 0E A4 71 30 6F 30 23 A0 10 30 0E A0 03 02 01 00 A1 07 04 05 73 61 6C 74 30 A1 0F 30 0D A0 03 02 01 02 A1 06 04 04 6B 65 79 30 30 23 A0 10 30 0E A0 03 02 01 01 A1 07 04 05 73 61 6C 74 31 A1 0F 30 0D A0 03 02 01 02 A1 06 04 04 6B 65 79 31 30 23 A0 10 30 0E A0 03 02 01 02 A1 07 04 05 73 61 6C 74 32 A1 0F 30 0D A0 03 02 01 02 A1 06 04 04 6B 65 79 32",acc.asn1_ldap_decode_sequence_of_keys,ktest_equal_ldap_sequence_of_keys,ktest_free_ldap_seqof_key_data);
+        ktest_empty_ldap_seqof_key_data(&ref);
     }
 
 #endif
@@ -1289,6 +1294,16 @@ ktest_free_reply_key_pack(krb5_context context, krb5_reply_key_pack *val)
 }
 
 #endif /* not DISABLE_PKINIT */
+
+#ifdef ENABLE_LDAP
+static void
+ktest_free_ldap_seqof_key_data(krb5_context context, ldap_seqof_key_data *val)
+{
+    if (val)
+        ktest_empty_ldap_seqof_key_data(val);
+    free(val);
+}
+#endif /* ENABLE_LDAP */
 
 static void
 ktest_free_kkdcp_message(krb5_context context,

--- a/src/tests/asn.1/krb5_encode_test.c
+++ b/src/tests/asn.1/krb5_encode_test.c
@@ -840,7 +840,7 @@ main(int argc, char **argv)
         ktest_make_sample_ldap_seqof_key_data(&skd);
         encode_run(skd, "ldap_seqof_key_data", "",
                    acc.asn1_ldap_encode_sequence_of_keys);
-        ktest_empty_ldap_seqof_key_data(test_context, &skd);
+        ktest_empty_ldap_seqof_key_data(&skd);
     }
 #endif
 

--- a/src/tests/asn.1/ktest.c
+++ b/src/tests/asn.1/ktest.c
@@ -1710,7 +1710,7 @@ void ktest_empty_pkinit_supp_pub_info(krb5_pkinit_supp_pub_info *p)
 
 #ifdef ENABLE_LDAP
 void
-ktest_empty_ldap_seqof_key_data(krb5_context ctx, ldap_seqof_key_data *p)
+ktest_empty_ldap_seqof_key_data(ldap_seqof_key_data *p)
 {
     int i;
 
@@ -1758,7 +1758,7 @@ ktest_empty_cammac(krb5_cammac *p)
 void
 ktest_empty_secure_cookie(krb5_secure_cookie *p)
 {
-    ktest_empty_pa_data_array(p->data);
+    ktest_destroy_pa_data_array(&p->data);
 }
 
 void

--- a/src/tests/asn.1/ktest.h
+++ b/src/tests/asn.1/ktest.h
@@ -195,7 +195,7 @@ void ktest_empty_pkinit_supp_pub_info(krb5_pkinit_supp_pub_info *p);
 #endif
 
 #ifdef ENABLE_LDAP
-void ktest_empty_ldap_seqof_key_data(krb5_context, ldap_seqof_key_data *p);
+void ktest_empty_ldap_seqof_key_data(ldap_seqof_key_data *p);
 #endif
 
 void ktest_empty_kkdcp_message(krb5_kkdcp_message *p);

--- a/src/tests/hammer/kdc5_hammer.c
+++ b/src/tests/hammer/kdc5_hammer.c
@@ -179,7 +179,8 @@ main(int argc, char **argv)
 	}
     }
 
-    if (!(num_to_check && prefix[0])) usage(prog, 1);
+    if (!(num_to_check && prefix[0]) || errflg)
+	usage(prog, 1);
 
     if (!cur_realm) {
 	if ((retval = krb5_get_default_realm(test_context, &cur_realm))) {


### PR DESCRIPTION
Github is transitioning the ubuntu-latest image from 22.04 to 24.04, which means our CI jobs sometimes run on one and sometimes on the other.

Most of the changes here are simple fixes to problems that previous escaped the various nets we've cast around them.  I am currently a bit stymied by an asan problem.  When asan has something to report, it tries to use llvm-symbolizer and fails with an error like:

```
/usr/bin/llvm-symbolizer-18: symbol lookup error: /home/runner/work/krb5/krb5/src/./lib/libkrb5support.so.0: undefined symbol: __asan_option_detect_stack_use_after_return
5131
==29597==WARNING: Can't read from symbolizer at fd 3
5132
```

In some cases this appears to cause the program to exit with status -13 (SIGPIPE).  Usually this is just a minor hindrance to analyzing a problem we want to fix anyway (and can debug locally with valgrind).  But in some cases, we intentionally cause a test program to exit early with an error.  In this cases, asan reports memory leaks even though the "leaked" memory is still accessible from the call stack leading up to the exit() call (valgrind does as well).  Currently that doesn't cause a `make check` failure because the test program's exit status is 1 with or without an asan leak report.  But if the exit status changes to -13 due to the symbolizer problem, the Python script doesn't see the status it expects and `make check` fails.

Possibly all of those tests should be restructured so that no leaks are reported (and perhaps so that any leaks that are reported cause `make check` failures).  But the symbolizer issue is annoying regardless.  We could run the asan build on ubuntu-22.04 instead of ubuntu-latest, which would kick the can down the road about two years, by which time the symbolizer issue might have been fixed by other people.  But I didn't find any useful search results for the error message, suggesting that the problem might be specific to our use of asan, in which case it's less likely to get fixed if we don't track it down ourselves.

The changes to shlib.conf are an unsuccessful attempt to fix the symbolizer issue (by passing `-fsanitize=address` when building shared libraries) and will likely not be retained.  Likewise the change to ignore SIGPIPE in t_credstore.c.

The changes to build.yml are just for the PR branch, and won't be merged.
