### PR TITLE
Prevent dangling result in tl_data2berval()

### DIFF
--- a/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
+++ b/src/plugins/kdb/ldap/libkdb_ldap/ldap_principal2.c
@@ -628,20 +628,24 @@ cleanup:
 static krb5_error_code
 tl_data2berval (krb5_tl_data *in, struct berval **out)
 {
-    *out = (struct berval *) malloc (sizeof (struct berval));
-    if (*out == NULL)
-        return ENOMEM;
+    struct berval *bv;
 
-    (*out)->bv_len = in->tl_data_length + 2;
-    (*out)->bv_val =  (char *) malloc ((*out)->bv_len);
-    if ((*out)->bv_val == NULL) {
-        free (*out);
+    *out = NULL;
+
+    bv = malloc(sizeof(*bv));
+    if (bv == NULL)
+        return ENOMEM;
+    bv->bv_len = in->tl_data_length + 2;
+    bv->bv_val = malloc(bv->bv_len);
+    if (bv->bv_val == NULL) {
+        free(bv);
         return ENOMEM;
     }
 
-    STORE16_INT((*out)->bv_val, in->tl_data_type);
-    k5memcpy((*out)->bv_val + 2, in->tl_data_contents, in->tl_data_length);
+    STORE16_INT(bv->bv_val, in->tl_data_type);
+    k5memcpy(bv->bv_val + 2, in->tl_data_contents, in->tl_data_length);
 
+    *out = bv;
     return 0;
 }
 


### PR DESCRIPTION
If the second malloc() fails in tl_data2berval(), do not leave a dangling freed pointer in *out, or the caller will free it a second time.  Reported by Vidal Segura García.
