### PR TITLE
Add OTP responder for IAKERB initial credential acquisition

### DIFF
--- a/doc/appdev/gssapi.rst
+++ b/doc/appdev/gssapi.rst
@@ -265,23 +265,34 @@ The following options are supported by the krb5 mechanism:
   be used for verification when initiator credentials are acquired
   using a password and verified.
 
+* **otp**: For acquiring initiator credentials, this option instructs
+  the mechanism to acquire fresh credentials into a unique memory
+  credential cache.  The value is used as a one-time password
+  credential if the KDC requests OTP preauthentication.  This option
+  may not be used with the **ccache** or **client_keytab** options,
+  and a *desired_name* must be specified.  (New in release 1.23.)
+
 * **password**: For acquiring initiator credentials, this option
   instructs the mechanism to acquire fresh credentials into a unique
-  memory credential cache.  This option may not be used with the
-  **ccache** or **client_keytab** options, and a *desired_name* must
-  be specified.  (New in release 1.19.)
+  memory credential cache.  The option value is used as the Kerberos
+  password.  This option may not be used with the **ccache** or
+  **client_keytab** options, and a *desired_name* must be specified.
+  This option may be used with the **otp** option, but only one of the
+  values will be used, depending on what preauthentication mechanisms
+  are made available by the KDC.  (New in release 1.19.)
 
 * **rcache**: For acquiring acceptor credentials, the name of the
   :ref:`replay cache <rcache_definition>` to be used when processing
   the initiator tokens.  (New in release 1.13.)
 
-* **verify**: For acquiring initiator credentials, this option
-  instructs the mechanism to verify the credentials by obtaining a
-  ticket to a service with a known key.  The service key is obtained
-  from the keytab specified with the **keytab** option or the default
-  keytab.  The value may be the name of a principal in the keytab, or
-  the empty string.  If the empty string is given, any ``host``
-  service principal in the keytab may be used.  (New in release 1.19.)
+* **verify**: When acquiring fresh initiator credentials with the
+  **password** or **otp** options, this option instructs the mechanism
+  to verify the credentials by obtaining a ticket to a service with a
+  known key.  The service key is obtained from the keytab specified
+  with the **keytab** option or the default keytab.  The value may be
+  the name of a principal in the keytab, or the empty string.  If the
+  empty string is given, any ``host`` service principal in the keytab
+  may be used.  (New in release 1.19.)
 
 In release 1.20 or later, if a collection name is specified for
 **cache** in a call to gss_store_cred_into(), an existing cache for

