### PR TITLE
Allow only one salt type per enctype in key data

### DIFF
--- a/src/lib/kdb/kdb_cpw.c
+++ b/src/lib/kdb/kdb_cpw.c
@@ -264,8 +264,7 @@ add_key_pwd(krb5_context context, krb5_keyblock *master_key,
                                                  &similar)))
                 return(retval);
 
-            if (similar &&
-                (ks_tuple[j].ks_salttype == ks_tuple[i].ks_salttype))
+            if (similar)
                 break;
         }
 


### PR DESCRIPTION
In the default libkdb5 password change method, omit requested key/salt combinations that duplicate an earlier encryption type, even if they have a different salt type.  Any use cases for multiple salts for the same enctype disappeared with single-DES support.  (We already have this behavior for chrand requests.)