### PR TITLE
Better validate key_data_ver in iprop decoding

### DIFF
--- a/src/lib/kdb/kdb_convert.c
+++ b/src/lib/kdb/kdb_convert.c
@@ -677,8 +677,10 @@ ulog_conv_2dbentry(krb5_context context, krb5_db_entry **entry,
                 kdbe_key_t *kv = &ULOG_ENTRY_KEYVAL(update, i, j);
                 kp->key_data_ver = (krb5_int16)kv->k_ver;
                 kp->key_data_kvno = (krb5_ui_2)kv->k_kvno;
-                if (kp->key_data_ver > 2) {
-                    ret = EINVAL; /* XXX ? */
+                if (kp->key_data_ver < 1 || kp->key_data_ver > 2 ||
+                    (u_int)kp->key_data_ver > kv->k_enctype.k_enctype_len ||
+                    (u_int)kp->key_data_ver > kv->k_contents.k_contents_len) {
+                    ret = EINVAL;
                     goto cleanup;
                 }
 


### PR DESCRIPTION
[This was reported via krbcore-security, but I determined that it does not necessitate a CVE.  To attack this bug, one would need to possess the kiprop long-term key, at which point the ability to crash a replica KDC's kpropd process or conceivably exfiltrate some of its process memory is not nearly as harmful as what one could do by sending well-formed but malicious DB updates.]

In ulog_conv_2dbentry(), when decoding an update's AT_KEYDATA attribute, the decoded key_data_ver value is used as a bound on the enctype and contents fields.  Verify that this value does not exceed the sizes of the update's enctype and contents XDR arrays, to prevent reading past the end of those arrays.  Also check against the expected lower bound.  Reported by Haruki Oyama.
