### PR TITLE
Avoid more undefined memcpy/etc. invocations

### DIFF
--- a/src/kdc/kdc_preauth.c
+++ b/src/kdc/kdc_preauth.c
@@ -1386,6 +1386,8 @@ keyblock_equal(const krb5_keyblock *k1, const krb5_keyblock *k2)
         return FALSE;
     if (k1->length != k2->length)
         return FALSE;
+    if (k1->length == 0)
+        return TRUE;
     return memcmp(k1->contents, k2->contents, k1->length) == 0;
 }
 

--- a/src/lib/gssapi/krb5/k5sealiov.c
+++ b/src/lib/gssapi/krb5/k5sealiov.c
@@ -98,7 +98,8 @@ make_seal_token_v1_iov(krb5_context context,
         /* Initialize padding buffer to pad itself */
         if (padding != NULL) {
             padding->buffer.length = gss_padlen;
-            memset(padding->buffer.value, (int)gss_padlen, gss_padlen);
+            if (gss_padlen > 0)
+                memset(padding->buffer.value, (int)gss_padlen, gss_padlen);
         }
 
         if (ctx->gss_flags & GSS_C_DCE_STYLE)

--- a/src/lib/gssapi/mechglue/g_acquire_cred_imp_name.c
+++ b/src/lib/gssapi/mechglue/g_acquire_cred_imp_name.c
@@ -454,10 +454,12 @@ gss_add_cred_impersonate_name(OM_uint32 *minor_status,
     /*
      * OK, expand the mechanism array and the credential array
      */
-    (void) memcpy(new_mechs_array, union_cred->mechs_array,
-		  sizeof (gss_OID_desc) * union_cred->count);
-    (void) memcpy(new_cred_array, union_cred->cred_array,
-		  sizeof (gss_cred_id_t) * union_cred->count);
+    if (union_cred->count > 0) {
+	memcpy(new_mechs_array, union_cred->mechs_array,
+	       sizeof (gss_OID_desc) * union_cred->count);
+	memcpy(new_cred_array, union_cred->cred_array,
+	       sizeof (gss_cred_id_t) * union_cred->count);
+    }
 
     new_cred_array[union_cred->count] = cred;
     if ((new_mechs_array[union_cred->count].elements =

--- a/src/lib/gssapi/mechglue/g_acquire_cred_with_pw.c
+++ b/src/lib/gssapi/mechglue/g_acquire_cred_with_pw.c
@@ -430,10 +430,12 @@ gss_add_cred_with_password(
     /*
      * OK, expand the mechanism array and the credential array
      */
-    (void) memcpy(new_mechs_array, union_cred->mechs_array,
-		  sizeof (gss_OID_desc) * union_cred->count);
-    (void) memcpy(new_cred_array, union_cred->cred_array,
-		  sizeof (gss_cred_id_t) * union_cred->count);
+    if (union_cred->count > 0) {
+	memcpy(new_mechs_array, union_cred->mechs_array,
+	       sizeof (gss_OID_desc) * union_cred->count);
+	memcpy(new_cred_array, union_cred->cred_array,
+	       sizeof (gss_cred_id_t) * union_cred->count);
+    }
 
     new_cred_array[union_cred->count] = cred;
     if ((new_mechs_array[union_cred->count].elements =

--- a/src/lib/kadm5/srv/svr_principal.c
+++ b/src/lib/kadm5/srv/svr_principal.c
@@ -124,12 +124,12 @@ get_policy(kadm5_server_handle_t handle, const char *name,
  * key/salts outside the policy.  We re-order the requested ks tuples
  * (which may be a subset of the policy) to reflect the policy order.
  */
-static kadm5_ret_t
+static krb5_error_code
 apply_keysalt_policy(kadm5_server_handle_t handle, const char *policy,
                      int n_ks_tuple, krb5_key_salt_tuple *ks_tuple,
                      int *new_n_kstp, krb5_key_salt_tuple **new_kstp)
 {
-    kadm5_ret_t ret;
+    krb5_error_code ret;
     kadm5_policy_ent_rec polent;
     krb5_boolean have_polent;
     int ak_n_ks_tuple = 0;
@@ -157,12 +157,10 @@ apply_keysalt_policy(kadm5_server_handle_t handle, const char *policy,
             ks_tuple = handle->params.keysalts;
         }
         /* Dup the requested or defaulted keysalt tuples. */
-        new_ks_tuple = malloc(n_ks_tuple * sizeof(*new_ks_tuple));
-        if (new_ks_tuple == NULL) {
-            ret = ENOMEM;
+        new_ks_tuple = k5calloc(n_ks_tuple, sizeof(*new_ks_tuple), &ret);
+        if (new_ks_tuple == NULL)
             goto cleanup;
-        }
-        memcpy(new_ks_tuple, ks_tuple, n_ks_tuple * sizeof(*new_ks_tuple));
+        k5memcpy(new_ks_tuple, ks_tuple, n_ks_tuple * sizeof(*new_ks_tuple));
         new_n_ks_tuple = n_ks_tuple;
         ret = 0;
         goto cleanup;

--- a/src/tests/gssapi/t_iov.c
+++ b/src/tests/gssapi/t_iov.c
@@ -57,7 +57,8 @@ concat_iov(gss_iov_buffer_desc *iov, size_t iovlen, char **buf_out,
     for (i = 0; i < iovlen; i++) {
         if (GSS_IOV_BUFFER_TYPE(iov[i].type) == GSS_IOV_BUFFER_TYPE_SIGN_ONLY)
             continue;
-        memcpy(buf + len, iov[i].buffer.value, iov[i].buffer.length);
+        if (iov[i].buffer.length > 0)
+            memcpy(buf + len, iov[i].buffer.value, iov[i].buffer.length);
         len += iov[i].buffer.length;
     }
     *buf_out = buf;

--- a/src/tests/kdbtest.c
+++ b/src/tests/kdbtest.c
@@ -224,7 +224,8 @@ check_entry(krb5_db_entry *ent)
         for (j = 0; j < k1->key_data_ver; j++) {
             CHECK_COND(k1->key_data_type[j] == k2->key_data_type[j]);
             CHECK_COND(k1->key_data_length[j] == k2->key_data_length[j]);
-            CHECK_COND(memcmp(k1->key_data_contents[j],
+            CHECK_COND(k1->key_data_length[j] == 0 ||
+                       memcmp(k1->key_data_contents[j],
                               k2->key_data_contents[j],
                               k1->key_data_length[j]) == 0);
         }


### PR DESCRIPTION
Fix additional cases where C standard library functions can be called with null pointers and a zero length.  Also prevent a potential zero-length memory allocation in apply_keysalt_policy().  Reported by Evgeny Shemyakin.