### PR TITLE
Limit -keepold for self-service key changes

### DIFF
--- a/src/include/kdb.h
+++ b/src/include/kdb.h
@@ -636,7 +636,7 @@ krb5_dbe_cpw( krb5_context        kcontext,
               int                         ks_tuple_count,
               char              * passwd,
               int                         new_kvno,
-              krb5_boolean        keepold,
+              unsigned int        keepold,
               krb5_db_entry     * db_entry);
 
 
@@ -652,7 +652,7 @@ krb5_dbe_crk( krb5_context        context,
               krb5_keyblock       * master_key,
               krb5_key_salt_tuple       * ks_tuple,
               int                         ks_tuple_count,
-              krb5_boolean        keepold,
+              unsigned int        keepold,
               krb5_db_entry     * db_entry);
 
 krb5_error_code
@@ -774,7 +774,7 @@ krb5_dbe_def_cpw( krb5_context    context,
                   int                     ks_tuple_count,
                   char          * passwd,
                   int                     new_kvno,
-                  krb5_boolean    keepold,
+                  unsigned int    keepold,
                   krb5_db_entry * db_entry);
 
 krb5_error_code
@@ -1250,7 +1250,7 @@ typedef struct _kdb_vftabl {
                                   krb5_keyblock *master_key,
                                   krb5_key_salt_tuple *ks_tuple,
                                   int ks_tuple_count, char *passwd,
-                                  int new_kvno, krb5_boolean keepold,
+                                  int new_kvno, unsigned int keepold,
                                   krb5_db_entry *db_entry);
 
     /*

--- a/src/lib/kadm5/admin.h
+++ b/src/lib/kadm5/admin.h
@@ -381,7 +381,7 @@ kadm5_ret_t    kadm5_chpass_principal(void *server_handle,
                                       char *pass);
 kadm5_ret_t    kadm5_chpass_principal_3(void *server_handle,
                                         krb5_principal principal,
-                                        krb5_boolean keepold,
+                                        unsigned int keepold,
                                         int n_ks_tuple,
                                         krb5_key_salt_tuple *ks_tuple,
                                         char *pass);
@@ -391,7 +391,7 @@ kadm5_ret_t    kadm5_randkey_principal(void *server_handle,
                                        int *n_keys);
 kadm5_ret_t    kadm5_randkey_principal_3(void *server_handle,
                                          krb5_principal principal,
-                                         krb5_boolean keepold,
+                                         unsigned int keepold,
                                          int n_ks_tuple,
                                          krb5_key_salt_tuple *ks_tuple,
                                          krb5_keyblock **keyblocks,
@@ -404,7 +404,7 @@ kadm5_ret_t    kadm5_setkey_principal(void *server_handle,
 
 kadm5_ret_t    kadm5_setkey_principal_3(void *server_handle,
                                         krb5_principal principal,
-                                        krb5_boolean keepold,
+                                        unsigned int keepold,
                                         int n_ks_tuple,
                                         krb5_key_salt_tuple *ks_tuple,
                                         krb5_keyblock *keyblocks,
@@ -412,7 +412,7 @@ kadm5_ret_t    kadm5_setkey_principal_3(void *server_handle,
 
 kadm5_ret_t    kadm5_setkey_principal_4(void *server_handle,
                                         krb5_principal principal,
-                                        krb5_boolean keepold,
+                                        unsigned int keepold,
                                         kadm5_key_data *key_data,
                                         int n_key_data);
 

--- a/src/lib/kadm5/clnt/client_principal.c
+++ b/src/lib/kadm5/clnt/client_principal.c
@@ -249,7 +249,7 @@ kadm5_chpass_principal(void *server_handle,
 
 kadm5_ret_t
 kadm5_chpass_principal_3(void *server_handle,
-                         krb5_principal princ, krb5_boolean keepold,
+                         krb5_principal princ, unsigned int keepold,
                          int n_ks_tuple, krb5_key_salt_tuple *ks_tuple,
                          char *password)
 {
@@ -300,7 +300,7 @@ kadm5_setkey_principal(void *server_handle,
 kadm5_ret_t
 kadm5_setkey_principal_3(void *server_handle,
                          krb5_principal princ,
-                         krb5_boolean keepold, int n_ks_tuple,
+                         unsigned int keepold, int n_ks_tuple,
                          krb5_key_salt_tuple *ks_tuple,
                          krb5_keyblock *keyblocks,
                          int n_keys)
@@ -329,7 +329,7 @@ kadm5_setkey_principal_3(void *server_handle,
 kadm5_ret_t
 kadm5_setkey_principal_4(void *server_handle,
                          krb5_principal princ,
-                         krb5_boolean keepold,
+                         unsigned int keepold,
                          kadm5_key_data *key_data,
                          int n_key_data)
 {
@@ -355,7 +355,7 @@ kadm5_setkey_principal_4(void *server_handle,
 kadm5_ret_t
 kadm5_randkey_principal_3(void *server_handle,
                           krb5_principal princ,
-                          krb5_boolean keepold, int n_ks_tuple,
+                          unsigned int keepold, int n_ks_tuple,
                           krb5_key_salt_tuple *ks_tuple,
                           krb5_keyblock **key, int *n_keys)
 {

--- a/src/lib/kadm5/srv/svr_principal.c
+++ b/src/lib/kadm5/srv/svr_principal.c
@@ -1218,7 +1218,7 @@ kadm5_chpass_principal(void *server_handle,
 
 kadm5_ret_t
 kadm5_chpass_principal_3(void *server_handle,
-                         krb5_principal principal, krb5_boolean keepold,
+                         krb5_principal principal, unsigned int keepold,
                          int n_ks_tuple, krb5_key_salt_tuple *ks_tuple,
                          char *password)
 {
@@ -1387,7 +1387,7 @@ kadm5_randkey_principal(void *server_handle,
 kadm5_ret_t
 kadm5_randkey_principal_3(void *server_handle,
                           krb5_principal principal,
-                          krb5_boolean keepold,
+                          unsigned int keepold,
                           int n_ks_tuple, krb5_key_salt_tuple *ks_tuple,
                           krb5_keyblock **keyblocks,
                           int *n_keys)
@@ -1518,7 +1518,7 @@ kadm5_setkey_principal(void *server_handle,
 kadm5_ret_t
 kadm5_setkey_principal_3(void *server_handle,
                          krb5_principal principal,
-                         krb5_boolean keepold,
+                         unsigned int keepold,
                          int n_ks_tuple, krb5_key_salt_tuple *ks_tuple,
                          krb5_keyblock *keyblocks,
                          int n_keys)
@@ -1579,7 +1579,7 @@ make_ks_from_key_data(krb5_context context, kadm5_key_data *key_data,
 
 kadm5_ret_t
 kadm5_setkey_principal_4(void *server_handle, krb5_principal principal,
-                         krb5_boolean keepold, kadm5_key_data *key_data,
+                         unsigned int keepold, kadm5_key_data *key_data,
                          int n_key_data)
 {
     krb5_db_entry *kdb;

--- a/src/lib/kdb/kdb_cpw.c
+++ b/src/lib/kdb/kdb_cpw.c
@@ -54,8 +54,6 @@
 #include <stdio.h>
 #include <errno.h>
 
-enum save { DISCARD_ALL, KEEP_LAST_KVNO, KEEP_ALL };
-
 int
 krb5_db_get_key_data_kvno(krb5_context context, int count, krb5_key_data *data)
 {
@@ -117,20 +115,28 @@ preserve_one_old_key(krb5_context context, krb5_keyblock *mkey,
 
 /*
  * Add key_data to dbent, making sure that each entry is encrypted in mkey.  If
- * kvno is non-zero, preserve only keys of that kvno.  May steal some elements
- * from key_data and zero them out.
+ * keepold is greater than 1, preserve only the first (keepold-1) key versions,
+ * so that the total number of key versions including the new key set is
+ * keepold.  May steal some elements from key_data and zero them out.
  */
 static krb5_error_code
 preserve_old_keys(krb5_context context, krb5_keyblock *mkey,
-                  krb5_db_entry *dbent, int kvno, int n_key_data,
+                  krb5_db_entry *dbent, unsigned int keepold, int n_key_data,
                   krb5_key_data *key_data)
 {
     krb5_error_code ret;
+    krb5_kvno last_kvno = 0, kvno_changes = 0;
     int i;
 
     for (i = 0; i < n_key_data; i++) {
-        if (kvno != 0 && key_data[i].key_data_kvno != kvno)
-            continue;
+        if (keepold > 1) {
+            if (i > 0 && key_data[i].key_data_kvno != last_kvno)
+                kvno_changes++;
+            if (kvno_changes >= keepold - 1)
+                break;
+            last_kvno = key_data[i].key_data_kvno;
+        }
+
         ret = krb5_dbe_create_key_data(context, dbent);
         if (ret)
             return ret;
@@ -334,11 +340,11 @@ add_key_pwd(krb5_context context, krb5_keyblock *master_key,
 static krb5_error_code
 rekey(krb5_context context, krb5_keyblock *mkey, krb5_key_salt_tuple *ks_tuple,
       int ks_tuple_count, const char *password, int new_kvno,
-      enum save savekeys, krb5_db_entry *db_entry)
+      unsigned int keepold, krb5_db_entry *db_entry)
 {
     krb5_error_code ret;
     krb5_key_data *key_data;
-    int n_key_data, old_kvno, save_kvno;
+    int n_key_data, old_kvno;
 
     /* Save aside the old key data. */
     n_key_data = db_entry->n_key_data;
@@ -372,9 +378,8 @@ rekey(krb5_context context, krb5_keyblock *mkey, krb5_key_salt_tuple *ks_tuple,
 
     /* Possibly add some or all of the old keys to the back of the list.  May
      * steal from and zero out some of the old key data entries. */
-    if (savekeys != DISCARD_ALL) {
-        save_kvno = (savekeys == KEEP_LAST_KVNO) ? old_kvno : 0;
-        ret = preserve_old_keys(context, mkey, db_entry, save_kvno, n_key_data,
+    if (keepold > 0) {
+        ret = preserve_old_keys(context, mkey, db_entry, keepold, n_key_data,
                                 key_data);
     }
 
@@ -392,10 +397,10 @@ rekey(krb5_context context, krb5_keyblock *mkey, krb5_key_salt_tuple *ks_tuple,
 krb5_error_code
 krb5_dbe_crk(krb5_context context, krb5_keyblock *mkey,
              krb5_key_salt_tuple *ks_tuple, int ks_tuple_count,
-             krb5_boolean keepold, krb5_db_entry *dbent)
+             unsigned int keepold, krb5_db_entry *dbent)
 {
-    return rekey(context, mkey, ks_tuple, ks_tuple_count, NULL, 0,
-                 keepold ? KEEP_ALL : DISCARD_ALL, dbent);
+    return rekey(context, mkey, ks_tuple, ks_tuple_count, NULL, 0, keepold,
+                 dbent);
 }
 
 /*
@@ -409,8 +414,7 @@ krb5_dbe_ark(krb5_context context, krb5_keyblock *mkey,
              krb5_key_salt_tuple *ks_tuple, int ks_tuple_count,
              krb5_db_entry *dbent)
 {
-    return rekey(context, mkey, ks_tuple, ks_tuple_count, NULL, 0,
-                 KEEP_LAST_KVNO, dbent);
+    return rekey(context, mkey, ks_tuple, ks_tuple_count, NULL, 0, 2, dbent);
 }
 
 /*
@@ -422,11 +426,11 @@ krb5_dbe_ark(krb5_context context, krb5_keyblock *mkey,
 krb5_error_code
 krb5_dbe_def_cpw(krb5_context context, krb5_keyblock *mkey,
                  krb5_key_salt_tuple *ks_tuple, int ks_tuple_count,
-                 char *password, int new_kvno, krb5_boolean keepold,
+                 char *password, int new_kvno, unsigned int keepold,
                  krb5_db_entry *dbent)
 {
     return rekey(context, mkey, ks_tuple, ks_tuple_count, password, new_kvno,
-                 keepold ? KEEP_ALL : DISCARD_ALL, dbent);
+                 keepold, dbent);
 }
 
 /*
@@ -440,6 +444,6 @@ krb5_dbe_apw(krb5_context context, krb5_keyblock *mkey,
              krb5_key_salt_tuple *ks_tuple, int ks_tuple_count, char *password,
              krb5_db_entry *dbent)
 {
-    return rekey(context, mkey, ks_tuple, ks_tuple_count, password, 0,
-                 KEEP_LAST_KVNO, dbent);
+    return rekey(context, mkey, ks_tuple, ks_tuple_count, password, 0, 2,
+                 dbent);
 }


### PR DESCRIPTION
In libkadm5, change the type of the keepold parameters from krb5_boolean to unsigned int (which is the underlying type of krb5_boolean, so this is not an API or ABI change).  In libkadm5srv, interpret a keepold value greater than 2 to be a limit on the number of resulting key versions including the new one.

In kadmind, when a principal changes its own keys, limit the number of resulting key versions to 5.