### PR TITLE
strerror_r.c: Use GNU strerror_r() when building on Linux

### DIFF
--- a/src/util/support/strerror_r.c
+++ b/src/util/support/strerror_r.c
@@ -30,6 +30,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "autoconf.h"
 #include <k5-platform.h>
 #undef strerror_r
 


### PR DESCRIPTION
While the POSIX (BSD) strerror_r() returns an int where 0 is success or an error number on failure, the GNU strerror() returns a char*, with NULL pointer on success or otherwise a pointer to an error message. This difference causes a buildworld failure when building FreeBSD on a Linux system.

This patch tells includes autoconf.h, which defines STRERROR_R_CHAR_P telling KRB5's strerror_p.c which form of the strerror() function to call.

Noted when building FreeBSD on an Ubuntu system. Tested on a Fedora system.

Applied to previously to the FreeBSD source tree.