### PR TITLE
GSSAPI: allow using cached S4U2Self ticket to itself

### DIFF
--- a/src/lib/gssapi/krb5/init_sec_context.c
+++ b/src/lib/gssapi/krb5/init_sec_context.c
@@ -124,7 +124,7 @@ get_credentials(krb5_context context, krb5_gss_cred_id_t cred,
 {
     krb5_error_code     code;
     krb5_creds          in_creds, evidence_creds, mcreds, *result_creds = NULL;
-    krb5_flags          flags = 0;
+    krb5_flags          flags = 0, cmpflag = 0;
     krb5_principal_data server_data;
 
     *out_creds = NULL;
@@ -163,10 +163,17 @@ get_credentials(krb5_context context, krb5_gss_cred_id_t cred,
 
     /* Try constrained delegation if we have proxy credentials. */
     if (cred->impersonator != NULL) {
-        /* If we are trying to get a ticket to ourselves, we should use the
-         * the evidence ticket directly from cache. */
-        if (krb5_principal_compare(context, cred->impersonator,
-                                   server->princ)) {
+        /*
+         * If we are trying to get a ticket to the impersonator, we should use
+         * the the evidence ticket directly from the cache.  If the server name
+         * is host-based, ignore the realm for this comparison;
+         * krb5_sname_to_principal() probably yielded an empty realm, and
+         * host-based principals generally only exist in one realm.
+         */
+        if (server->princ->type == KRB5_NT_SRV_HST)
+            cmpflag = KRB5_PRINCIPAL_COMPARE_IGNORE_REALM;
+        if (krb5_principal_compare_flags(context, cred->impersonator,
+                                         server->princ, cmpflag)) {
             flags |= KRB5_GC_CACHED;
         } else {
             memset(&mcreds, 0, sizeof(mcreds));


### PR DESCRIPTION
When there is already a cached service ticket to itself in the ccache, gss_init_sec_context() would not match it.

The code already strips the realm from server_data for host-based principals, but the "same service" guard still uses server->princ with the original realm. It should use realm-insensitive comparison for KRB5_NT_SRV_HST principals.

Enables login with protocol transition (S4U2Self) to be actually useful against the same service.

```
$ ssh -l ab some-system
[ab@some-system ~]$ klist
Ticket cache: KCM:1001
Default principal: ab@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1

Valid starting       Expires              Service principal
03/28/2026 06:51:27  03/29/2026 06:51:27  host/some-system@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1
	renew until 03/28/2026 06:51:27
[ab@some-system ~]$ klist -C
Ticket cache: KCM:1001
Default principal: ab@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1

Valid starting       Expires              Service principal
config: refresh_time = 	for client host/some-system@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F11774738287

config: fast_avail(krbtgt/LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1) = 	for client host/some-system@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1 yes

config: proxy_impersonator = host/some-system@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1
config: pa_type(krbtgt/LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1) = 	for client host/some-system@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1 151

03/28/2026 06:51:27  03/29/2026 06:51:27  host/some-system@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1
	renew until 03/28/2026 06:51:27
$ KRB5_TRACE=/dev/stderr ssh -v -l ab `hostname`
debug1: OpenSSH_10.2p1, OpenSSL 3.5.5 27 Jan 2026
[...]
debug1: Authentications that can continue: publickey,gssapi-keyex,gssapi-with-mic,password
debug1: Next authentication method: gssapi-with-mic
[17387] 1774695121.044119: ccselect can't find appropriate cache for server principal host/some-system@SOME-SYSTEM
[17387] 1774695121.044737: Getting credentials ab@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1 -> host/some-system@ using ccache KCM:1001
[17387] 1774695121.045384: Retrieving ab@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1 -> krb5_ccache_conf_data/start_realm@X-CACHECONF: from KCM:1001 with result: -1765328243/Matching credential not found
[17387] 1774695121.045718: Retrieving ab@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1 -> host/some-system@ from KCM:1001 with result: -1765328243/Matching credential not found
[17387] 1774695121.046033: Retrying ab@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1 -> host/some-system@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1 with result: 0/Success
[17387] 1774695121.046087: Creating authenticator for ab@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1 -> host/some-system@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1, seqnum 16626238, subkey aes256-sha2/CAF0, session key aes256-sha2/922E
[17387] 1774695121.062891: ccselect can't find appropriate cache for server principal host/some-system@SOME-SYSTEM
[17387] 1774695121.063511: Getting credentials ab@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1 -> host/some-system@ using ccache KCM:1001
[17387] 1774695121.063976: Retrieving ab@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1 -> krb5_ccache_conf_data/start_realm@X-CACHECONF: from KCM:1001 with result: -1765328243/Matching credential not found
[17387] 1774695121.064281: Retrieving ab@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1 -> host/some-system@ from KCM:1001 with result: -1765328243/Matching credential not found
[17387] 1774695121.064542: Retrying ab@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1 -> host/some-system@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1 with result: 0/Success
[17387] 1774695121.064637: Creating authenticator for ab@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1 -> host/some-system@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1, seqnum 583593098, subkey aes256-sha2/A741, session key aes256-sha2/922E
[17387] 1774695121.070603: Read AP-REP, time 1774695121.64649, subkey aes256-sha2/3DB4, seqnum 782062621
Authenticated to some-system (ip-address:22) using "gssapi-with-mic".
debug1: channel 0: new session [client-session] (inactive timeout: 0)
debug1: Requesting no-more-sessions@openssh.com
debug1: Entering interactive session.
Last login: Sat Mar 28 06:51:27 2026 from 10.44.32.20
[ab@some-system ~]$ klist
Ticket cache: KCM:1001
Default principal: ab@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1

Valid starting       Expires              Service principal
03/28/2026 06:51:27  03/29/2026 06:51:27  host/some-system@LOCALKDC.17CD7FFB-5A65-4DBF-9812-7B45837D20F1
	renew until 03/28/2026 06:51:27
```