### PR TITLE
Redesign FAST OTP tests

### DIFF
--- a/src/tests/t_otp.py
+++ b/src/tests/t_otp.py
@@ -29,139 +29,9 @@
 #
 
 from k5test import *
-from queue import Empty
-import io
-import multiprocessing
-import struct
 
-try:
-    from pyrad import packet, dictionary
-except ImportError:
+if not have_pyrad:
     skip_rest('OTP tests', 'Python pyrad module not found')
-
-# Since Python 3.14 (3.8 on macOS), "forkserver" replaces "fork" as
-# default method on POSIX, because forking and continuing execution is
-# inherently unsafe in threaded processes, and because system
-# libraries may have created threads without specific direction from
-# the main process (this is most often seen on macOS so far).
-#
-# "forkserver" relies on being able to re-import the invoking module.
-# That doesn't work for k5test scripts as we don't use __name__ ==
-# 'main' guards and because k5test installs an atexit handler.  For
-# now, switch back to using the "fork" method.
-multiprocessing.set_start_method('fork', force=True)
-
-# We could use a dictionary file, but since we need so few attributes,
-# we'll just include them here.
-radius_attributes = '''
-ATTRIBUTE    User-Name    1    string
-ATTRIBUTE    User-Password   2    octets
-ATTRIBUTE    Service-Type    6    integer
-ATTRIBUTE    NAS-Identifier  32    string
-ATTRIBUTE    Message-Authenticator 80 octets
-'''
-
-class RadiusDaemon(multiprocessing.Process):
-    MAX_PACKET_SIZE = 4096
-    DICTIONARY = dictionary.Dictionary(io.StringIO(radius_attributes))
-
-    def listen(self, addr):
-        raise NotImplementedError()
-
-    def recvRequest(self, data):
-        raise NotImplementedError()
-
-    def run(self):
-        addr = self._args[0]
-        secrfile = self._args[1]
-        pswd = self._args[2]
-        outq = self._args[3]
-
-        if secrfile:
-            with open(secrfile, 'rb') as file:
-                secr = file.read().strip()
-        else:
-            secr = b''
-
-        data = self.listen(addr)
-        outq.put("started")
-        (buf, sock, addr) = self.recvRequest(data)
-        pkt = packet.AuthPacket(secret=secr,
-                                dict=RadiusDaemon.DICTIONARY,
-                                packet=buf)
-
-        usernm = []
-        passwd = []
-        for key in pkt.keys():
-            if key == 'User-Password':
-                passwd = list(map(pkt.PwDecrypt, pkt[key]))
-            elif key == 'User-Name':
-                usernm = pkt[key]
-
-        reply = pkt.CreateReply()
-        replyq = {'user': usernm, 'pass': passwd}
-        if passwd == [pswd]:
-            reply.code = packet.AccessAccept
-            replyq['reply'] = True
-        else:
-            reply.code = packet.AccessReject
-            replyq['reply'] = False
-
-        reply.add_message_authenticator()
-
-        outq.put(replyq)
-        if addr is None:
-            sock.send(reply.ReplyPacket())
-        else:
-            sock.sendto(reply.ReplyPacket(), addr)
-        sock.close()
-
-class UDPRadiusDaemon(RadiusDaemon):
-    def listen(self, addr):
-        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        sock.bind((addr.split(':')[0], int(addr.split(':')[1])))
-        return sock
-
-    def recvRequest(self, sock):
-        (buf, addr) = sock.recvfrom(RadiusDaemon.MAX_PACKET_SIZE)
-        return (buf, sock, addr)
-
-class UnixRadiusDaemon(RadiusDaemon):
-    def listen(self, addr):
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        if os.path.exists(addr):
-            os.remove(addr)
-        sock.bind(addr)
-        sock.listen(1)
-        return (sock, addr)
-
-    def recvRequest(self, sock_and_addr):
-        sock, addr = sock_and_addr
-        conn = sock.accept()[0]
-        sock.close()
-        os.remove(addr)
-
-        buf = b''
-        remain = RadiusDaemon.MAX_PACKET_SIZE
-        while True:
-            buf += conn.recv(remain)
-            remain = RadiusDaemon.MAX_PACKET_SIZE - len(buf)
-            if (len(buf) >= 4):
-                remain = struct.unpack("!BBH", buf[0:4])[2] - len(buf)
-                if (remain <= 0):
-                    return (buf, conn, None)
-
-def verify(daemon, queue, reply, usernm, passwd):
-    try:
-        data = queue.get(timeout=1)
-    except Empty:
-        sys.stderr.write("ERROR: Packet not received by daemon!\n")
-        daemon.terminate()
-        sys.exit(1)
-    assert data['reply'] is reply
-    assert data['user'] == [usernm]
-    assert data['pass'] == [passwd]
-    daemon.join()
 
 # Compose a single token configuration.
 def otpconfig_1(toktype, username=None, indicators=None):
