### PR TITLE
kdb/ldap: fix error handling in krb5_ldap_read_policy()

### DIFF
--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_tkt_policy.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_tkt_policy.c
@@ -217,7 +217,7 @@ krb5_ldap_read_policy(krb5_context context, char *policyname,
     if (policyname == NULL  || policy == NULL) {
         st = EINVAL;
         k5_setmsg(context, st, _("Ticket Policy Object information missing"));
-        goto cleanup;
+        return st;
     }
 
     SETUP_CONTEXT();


### PR DESCRIPTION
In case policy = NULL, program goes to cleanup and NULL-dereference happens. Return without goto to avoid it.