### PR TITLE
Set MIDL target environment on Windows

### DIFF
--- a/src/ccapi/lib/win/Makefile.in
+++ b/src/ccapi/lib/win/Makefile.in
@@ -67,12 +67,12 @@ LFLAGS	= /nologo $(LOPTS)
 all: Makefile copysrc midl $(OUTPRE)$(CCLIB).dll finish
 
 ccs_request.h ccs_request_c.c ccs_request_s.c : ccs_request.idl ccs_request.acf
-    midl $(MIDL_OPTIMIZATION) $(MIDLI) -oldnames -cpp_cmd $(CC) -cpp_opt "-E" \
-    ccs_request.idl
+    midl $(MIDL_OPTIMIZATION) $(MIDLI) $(MIDL_ENV) -oldnames -cpp_cmd $(CC) \
+    -cpp_opt "-E" ccs_request.idl
 
 ccs_reply.h   ccs_reply_c.c   ccs_reply_s.c   : ccs_reply.idl   ccs_reply.acf
-    midl $(MIDL_OPTIMIZATION) $(MIDLI) -oldnames -cpp_cmd $(CC) -cpp_opt "-E" \
-    ccs_reply.idl
+    midl $(MIDL_OPTIMIZATION) $(MIDLI) $(MIDL_ENV) -oldnames -cpp_cmd $(CC) \
+    -cpp_opt "-E" ccs_reply.idl
 
 copysrc :
     echo "Copying all sources needed to build $(CCLIB).dll to $(SRCTMP)"

--- a/src/ccapi/server/win/Makefile.in
+++ b/src/ccapi/server/win/Makefile.in
@@ -72,12 +72,12 @@ LFLAGS	= /nologo $(LOPTS)
 all: Makefile copysrc midl $(OUTPRE)ccapiserver.exe finish
 
 ccs_request.h ccs_request_c.c ccs_request_s.c : ccs_request.idl ccs_request.acf
-    midl $(MIDL_OPTIMIZATION) $(MIDLI) -oldnames -cpp_cmd $(CC) -cpp_opt "-E" \
-    ccs_request.idl
+    midl $(MIDL_OPTIMIZATION) $(MIDLI) $(MIDL_ENV) -oldnames -cpp_cmd $(CC) \
+    -cpp_opt "-E" ccs_request.idl
 
 ccs_reply.h   ccs_reply_c.c   ccs_reply_s.c   : ccs_reply.idl   ccs_reply.acf
-    midl $(MIDL_OPTIMIZATION) $(MIDLI) -oldnames -cpp_cmd $(CC) -cpp_opt "-E" \
-    ccs_reply.idl
+    midl $(MIDL_OPTIMIZATION) $(MIDLI) $(MIDL_ENV) -oldnames -cpp_cmd $(CC) \
+    -cpp_opt "-E" ccs_reply.idl
 
 copysrc :
     echo "Copying all sources needed to build ccapiserver.exe to $(SRCTMP)"

--- a/src/config/win-pre.in
+++ b/src/config/win-pre.in
@@ -126,6 +126,13 @@ CCOPTS=-nologo /EHsc /W3 /we4020 /we4024 /we4047 $(PDB_OPTS) $(DLL_FILE_DEF)
 LOPTS=-nologo -incremental:no -manifest
 
 CCLINKOPTION=
+MIDL_ENV=
+!if "$(CPU)" == "AMD64"
+MIDL_ENV=/env x64
+!elseif "$(CPU)" == "ARM64"
+MIDL_ENV=/env arm64
+!endif
+
 DEBUGOPT=/guard:cf /Zi
 
 #if the compiler is vstudio 8, generate manifest


### PR DESCRIPTION
When building for Windows ARM64, the Windows build runs MIDL without passing the target CPU architecture, so MIDL may generate files for its default environment instead of ARM64. Here we define a MIDL environment option from the existing Windows `CPU` value for the actively relevant 64-bit Windows targets, and pass it to the CCAPI MIDL invocations.

Validation: a conda-forge Windows ARM64 krb5 package build succeeded with the equivalent `/env arm64` patch applied: https://github.com/conda-forge/krb5-feedstock/pull/55