### PR TITLE
Implement fault tolerance for empty TXT record strings

### DIFF
--- a/src/lib/krb5/os/dnsglue.c
+++ b/src/lib/krb5/os/dnsglue.c
@@ -470,12 +470,10 @@ k5_try_realm_txt_rr(krb5_context context, const char *prefix, const char *name,
     }
 
     ret = krb5int_dns_nextans(ds, &base, &rdlen);
-    if (ret < 0 || base == NULL)
+    if (ret < 0 || rdlen < 2 || *base == 0 || *base > rdlen - 1)
         goto errout;
 
     p = base;
-    if (!INCR_OK(base, rdlen, p, 1))
-        goto errout;
     len = *p++;
     *realm = malloc((size_t)len + 1);
     if (*realm == NULL) {


### PR DESCRIPTION
When the TXT-DATA value returned by DNS is empty, it causes the program to crash. 
This fix adds fault tolerance to prevent the program from crashing in such cases.