@@ -180,59 +50,45 @@ def otpconfig_1(toktype, username=None, indicators=None):
 def otpconfig(toktype, username=None, indicators=None):
     return '[' + otpconfig_1(toktype, username, indicators) + ']'
 
-prefix = "/tmp/%d" % os.getpid()
-secret_file = prefix + ".secret"
-socket_file = prefix + ".socket"
-with open(secret_file, "w") as file:
-    file.write("otptest")
-atexit.register(lambda: os.remove(secret_file))
-
 conf = {'plugins': {'kdcpreauth': {'enable_only': 'otp'}},
         'otp': {'udp': {'server': '127.0.0.1:$port9',
-                        'secret': secret_file,
+                        'secret': '$testdir/radius.secret',
                         'strip_realm': 'true',
                         'indicator': ['indotp1', 'indotp2']},
-                'unix': {'server': socket_file,
+                'unix': {'server': '$testdir/radius.socket',
                          'strip_realm': 'false'}}}
-
-queue = multiprocessing.Queue()
 
 realm = K5Realm(kdc_conf=conf)
 realm.run([kadminl, 'modprinc', '+requires_preauth', realm.user_princ])
 flags = ['-T', realm.ccache]
-server_addr = '127.0.0.1:' + str(realm.portbase + 9)
+socket_file = os.path.join(realm.testdir, 'radius.socket')
+udp_addr = '127.0.0.1:' + str(realm.portbase + 9)
 
 ## Test UDP fail / custom username
 mark('UDP fail / custom username')
-daemon = UDPRadiusDaemon(args=(server_addr, secret_file, 'accept', queue))
-daemon.start()
-queue.get()
+daemon = start_mockradius(udp_addr, 'accept')
 realm.run([kadminl, 'setstr', realm.user_princ, 'otp',
            otpconfig('udp', 'custom')])
 realm.kinit(realm.user_princ, 'reject', flags=flags, expected_code=1)
-verify(daemon, queue, False, 'custom', 'reject')
+check_mockradius(daemon, 'False custom reject')
 
 ## Test UDP success / standard username
 mark('UDP success / standard username')
-daemon = UDPRadiusDaemon(args=(server_addr, secret_file, 'accept', queue))
-daemon.start()
-queue.get()
+daemon = start_mockradius(udp_addr, 'accept')
 realm.run([kadminl, 'setstr', realm.user_princ, 'otp', otpconfig('udp')])
 realm.kinit(realm.user_princ, 'accept', flags=flags)
-verify(daemon, queue, True, realm.user_princ.split('@')[0], 'accept')
+check_mockradius(daemon, 'True user accept')
 realm.extract_keytab(realm.krbtgt_princ, realm.keytab)
 realm.run(['./adata', realm.krbtgt_princ],
           expected_msg='+97: [indotp1, indotp2]')
 
 # Repeat with an indicators override in the string attribute.
 mark('auth indicator override')
-daemon = UDPRadiusDaemon(args=(server_addr, secret_file, 'accept', queue))
-daemon.start()
-queue.get()
+daemon = start_mockradius(udp_addr, 'accept')
 oconf = otpconfig('udp', indicators=['indtok1', 'indtok2'])
 realm.run([kadminl, 'setstr', realm.user_princ, 'otp', oconf])
 realm.kinit(realm.user_princ, 'accept', flags=flags)
-verify(daemon, queue, True, realm.user_princ.split('@')[0], 'accept')
+check_mockradius(daemon, 'True user accept')
 realm.extract_keytab(realm.krbtgt_princ, realm.keytab)
 realm.run(['./adata', realm.krbtgt_princ],
           expected_msg='+97: [indtok1, indtok2]')
@@ -240,6 +96,7 @@ realm.run(['./adata', realm.krbtgt_princ],
 # Detect upstream pyrad bug
 #   https://github.com/wichert/pyrad/pull/18
 try:
+    from pyrad import packet
     auth = packet.Packet.CreateAuthenticator()
     packet.Packet(authenticator=auth, secret=b'').ReplyPacket()
 except AssertionError:
@@ -247,38 +104,29 @@ except AssertionError:
 
 ## Test Unix fail / custom username
 mark('Unix socket fail / custom username')
-daemon = UnixRadiusDaemon(args=(socket_file, None, 'accept', queue))
-daemon.start()
-queue.get()
+daemon = start_mockradius(socket_file, 'accept')
 realm.run([kadminl, 'setstr', realm.user_princ, 'otp',
            otpconfig('unix', 'custom')])
 realm.kinit(realm.user_princ, 'reject', flags=flags, expected_code=1)
-verify(daemon, queue, False, 'custom', 'reject')
+check_mockradius(daemon, 'False custom reject')
 
 ## Test Unix success / standard username
 mark('Unix socket success / standard username')
-daemon = UnixRadiusDaemon(args=(socket_file, None, 'accept', queue))
-daemon.start()
-queue.get()
+daemon = start_mockradius(socket_file, 'accept')
 realm.run([kadminl, 'setstr', realm.user_princ, 'otp', otpconfig('unix')])
 realm.kinit(realm.user_princ, 'accept', flags=flags)
-verify(daemon, queue, True, realm.user_princ, 'accept')
+check_mockradius(daemon, 'True user@KRBTEST.COM accept')
 
 ## Regression test for #8708: test with the standard username and two
 ## tokens configured, with the first rejecting and the second
 ## accepting.  With the bug, the KDC incorrectly rejects the request
 ## and then performs invalid memory accesses, most likely crashing.
-queue2 = multiprocessing.Queue()
-daemon1 = UDPRadiusDaemon(args=(server_addr, secret_file, 'accept1', queue))
-daemon2 = UnixRadiusDaemon(args=(socket_file, None, 'accept2', queue2))
-daemon1.start()
-queue.get()
-daemon2.start()
-queue2.get()
+daemon1 = start_mockradius(udp_addr, 'accept1')
+daemon2 = start_mockradius(socket_file, 'accept2')
 oconf = '[' + otpconfig_1('udp') + ', ' + otpconfig_1('unix') + ']'
 realm.run([kadminl, 'setstr', realm.user_princ, 'otp', oconf])
 realm.kinit(realm.user_princ, 'accept2', flags=flags)
-verify(daemon1, queue, False, realm.user_princ.split('@')[0], 'accept2')
-verify(daemon2, queue2, True, realm.user_princ, 'accept2')
+check_mockradius(daemon1, 'False user accept2')
+check_mockradius(daemon2, 'True user@KRBTEST.COM accept2')
 
 success('OTP tests')

--- a/src/util/k5test.py
+++ b/src/util/k5test.py
@@ -167,6 +167,19 @@ Scripts may use the following functions and variables:
   the port needs to be reused; daemon processes will be stopped
   automatically when the script exits.
 
+* start_mockradius(addr, expected_password): Start a RADIUS daemon
+  that will answer one request on a UDP port or Unix domain socket.
+  This function must only be used if have_pyrad is True.  The answer
+  will be Access-Accept if the password matches expected_password,
+  Access-Reject otherwise.  addr can be an absolute pathname for a
+  Unix-domain socket, or ipaddr:port for a UDP socket.  For UDP
+  listeners a trivial OTP secret will be used, matching the contents
+  of $testdir/radius.secret.
+
+* check_mockradius(proc, expected_line): Check the report from the
+  mock RADIUS server, which is of the form 'True/False username
+  password', and wait for the daemon process to terminate.
+
 * multipass_realms(**keywords): This is an iterator function.  Yields
   a realm for each of the standard test passes, each of which alters
   the default configuration in some way to exercise different parts of
@@ -195,6 +208,8 @@ Scripts may use the following functions and variables:
   arguments taking priority.
 
 * buildtop: The top of the build directory (absolute path).
+
+* have_pyrad: True if the pyrad Python module is present.
 
 * srctop: The top of the source directory (absolute path).
 
@@ -393,6 +408,7 @@ command-line flags.  These are documented in the --help output.
 import atexit
 import fcntl
 import glob
+import importlib.util
 import optparse
 import os
 import shlex
@@ -931,6 +947,23 @@ def stop_daemon(proc):
     return await_daemon_exit(proc)
 
 
+# Start a mock RADIUS daemon.  Do not use if have_pyrad is false.
+def start_mockradius(addr, expected_password):
+    assert have_pyrad
+    mockradius = os.path.join(srctop, 'util', 'mockradius.py')
+    return _start_daemon([sys.executable, mockradius, addr, expected_password],
+                         None, 'starting...')
+
+
+# Check the status result from a mock RADIUS daemon process and wait
+# for the process to terminate.
+def check_mockradius(proc, expected_line):
+    line = proc.stdout.readline().strip()
+    if line != expected_line:
+        fail('Expected %s, got %s from mockradius' % (expected_line, line))
+    await_daemon_exit(proc)
+
+
 class K5Realm(object):
     """An object representing a functional krb5 test realm."""
 
@@ -938,7 +971,8 @@ class K5Realm(object):
                  krb5_conf=None, kdc_conf=None, create_kdb=True,
                  krbtgt_keysalt=None, create_user=True, get_creds=True,
                  create_host=True, start_kdc=True, start_kadmind=False,
-                 start_kpropd=False, bdb_only=False, pkinit=False):
+                 start_kpropd=False, bdb_only=False, pkinit=False,
+                 radius_secret=None):
         global hostname, _default_krb5_conf, _default_kdc_conf
         global _lmdb_kdc_conf, _current_db
 
