### PR TITLE
Fix use of strchr with new GCC

### DIFF
--- a/src/lib/krb5/ccache/ccbase.c
+++ b/src/lib/krb5/ccache/ccbase.c
@@ -201,8 +201,8 @@ krb5_cc_register(krb5_context context, const krb5_cc_ops *ops,
 krb5_error_code KRB5_CALLCONV
 krb5_cc_resolve (krb5_context context, const char *name, krb5_ccache *cache)
 {
-    char *pfx, *cp;
-    const char *resid;
+    char *pfx;
+    const char *cp, *resid;
     unsigned int pfxlen;
     krb5_error_code err;
     const krb5_cc_ops *ops;

--- a/src/lib/krb5/os/expand_path.c
+++ b/src/lib/krb5/os/expand_path.c
@@ -454,7 +454,8 @@ k5_expand_path_tokens_extra(krb5_context context, const char *path_in,
 {
     krb5_error_code ret;
     struct k5buf buf;
-    char *tok_begin, *tok_end, *tok_val, **extra_tokens = NULL, *path;
+    const char *tok_begin, *tok_end;
+    char *tok_val, **extra_tokens = NULL, *path;
     const char *path_left;
     size_t nargs = 0, i;
     va_list ap;

--- a/src/lib/krb5/os/locate_kdc.c
+++ b/src/lib/krb5/os/locate_kdc.c
@@ -214,8 +214,8 @@ oom:
 }
 
 static void
-parse_uri_if_https(const char *host_or_uri, k5_transport *transport,
-                   const char **host, const char **uri_path)
+parse_uri_if_https(char *host_or_uri, k5_transport *transport,
+                   char **host, const char **uri_path)
 {
     char *cp;
 
@@ -257,8 +257,7 @@ locate_srv_conf_1(krb5_context context, const krb5_data *realm,
                   k5_transport transport, int udpport)
 {
     const char *realm_srv_names[4];
-    char **hostlist = NULL, *realmstr = NULL, *host = NULL;
-    const char *hostspec;
+    char **hostlist = NULL, *realmstr = NULL, *host = NULL, *hostspec;
     krb5_error_code code;
     size_t i;
     int default_port;
@@ -587,8 +586,8 @@ prof_locate_server(krb5_context context, const krb5_data *realm,
  * Return a NULL *host_out if there are any problems parsing the URI.
  */
 static void
-parse_uri_fields(const char *uri, k5_transport *transport_out,
-                 const char **host_out, int *primary_out)
+parse_uri_fields(char *uri, k5_transport *transport_out,
+                 char **host_out, int *primary_out)
 
 {
     k5_transport transport;
@@ -656,8 +655,8 @@ locate_uri(krb5_context context, const krb5_data *realm,
     krb5_error_code ret;
     k5_transport transport, host_trans;
     struct srv_dns_entry *answers, *entry;
-    char *host, *sitename;
-    const char *host_field, *path;
+    char *host, *sitename, *host_field;
+    const char *path;
     int port, def_port, primary;
 
     ret = get_sitename(context, realm, &sitename);

--- a/src/plugins/preauth/pkinit/pkinit_crypto.h
+++ b/src/plugins/preauth/pkinit/pkinit_crypto.h
@@ -440,7 +440,7 @@ krb5_error_code crypto_load_cas_and_crls
 		    defines the storage type (file, directory, etc) */
 	int catype,					/* IN
 		    defines the ca type (anchor, intermediate, crls) */
-	char *id);					/* IN
+	const char *id);				/* IN
 		    defines the location (filename, directory name, etc) */
 
 /*

--- a/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
+++ b/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c
@@ -4999,7 +4999,7 @@ load_cas_and_crls(krb5_context context,
                   pkinit_req_crypto_context req_cryptoctx,
                   pkinit_identity_crypto_context id_cryptoctx,
                   int catype,
-                  char *filename)
+                  const char *filename)
 {
     STACK_OF(X509_INFO) *sk = NULL;
     STACK_OF(X509) *ca_certs = NULL;
@@ -5157,7 +5157,7 @@ load_cas_and_crls_dir(krb5_context context,
                       pkinit_req_crypto_context req_cryptoctx,
                       pkinit_identity_crypto_context id_cryptoctx,
                       int catype,
-                      char *dirname)
+                      const char *dirname)
 {
     krb5_error_code retval = EINVAL;
     char **fnames = NULL, *filename;
@@ -5201,7 +5201,7 @@ crypto_load_cas_and_crls(krb5_context context,
                          pkinit_identity_crypto_context id_cryptoctx,
                          int idtype,
                          int catype,
-                         char *id)
+                         const char *id)
 {
     switch (idtype) {
     case IDTYPE_FILE:

--- a/src/plugins/preauth/pkinit/pkinit_identity.c
+++ b/src/plugins/preauth/pkinit/pkinit_identity.c
@@ -473,7 +473,7 @@ process_option_ca_crl(krb5_context context,
                       const char *value,
                       int catype)
 {
-    char *residual;
+    const char *residual;
     unsigned int typelen;
     int idtype;
 

--- a/src/plugins/preauth/pkinit/pkinit_matching.c
+++ b/src/plugins/preauth/pkinit/pkinit_matching.c
@@ -262,7 +262,7 @@ parse_rule_component(krb5_context context,
     char err_buf[128];
     int ret;
     struct keyword_desc *kw, *nextkw;
-    char *nk;
+    const char *nk;
     int found_next_kw = 0;
     char *value = NULL;
     size_t len;

--- a/src/tests/responder.c
+++ b/src/tests/responder.c
@@ -282,8 +282,7 @@ responder(krb5_context ctx, void *rawdata, krb5_responder_context rctx)
     /* Provide a particular response for an OTP challenge. */
     if (data->otp_answer != NULL) {
         if (krb5_responder_otp_get_challenge(ctx, rctx, &ochl) == 0) {
-            key = strchr(data->otp_answer, '=');
-            if (key != NULL) {
+            if (strchr(data->otp_answer, '=') != NULL) {
                 /* Make a copy of the answer that we can chop up. */
                 key = strdup(data->otp_answer);
                 if (key == NULL)


### PR DESCRIPTION
According to C specification, 7.28.5.1, strchr() is a generic function and its string argument's type is promoted to the result. So if it is const char*, the result will be const char* as well.

gcc in Rawhide (15.2.1 20251111) implements this conformance, resulting in a compilation fail with -Werror=discarded-qualifiers.

We either have to change target variable definition to be 'const char *' or cast the argument to 'char *'.