### PR TITLE
pkinit: fix error handling in pkinit_server_verify_padata()

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_srv.c
+++ b/src/plugins/preauth/pkinit/pkinit_srv.c
@@ -463,8 +463,10 @@ pkinit_server_verify_padata(krb5_context context,
 #endif
     /* create a per-request context */
     retval = pkinit_init_kdc_req_context(context, &reqctx);
-    if (retval)
-        goto cleanup;
+    if (retval) {
+        (*respond)(arg, retval, NULL, NULL, NULL);
+        return;
+    }
     reqctx->pa_type = data->pa_type;
 
     PADATA_TO_KRB5DATA(data, &k5data);


### PR DESCRIPTION
In case pkinit_init_kdc_req_context() fails to allocate reqctx, NULL-dereference in cleanup is possible.
In this point there is no need to free any resources so it is possible to respond and return immediatly.