### PR TITLE
Fix IAKERB accept_sec_context null pointer crash

### DIFF
--- a/src/appl/gss-sample/t_gss_sample.py
+++ b/src/appl/gss-sample/t_gss_sample.py
@@ -116,6 +116,13 @@ for realm in multipass_realms():
     # test default (i.e., krb5) mechanism with GSS_C_DCE_STYLE
     tgs_test(realm, ['-dce'])
 
+    mark('AP')
+    ccache_save(realm)
+    tgs_test(realm, ['-krb5'])
+    tgs_test(realm, ['-spnego'])
+    tgs_test(realm, ['-iakerb'], ['-iakerb'])
+    tgs_test(realm, ['-dce'])
+
     mark('pw')
     pw_test(realm, ['-krb5'])
     pw_test(realm, ['-spnego'])


### PR DESCRIPTION
A regression in commit e04f0283516e80d2f93366e0d479d13c9b5c8c2a leads to iakerb_gss_init_sec_context() returning successfully with *context_handle still set to null, in the case where no IAKERB steps are necessary.  Subsequent GSS calls using this context will dereference a null pointer and crash.

Fix this bug by moving the *context_handle assignment to the cleanup handler, alongside the code to clean up new contexts on error.

[ghudson@mit.edu: moved fix to cleanup handler to avoid code duplication; rewrote commit message]