### PR TITLE
Fix deserializing context with missing profile files

### DIFF
--- a/src/util/profile/prof_init.c
+++ b/src/util/profile/prof_init.c
@@ -654,12 +654,12 @@ errcode_t profile_ser_internalize(profile_t *profilep,
         goto cleanup;
     }
 
-    if ((retval = profile_init((const_profile_filespec_t *) flist,
-                               profilep)))
-        goto cleanup;
-
+    /* Update the buffer pointer even if profile initialization fails, so the
+     * caller can keep deserializing from the correct position.  */
     *bufpp = bp;
     *remainp = remain;
+
+    retval = profile_init((const_profile_filespec_t *) flist, profilep);
 
 cleanup:
     if (flist) {


### PR DESCRIPTION
The code path in `k5_internalize_context` tolerates some failures of `internalize_oscontext` and `profile_ser_internalize` (`EINVAL` and `ENOENT`), and attempts to proceed nevertheless. A specific non-fatal failure that can happen when loading the profile is missing configuration files (i.e. `/etc/krb5.conf`): `profile_init_flags` tries to read at least one file, returns `ENOENT` if they all turned out to be missing, and then `profile_ser_internalize` attempts to proceed despite that.

However, `profile_ser_internalize` was only updating the buffer pointer in case of complete success, which meant that, when `k5_internalize_context` tried to proceed after an error, it was actually re-reading profile data (starting with `PROF_MAGIC_PROFILE`), and not the trailer of the serialized context (`KV5M_CONTEXT`) that it expected. So it failed on that.

I observed this failure in the following scenario:
* An application using GSS API is running in the [Flatpak](https://flatpak.org/) environment;
* Kerberos is properly set up and configured on the host system;
* Flatpak provides the application with a different view of the file system compared to the host, relevantly for our case a separate `/etc`;
* [gssproxy](https://github.com/gssapi/gssproxy/) (cc @simo5) is used (transparently to the app, https://github.com/flatpak/flatpak/pull/4914) to proxy GSS API calls to the host system, where the Kerberos GSS implementation serves them;
* As a part of `gss_unwrap` implementation, gssproxy transfers the established context from the host system to the app inside Flatpak (`gssi_unwrap` -> `gpp_remote_to_local_ctx`);
* The serialized context representation encodes `/etc/krb5.conf`, but no such file exists in the Flatpak environment, therefore deserialization fails near the very end, in the manner described above.

It looks like this was intended to work, and missing conf files are not supposed to fail the entire deserialization process. To make it work, advance the buffer pointer as soon as `profile_ser_internalize` finishes actually reading the serialized profile data, whether `profile_init` succeeds or not.

With this change, `gss_unwrap` in Flatpak via gssproxy succeeds.

------------------

It looks like GitHub PRs is the preferred way of submitting patches now, but if it's not, I could post this to a mailing list instead.