### PR TITLE
Fix correctness in LDAP delegation ACL checking

### DIFF
--- a/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/kdb_ldap.c
@@ -296,7 +296,9 @@ krb5_ldap_check_allowed_to_delegate(krb5_context context,
     for (tlp = server->tl_data; tlp != NULL; tlp = tlp->tl_data_next) {
         krb5_principal acl;
 
-        if (tlp->tl_data_type != KRB5_TL_CONSTRAINED_DELEGATION_ACL)
+        if (tlp->tl_data_type != KRB5_TL_CONSTRAINED_DELEGATION_ACL ||
+            tlp->tl_data_length < 1 ||
+            tlp->tl_data_contents[tlp->tl_data_length - 1] != '\0')
             continue;
 
         if (krb5_parse_name(context, (char *)tlp->tl_data_contents, &acl) != 0)

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.c
@@ -1606,7 +1606,7 @@ populate_krb5_db_entry(krb5_context context, krb5_ldap_context *ldap_context,
             if (tl == NULL)
                 goto cleanup;
             tl->tl_data_type = KRB5_TL_CONSTRAINED_DELEGATION_ACL;
-            tl->tl_data_length = strlen(a2d2[i]);
+            tl->tl_data_length = strlen(a2d2[i]) + 1;
             tl->tl_data_contents = (unsigned char *)strdup(a2d2[i]);
             if (tl->tl_data_contents == NULL) {
                 ret = ENOMEM;


### PR DESCRIPTION
The LDAP KDB module synthesizes KRB5_TL_CONSTRAINED_DELEGATION_ACL tl-data when fetching a principal entry, and checks against those values in krb5_ldap_check_allowed_to_delegate().  To avoid a locally incorrect use of a counted data type, adjust the synthesized attributes to include the trailing zero byte in tl_data_length, and verify the zero terminator before calling krb5_parse_name() on the value.