### PR TITLE
Work around llvm-symbolizer LD_LIBRARY_PATH issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,8 @@ jobs:
             matrix:
                 name: [linux-clang, linux-clang-openssl, linux-gcc]
                 include:
-                    # llvm-symbolizer fails on Ubuntu 24.04 until we
-                    # can avoid using LD_LIBRARY_PATH in the test
-                    # suite.  This causes test suite failures due to
-                    # SIGPIPE exits from test programs.  See
-                    # https://github.com/llvm/llvm-project/issues/120915
                     - name: linux-clang
-                      os: ubuntu-22.04
+                      os: ubuntu-latest
                       compiler: clang
                       makevars: CPPFLAGS=-Werror
                       configureopts: --enable-asan

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -515,11 +515,13 @@ testrealm: runenv.py
 
 # environment variable settings to propagate to Python-based tests
 
+ASAN = @ASAN@
 pyrunenv.vals: Makefile
 	$(RUN_SETUP); \
 	for i in $(RUN_VARS); do \
 		eval echo 'env['\\\'$$i\\\''] = '\\\'\$$$$i\\\'; \
 	done > $@
+	echo "asan = '$(ASAN)'" >> $@
 	echo "tls_impl = '$(TLS_IMPL)'" >> $@
 	echo "have_sasl = '$(HAVE_SASL)'" >> $@
 	echo "have_spake_openssl = '$(HAVE_SPAKE_OPENSSL)'" >> $@

--- a/src/tests/t_kdb.py
+++ b/src/tests/t_kdb.py
@@ -591,6 +591,9 @@ dbmod['ldap_kdc_sasl_authcid'] = 'digestuser'
 dbmod['ldap_kadmind_sasl_authcid'] = 'digestuser'
 dbmod['ldap_service_password_file'] = ldap_pwfile
 realm = K5Realm(create_kdb=False, kdc_conf=conf)
+# Work around https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1091694
+if runenv.asan == 'yes':
+    realm.env['ASAN_OPTIONS'] = 'detect_leaks=false'
 input = admin_pw + '\n' + admin_pw + '\n'
 realm.run([kdb5_ldap_util, 'stashsrvpw', 'digestuser'], input=input)
 realm.run([kdb5_ldap_util, 'create', '-s', '-P', 'master'])


### PR DESCRIPTION
On some platforms llvm-symbolizer is linked against libcurl, which depends on the krb5 libraries.  When the test suite runs programs with LD_LIBRARY_PATH pointed at asan-compiled krb5 libraries, llvm-symbolizer will encounter a dynamic linker error at startup, interfering with the display of stack traces.

In k5test.py, when the build enables asan, wrap the platform's symbolizer in a script that unsets LD_LIBRARY_PATH (or similar) and then runs the real llvm-symbolizer.

[I thought of this workaround for the symbolizer problem described in PR #1404, and it appears to work without requiring major changes to the build system.  Unfortunately, fixing it revealed another detected leak in t_kdb.py.  I'm not sure this leak is ours, since the allocations occur inside a call to ldap_sasl_interactive_bind_s() and it does not appear that the entire handle is leaked.  But we'll have to address it in some fashion.]
