### PR TITLE
Add k5test --trace option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ obj/
 skiptests
 testdir/
 testlog
-testtrace
+testtrace*
 
 # Ignore the build directory
 /build/

--- a/src/config/post.in
+++ b/src/config/post.in
@@ -168,7 +168,7 @@ clean: clean-$(WHAT)
 
 clean-unix::
 	$(RM) $(OBJS) $(DEPTARGETS_CLEAN) $(EXTRA_FILES)
-	$(RM) et-[ch]-*.et et-[ch]-*.[ch] testlog testtrace runenv.sh
+	$(RM) et-[ch]-*.et et-[ch]-*.[ch] testlog testtrace* runenv.sh
 	-$(RM) -r testdir
 
 clean-windows::


### PR DESCRIPTION
Make it easier to collect trace logs for commands invoked by test scripts.  Trace output will be placed in testtrace.<cmdnum> for daemons, or collected in the log for regular command invocations.