### PR TITLE
Fix key usage list parsing in PKINIT matching code

### DIFF
--- a/src/plugins/preauth/pkinit/pkinit_matching.c
+++ b/src/plugins/preauth/pkinit/pkinit_matching.c
@@ -224,7 +224,8 @@ parse_list_value(krb5_context context,
         }
 
         for (; ku->value != NULL; ku++) {
-            if (strncasecmp(value, ku->value, len) == 0) {
+            if (len == ku->length &&
+                strncasecmp(value, ku->value, ku->length) == 0) {
                 *bitptr |= ku->bitval;
                 found = 1;
                 pkiDebug("%s: Found value '%s', bitfield is now 0x%x\n",


### PR DESCRIPTION
pkinit_matching.c:parse_list_value() uses strncasecmp() to compare a comma-delimited substring of the configured input rule (value) against a string literal (ku->value).  The strncasecmp() call uses the wrong bound, so could erroneously match a prefix of ku->value.  When this happens, the pointer into the rule is incremented by the full length of the string literal (not the matched prefix), possibly advancing past the end of the rule and causing a subsequent undefined memory read.

Fix this bug by checking the rule substring length against the string literal length before comparing.  Reported by Aisle Research (Ze Sheng, Dmitrijs Trizna, Luigino Camastra, Guido Vranken).

[This bug is not a security concern because PKINIT matching rule configuration is not attacker-controlled.  It comes either from krb5.conf or a string attribute in the KDB.]