### PR TITLE
Avoid asymmetric WSACleanup() in libkrb5

### DIFF
--- a/src/lib/krb5/os/init_os_ctx.c
+++ b/src/lib/krb5/os/init_os_ctx.c
@@ -416,8 +416,11 @@ k5_os_init_context(krb5_context ctx, profile_t profile, krb5_flags flags)
     krb5_os_context os_ctx;
     krb5_error_code    retval = 0;
 #ifdef _WIN32
-    WORD wVersionRequested;
     WSADATA wsaData;
+
+    /* Initialize winsock to version 1.1.  Do this first so that we know it was
+     * done in k5_os_free_context(), and can safely call WSACleanup(). */
+    WSAStartup(0x0101, &wsaData);
 #endif /* _WIN32 */
 
     os_ctx = &ctx->os_context;
@@ -437,14 +440,6 @@ k5_os_init_context(krb5_context ctx, profile_t profile, krb5_flags flags)
         retval = os_init_paths(ctx, (flags & KRB5_INIT_CONTEXT_KDC) != 0);
     if (retval)
         return retval;
-
-#ifdef _WIN32
-    /* We initialize winsock to version 1.1 but
-     * we do not care if we succeed or fail.
-     */
-    wVersionRequested = 0x0101;
-    WSAStartup (wVersionRequested, &wsaData);
-#endif /* _WIN32 */
 
     return 0;
 }


### PR DESCRIPTION
In k5_os_init_context(), call WSAStartup() before doing anything else. Otherwise, a failure to read or parse krb5.conf could cause an asymmetric call to WSACleanup() in k5_os_free_context().  Reported by Zvika Meiseles.