### PR TITLE
Validate ticket_info count in KRB-CRED processing

### DIFF
--- a/src/lib/krb5/krb/rd_cred.c
+++ b/src/lib/krb5/krb/rd_cred.c
@@ -98,6 +98,11 @@ make_cred_list(krb5_context context, krb5_cred *krbcred,
             goto cleanup;
 
         info = encpart->ticket_info[i];
+        if (info == NULL) {
+            /* We unexpectedly reached the end of the encrypted ticket info. */
+            ret = KRB5KRB_AP_ERR_MODIFIED;
+            goto cleanup;
+        }
         ret = krb5_copy_principal(context, info->client, &list[i]->client);
         if (ret)
             goto cleanup;


### PR DESCRIPTION
## Summary

`make_cred_list()` in `rd_cred.c` counts the number of tickets from the `KRB-CRED.tickets` array but indexes into the separately-decoded `EncKrbCredPart.ticket_info` array without verifying both arrays have the same length. If a crafted KRB-CRED message has more tickets than ticket_info entries, the loop reads past the null-terminated `ticket_info` array, dereferencing garbage pointers as `krb5_cred_info` structures.

This is reachable via `krb5_rd_cred()` (called from GSS-API credential delegation in `accept_sec_context.c`). RFC 6448 unencrypted KRB-CRED mode allows unauthenticated trigger.

## Fix

Count both arrays before the processing loop and reject the message with `KRB5KRB_AP_ERR_MODIFIED` if the counts do not match.

ticket: new
tags: pullup
target_version: 1.22-next