### PR TITLE
Fix MSan report in prng

### DIFF
--- a/src/lib/crypto/krb/prng.c
+++ b/src/lib/crypto/krb/prng.c
@@ -26,6 +26,12 @@
 
 #include "crypto_int.h"
 
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+#include <sanitizer/msan_interface.h>
+#endif
+#endif
+
 krb5_error_code KRB5_CALLCONV
 krb5_c_random_seed(krb5_context context, krb5_data *data)
 {
@@ -138,6 +144,13 @@ get_os_entropy(unsigned char *buf, size_t len)
             /* ENOSYS or other unrecoverable failure */
             break;
         }
+
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+        __msan_unpoison(buf, r);
+#endif
+#endif
+
         len -= r;
         buf += r;
     }


### PR DESCRIPTION
We ([ClickHouse](https://github.com/ClickHouse/ClickHouse/)), carried this small patch in our krb5 fork around since four years and we like to upstream it. It addresses an issue found by [msan](https://clang.llvm.org/docs/MemorySanitizer.html). I unfortunately did not find an associated original error report (e.g. crashdump), so I can't tell you more information. My kind ask would be that you double-check and suggest improvements to this fix, thanks.