### PR TITLE
Fix kdb5_util ark with no -e option

### DIFF
--- a/src/kadmin/dbutil/kdb5_util.c
+++ b/src/kadmin/dbutil/kdb5_util.c
@@ -522,7 +522,7 @@ add_random_key(int argc, char **argv)
 
     int free_keysalts;
     char *me = progname;
-    char *ks_str = NULL;
+    char *ks_str = "";
     char *pr_str;
     krb5_keyblock *tmp_mkey;
 


### PR DESCRIPTION
Avoid passing NULL to krb5_string_to_keysalt() in add_random_key(). When add_random_key() was first written, krb5_string_to_keysalts() did nothing on a null string input.  After commit
3576bd662be9b7cc2cca97065fe467e745542b69 it calls strdup(NULL) and crashes.