### PR TITLE
Fix DB2 hash bitmap page count validation

### DIFF
--- a/src/plugins/kdb/db2/libdb2/hash/hash.c
+++ b/src/plugins/kdb/db2/libdb2/hash/hash.c
@@ -170,6 +170,9 @@ __kdb2_hash_open(const char *file, int flags, int mode, const HASHINFO *info,
 		    (hashp->hdr.bsize << BYTE_SHIFT) - 1) >>
 		    (hashp->hdr.bshift + BYTE_SHIFT);
 
+		if (bpages > NCACHED || bpages < 0)
+			RETURN_ERROR(EFTYPE, error1);
+
 		hashp->nmaps = bpages;
 		(void)memset(&hashp->mapp[0], 0, bpages * sizeof(u_int32_t *));
 	}


### PR DESCRIPTION
[I am not planning to backport this.  Although it is facially concerning as it can lead to a memory error, (1) hash databases are not the default for the db2 back end and therefore are probably rarely or never used, and (2) the binary database contents live at the same privilege level as the processes that use them, so memory errors will only be seen in the event of data corruption.  There are other hash database validation issues, some of which are described in https://krbdev.mit.edu/rt/Ticket/Display.html?id=9150 .  Ordinarily I would like to fix all unimportant bugs of a category in one commit, but in this case the unimportant code is also very subtle and complicated, so it would require a lot of work to have any confidence in having found them all and fixed them correctly.  Since that work is unlikely to ever happen, I decided I should be open to committing submitted libdb2 hash fixes one at a time if I can be confident in them individually, as I am for this one.]

In __kdb2_hash_open(), bpages is computed from the hash file header and then used as the size argument when clearing hashp->mapp.  The mapp array has only NCACHED entries, so a malformed hash database can cause memset() to write past the end of the array.  Return EFTYPE if the computed bitmap page count is negative or greater then NCACHED.

Found by Linux Verification Center (linuxtesting.org) with SVACE.
