### PR TITLE
Remove outdated comments in pre.in

### DIFF
--- a/src/config/pre.in
+++ b/src/config/pre.in
@@ -381,10 +381,8 @@ HESIOD_LIBS	= @HESIOD_LIBS@
 KRB5_BASE_LIBS	= $(KRB5_LIB) $(K5CRYPTO_LIB) $(COM_ERR_LIB) $(SUPPORT_LIB) $(LIBS) $(DL_LIB)
 KDB5_LIBS	= $(KDB5_LIB) $(GSSRPC_LIBS)
 GSS_LIBS	= $(GSS_KRB5_LIB)
-# needs fixing if ever used on macOS!
 GSSRPC_LIBS	= -lgssrpc $(GSS_LIBS)
 KADM_COMM_LIBS	= $(GSSRPC_LIBS)
-# need fixing if ever used on macOS!
 KADMSRV_LIBS	= -lkadm5srv_mit $(HESIOD_LIBS) $(KDB5_LIBS) $(KADM_COMM_LIBS)
 KADMCLNT_LIBS	= -lkadm5clnt_mit $(KADM_COMM_LIBS)
 


### PR DESCRIPTION
These comments were added in commit
5969630081b7eb43a4e6d4374407544174d77770 to indicate that certain library dependencies would need framework alternatives for a planned macOS build design.  The framework placeholders were reverted in commit 25935ea0f4fcd60eca8dba0371ea168fd729e908, rendering the comments obsolete.

Reported by Gordon Steemson.