### PR TITLE
Free small client memory leak on OTP failure

### DIFF
--- a/src/lib/krb5/krb/preauth_otp.c
+++ b/src/lib/krb5/krb/preauth_otp.c
@@ -992,7 +992,7 @@ otp_client_prep_questions(krb5_context context, krb5_clpreauth_moddata moddata,
                           krb5_data *encoded_previous_request,
                           krb5_pa_data *pa_data)
 {
-    krb5_pa_otp_challenge *chl;
+    krb5_pa_otp_challenge *chl, **chp = (krb5_pa_otp_challenge **)modreq;
     krb5_error_code retval;
     krb5_data tmp;
     char *json;
@@ -1000,13 +1000,17 @@ otp_client_prep_questions(krb5_context context, krb5_clpreauth_moddata moddata,
     if (modreq == NULL)
         return ENOMEM;
 
+    /* We shouldn't normally be called twice during the same initial
+     * credentials request, but if we are, free the previous challenge. */
+    k5_free_pa_otp_challenge(context, *chp);
+    *chp = NULL;
+
     /* Decode the challenge. */
     tmp = make_data(pa_data->contents, pa_data->length);
-    retval = decode_krb5_pa_otp_challenge(&tmp,
-                                          (krb5_pa_otp_challenge **)modreq);
+    retval = decode_krb5_pa_otp_challenge(&tmp, chp);
     if (retval != 0)
         return retval;
-    chl = *(krb5_pa_otp_challenge **)modreq;
+    chl = *chp;
 
     /* Remove unsupported tokeninfos. */
     retval = filter_supported_tokeninfos(context, chl->tokeninfo);


### PR DESCRIPTION
When an initial credentials request using FAST OTP fails due to a rejection from the KDC, otp_client_prep_questions() may be called during the processing of the PREAUTH_FAILED response, due to a minor malfunction in the preauth logic (to be fixed separately).  When this happens the OTP challenge in the PREAUTH_FAILED padata is decoded a second time, overwriting and leaking the decoded challenge from the PREAUTH_REQUIRED response.

Although we don't expect multiple otp_client_prep_questions() calls when the preauth logic is behaving properly, it could still happen due to unexpected KDC behavior (such as a MORE_PREAUTH_DATA_REQUIRED response).  Fix the leak in otp_client_prep_questions() so that it isn't admitted under any KDC behavior.