@@ -977,6 +1011,7 @@ class K5Realm(object):
         self._create_conf(self._kdc_conf, kdc_conf_path)
         self._create_acl()
         self._create_dictfile()
+        self._create_radius_secret()
 
         if create_kdb:
             self.create_kdb()
@@ -1069,6 +1104,10 @@ class K5Realm(object):
         file = open(filename, 'w')
         file.write('weak_password\n')
         file.close()
+
+    def _create_radius_secret(self):
+        with open(os.path.join(self.testdir, 'radius.secret'), 'w') as f:
+            f.write('otptest')
 
     def _make_env(self, krb5_conf_path, kdc_conf_path):
         env = _build_env()
@@ -1472,6 +1511,7 @@ srctop = _find_srctop()
 plugins = os.path.join(buildtop, 'plugins')
 pkinit_enabled = os.path.exists(os.path.join(plugins, 'preauth', 'pkinit.so'))
 pkinit_certs = os.path.join(srctop, 'tests', 'pkinit-certs')
+have_pyrad = importlib.util.find_spec('pyrad') is not None
 hostname = socket.gethostname().lower()
 null_input = open(os.devnull, 'r')
 

--- a/src/util/mockradius.py
+++ b/src/util/mockradius.py
@@ -1,0 +1,106 @@
+# Author: Nathaniel McCallum <npmccallum@redhat.com>
+#
+# Copyright (c) 2013 Red Hat, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# This simple RADIUS daemon is intended to help test FAST OTP over UDP
+# and Unix domain sockets.
+
+import io
+import os
+import socket
+import struct
+import sys
+from pyrad import packet, dictionary
+
+# We could use a dictionary file, but since we need so few attributes,
+# we'll just include them here.
+radius_attributes = '''
+ATTRIBUTE    User-Name    1    string
+ATTRIBUTE    User-Password   2    octets
+ATTRIBUTE    Service-Type    6    integer
+ATTRIBUTE    NAS-Identifier  32    string
+ATTRIBUTE    Message-Authenticator 80 octets
+'''
+
+MAX_PACKET_SIZE = 4096
+DICTIONARY = dictionary.Dictionary(io.StringIO(radius_attributes))
+
+addr = sys.argv[1]
+expected_password = sys.argv[2]
+
+# Get one request from addr (a Unix domain or UDP socket).
+if addr.startswith('/'):
+    # Use an empty secret for a Unix domain socket.
+    secret = b''
+
+    # Bind to the path, accept a stream connection, and close the
+    # listener socket.
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    if os.path.exists(addr):
+        os.remove(addr)
+    sock.bind(addr)
+    sock.listen(1)
+    print('starting...', file=sys.stderr)
+    conn = sock.accept()[0]
+    sock.close()
+    os.remove(addr)
+
+    buf = b''
+    remain = MAX_PACKET_SIZE
+    while True:
+        buf += conn.recv(remain)
+        remain = MAX_PACKET_SIZE - len(buf)
+        if len(buf) >= 4:
+            remain = struct.unpack("!BBH", buf[0:4])[2] - len(buf)
+            if remain <= 0:
+                break
+else:
+    # Use a non-empty (but trivial) secret for a UDP socket.
+    secret = b'otptest'
+
+    # Bind to the UDP address and read a packet, remembering its
+    # source address.  Keep the listener socket open.
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind((addr.split(':')[0], int(addr.split(':')[1])))
+    print('starting...', file=sys.stderr)
+    buf, reply_addr = sock.recvfrom(MAX_PACKET_SIZE)
+
+# Parse the packet and compose a reply.
+pkt = packet.AuthPacket(secret=secret, dict=DICTIONARY, packet=buf)
+passwords = [pkt.PwDecrypt(x) for x in pkt['User-Password']]
+usernames = pkt['User-Name']
+success = (passwords == [expected_password])
+reply = pkt.CreateReply()
+reply.code = packet.AccessAccept if success else packet.AccessReject
+reply.add_message_authenticator()
+
+if addr.startswith('/'):
+    # Reply on the Unix domain stream socket.
+    conn.send(reply.ReplyPacket())
+    conn.close()
+else:
+    # Reply on the UDP listener socket at the packet source address.
+    sock.sendto(reply.ReplyPacket(), reply_addr)
+    sock.close()
+
+# Send the result, username, and password to stdout for additional
+# verification by the calling process.
+print(success, usernames[0], passwords[0])


### PR DESCRIPTION
[This work is intended to support PR #1536]

Change the way we test FAST OTP to remove the dependency on the multiprocessing module (which does not fit well with our test framework) and to allow tests in multiple scripts.  Move the mock RADIUS daemon to a new standalone script util/mockradius.py, and add functions to invoke and check it to k5test.py.