### PR TITLE
kdb/ldap: fix error handling in krb5_ldap_read_policy()

### DIFF
--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_krbcontainer.h
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_krbcontainer.h
@@ -41,7 +41,4 @@ krb5_ldap_read_krbcontainer_dn(krb5_context, char **);
 krb5_error_code
 krb5_ldap_create_krbcontainer(krb5_context, const char *);
 
-krb5_error_code
-krb5_ldap_delete_krbcontainer(krb5_context, const char *);
-
 #endif

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_misc.c
@@ -1163,11 +1163,6 @@ krb5_ldap_get_reference_count(krb5_context context, char *dn, char *refattr,
     krb5_ldap_server_handle *ldap_server_handle = NULL;
     LDAPMessage *result = NULL;
 
-    if (dn == NULL || refattr == NULL) {
-        st = EINVAL;
-        goto cleanup;
-    }
-
     SETUP_CONTEXT();
     if (ld == NULL) {
         GET_HANDLE();

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_pwd_policy.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_pwd_policy.c
@@ -146,7 +146,7 @@ krb5_ldap_create_password_policy(krb5_context context, osa_policy_ent_t policy)
     krb5_clear_error_message(context);
 
     /* validate the input parameters */
-    if (policy == NULL || policy->name == NULL)
+    if (policy->name == NULL)
         return EINVAL;
 
     SETUP_CONTEXT();
@@ -200,7 +200,7 @@ krb5_ldap_put_password_policy(krb5_context context, osa_policy_ent_t policy)
     krb5_clear_error_message(context);
 
     /* validate the input parameters */
-    if (policy == NULL || policy->name == NULL)
+    if (policy->name == NULL)
         return EINVAL;
 
     SETUP_CONTEXT();
@@ -296,10 +296,6 @@ krb5_ldap_get_password_policy_from_dn(krb5_context context, char *pol_name,
     /* Clear the global error string */
     krb5_clear_error_message(context);
 
-    /* validate the input parameters */
-    if (pol_dn == NULL)
-        return EINVAL;
-
     *policy = NULL;
     SETUP_CONTEXT();
     GET_HANDLE();
@@ -347,12 +343,6 @@ krb5_ldap_get_password_policy(krb5_context context, char *name,
     /* Clear the global error string */
     krb5_clear_error_message(context);
 
-    /* validate the input parameters */
-    if (name == NULL) {
-        st = EINVAL;
-        goto cleanup;
-    }
-
     st = krb5_ldap_name_to_policydn(context, name, &policy_dn);
     if (st != 0)
         goto cleanup;
@@ -378,10 +368,6 @@ krb5_ldap_delete_password_policy(krb5_context context, char *policy)
 
     /* Clear the global error string */
     krb5_clear_error_message(context);
-
-    /* validate the input parameters */
-    if (policy == NULL)
-        return EINVAL;
 
     SETUP_CONTEXT();
     GET_HANDLE();

--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_tkt_policy.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_tkt_policy.c
@@ -61,11 +61,8 @@ krb5_ldap_create_policy(krb5_context context, krb5_ldap_policy_params *policy,
     krb5_ldap_server_handle     *ldap_server_handle=NULL;
 
     /* validate the input parameters */
-    if (policy == NULL || policy->policy == NULL) {
-        st = EINVAL;
-        k5_setmsg(context, st, _("Ticket Policy Name missing"));
-        goto cleanup;
-    }
+    if (policy->policy == NULL)
+        return EINVAL;
 
     SETUP_CONTEXT();
     GET_HANDLE();
@@ -137,11 +134,8 @@ krb5_ldap_modify_policy(krb5_context context, krb5_ldap_policy_params *policy,
     krb5_ldap_server_handle     *ldap_server_handle=NULL;
 
     /* validate the input parameters */
-    if (policy == NULL || policy->policy==NULL) {
-        st = EINVAL;
-        k5_setmsg(context, st, _("Ticket Policy Name missing"));
-        goto cleanup;
-    }
+    if (policy->policy == NULL)
+        return EINVAL;
 
     SETUP_CONTEXT();
     GET_HANDLE();
@@ -212,13 +206,6 @@ krb5_ldap_read_policy(krb5_context context, char *policyname,
     kdb5_dal_handle             *dal_handle=NULL;
     krb5_ldap_context           *ldap_context=NULL;
     krb5_ldap_server_handle     *ldap_server_handle=NULL;
-
-    /* validate the input parameters */
-    if (policyname == NULL  || policy == NULL) {
-        st = EINVAL;
-        k5_setmsg(context, st, _("Ticket Policy Object information missing"));
-        goto cleanup;
-    }
 
     SETUP_CONTEXT();
     GET_HANDLE();
@@ -305,13 +292,6 @@ krb5_ldap_delete_policy(krb5_context context, char *policyname)
     kdb5_dal_handle             *dal_handle=NULL;
     krb5_ldap_context           *ldap_context=NULL;
     krb5_ldap_server_handle     *ldap_server_handle=NULL;
-
-    if (policyname == NULL) {
-        st = EINVAL;
-        k5_prependmsg(context, st, _("Ticket Policy Object DN missing"));
-        goto cleanup;
-    }
-
 
     SETUP_CONTEXT();
     GET_HANDLE();

--- a/src/tests/t_kdb.py
+++ b/src/tests/t_kdb.py
@@ -632,6 +632,5 @@ realm.run([kdb5_ldap_util, 'destroy', '-f'])
 # * Out-of-memory error conditions
 # * Handling of failures from slapd (including krb5_retry_get_ldap_handle)
 # * Handling of servers which don't support mod-increment
-# * krb5_ldap_delete_krbcontainer (only happens if krb5_ldap_create fails)
 
 success('LDAP and DB2 KDB tests')


### PR DESCRIPTION
In case policy = NULL, program goes to cleanup and NULL-dereference happens. Return without goto to avoid it.