### PR TITLE
Fix error propagation in get_pac_princ_with_realm

### DIFF
--- a/src/kdc/kdc_util.c
+++ b/src/kdc/kdc_util.c
@@ -665,13 +665,13 @@ get_pac_princ_with_realm(krb5_context context, krb5_pac pac,
 
     ret = krb5_parse_name_flags(context, client_str, flags, princ_out);
     if (ret)
-        return ret;
+        goto cleanup;
 
     (*princ_out)->type = KRB5_NT_MS_PRINCIPAL;
 
 cleanup:
     free(client_str);
-    return 0;
+    return ret;
 }
 
 /* This probably wants to be updated if you support last_req stuff */


### PR DESCRIPTION
## Summary

The cleanup label in `get_pac_princ_with_realm()` unconditionally returns 0 instead of the error code in `ret`. When the PAC client name string has an unexpected number of `@` characters (0 or 3+), `ret` is set to `KRB5_PARSE_MALFORMED` but the function still returns success. The caller in `do_tgs_req.c` then proceeds with a NULL `stkt_pac_client` pointer (initialized to NULL at line 647), causing a NULL pointer dereference crash in the KDC during cross-realm S4U2Proxy (constrained delegation) processing.

## Fix

Change `return 0` to `return ret` in the cleanup label.

Note: the success path through `krb5_parse_name_flags()` (line 666) returns directly on success (line 668) or falls through to cleanup with the error in `ret`, so changing cleanup to return `ret` is correct for all paths:
- Malformed name (0 or 3+ `@`): `ret = KRB5_PARSE_MALFORMED`, cleanup returns error
- Parse failure: `ret` holds the parse error, cleanup returns it
- Success: returns at line 668, does not reach cleanup

ticket: new
tags: pullup
target_version: 1.22-next