### PR TITLE
libkrb5: fix client preauth handling of fallback_disabled

### DIFF
--- a/src/lib/krb5/krb/get_in_tkt.c
+++ b/src/lib/krb5/krb/get_in_tkt.c
@@ -1331,9 +1331,6 @@ init_creds_step_request(krb5_context context,
     /* Don't continue after a keyboard interrupt. */
     if (code == KRB5_LIBOS_PWDINTR)
         goto cleanup;
-    /* Don't continue if fallback is disabled. */
-    if (code && ctx->fallback_disabled)
-        goto cleanup;
     if (code) {
         /* See if we can try a different preauth mech before giving up. */
         k5_save_ctx_error(context, code, &save);

--- a/src/lib/krb5/krb/init_creds_ctx.h
+++ b/src/lib/krb5/krb/init_creds_ctx.h
@@ -63,9 +63,9 @@ struct _krb5_init_creds_context {
     krb5_enctype etype;
     krb5_boolean info_pa_permitted;
     krb5_boolean restarted;
-    krb5_boolean fallback_disabled;
     krb5_boolean encts_disabled;
     struct krb5_responder_context_st rctx;
+    krb5_preauthtype current_preauth_type;
     krb5_preauthtype selected_preauth_type;
     krb5_preauthtype allowed_preauth_type;
     k5_json_object cc_config_in;

--- a/src/lib/krb5/krb/preauth2.c
+++ b/src/lib/krb5/krb/preauth2.c
@@ -552,7 +552,9 @@ set_cc_config(krb5_context context, krb5_clpreauth_rock rock,
 static void
 disable_fallback(krb5_context context, krb5_clpreauth_rock rock)
 {
-    ((krb5_init_creds_context)rock)->fallback_disabled = TRUE;
+    krb5_init_creds_context ctx = (krb5_init_creds_context)rock;
+
+    ctx->allowed_preauth_type = ctx->current_preauth_type;
 }
 
 static struct krb5_clpreauth_callbacks_st callbacks = {
@@ -676,6 +678,7 @@ process_pa_data(krb5_context context, krb5_init_creds_context ctx,
             if (real && previously_failed(ctx, pa->pa_type))
                 continue;
             mod_pa = NULL;
+            ctx->current_preauth_type = pa->pa_type;
             ret = clpreauth_process(context, h, modreq, ctx->opt, &callbacks,
                                     (krb5_clpreauth_rock)ctx, ctx->request,
                                     ctx->inner_request_body,
@@ -908,6 +911,7 @@ k5_preauth_tryagain(krb5_context context, krb5_init_creds_context ctx,
     if (h == NULL)
         return KRB5KRB_ERR_GENERIC;
     mod_pa = NULL;
+    ctx->current_preauth_type = pa_type;
     ret = clpreauth_tryagain(context, h, modreq, ctx->opt, &callbacks,
                              (krb5_clpreauth_rock)ctx, ctx->request,
                              ctx->inner_request_body,
@@ -954,6 +958,7 @@ fill_response_items(krb5_context context, krb5_init_creds_context ctx,
         h = find_module(context, ctx, pa->pa_type, &modreq);
         if (h == NULL)
             continue;
+        ctx->current_preauth_type = pa->pa_type;
         ret = clpreauth_prep_questions(context, h, modreq, ctx->opt,
                                        &callbacks, (krb5_clpreauth_rock)ctx,
                                        ctx->request, ctx->inner_request_body,


### PR DESCRIPTION
I've run across an unexpected behavior with SPAKE in MIT Kerberos 1.21.3, which may be a bug. It occurs when some KDCs have SPAKE enabled (by setting `spake_preauth_groups`), while it is off in other KDCs for the same realm. Consider:

KDC A has:

```
[libdefaults]
spake_preauth_groups = edwards25519

[kdcdefaults]
spake_preauth_kdc_challenge = edwards25519
```

while KDC B has both unset. Suppose that the only other supported preauthentication mechanism is encrypted-timestamp. The following can occur with client C:

```
C -> A : AS-REQ
A -> C : KRB5KDC_ERR_PREAUTH_REQUIRED + SPAKE challenge
C -> B : AS-REQ with SPAKE response
B -> C : KRB5KDC_ERR_PREAUTH_REQUIRED (because B does not support SPAKE)

```
At this point the client should stop: it has replaced the reply key as part of sending the SPAKE challenge, and called `disable_fallback()` to ensure it will not continue to another mechanism and use the wrong reply key (`spake_client.c`). However, it *does* in fact continue, generating an AS-REQ with encrypted-timestamp using the abandoned SPAKE reply key, which then fails no matter which KDC it picks for that next attempt. This happens because the code to respect `disable_fallback()` is this (`get_in_tkt.c`):

```
    /* Don't continue if fallback is disabled. */
    if (code && ctx->fallback_disabled)
        goto cleanup;
```

but here, `code == 0,` so this case is not triggered.

My best guess at a fix is this:

```
    /* Don't continue if fallback is disabled. */
    if (ctx->fallback_disabled) {
        if (code == 0)
            code = KRB5_PREAUTH_FAILED;
        goto cleanup;
    }
```

which seems fine in that the client stops, but `kinit(1)` gives an odd error message:

`kinit: No user identity options specified while getting initial credentials`

so I'm not sure this is quite right.

The same thing can happen without the optimistic challenge; it just requires that the client talk to a KDC with SPAKE enabled the first two times, then to one without it next (so a bit less likely). And of course sometimes the failure doesn't happen at all if the problematic sequence of KDC choices doesn't happen (random via SRV records in my case), so it occurs sporadically with frequency depending on how many SPAKE vs non-SPAKE KDCs there are.

Obviously, ordinarily all the KDCs for a realm will agree on their SPAKE configuration and so this would not happen; I noticed it when I enabled SPAKE in just one KDC out of several as a test. Nonetheless, this behavior seems like a bug.

Separately, I’m also wondering why fallback must be disabled in the first place in this situation. It certainly seems better, ideally, if the client can continue to try another shared-key preauthentication method, just resetting the reply key to its initial one when starting over. I imagine it has something to do with the general preauthentication state model laid out in RFC-6113?

Thanks,

-- Richard
