### PR TITLE
Fix iprop termination race in kpropd

### DIFF
--- a/src/kprop/kpropd.c
+++ b/src/kprop/kpropd.c
@@ -142,6 +142,8 @@ static const char *port = KPROP_SERVICE;
 static char **db_args = NULL;
 static size_t db_args_size = 0;
 
+static volatile sig_atomic_t signal_requests_exit = 0;
+
 static void parse_args(int argc, char **argv);
 static void do_standalone(void);
 static void doit(int fd);
@@ -233,6 +235,12 @@ kill_do_standalone(int sig)
                     (int)fullprop_child);
         }
         kill(fullprop_child, sig);
+        if (sig == SIGINT || sig == SIGTERM) {
+            /* Defer termination to avoid exiting in the middle of a critical
+             * DB or ulog section. */
+            signal_requests_exit = 1;
+            return;
+        }
     }
     /* Make sure our exit status code reflects our having been signaled */
     signal_wrapper(sig, SIG_DFL);
@@ -757,6 +765,9 @@ reinit:
         incr_ret = NULL;
         full_ret = NULL;
 
+        if (signal_requests_exit)
+            goto done;
+
         /*
          * Get the most recent ulog entry sno + ts, which
          * we package in the request to the primary KDC
@@ -999,7 +1010,7 @@ done:
     ulog_fini(kpropd_context);
     krb5_free_context(kpropd_context);
 
-    return (runonce == 1) ? 0 : 1;
+    return (runonce || signal_requests_exit) ? 0 : 1;
 }
 
 

--- a/src/lib/kdb/kdb_convert.c
+++ b/src/lib/kdb/kdb_convert.c
@@ -745,6 +745,18 @@ ulog_conv_2dbentry(krb5_context context, krb5_db_entry **entry,
 #undef u
     }
 
+    if (ent->len == 0) {
+        /*
+         * The len field should have been set in the existing principal or (for
+         * a creation update) set in the update entry.  If was not set, we just
+         * applied a non-creation update to a nonexistent principal, implying
+         * that our database is out of sync with our ulog metadata.  Return an
+         * error to force a full resync.
+         */
+        ret = KRB5_KDB_NOENTRY;
+        goto cleanup;
+    }
+
     /*
      * process mod_princ_data request
      */

--- a/src/plugins/kdb/db2/kdb_xdr.c
+++ b/src/plugins/kdb/db2/kdb_xdr.c
@@ -161,9 +161,11 @@ krb5_encode_princ_entry(krb5_context context, krb5_data *content,
     krb5_kdb_encode_int16(entry->n_key_data, nextloc);
     nextloc += 2;
 
-    /* Put extended fields here */
-    if (entry->len != KRB5_KDB_V1_BASE_LENGTH)
-        abort();
+    if (entry->len != KRB5_KDB_V1_BASE_LENGTH) {
+        retval = KRB5_KDB_TRUNCATED_RECORD;
+        k5_setmsg(context, retval, _("KDB entry length must be at least %d"),
+                  KRB5_KDB_V1_BASE_LENGTH);
+    }
 
     /* Any extra data that this version doesn't understand. */
     if (entry->e_length) {


### PR DESCRIPTION
There's a race condition in iprop code handling the SIGTERM signal. The signal terminates the process unconditionally, even in critical regions updating the database. The error manifests during the next kpropd startup as a SIGSEGV (when interrupted in the db code) or SIGABRT (if there's a replication gap).

The probability of this race is low, but can be increased if the database is locked by "kdb5_util dump" during the shutdown, forcing ulog_replay() to wait. This patch intercepts the signal and notifies the main loop to terminate instead of delivering at once. This solution is similar that is implemented in kadmind.

As an extra safety measure, the second patch triggers full resync upon detecting replication gaps before an assertation failure activates in plugins/kdb/db2/kdb_xdr.c:
```
164     /* Put extended fields here */
165     if (entry->len != KRB5_KDB_V1_BASE_LENGTH)
166         abort();
```

**Legal**
THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE MIT LICENSE. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://opensource.org/licenses/MIT.
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.