### PR TITLE
Remove redundant test in acquire_cred_from()

### DIFF
--- a/src/lib/gssapi/krb5/acquire_cred.c
+++ b/src/lib/gssapi/krb5/acquire_cred.c
@@ -1283,8 +1283,8 @@ acquire_cred_from(OM_uint32 *minor_status, const gss_name_t desired_name,
             ret = GSS_S_BAD_NAME;
             goto out;
         }
-        if (cred_usage == GSS_C_ACCEPT || desired_name == GSS_C_NO_NAME ||
-            ccache != NULL || client_keytab != NULL) {
+        if (cred_usage == GSS_C_ACCEPT || ccache != NULL ||
+            client_keytab != NULL) {
             *minor_status = (OM_uint32)G_BAD_USAGE;
             ret = GSS_S_FAILURE;
             goto out;


### PR DESCRIPTION
This fix is just about code sanity.

In case the `cred_store` type is `KRB5_CS_PASSWORD_URN` and the `desired_name` is not set, its value is tested twice while the first test sends the program counter to the end of the function.

This commit removes the second test, because it cannot be true.