### PR TITLE
Fix reachable assert when importing krb5 names

### DIFF
--- a/src/lib/gssapi/krb5/import_name.c
+++ b/src/lib/gssapi/krb5/import_name.c
@@ -297,7 +297,8 @@ import_name(OM_uint32 *minor_status, gss_buffer_t input_name_buffer,
                     goto fail_name;
                 cp += length;
             }
-            assert(cp == end);
+            if (cp != end)
+                goto fail_name;
         } else {
             status = GSS_S_BAD_NAMETYPE;
             goto cleanup;


### PR DESCRIPTION
If a name token contains trailing garbage, error out from krb5_gss_import_name() instead of crashing the process with an assertion failure.  Reported by Aisle Research (Ze Sheng, Dmitrijs Trizna, Luigino Camastra, Guido Vranken).
