### PR TITLE
Remedy CI failure [WIP]

### DIFF
--- a/src/kdc/t_sockact.c
+++ b/src/kdc/t_sockact.c
@@ -56,7 +56,7 @@ create_socket(const struct sockaddr *addr)
         abort();
     if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one)) != 0)
         abort();
-#ifdef SO_REUSEPORT
+#if defined(SO_REUSEPORT) && defined(__APPLE__)
     if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &one, sizeof(one)) != 0)
         abort();
 #endif

--- a/src/lib/apputils/net-server.c
+++ b/src/lib/apputils/net-server.c
@@ -92,7 +92,9 @@ setreuseaddr(int sock, int value)
     st = setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &value, sizeof(value));
     if (st)
         return st;
-#ifdef SO_REUSEPORT
+#if defined(SO_REUSEPORT) && defined(__APPLE__)
+    /* macOS experimentally needs this flag as well to avoid conflicts between
+     * recently exited server processes and new ones. */
     st = setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &value, sizeof(value));
     if (st)
         return st;


### PR DESCRIPTION
Our CI recently started failing on an invocation of kdc/t_sockact.c.  In create_socket(), we try to set SO_REUSEPORT on a UNIX domain socket and get back EOPNOTSUPP, causing an abort.  We also set SO_REUSEPORT on UNIX domain sockets in net-server.c, but failures just lead to a log message (which can be found in testdir/kdc.log after running t_sendto_kdc.py with an affected kernel version).

I found https://github.com/python/cpython/issues/128916 which linked to the kernel commit https://github.com/torvalds/linux/commit/5b0af621c3f6ef9261cf6067812f2fd9943acb4b .  I don't think the kernel behavior change makes sense, but litigating it here doesn't serve any purpose, so I'll move on to workarounds.

We set SO_REUSEADDR so that a recently stopped KDC process won't get in the way of a new one due to listener sockets in time-wait.  We set SO_REUSEPORT because I found it necessary on macOS for the same purpose (commit c423f13cc2f3fbdbf48390535cb1629b99b0eb27).  We do not need the typical SO_REUSEPORT semantics (multiple live binds to the same endpoint).

The obvious workarounds are:

1. Ignore EOPNOTSUPP errors from setting SO_REUSEPORT, in the test program and net-server.c.
2. Avoid setting SO_REUSEPORT on UNIX domain sockets.
3. Only set SO_REUSEPORT on macOS.

Option 2 would make sense if there were some inherent mismatch between the meaning of SO_REUSEPORT and the nature of UNIX domain socket endpoints.  But apart from "port" being in the name, I don't think there is.  I am currently leaning towards option 3, because we don't need (or particularly want) the SO_REUSEPORT semantics when SO_REUSEADDR will do.

(As always, the most comprehensive reference on SO_REUSEADDR/SO_REUSEPORT is https://stackoverflow.com/questions/14388706/how-do-so-reuseaddr-and-so-reuseport-differ .  Although it doesn't explain why we seem to need SO_REUSEPORT on macOS.)
