### PR TITLE
Avoid prep_questions calls after preauth failures

### DIFF
--- a/src/lib/krb5/krb/preauth2.c
+++ b/src/lib/krb5/krb/preauth2.c
@@ -955,7 +955,8 @@ fill_response_items(krb5_context context, krb5_init_creds_context ctx,
     k5_response_items_reset(ctx->rctx.items);
     for (i = 0; in_padata[i] != NULL; i++) {
         pa = in_padata[i];
-        if (!pa_type_allowed(ctx, pa->pa_type))
+        if (!pa_type_allowed(ctx, pa->pa_type) ||
+            previously_failed(ctx, pa->pa_type))
             continue;
         h = find_module(context, ctx, pa->pa_type, &modreq);
         if (h == NULL)


### PR DESCRIPTION
In the libkrb5 AS-REQ logic, on receipt of a PREAUTH_FAILED reply from the KDC, we mark the selected preauth type as having failed using k5_preauth_note_failed(), and see if we can preauthenticate using a different mechanism.  process_pa_data() correctly filters out types marked as failed, but fill_response_items() does not, so we still call the prep_questions() method of previously failed mechanisms.  Add the missing filtering to avoid confusing mechanisms and/or adding inappropriate response items to the set.