### PR TITLE
Fix TSan report in Kerberos

### DIFF
--- a/src/util/profile/prof_file.c
+++ b/src/util/profile/prof_file.c
@@ -220,9 +220,11 @@ errcode_t profile_open_file(const_profile_filespec_t filespec,
     }
     if (data) {
         data->refcount++;
-        data->last_stat = 0;    /* Make sure to stat when updating. */
         k5_mutex_unlock(&g_shared_trees_mutex);
-        retval = profile_update_file_data(data, NULL);
+        k5_mutex_lock(&data->lock);
+        data->last_stat = 0;    /* Make sure to stat when updating. */
+        retval = profile_update_file_data_locked(data, NULL);
+        k5_mutex_unlock(&data->lock);
         free(expanded_filename);
         if (retval) {
             profile_dereference_data(data);


### PR DESCRIPTION
We ([ClickHouse](https://github.com/ClickHouse/ClickHouse/)), carried this small patch in our krb5 fork around since two years and we like to upstream it. It addresses an issue found by [tsan](https://clang.llvm.org/docs/ThreadSanitizer.html). I unfortunately did not find an associated original error report (e.g. crashdump), so I can't tell you more information. My kind ask would be that you double-check and suggest improvements to this fix, thanks.