--- a/src/lib/gssapi/krb5/acquire_cred.c
+++ b/src/lib/gssapi/krb5/acquire_cred.c
@@ -325,7 +325,7 @@ can_get_initial_creds(krb5_context context, krb5_gss_cred_id_rec *cred)
 {
     krb5_error_code code;
 
-    if (cred->password != NULL)
+    if (cred->password != NULL || cred->otp != NULL)
         return TRUE;
 
     if (cred->client_keytab == NULL)
@@ -477,9 +477,8 @@ get_cache_for_name(krb5_context context, krb5_gss_cred_id_rec *cred)
     cctype = krb5_cc_get_type(context, defcc);
     have_collection = krb5_cc_support_switch(context, cctype);
 
-    /* We can use an empty default ccache if we're using a password or if
-     * there's no collection. */
-    if (cred->password != NULL || !have_collection) {
+    /* We can use an empty default ccache if there is no collection. */
+    if (!have_collection) {
         if (krb5_cc_get_principal(context, defcc, &princ) == KRB5_FCC_NOFILE) {
             cred->ccache = defcc;
             defcc = NULL;
@@ -579,8 +578,9 @@ kg_cred_set_initial_refresh(krb5_context context, krb5_gss_cred_id_rec *cred,
 {
     krb5_timestamp refresh;
 
-    /* For now, we only mark keytab-acquired credentials for refresh. */
-    if (cred->password != NULL)
+    /* For now, we only mark keytab-acquired credentials for refresh.  An OTP
+     * value is single-use, so it cannot be used to refresh. */
+    if (cred->password != NULL || cred->otp != NULL)
         return;
 
     /* Make a note to refresh these when they are halfway to expired. */
@@ -606,7 +606,35 @@ verify_initial_cred(krb5_context context, krb5_creds *creds,
                                   verify->keytab, NULL, &vopts);
 }
 
-/* Get initial credentials using the supplied password or client keytab. */
+/*
+ * Answer an OTP challenge with the OTP value from the credential store.  No
+ * prompter is available during credential acquisition, so the OTP preauth
+ * module cannot otherwise collect a value.
+ */
+krb5_error_code KRB5_CALLCONV
+kg_otp_responder(krb5_context context, void *data,
+                 krb5_responder_context rctx)
+{
+    const char *otp = data;
+    krb5_responder_otp_challenge *chl = NULL;
+    krb5_error_code ret;
+
+    if (krb5_responder_get_challenge(context, rctx,
+                                     KRB5_RESPONDER_QUESTION_OTP) == NULL)
+        return 0;
+
+    ret = krb5_responder_otp_get_challenge(context, rctx, &chl);
+    if (ret != 0 || chl == NULL)
+        return 0;
+
+    /* Answer the first token-info with the OTP value. */
+    ret = krb5_responder_otp_set_answer(context, rctx, 0, otp, NULL);
+    krb5_responder_otp_challenge_free(context, rctx, chl);
+    return ret;
+}
+
+/* Get initial credentials using the supplied password, OTP value, or client
+ * keytab. */
 static krb5_error_code
 get_initial_cred(krb5_context context, const struct verify_params *verify,
                  krb5_gss_cred_id_rec *cred)
@@ -621,7 +649,14 @@ get_initial_cred(krb5_context context, const struct verify_params *verify,
     code = krb5_get_init_creds_opt_set_out_ccache(context, opt, cred->ccache);
     if (code)
         goto cleanup;
-    if (cred->password != NULL) {
+    if (cred->otp != NULL) {
+        code = krb5_get_init_creds_opt_set_responder(context, opt,
+                                                     kg_otp_responder,
+                                                     cred->otp);
+        if (code)
+            goto cleanup;
+    }
+    if (cred->password != NULL || cred->otp != NULL) {
         code = krb5_get_init_creds_password(context, &creds, cred->name->princ,
                                             cred->password, NULL, NULL, 0,
                                             NULL, opt);
@@ -633,7 +668,7 @@ get_initial_cred(krb5_context context, const struct verify_params *verify,
     }
     if (code)
         goto cleanup;
-    if (cred->password != NULL && verify != NULL) {
+    if ((cred->password != NULL || cred->otp != NULL) && verify != NULL) {
         code = verify_initial_cred(context, &creds, verify);
         if (code)
             goto cleanup;
@@ -680,7 +715,7 @@ maybe_get_initial_cred(krb5_context context,
 static OM_uint32
 acquire_init_cred(krb5_context context, OM_uint32 *minor_status,
                   krb5_ccache req_ccache, gss_buffer_t password,
-                  krb5_keytab client_keytab,
+                  const char *otp, krb5_keytab client_keytab,
                   const struct verify_params *verify,
                   krb5_gss_cred_id_rec *cred)
 {
@@ -695,13 +730,23 @@ acquire_init_cred(krb5_context context, OM_uint32 *minor_status,
                                                  &caller_ccname)))
         return GSS_S_FAILURE;
 
+    if (otp != NULL) {
+        cred->otp = strdup(otp);
+        if (cred->otp == NULL) {
+            code = ENOMEM;
+            goto error;
+        }
+    }
+
     if (password != GSS_C_NO_BUFFER) {
         pwdata = make_data(password->value, password->length);
         code = krb5int_copy_data_contents_add0(context, &pwdata, &pwcopy);
         if (code)
             goto error;
         cred->password = pwcopy.data;
+    }
 
+    if (password != GSS_C_NO_BUFFER || otp != NULL) {
         /* We will fetch the credential into a private memory ccache. */
         assert(req_ccache == NULL);
         code = krb5_cc_new_unique(context, "MEMORY", NULL, &cred->ccache);
@@ -781,10 +826,10 @@ error:
 static OM_uint32
 acquire_cred_context(krb5_context context, OM_uint32 *minor_status,
                      gss_name_t desired_name, gss_buffer_t password,
-                     OM_uint32 time_req, gss_cred_usage_t cred_usage,
-                     krb5_ccache ccache, krb5_keytab client_keytab,
-                     krb5_keytab keytab, const char *rcname,
-                     const struct verify_params *verify,
+                     const char *otp, OM_uint32 time_req,
+                     gss_cred_usage_t cred_usage, krb5_ccache ccache,
+                     krb5_keytab client_keytab, krb5_keytab keytab,
+                     const char *rcname, const struct verify_params *verify,
                      krb5_boolean iakerb, gss_cred_id_t *output_cred_handle,
                      OM_uint32 *time_rec)
 {
@@ -853,7 +898,7 @@ acquire_cred_context(krb5_context context, OM_uint32 *minor_status,
      * in cred->name if it wasn't set above.
      */
     if (cred_usage == GSS_C_INITIATE || cred_usage == GSS_C_BOTH) {
-        ret = acquire_init_cred(context, minor_status, ccache, password,
+        ret = acquire_init_cred(context, minor_status, ccache, password, otp,
                                 client_keytab, verify, cred);
         if (ret != GSS_S_COMPLETE)
             goto error_out;
@@ -925,8 +970,8 @@ acquire_cred(OM_uint32 *minor_status, gss_name_t desired_name,
     }
 
     ret = acquire_cred_context(context, minor_status, desired_name, password,
-                               time_req, cred_usage, ccache, NULL, keytab,
-                               NULL, NULL, iakerb, output_cred_handle,
+                               NULL, time_req, cred_usage, ccache, NULL,
+                               keytab, NULL, NULL, iakerb, output_cred_handle,
                                time_rec);
 
 out:
@@ -1187,7 +1232,7 @@ acquire_cred_from(OM_uint32 *minor_status, const gss_name_t desired_name,
     krb5_keytab keytab = NULL;
     krb5_ccache ccache = NULL;
     krb5_principal verify_princ = NULL;
-    const char *rcname, *value;
+    const char *rcname, *value, *otp = NULL;
     struct verify_params vparams = { NULL };
     const struct verify_params *verify = NULL;
     gss_buffer_desc pwbuf;
@@ -1254,10 +1299,23 @@ acquire_cred_from(OM_uint32 *minor_status, const gss_name_t desired_name,
     ret = kg_value_from_cred_store(cred_store, KRB5_CS_PASSWORD_URN, &value);
     if (GSS_ERROR(ret))
         goto out;
-
     if (value) {
-        /* We must be acquiring an initiator cred with an explicit name.  A
-         * password is mutually exclusive with a client keytab or ccache. */
+        pwbuf.length = strlen(value);
+        pwbuf.value = (void *)value;
+        password = &pwbuf;
+    }
+
+    ret = kg_value_from_cred_store(cred_store, KRB5_CS_OTP_URN, &otp);
+    if (GSS_ERROR(ret))
+        goto out;
+
+    if (password != NULL || otp != NULL) {
+        /*
+         * When acquiring fresh credentials, we must be acquiring an initiator
+         * cred with an explicit name, and the caller must not specify a ccache
+         * (the credentials will be stored in a new memory ccache) or client
+         * keytab.
+         */
         if (desired_name == GSS_C_NO_NAME) {
             ret = GSS_S_BAD_NAME;
             goto out;
@@ -1268,9 +1326,6 @@ acquire_cred_from(OM_uint32 *minor_status, const gss_name_t desired_name,
             ret = GSS_S_FAILURE;
             goto out;
         }
-        pwbuf.length = strlen(value);
-        pwbuf.value = (void *)value;
-        password = &pwbuf;
     }
 
     ret = kg_value_from_cred_store(cred_store, KRB5_CS_VERIFY_URN, &value);
@@ -1297,8 +1352,8 @@ acquire_cred_from(OM_uint32 *minor_status, const gss_name_t desired_name,
         verify = &vparams;
     }
     ret = acquire_cred_context(context, minor_status, desired_name, password,
-                               time_req, cred_usage, ccache, client_keytab,
-                               keytab, rcname, verify, iakerb,
+                               otp, time_req, cred_usage, ccache,
+                               client_keytab, keytab, rcname, verify, iakerb,
                                output_cred_handle, time_rec);
 
 out:

--- a/src/lib/gssapi/krb5/export_cred.c
+++ b/src/lib/gssapi/krb5/export_cred.c
@@ -381,6 +381,7 @@ json_kgcred(krb5_context context, krb5_gss_cred_id_t cred,
     k5_json_array array;
     k5_json_value name = NULL, imp = NULL, keytab = NULL, rcache = NULL;
     k5_json_value ccache = NULL, ckeytab = NULL, etypes = NULL;
+    k5_json_string otp;
 
     *val_out = NULL;
     ret = json_kgname(context, cred->name, &name);
@@ -413,6 +414,20 @@ json_kgcred(krb5_context context, krb5_gss_cred_id_t cred,
                             cred->password);
     if (ret)
         goto cleanup;
+
+    /* Add an otp element only if one is set, so that credentials without one
+     * remain importable by older library versions. */
+    if (cred->otp != NULL) {
+        ret = k5_json_string_create(cred->otp, &otp);
+        if (!ret) {
+            ret = k5_json_array_add(array, otp);
+            k5_json_release(otp);
+        }
+        if (ret) {
+            k5_json_release(array);
+            goto cleanup;
+        }
+    }
     *val_out = array;
 
 cleanup:

--- a/src/lib/gssapi/krb5/gssapiP_krb5.h
+++ b/src/lib/gssapi/krb5/gssapiP_krb5.h
@@ -194,6 +194,7 @@ typedef struct _krb5_gss_cred_id_rec {
     krb5_timestamp refresh_time;
     krb5_enctype *req_enctypes;  /* limit negotiated enctypes to this list */
     char *password;
+    char *otp;
 } krb5_gss_cred_id_rec, *krb5_gss_cred_id_t;
 
 typedef struct _krb5_gss_ctx_ext_rec {
@@ -1306,7 +1307,12 @@ data_to_gss(krb5_data *input_k5data, gss_buffer_t output_buffer)
 #define KRB5_CS_CCACHE_URN "ccache"
 #define KRB5_CS_RCACHE_URN "rcache"
 #define KRB5_CS_PASSWORD_URN "password"
+#define KRB5_CS_OTP_URN "otp"
 #define KRB5_CS_VERIFY_URN "verify"
+
+krb5_error_code KRB5_CALLCONV
+kg_otp_responder(krb5_context context, void *data,
+                 krb5_responder_context rctx);
 
 OM_uint32
 kg_value_from_cred_store(gss_const_key_value_set_t cred_store,

--- a/src/lib/gssapi/krb5/iakerb.c
+++ b/src/lib/gssapi/krb5/iakerb.c
@@ -486,6 +486,14 @@ iakerb_init_creds_ctx(iakerb_ctx_id_t ctx,
     if (code != 0)
         goto cleanup;
 
+    if (cred->otp != NULL) {
+        code = krb5_get_init_creds_opt_set_responder(ctx->k5c, ctx->gic_opts,
+                                                     kg_otp_responder,
+                                                     cred->otp);
+        if (code != 0)
+            goto cleanup;
+    }
+
     code = krb5_init_creds_init(ctx->k5c,
                                 cred->name->princ,
                                 NULL,   /* prompter */
@@ -502,7 +510,9 @@ iakerb_init_creds_ctx(iakerb_ctx_id_t ctx,
     } else if (cred->client_keytab != NULL) {
         code = krb5_init_creds_set_keytab(ctx->k5c, ctx->icc,
                                           cred->client_keytab);
-    } else {
+    } else if (cred->otp == NULL) {
+        /* We need a password, keytab, or OTP value (whose preauth module
+         * determines the reply key) to get initial credentials. */
         code = KRB5_KT_NOTFOUND;
     }
     if (code != 0)

--- a/src/lib/gssapi/krb5/import_cred.c
+++ b/src/lib/gssapi/krb5/import_cred.c
@@ -509,9 +509,12 @@ json_to_kgcred(krb5_context context, k5_json_array array,
     k5_json_bool b;
     krb5_boolean is_new;
     OM_uint32 tmp;
+    size_t len;
 
     *cred_out = NULL;
-    if (k5_json_array_length(array) != 14)
+    /* Tokens from before the otp field was added have 14 elements. */
+    len = k5_json_array_length(array);
+    if (len != 14 && len != 15)
         return -1;
 
     cred = calloc(1, sizeof(*cred));
@@ -578,6 +581,10 @@ json_to_kgcred(krb5_context context, k5_json_array array,
         goto invalid;
 
     if (json_to_optional_string(k5_json_array_get(array, 13), &cred->password))
+        goto invalid;
+
+    if (len > 14 &&
+        json_to_optional_string(k5_json_array_get(array, 14), &cred->otp))
         goto invalid;
 
     *cred_out = cred;

--- a/src/lib/gssapi/krb5/rel_cred.c
+++ b/src/lib/gssapi/krb5/rel_cred.c
@@ -50,6 +50,7 @@ kg_release_cred(krb5_context context, krb5_gss_cred_id_t cred)
     krb5_free_principal(context, cred->impersonator);
     free(cred->req_enctypes);
     zapfreestr(cred->password);
+    zapfreestr(cred->otp);
     free(cred);
     return ret;
 }

--- a/src/tests/gssapi/t_credstore.c
+++ b/src/tests/gssapi/t_credstore.c
@@ -33,7 +33,7 @@ static void
 usage(void)
 {
     fprintf(stderr,
-            "Usage: t_credstore [-sabi] principal [{key value} ...]\n");
+            "Usage: t_credstore [-sabik] principal [{key value} ...]\n");
     exit(1);
 }
 
@@ -64,6 +64,8 @@ main(int argc, char *argv[])
             cred_usage = GSS_C_BOTH;
         else if (opt == 'i')
             cred_usage = GSS_C_INITIATE;
+        else if (opt == 'k')
+            mechs = &mechset_krb5;
         else
             usage();
     }

--- a/src/tests/gssapi/t_gssapi.py
+++ b/src/tests/gssapi/t_gssapi.py
@@ -270,7 +270,48 @@ if pkinit_enabled:
             'Preauth module encrypted_challenge (138) (real) returned: 0')
     realm.run(['./t_iakerb', 'p:' + realm.user_princ, password('user'),
                'h:host@' + hostname, 'h:host'], expected_trace=msgs)
+    realm.stop()
 else:
     print('Skipping IAKERB auto_fast_armor test: PKINIT not built')
+
+# Test FAST OTP over IAKERB and regular GSS krb5.
+if pkinit_enabled and have_pyrad:
+    mark('IAKERB with FAST OTP')
+    otp_conf = {'plugins': {'kdcpreauth': {'enable_only': ['otp', 'pkinit']}},
+                'otp': {'unix': {'server': '$testdir/radius.socket',
+                                 'strip_realm': 'true'}}}
+    afa_conf = {'realms': {'$realm': {'auto_fast_armor': 'true'}}}
+    realm = K5Realm(kdc_conf=otp_conf, krb5_conf=afa_conf, get_creds=False,
+                    pkinit=True)
+    socket_file = os.path.join(realm.testdir, 'radius.socket')
+    otpval = 'otptestvalue'
+    daemon = start_mockradius(socket_file, otpval)
+
+    realm.run([kadminl, 'modprinc', '+requires_preauth', realm.user_princ])
+    realm.run([kadminl, 'setstr', realm.user_princ, 'otp',
+               '[{"type": "unix"}]'])
+    realm.addprinc('WELLKNOWN/ANONYMOUS')
+
+    msgs = ('Acquiring anonymous PKINIT armor ticket for FAST',
+            'Preauth module otp (141) (real) returned: 0')
+    realm.run(['./t_iakerb', 'p:' + realm.user_princ, 'otp:' + otpval,
+               'h:host@' + hostname, 'h:host'], expected_trace=msgs)
+
+    check_mockradius(daemon, 'True user %s' % otpval)
+
+    # Test the otp option with the regular krb5 mechanism, which acquires
+    # initial credentials eagerly during gss_acquire_cred_from().
+    mark('krb5 mech with OTP credential store option')
+    daemon = start_mockradius(socket_file, otpval)
+
+    # Use the -k option to suppress SPNEGO (which would generate a
+    # second OTP request; the mock RADIUS daemon only handles one).
+    realm.run(['./t_credstore', '-i', '-k', 'p:' + realm.user_princ,
+               'otp', otpval], expected_trace=msgs)
+
+    check_mockradius(daemon, 'True user %s' % otpval)
+    realm.stop()
+else:
+    print('Skipping GSS OTP tests: PKINIT not built or pyrad not found')
 
 success('GSSAPI tests')

--- a/src/tests/gssapi/t_iakerb.c
+++ b/src/tests/gssapi/t_iakerb.c
@@ -45,8 +45,8 @@ main(int argc, char **argv)
     gss_buffer_desc pwbuf;
 
     if (argc != 5) {
-        fprintf(stderr, "Usage: %s initiatorname password|- targetname "
-                "acceptorname\n", argv[0]);
+        fprintf(stderr, "Usage: %s initiatorname password|otp:value|- "
+                "targetname acceptorname\n", argv[0]);
         return 1;
     }
 
@@ -55,7 +55,15 @@ main(int argc, char **argv)
     tname = import_name(argv[3]);
     aname = import_name(argv[4]);
 
-    if (strcmp(password, "-") != 0) {
+    if (strncmp(password, "otp:", 4) == 0) {
+        gss_key_value_element_desc elem = { "otp", password + 4 };
+        gss_key_value_set_desc store = { 1, &elem };
+
+        major = gss_acquire_cred_from(&minor, iname, 0, &mechset_iakerb,
+                                      GSS_C_INITIATE, &store, &icred, NULL,
+                                      NULL);
+        check_gsserr("gss_acquire_cred_from", major, minor);
+    } else if (strcmp(password, "-") != 0) {
         pwbuf.value = (void *)password;
         pwbuf.length = strlen(password);
         major = gss_acquire_cred_with_password(&minor, iname, &pwbuf, 0,

--- a/src/tests/t_otp.py
+++ b/src/tests/t_otp.py
@@ -29,139 +29,9 @@
 #
 
 from k5test import *
-from queue import Empty
-import io
-import multiprocessing
-import struct
 
-try:
-    from pyrad import packet, dictionary
-except ImportError:
+if not have_pyrad:
     skip_rest('OTP tests', 'Python pyrad module not found')
-
-# Since Python 3.14 (3.8 on macOS), "forkserver" replaces "fork" as
-# default method on POSIX, because forking and continuing execution is
-# inherently unsafe in threaded processes, and because system
-# libraries may have created threads without specific direction from
-# the main process (this is most often seen on macOS so far).
-#
-# "forkserver" relies on being able to re-import the invoking module.
-# That doesn't work for k5test scripts as we don't use __name__ ==
-# 'main' guards and because k5test installs an atexit handler.  For
-# now, switch back to using the "fork" method.
-multiprocessing.set_start_method('fork', force=True)
-
-# We could use a dictionary file, but since we need so few attributes,
-# we'll just include them here.
-radius_attributes = '''
-ATTRIBUTE    User-Name    1    string
-ATTRIBUTE    User-Password   2    octets
-ATTRIBUTE    Service-Type    6    integer
-ATTRIBUTE    NAS-Identifier  32    string
-ATTRIBUTE    Message-Authenticator 80 octets
-'''
-
-class RadiusDaemon(multiprocessing.Process):
-    MAX_PACKET_SIZE = 4096
-    DICTIONARY = dictionary.Dictionary(io.StringIO(radius_attributes))
-
-    def listen(self, addr):
-        raise NotImplementedError()
-
-    def recvRequest(self, data):
-        raise NotImplementedError()
-
-    def run(self):
-        addr = self._args[0]
-        secrfile = self._args[1]
-        pswd = self._args[2]
-        outq = self._args[3]
-
-        if secrfile:
-            with open(secrfile, 'rb') as file:
-                secr = file.read().strip()
-        else:
-            secr = b''
-
-        data = self.listen(addr)
-        outq.put("started")
-        (buf, sock, addr) = self.recvRequest(data)
-        pkt = packet.AuthPacket(secret=secr,
-                                dict=RadiusDaemon.DICTIONARY,
-                                packet=buf)
-
-        usernm = []
-        passwd = []
-        for key in pkt.keys():
-            if key == 'User-Password':
-                passwd = list(map(pkt.PwDecrypt, pkt[key]))
-            elif key == 'User-Name':
-                usernm = pkt[key]
-
-        reply = pkt.CreateReply()
-        replyq = {'user': usernm, 'pass': passwd}
-        if passwd == [pswd]:
-            reply.code = packet.AccessAccept
-            replyq['reply'] = True
-        else:
-            reply.code = packet.AccessReject
-            replyq['reply'] = False
-
-        reply.add_message_authenticator()
-
-        outq.put(replyq)
-        if addr is None:
-            sock.send(reply.ReplyPacket())
-        else:
-            sock.sendto(reply.ReplyPacket(), addr)
-        sock.close()
-
-class UDPRadiusDaemon(RadiusDaemon):
-    def listen(self, addr):
-        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        sock.bind((addr.split(':')[0], int(addr.split(':')[1])))
-        return sock
-
-    def recvRequest(self, sock):
-        (buf, addr) = sock.recvfrom(RadiusDaemon.MAX_PACKET_SIZE)
-        return (buf, sock, addr)
-
-class UnixRadiusDaemon(RadiusDaemon):
-    def listen(self, addr):
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        if os.path.exists(addr):
-            os.remove(addr)
-        sock.bind(addr)
-        sock.listen(1)
-        return (sock, addr)
-
-    def recvRequest(self, sock_and_addr):
-        sock, addr = sock_and_addr
-        conn = sock.accept()[0]
-        sock.close()
-        os.remove(addr)
-
-        buf = b''
-        remain = RadiusDaemon.MAX_PACKET_SIZE
-        while True:
-            buf += conn.recv(remain)
-            remain = RadiusDaemon.MAX_PACKET_SIZE - len(buf)
-            if (len(buf) >= 4):
-                remain = struct.unpack("!BBH", buf[0:4])[2] - len(buf)
-                if (remain <= 0):
-                    return (buf, conn, None)
-
-def verify(daemon, queue, reply, usernm, passwd):
-    try:
-        data = queue.get(timeout=1)
-    except Empty:
-        sys.stderr.write("ERROR: Packet not received by daemon!\n")
-        daemon.terminate()
-        sys.exit(1)
-    assert data['reply'] is reply
-    assert data['user'] == [usernm]
-    assert data['pass'] == [passwd]
-    daemon.join()
 
 # Compose a single token configuration.
 def otpconfig_1(toktype, username=None, indicators=None):
@@ -180,59 +50,45 @@ def otpconfig_1(toktype, username=None, indicators=None):
 def otpconfig(toktype, username=None, indicators=None):
     return '[' + otpconfig_1(toktype, username, indicators) + ']'
 
-prefix = "/tmp/%d" % os.getpid()
-secret_file = prefix + ".secret"
-socket_file = prefix + ".socket"
-with open(secret_file, "w") as file:
-    file.write("otptest")
-atexit.register(lambda: os.remove(secret_file))
-
 conf = {'plugins': {'kdcpreauth': {'enable_only': 'otp'}},
         'otp': {'udp': {'server': '127.0.0.1:$port9',
-                        'secret': secret_file,
+                        'secret': '$testdir/radius.secret',
                         'strip_realm': 'true',
                         'indicator': ['indotp1', 'indotp2']},
-                'unix': {'server': socket_file,
+                'unix': {'server': '$testdir/radius.socket',
                          'strip_realm': 'false'}}}
-
-queue = multiprocessing.Queue()
 
 realm = K5Realm(kdc_conf=conf)
 realm.run([kadminl, 'modprinc', '+requires_preauth', realm.user_princ])
 flags = ['-T', realm.ccache]
-server_addr = '127.0.0.1:' + str(realm.portbase + 9)
+socket_file = os.path.join(realm.testdir, 'radius.socket')
+udp_addr = '127.0.0.1:' + str(realm.portbase + 9)
 
 ## Test UDP fail / custom username
 mark('UDP fail / custom username')
-daemon = UDPRadiusDaemon(args=(server_addr, secret_file, 'accept', queue))
-daemon.start()
-queue.get()
+daemon = start_mockradius(udp_addr, 'accept')
 realm.run([kadminl, 'setstr', realm.user_princ, 'otp',
            otpconfig('udp', 'custom')])
 realm.kinit(realm.user_princ, 'reject', flags=flags, expected_code=1)
-verify(daemon, queue, False, 'custom', 'reject')
+check_mockradius(daemon, 'False custom reject')
 
 ## Test UDP success / standard username
 mark('UDP success / standard username')
-daemon = UDPRadiusDaemon(args=(server_addr, secret_file, 'accept', queue))
-daemon.start()
-queue.get()
+daemon = start_mockradius(udp_addr, 'accept')
 realm.run([kadminl, 'setstr', realm.user_princ, 'otp', otpconfig('udp')])
 realm.kinit(realm.user_princ, 'accept', flags=flags)
-verify(daemon, queue, True, realm.user_princ.split('@')[0], 'accept')
+check_mockradius(daemon, 'True user accept')
 realm.extract_keytab(realm.krbtgt_princ, realm.keytab)
 realm.run(['./adata', realm.krbtgt_princ],
           expected_msg='+97: [indotp1, indotp2]')
 
 # Repeat with an indicators override in the string attribute.
 mark('auth indicator override')
-daemon = UDPRadiusDaemon(args=(server_addr, secret_file, 'accept', queue))
-daemon.start()
-queue.get()
+daemon = start_mockradius(udp_addr, 'accept')
 oconf = otpconfig('udp', indicators=['indtok1', 'indtok2'])
 realm.run([kadminl, 'setstr', realm.user_princ, 'otp', oconf])
 realm.kinit(realm.user_princ, 'accept', flags=flags)
-verify(daemon, queue, True, realm.user_princ.split('@')[0], 'accept')
+check_mockradius(daemon, 'True user accept')
 realm.extract_keytab(realm.krbtgt_princ, realm.keytab)
 realm.run(['./adata', realm.krbtgt_princ],
           expected_msg='+97: [indtok1, indtok2]')
@@ -240,6 +96,7 @@ realm.run(['./adata', realm.krbtgt_princ],
 # Detect upstream pyrad bug
 #   https://github.com/wichert/pyrad/pull/18
 try:
+    from pyrad import packet
     auth = packet.Packet.CreateAuthenticator()
     packet.Packet(authenticator=auth, secret=b'').ReplyPacket()
 except AssertionError:
@@ -247,38 +104,29 @@ except AssertionError:
 
 ## Test Unix fail / custom username
 mark('Unix socket fail / custom username')
-daemon = UnixRadiusDaemon(args=(socket_file, None, 'accept', queue))
-daemon.start()
-queue.get()
+daemon = start_mockradius(socket_file, 'accept')
 realm.run([kadminl, 'setstr', realm.user_princ, 'otp',
            otpconfig('unix', 'custom')])
 realm.kinit(realm.user_princ, 'reject', flags=flags, expected_code=1)
-verify(daemon, queue, False, 'custom', 'reject')
+check_mockradius(daemon, 'False custom reject')
 
 ## Test Unix success / standard username
 mark('Unix socket success / standard username')
-daemon = UnixRadiusDaemon(args=(socket_file, None, 'accept', queue))
-daemon.start()
-queue.get()
+daemon = start_mockradius(socket_file, 'accept')
 realm.run([kadminl, 'setstr', realm.user_princ, 'otp', otpconfig('unix')])
 realm.kinit(realm.user_princ, 'accept', flags=flags)
-verify(daemon, queue, True, realm.user_princ, 'accept')
+check_mockradius(daemon, 'True user@KRBTEST.COM accept')
 
 ## Regression test for #8708: test with the standard username and two
 ## tokens configured, with the first rejecting and the second
 ## accepting.  With the bug, the KDC incorrectly rejects the request
 ## and then performs invalid memory accesses, most likely crashing.
-queue2 = multiprocessing.Queue()
-daemon1 = UDPRadiusDaemon(args=(server_addr, secret_file, 'accept1', queue))
-daemon2 = UnixRadiusDaemon(args=(socket_file, None, 'accept2', queue2))
-daemon1.start()
-queue.get()
-daemon2.start()
-queue2.get()
+daemon1 = start_mockradius(udp_addr, 'accept1')
+daemon2 = start_mockradius(socket_file, 'accept2')
 oconf = '[' + otpconfig_1('udp') + ', ' + otpconfig_1('unix') + ']'
 realm.run([kadminl, 'setstr', realm.user_princ, 'otp', oconf])
 realm.kinit(realm.user_princ, 'accept2', flags=flags)
-verify(daemon1, queue, False, realm.user_princ.split('@')[0], 'accept2')
-verify(daemon2, queue2, True, realm.user_princ, 'accept2')
+check_mockradius(daemon1, 'False user accept2')
+check_mockradius(daemon2, 'True user@KRBTEST.COM accept2')
 
 success('OTP tests')

--- a/src/util/k5test.py
+++ b/src/util/k5test.py
@@ -167,6 +167,19 @@ Scripts may use the following functions and variables:
   the port needs to be reused; daemon processes will be stopped
   automatically when the script exits.
 
+* start_mockradius(addr, expected_password): Start a RADIUS daemon
+  that will answer one request on a UDP port or Unix domain socket.
+  This function must only be used if have_pyrad is True.  The answer
+  will be Access-Accept if the password matches expected_password,
+  Access-Reject otherwise.  addr can be an absolute pathname for a
+  Unix-domain socket, or ipaddr:port for a UDP socket.  For UDP
+  listeners a trivial OTP secret will be used, matching the contents
+  of $testdir/radius.secret.
+
+* check_mockradius(proc, expected_line): Check the report from the
+  mock RADIUS server, which is of the form 'True/False username
+  password', and wait for the daemon process to terminate.
+
 * multipass_realms(**keywords): This is an iterator function.  Yields
   a realm for each of the standard test passes, each of which alters
   the default configuration in some way to exercise different parts of
@@ -195,6 +208,8 @@ Scripts may use the following functions and variables:
   arguments taking priority.
 
 * buildtop: The top of the build directory (absolute path).
+
+* have_pyrad: True if the pyrad Python module is present.
 
 * srctop: The top of the source directory (absolute path).
 
@@ -393,6 +408,7 @@ command-line flags.  These are documented in the --help output.
 import atexit
 import fcntl
 import glob
+import importlib.util
 import optparse
 import os
 import shlex
@@ -931,6 +947,23 @@ def stop_daemon(proc):
     return await_daemon_exit(proc)
 
 
+# Start a mock RADIUS daemon.  Do not use if have_pyrad is false.
+def start_mockradius(addr, expected_password):
+    assert have_pyrad
+    mockradius = os.path.join(srctop, 'util', 'mockradius.py')
+    return _start_daemon([sys.executable, mockradius, addr, expected_password],
+                         None, 'starting...')
+
+
+# Check the status result from a mock RADIUS daemon process and wait
+# for the process to terminate.
+def check_mockradius(proc, expected_line):
+    line = proc.stdout.readline().strip()
+    if line != expected_line:
+        fail('Expected %s, got %s from mockradius' % (expected_line, line))
+    await_daemon_exit(proc)
+
+
 class K5Realm(object):
     """An object representing a functional krb5 test realm."""
 
@@ -938,7 +971,8 @@ class K5Realm(object):
                  krb5_conf=None, kdc_conf=None, create_kdb=True,
                  krbtgt_keysalt=None, create_user=True, get_creds=True,
                  create_host=True, start_kdc=True, start_kadmind=False,
-                 start_kpropd=False, bdb_only=False, pkinit=False):
+                 start_kpropd=False, bdb_only=False, pkinit=False,
+                 radius_secret=None):
         global hostname, _default_krb5_conf, _default_kdc_conf
         global _lmdb_kdc_conf, _current_db
 
@@ -977,6 +1011,7 @@ class K5Realm(object):
         self._create_conf(self._kdc_conf, kdc_conf_path)
         self._create_acl()
         self._create_dictfile()
+        self._create_radius_secret()
 
         if create_kdb:
             self.create_kdb()
@@ -1069,6 +1104,10 @@ class K5Realm(object):
         file = open(filename, 'w')
         file.write('weak_password\n')
         file.close()
+
+    def _create_radius_secret(self):
+        with open(os.path.join(self.testdir, 'radius.secret'), 'w') as f:
+            f.write('otptest')
 
     def _make_env(self, krb5_conf_path, kdc_conf_path):
         env = _build_env()
@@ -1472,6 +1511,7 @@ srctop = _find_srctop()
 plugins = os.path.join(buildtop, 'plugins')
 pkinit_enabled = os.path.exists(os.path.join(plugins, 'preauth', 'pkinit.so'))
 pkinit_certs = os.path.join(srctop, 'tests', 'pkinit-certs')
+have_pyrad = importlib.util.find_spec('pyrad') is not None
 hostname = socket.gethostname().lower()
 null_input = open(os.devnull, 'r')
 

--- a/src/util/mockradius.py
+++ b/src/util/mockradius.py
@@ -1,0 +1,106 @@
+# Author: Nathaniel McCallum <npmccallum@redhat.com>
+#
+# Copyright (c) 2013 Red Hat, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# This simple RADIUS daemon is intended to help test FAST OTP over UDP
+# and Unix domain sockets.
+
+import io
+import os
+import socket
+import struct
+import sys
+from pyrad import packet, dictionary
+
+# We could use a dictionary file, but since we need so few attributes,
+# we'll just include them here.
+radius_attributes = '''
+ATTRIBUTE    User-Name    1    string
+ATTRIBUTE    User-Password   2    octets
+ATTRIBUTE    Service-Type    6    integer
+ATTRIBUTE    NAS-Identifier  32    string
+ATTRIBUTE    Message-Authenticator 80 octets
+'''
+
+MAX_PACKET_SIZE = 4096
+DICTIONARY = dictionary.Dictionary(io.StringIO(radius_attributes))
+
+addr = sys.argv[1]
+expected_password = sys.argv[2]
+
+# Get one request from addr (a Unix domain or UDP socket).
+if addr.startswith('/'):
+    # Use an empty secret for a Unix domain socket.
+    secret = b''
+
+    # Bind to the path, accept a stream connection, and close the
+    # listener socket.
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    if os.path.exists(addr):
+        os.remove(addr)
+    sock.bind(addr)
+    sock.listen(1)
+    print('starting...', file=sys.stderr)
+    conn = sock.accept()[0]
+    sock.close()
+    os.remove(addr)
+
+    buf = b''
+    remain = MAX_PACKET_SIZE
+    while True:
+        buf += conn.recv(remain)
+        remain = MAX_PACKET_SIZE - len(buf)
+        if len(buf) >= 4:
+            remain = struct.unpack("!BBH", buf[0:4])[2] - len(buf)
+            if remain <= 0:
+                break
+else:
+    # Use a non-empty (but trivial) secret for a UDP socket.
+    secret = b'otptest'
+
+    # Bind to the UDP address and read a packet, remembering its
+    # source address.  Keep the listener socket open.
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind((addr.split(':')[0], int(addr.split(':')[1])))
+    print('starting...', file=sys.stderr)
+    buf, reply_addr = sock.recvfrom(MAX_PACKET_SIZE)
+
+# Parse the packet and compose a reply.
+pkt = packet.AuthPacket(secret=secret, dict=DICTIONARY, packet=buf)
+passwords = [pkt.PwDecrypt(x) for x in pkt['User-Password']]
+usernames = pkt['User-Name']
+success = (passwords == [expected_password])
+reply = pkt.CreateReply()
+reply.code = packet.AccessAccept if success else packet.AccessReject
+reply.add_message_authenticator()
+
+if addr.startswith('/'):
+    # Reply on the Unix domain stream socket.
+    conn.send(reply.ReplyPacket())
+    conn.close()
+else:
+    # Reply on the UDP listener socket at the packet source address.
+    sock.sendto(reply.ReplyPacket(), reply_addr)
+    sock.close()
+
+# Send the result, username, and password to stdout for additional
+# verification by the calling process.
+print(success, usernames[0], passwords[0])


### PR DESCRIPTION
IAKERB drives init_creds programmatically with no prompter available, so an OTP preauth challenge cannot be answered and the OTP client preauth module fails with EIO.
Register a responder that answers the OTP question using the caller-supplied password when one is available, leaving other preauth mechanisms unchanged.

Together with the auto_fast_armor variable from #1534, this allows OTP authentication over IAKERB without existing credentials or an armor ccache.

Add a test covering the full IAKERB + FAST + OTP path using the simulated RADIUS backend. The test verifies that the responder supplies the password to the OTP challenge and that the RADIUS server receives and accepts it.
