### PR TITLE
Avoid undefined memcpy in asn1_encode.c

### DIFF
--- a/src/lib/krb5/asn.1/asn1_encode.c
+++ b/src/lib/krb5/asn.1/asn1_encode.c
@@ -49,7 +49,7 @@ insert_byte(asn1buf *buf, uint8_t o)
 static inline void
 insert_bytes(asn1buf *buf, const void *bytes, size_t len)
 {
-    if (buf->ptr != NULL) {
+    if (buf->ptr != NULL && len > 0) {
         memcpy(buf->ptr - len, bytes, len);
         buf->ptr -= len;
     }


### PR DESCRIPTION
The C standard specifies that passing null pointers to most standard library functions results in undefined behavior (C99 7.1.4).  This applies to memcpy() even when the length is 0.  insert_bytes() in asn1_encode.c may be called with a null pointer from an empty krb5_data or other counted value in a structure to be encoded.  Do not call memcpy() in this case.
