### PR TITLE
Bind shared libraries to programs with 'nodelete' on HP-UX

### DIFF
--- a/src/config/lib.in
+++ b/src/config/lib.in
@@ -75,12 +75,6 @@ osf1.exports: $(SHLIB_EXPORT_FILE) Makefile
 hpux.exports: $(SHLIB_EXPORT_FILE) Makefile
 	$(RM) hpux.tmp hpux.exports
 	sed "s/^/+e /" < $(SHLIB_EXPORT_FILE) > hpux.tmp
-	a=""; \
-	for f in . $(LIBFINIFUNC); do \
-	  if test "$$f" != .; then \
-	    a="+I $${f}__auxfini $$a"; \
-	  else :; fi; \
-	done; echo "$$a" >> hpux.tmp
 	echo "+e errno" >> hpux.tmp
 	base=`echo "$(LIBBASE)" | sed -e 's/-/_/'`; \
 	echo "+e _GLOBAL__FD_lib$${base}_$(LIBMAJOR)_$(LIBMINOR)" >> hpux.tmp; \

--- a/src/config/libnover.in
+++ b/src/config/libnover.in
@@ -64,12 +64,6 @@ osf1.exports: $(SHLIB_EXPORT_FILE) Makefile
 hpux.exports: $(SHLIB_EXPORT_FILE) Makefile
 	$(RM) hpux.tmp hpux.exports
 	sed "s/^/+e /" < $(SHLIB_EXPORT_FILE) > hpux.tmp
-	a=""; \
-	for f in . $(LIBFINIFUNC); do \
-	  if test "$$f" != .; then \
-	    a="+I $${f}__auxfini $$a"; \
-	  else :; fi; \
-	done; echo "$$a" >> hpux.tmp
 	echo "+e errno" >> hpux.tmp
 	mv -f hpux.tmp hpux.exports
 

--- a/src/config/shlib.conf
+++ b/src/config/shlib.conf
@@ -93,12 +93,12 @@ case $krb5_cv_host in
 		PICFLAGS=-fPIC
 		SHLIB_RPATH_FLAGS='-Wl,+b,$(SHLIB_RDIRS)'
 		SHLIB_EXPFLAGS='-Wl,+s $(SHLIB_RPATH_FLAGS) $(SHLIB_DIRS) $(SHLIB_EXPLIBS)'
-		LDCOMBINE='gcc -fPIC -shared -Wl,+h,$(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT) -Wl,-c,hpux.exports'
+		LDCOMBINE='gcc -fPIC -shared -Wl,+h,$(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT) -Wl,-c,hpux.exports -Wl,-B,nodelete'
 	else
 		PICFLAGS=+z
 		SHLIB_RPATH_FLAGS='+b $(SHLIB_RDIRS)'
 		SHLIB_EXPFLAGS='$(SHLIB_RPATH_FLAGS) $(SHLIB_DIRS) $(SHLIB_EXPLIBS)'
-		LDCOMBINE='ld -b +h $(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT) -c hpux.exports'
+		LDCOMBINE='ld -b +h $(LIBPREFIX)$(LIBBASE)$(SHLIBSEXT) -c hpux.exports -B nodelete'
 	fi
 	MAKE_SHLIB_COMMAND="${LDCOMBINE} -o \$@ \$\$objlist \$(LDFLAGS) \$(SHLIB_EXPFLAGS) ${LDCOMBINE_TAIL}"
 	PROG_RPATH_FLAGS='$(RPATH_FLAG)$(PROG_RPATH)'
@@ -112,12 +112,8 @@ case $krb5_cv_host in
 	# Do *not* set use_linker_init_option=yes here, because in the
 	# case where the library is specified at program link time, the
 	# initialization function appears not to get called, only for
-	# shl_load.  But for finalization functions, the shl_load case
-	# is the one we care about.
-	#
-	# Not setting use_linker_init_option here should cause compilation
-	# failures if the user tries to disable delayed initialization.
-	use_linker_fini_option=yes
+	# shl_load.
+	lib_unload_prevented=yes
 	;;
 
 mips-*-netbsd*)

--- a/src/include/k5-platform.h
+++ b/src/include/k5-platform.h
@@ -376,34 +376,8 @@ typedef struct { int error; unsigned char did_run; } k5_init_t;
    matter what compiler we're using.  Do it the same way
    regardless.  */
 
-# ifdef __hpux
-
-     /* On HP-UX, we need this auxiliary function.  At dynamic load or
-        unload time (but *not* program startup and termination for
-        link-time specified libraries), the linker-indicated function
-        is called with a handle on the library and a flag indicating
-        whether it's being loaded or unloaded.
-
-        The "real" fini function doesn't need to be exported, so
-        declare it static.
-
-        As usual, the final declaration is just for syntactic
-        convenience, so the top-level invocation of this macro can be
-        followed by a semicolon.  */
-
-#  include <dl.h>
-#  define MAKE_FINI_FUNCTION(NAME)                                          \
-        static void NAME(void);                                             \
-        void JOIN__2(NAME, auxfini)(shl_t, int); /* silence gcc warnings */ \
-        void JOIN__2(NAME, auxfini)(shl_t h, int l) { if (!l) NAME(); }     \
-        static void NAME(void)
-
-# else /* not hpux */
-
 #  define MAKE_FINI_FUNCTION(NAME)      \
         void NAME(void)
-
-# endif
 
 #elif !defined(SHARED) || defined(LIB_UNLOAD_PREVENTED)
 


### PR DESCRIPTION
from the manpage of `ld(1)`:
```
           -B bind        Select run-time binding behavior of a program
                          using shared libraries or the binding preference
                          in building a shared library.  The most common
                          values for bind are:

                          nodelete   Mark the shared library so that an
                                     explicit unload using dlclose() or
                                     shl_load() returns success silently
                                     without detaching the shared library
                                     from the process.  Subsequently, the
                                     shared library handle is valid only for
                                     shl_findsym().  It stays invalid for
                                     dlsym(), dlclose(), and shl_unload()
                                     until the next explicit load using
                                     shl_load() or dlopen().
```