### PR TITLE
Fix gss_iakerb client realm discovery

### DIFF
--- a/src/lib/gssapi/krb5/import_name.c
+++ b/src/lib/gssapi/krb5/import_name.c
@@ -215,6 +215,9 @@ krb5_gss_import_name(OM_uint32 *minor_status, gss_buffer_t input_name_buffer,
         } else if (g_OID_equal(input_name_type, GSS_KRB5_NT_ENTERPRISE_NAME)) {
             stringrep = tmp;
             flags |= KRB5_PRINCIPAL_PARSE_ENTERPRISE;
+            // if (how to detect if this is iakerb???)
+            //    /* realm discovery */
+            //    flags |= KRB5_PRINCIPAL_PARSE_NO_DEF_REALM
 #ifndef NO_PASSWORD
         } else if (g_OID_equal(input_name_type, gss_nt_machine_uid_name)) {
             uid = *(uid_t *) input_name_buffer->value;


### PR DESCRIPTION
Hi Greg,

Alexander and I tried to implement client realm discovery as described in the RFC.

[3.1 Enterprise principal names](https://datatracker.ietf.org/doc/html/draft-ietf-kitten-iakerb-03#section-3.1)

However the default realm is always is always added in the gss_krb5_import_name(). The question is how do we detect that we are doing iakerb and and skip adding the default realm.

The top commit in my asn-iakerb samba branch shows the changes we did on the client:
https://git.samba.org/?p=asn/samba.git;a=shortlog;h=refs/heads/asn-iakerb

Thanks for your help!