### PR TITLE
Fix argument order in t_authdata.py

### DIFF
--- a/src/tests/t_authdata.py
+++ b/src/tests/t_authdata.py
@@ -331,7 +331,7 @@ rb.extract_keytab('user@B', rb.keytab)
 
 usercache = 'FILE:' + os.path.join(rb.testdir, 'usercache')
 rb.kinit(rb.user_princ, None, ['-k', '-f', '-c', usercache])
-rb.run([kvno, '-C', 'impersonator@A', '-c', usercache])
+rb.run([kvno, '-C', '-c', usercache, 'impersonator@A'])
 
 ra.kinit('impersonator@A', None, ['-f', '-k', '-t', ra.keytab])
 ra.run(['./s4u2proxy', usercache, 'resource@A'])

--- a/src/util/k5test.py
+++ b/src/util/k5test.py
@@ -671,6 +671,8 @@ def _build_env():
     # Make sure we don't get confused by translated messages
     # or localized times.
     env['LC_ALL'] = 'C'
+    # Enforce proper argument order in tests with GNU getopt.
+    env['POSIXLY_CORRECT'] = '1'
     return env
 
 


### PR DESCRIPTION
Tests rely on behavior of GNU getopt wich is by default non POSIX-compliant and accepts optional and positional arguments in any order. This can be enforced by setting the environment variable POSIXLY_CORRECT. Other platforms like FreeBSD or HP-UX will fail the test.