### PR TITLE
Fix NULL pointer dereference in get_negTokenResp

### DIFF
--- a/src/lib/gssapi/spnego/spnego_mech.c
+++ b/src/lib/gssapi/spnego/spnego_mech.c
@@ -3517,6 +3517,8 @@ get_negTokenResp(OM_uint32 *minor_status, struct k5input *in,
 
 	if (k5_der_get_value(&seq, CONTEXT | 0x03, &field)) {
 		*mechListMIC = get_octet_string(&field);
+		if (*mechListMIC == GSS_C_NO_BUFFER)
+			return GSS_S_DEFECTIVE_TOKEN;
 
                 /* Handle Windows 2000 duplicate response token */
                 if (*responseToken &&


### PR DESCRIPTION
In get_negTokenResp(), when parsing the mechListMIC field (context tag 0x03) of a SPNEGO NegTokenResp, the return
value of get_octet_string() was not checked for failure before being dereferenced. If get_octet_string() returned GSS_C_NO_BUFFER (i.e., NULL), the subsequent duplicate response token comparison would dereference the NULL pointer when accessing (*mechListMIC)->length and (*mechListMIC)->value.

This adds a NULL check consistent with the identical pattern already used for the responseToken field (context tag 0x02) and the supportedMech field (context tag 0x01), returning GSS_S_DEFECTIVE_TOKEN on allocation failure. A malformedSPNEGO token could trigger this crash without the fix.