### PR TITLE
Update src/windows/README, add required UNIX utilities

### DIFF
--- a/src/windows/README
+++ b/src/windows/README
@@ -29,8 +29,8 @@ To build Kerberos 5 on Windows, you will need the following:
 * A version of Perl.  We recommend Strawberry Perl as it will work
   to build OpenSSL.
 
-* Some common Unix utilities such as sed/awk/cp/cat installed in the
-  command-line path.
+* Some common Unix utilities such as sed/awk/cp/cat/mv/rm installed in
+  the command-line path.
 
 * To build an MSI installer, the Windows Installer XML (WiX) toolkit,
   and to ensure that the HTML Help Compiler (hhc.exe) and the WiX
@@ -71,7 +71,7 @@ defining DEBUG_SYMBOL in the environment or on the nmake command line.
 Building the code and installer:
 -------------------------------
 
-First, make sure you have sed, (g)awk, cat, and cp.
+First, make sure you have sed, (g)awk, cat, mv, rm and cp.
 You must also define KRB_INSTALL_DIR either in the environment or
 on the command line (for nmake install).  If you are proceeding to build
 the MSI installer, this directory should be a temporary staging area in or


### PR DESCRIPTION
This is my log when running `nmake -f Makefile.in prep-windows`. And you can see clearly mv and rm command which is missing in the README.

```cmd
D:\deps\krb5-krb5-1.22-beta1\src>nmake -f Makefile.in prep-windows

        cat config/win-pre.in Makefile.in config/win-post.in |  sed -e "s/^##DOS##//" -e "s/^##DOS//" > Makefile.tmp
        mv Makefile.tmp Makefile

D:\deps\krb5-krb5-1.22-beta1\src>move Makefile.tmp Makefile
Moved 1 file.
        awk -f util/et/et_h.awk outfile=include/asn1_err.h lib/krb5/error_tables/asn1_err.et
        awk -f util/et/et_c.awk outfile=lib/krb5/error_tables/asn1_err.c lib/krb5/error_tables/asn1_err.et
        awk -f util/et/et_h.awk outfile=include/kdb5_err.h lib/krb5/error_tables/kdb5_err.et
        awk -f util/et/et_c.awk outfile=lib/krb5/error_tables/kdb5_err.c lib/krb5/error_tables/kdb5_err.et
        awk -f util/et/et_h.awk outfile=include/krb5_err.h lib/krb5/error_tables/krb5_err.et
        awk -f util/et/et_c.awk outfile=lib/krb5/error_tables/krb5_err.c lib/krb5/error_tables/krb5_err.et
        awk -f util/et/et_h.awk outfile=include/k5e1_err.h lib/krb5/error_tables/k5e1_err.et
        awk -f util/et/et_c.awk outfile=lib/krb5/error_tables/k5e1_err.c lib/krb5/error_tables/k5e1_err.et
        awk -f util/et/et_h.awk outfile=include/kv5m_err.h lib/krb5/error_tables/kv5m_err.et
        awk -f util/et/et_c.awk outfile=lib/krb5/error_tables/kv5m_err.c lib/krb5/error_tables/kv5m_err.et
        awk -f util/et/et_h.awk outfile=include/krb524_err.h lib/krb5/error_tables/krb524_err.et
        awk -f util/et/et_c.awk outfile=lib/krb5/error_tables/krb524_err.c lib/krb5/error_tables/krb524_err.et
        awk -f util/et/et_h.awk outfile=util/profile/prof_err.h util/profile/prof_err.et
        awk -f util/et/et_c.awk outfile=util/profile/prof_err.c util/profile/prof_err.et
        awk -f util/et/et_h.awk outfile=lib/gssapi/generic/gssapi_err_generic.h lib/gssapi/generic/gssapi_err_generic.et
        awk -f util/et/et_c.awk outfile=lib/gssapi/generic/gssapi_err_generic.c lib/gssapi/generic/gssapi_err_generic.et
        awk -f util/et/et_h.awk outfile=lib/gssapi/krb5/gssapi_err_krb5.h lib/gssapi/krb5/gssapi_err_krb5.et
        awk -f util/et/et_c.awk outfile=lib/gssapi/krb5/gssapi_err_krb5.c lib/gssapi/krb5/gssapi_err_krb5.et
        awk -f util/et/et_h.awk outfile=ccapi/lib/ccapi_err.h ccapi/lib/ccapi_err.et
        awk -f util/et/et_c.awk outfile=ccapi/lib/ccapi_err.c ccapi/lib/ccapi_err.et
        rm -f include/krb5/krb5.h
        cat include/krb5/krb5.hin include/krb5_err.h include/k5e1_err.h  include/kdb5_err.h include/kv5m_err.h include/krb524_err.h include/asn1_err.h > include/krb5/krb5.h
        rm -f lib/gssapi/generic/gssapi.h
        cat lib/gssapi/generic/gssapi.hin > lib/gssapi/generic/gssapi.h
        rm -f util/profile/profile.h
        cat util/profile/profile.hin util/profile/prof_err.h > util/profile/profile.h
```