### PR TITLE
Prevent read overrun in libkdb_ldap

### DIFF
--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
@@ -80,6 +80,9 @@ getstringtime(krb5_timestamp);
 krb5_error_code
 berval2tl_data(struct berval *in, krb5_tl_data **out)
 {
+    if (in->bv_len < 2)
+        return EINVAL;
+
     *out = (krb5_tl_data *) malloc (sizeof (krb5_tl_data));
     if (*out == NULL)
         return ENOMEM;


### PR DESCRIPTION
In berval2tl_data(), reject inputs of length less than 2 to prevent an integer underflow and subsequent read overrun.  (The security impact is negligible as the attacker would have to control the KDB LDAP server.)
