### PR TITLE
Fix S4U2Self ignoring time_req when acquiring impersonated credentials

### DIFF
--- a/src/lib/gssapi/krb5/s4u_gss_glue.c
+++ b/src/lib/gssapi/krb5/s4u_gss_glue.c
@@ -53,6 +53,17 @@ kg_impersonate_name(OM_uint32 *minor_status,
     *output_cred = NULL;
     memset(&in_creds, 0, sizeof(in_creds));
 
+    if (time_req != 0 && time_req != GSS_C_INDEFINITE) {
+        krb5_timestamp now;
+
+        code = krb5_timeofday(context, &now);
+        if (code != 0) {
+            *minor_status = code;
+            return GSS_S_FAILURE;
+        }
+        in_creds.times.endtime = ts_incr(now, time_req);
+    }
+
     if (user->is_cert)
         subject_cert = user->princ->data;
     else

--- a/src/lib/gssapi/krb5/s4u_gss_glue.c
+++ b/src/lib/gssapi/krb5/s4u_gss_glue.c
@@ -192,14 +192,35 @@ krb5_gss_acquire_cred_impersonate_name(OM_uint32 *minor_status,
  */
 static krb5_error_code
 make_proxy_cred(krb5_context context, krb5_gss_cred_id_t cred,
-                krb5_gss_cred_id_t impersonator_cred)
+                krb5_gss_cred_id_t impersonator_cred,
+                krb5_timestamp max_endtime)
 {
     krb5_error_code code;
     krb5_data data;
+    krb5_cc_cursor cur = 0;
+    krb5_creds cur_creds;
     char *str;
 
-    code = krb5_cc_copy_creds(context, impersonator_cred->ccache,
-                              cred->ccache);
+    /* Copy credentials from the impersonator ccache, bounding endtime when
+     * requested so copied TGTs don't outlive the S4U2Self evidence ticket. */
+    code = krb5_cc_start_seq_get(context, impersonator_cred->ccache, &cur);
+    if (code)
+        return code;
+
+    while (!(code = krb5_cc_next_cred(context, impersonator_cred->ccache,
+                                      &cur, &cur_creds))) {
+        if (max_endtime != 0 && cur_creds.times.endtime > max_endtime)
+            cur_creds.times.endtime = max_endtime;
+        code = krb5_cc_store_cred(context, cred->ccache, &cur_creds);
+        krb5_free_cred_contents(context, &cur_creds);
+        if (code)
+            break;
+    }
+
+    if (cur)
+        krb5_cc_end_seq_get(context, impersonator_cred->ccache, &cur);
+    if (code == KRB5_CC_END)
+        code = 0;
     if (code)
         return code;
 
@@ -275,7 +296,11 @@ kg_compose_deleg_cred(OM_uint32 *minor_status,
     if (code != 0)
         goto cleanup;
 
-    code = make_proxy_cred(context, cred, impersonator_cred);
+    /* Bound copied credentials to the evidence ticket's endtime when the
+     * caller specified a time_req, so TGTs don't outlive the impersonation. */
+    code = make_proxy_cred(context, cred, impersonator_cred,
+                           (time_req != 0 && time_req != GSS_C_INDEFINITE) ?
+                           subject_creds->times.endtime : 0);
     if (code != 0)
         goto cleanup;
 

--- a/src/tests/gssapi/t_s4u.c
+++ b/src/tests/gssapi/t_s4u.c
@@ -57,6 +57,7 @@
 #include "common.h"
 
 static int use_spnego = 0;
+static OM_uint32 time_req = GSS_C_INDEFINITE;
 
 static void
 test_greet_authz_data(gss_name_t *name)
@@ -120,6 +121,66 @@ init_accept_sec_context(gss_cred_id_t claimant_cred_handle,
     (void)gss_release_name(&minor, &target_name);
     (void)gss_delete_sec_context(&minor, &initiator_context, NULL);
     (void)gss_delete_sec_context(&minor, &acceptor_context, NULL);
+}
+
+/*
+ * Export cred to a MEMORY ccache and verify that every non-config ticket's
+ * endtime is within secs seconds of now.  Used to check that time_req is
+ * honoured for all credentials copied into the delegated-cred ccache (not
+ * just the S4U2Self evidence ticket).
+ */
+static void
+check_cred_endtimes(gss_cred_id_t cred, OM_uint32 secs)
+{
+    krb5_error_code ret;
+    krb5_context context = NULL;
+    krb5_creds kcred;
+    krb5_cc_cursor cur;
+    krb5_ccache ccache;
+    krb5_timestamp now, max_endtime;
+    gss_key_value_set_desc store;
+    gss_key_value_element_desc elem;
+    OM_uint32 major, minor;
+    const char *ccname = "MEMORY:endtime";
+
+    store.count = 1;
+    store.elements = &elem;
+    elem.key = "ccache";
+    elem.value = ccname;
+    major = gss_store_cred_into(&minor, cred, GSS_C_INITIATE, &mech_krb5, 1, 0,
+                                &store, NULL, NULL);
+    check_gsserr("gss_store_cred_into", major, minor);
+
+    ret = krb5_init_context(&context);
+    check_k5err(context, "krb5_init_context", ret);
+
+    ret = krb5_timeofday(context, &now);
+    check_k5err(context, "krb5_timeofday", ret);
+
+    /* Allow 5 seconds of slack for test overhead. */
+    max_endtime = now + (krb5_timestamp)secs + 5;
+
+    ret = krb5_cc_resolve(context, ccname, &ccache);
+    check_k5err(context, "krb5_cc_resolve", ret);
+
+    ret = krb5_cc_start_seq_get(context, ccache, &cur);
+    check_k5err(context, "krb5_cc_start_seq_get", ret);
+
+    while (!krb5_cc_next_cred(context, ccache, &cur, &kcred)) {
+        if (!krb5_is_config_principal(context, kcred.server) &&
+            kcred.times.endtime > max_endtime) {
+            printf("Credential endtime %d exceeds allowed %d (time_req=%u)\n",
+                   (int)kcred.times.endtime, (int)max_endtime, secs);
+            exit(1);
+        }
+        krb5_free_cred_contents(context, &kcred);
+    }
+
+    ret = krb5_cc_end_seq_get(context, ccache, &cur);
+    check_k5err(context, "krb5_cc_end_seq_get", ret);
+
+    krb5_cc_destroy(context, ccache);
+    krb5_free_context(context);
 }
 
 static void
@@ -244,8 +305,8 @@ main(int argc, char *argv[])
     gss_OID_set mechs;
     gss_buffer_set_t bufset = GSS_C_NO_BUFFER_SET;
 
-    if (argc < 2 || argc > 5) {
-        fprintf(stderr, "Usage: %s [--spnego] [user] "
+    if (argc < 2 || argc > 7) {
+        fprintf(stderr, "Usage: %s [--spnego] [--time-req N] user "
                 "[proxy-target] [keytab]\n", argv[0]);
         fprintf(stderr, "       proxy-target and keytab are optional\n");
         exit(1);
@@ -255,6 +316,12 @@ main(int argc, char *argv[])
         use_spnego++;
         argc--;
         argv++;
+    }
+
+    if (argc > 2 && strcmp(argv[1], "--time-req") == 0) {
+        time_req = (OM_uint32)atol(argv[2]);
+        argc -= 2;
+        argv += 2;
     }
 
     user = import_name(argv[1]);
@@ -281,10 +348,15 @@ main(int argc, char *argv[])
 
     /* Get S4U2Self cred. */
     major = gss_acquire_cred_impersonate_name(&minor, impersonator_cred_handle,
-                                              user, GSS_C_INDEFINITE, mechs,
+                                              user, time_req, mechs,
                                               GSS_C_INITIATE,
                                               &user_cred_handle, NULL, NULL);
     check_gsserr("gss_acquire_cred_impersonate_name", major, minor);
+
+    /* When a time_req was specified, verify all ccache credentials are
+     * bounded by it, including any TGT copied from the impersonator. */
+    if (time_req != GSS_C_INDEFINITE)
+        check_cred_endtimes(user_cred_handle, time_req);
 
     init_accept_sec_context(user_cred_handle, impersonator_cred_handle,
                             &delegated_cred_handle);

--- a/src/tests/gssapi/t_s4u.py
+++ b/src/tests/gssapi/t_s4u.py
@@ -113,6 +113,11 @@ if 'auth1: user@' not in out or 'auth2: user@' not in out:
 # Successful S4U2Self -> S4U2Proxy.
 out = realm.run(['./t_s4u', puser, pservice2])
 
+# Verify that time_req bounds all credentials in the delegated ccache,
+# including the impersonator TGT copied by make_proxy_cred().
+mark('S4U2Self time_req bounds impersonator TGT in delegated ccache')
+realm.run(['./t_s4u', '--time-req', '600', puser, pservice2])
+
 # Regression test for #8139: get a user ticket directly for service1 and
 # try krb5 -> S4U2Proxy.
 realm.kinit(realm.user_princ, None, ['-f', '-k', '-c', usercache,


### PR DESCRIPTION
gss_acquire_cred() for the service locates the existing TGT in the ccache and records its KDC-granted endtime as cred->expire; it never requests a shorter-lived TGT.  So when gss_acquire_cred_impersonate_name() calls kg_impersonate_name() with a time_req, the impersonator TGT already carries a KDC-defined lifetime, not the requested one.

kg_impersonate_name() compounds this by zero-initialising in_creds (leaving in_creds.times.endtime = 0) and never writing time_req into it. When that reaches send_tgs.c:
```
    req.till = desired->times.endtime ? desired->times.endtime
                                      : tgt->times.endtime;
```
the zero endtime causes the fallback to tgt->times.endtime — the impersonator TGT's full KDC-granted lifetime.  The KDC therefore issues the S4U2Self ticket with KDC-policy lifetime, not the requested time_req.

The subsequent S4U2Proxy request via gss_init_sec_context() gets the correct lifetime because that is an entirely separate call with its own time_req: kg_new_connection() converts it to an absolute timestamp (ctx->krb_times.endtime = ts_incr(now, time_req)) and get_credentials() places it into in_creds.times.endtime before calling krb5_get_credentials(). send_tgs.c then takes the first branch and sends the requested deadline. This has nothing to do with what gss_acquire_cred_impersonate_name() did.

Fix kg_impersonate_name() to apply the same time_req-to-endtime conversion that kg_new_connection() already performs, so the S4U2Self TGS-REQ carries the caller's requested deadline rather than silently falling back to the impersonator TGT's full lifetime.